### PR TITLE
Added the ability to ignore or disable deleted Redcap records, with related documentation and UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ The [Unreleased](#unreleased) section collects notes for unreleased changes and 
 Note that not every tagged version may be suitable for production use. A Github
 release will be created for any release tested in production, and may be marked below with the tag [Release]
 
+## Unreleased
+
+- [Added] the ability to ignore or disable deleted Redcap records
+- [Added] documentation for Redcap project admin
+- [Changed] handling of data_options.add_multi_choice_summary_fields
+- [Changed] presentation of Redcap project admin details block
+- [Changed] "force reconfiguration" action to warn users that it is destructive and provide a confirmation to continue
+- [Fixed] handling of Redcap record identification for repeating instruments
+
 ## [8.2.91] - 2023-09-25
 
 - [Fixed] build script

--- a/app/assets/stylesheets/admin/admin.scss
+++ b/app/assets/stylesheets/admin/admin.scss
@@ -118,7 +118,7 @@ a.collapsed > .caret {
 }
 
 .info-danger {
-  color: red;
+  color: #cc0000;
 }
 
 div#creddocframe {

--- a/app/controllers/redcap/project_admins_controller.rb
+++ b/app/controllers/redcap/project_admins_controller.rb
@@ -124,6 +124,10 @@ class Redcap::ProjectAdminsController < AdminController
     %i[study name server_url api_key dynamic_model_table transfer_mode frequency disabled options notes]
   end
 
+  def title
+    'REDCap: Project Transfer'
+  end
+
   def filters
     pas = Redcap::ProjectAdmin.pluck(:study).uniq
     {

--- a/app/models/redcap/data_dictionaries/field.rb
+++ b/app/models/redcap/data_dictionaries/field.rb
@@ -240,6 +240,13 @@ module Redcap
         name.to_s.split('___').last
       end
 
+      def multiple_choice?
+        return unless field_type.name == :checkbox
+
+        ccf = field_choices&.choices_plain_text
+        ccf.present? && ccf.length > 1
+      end
+
       #
       # Generate the field name for a summary array field to hold all the
       # individual checkbox choices in a single place

--- a/app/models/redcap/dynamic_storage.rb
+++ b/app/models/redcap/dynamic_storage.rb
@@ -52,6 +52,15 @@ module Redcap
         @field_types[field_name] = field.field_type.database_type.to_s
       end
 
+      extra_fields&.each do |ef|
+        ft = if ef == 'disabled'
+               'boolean'
+             else
+               'string'
+             end
+        @field_types[ef] = ft
+      end
+
       @field_types
     end
 
@@ -66,6 +75,11 @@ module Redcap
       @array_fields = {}
       data_dictionary&.all_retrievable_fields(summary_fields: true)&.each do |field_name, field|
         @array_fields[field_name] = field.field_type.database_array?
+      end
+
+      extra_fields&.each do |ef|
+        ft = (ef != 'disabled')
+        @array_fields[ef] = ft
       end
 
       @array_fields
@@ -120,10 +134,7 @@ module Redcap
 
         next unless field.field_type.name == :checkbox
 
-        ccf = field.field_choices&.choices_plain_text
-        next unless ccf.present?
-
-        if project_admin.data_options.add_multi_choice_summary_fields && ccf.length > 1
+        if project_admin.data_options.add_multi_choice_summary_fields && field.multiple_choice?
           # Create a "chosen array" if the project configuration requires a summary field
           # to capture all of the multiple choice values in one place
           # But only do this if the number of choices is greater than 1, since we don't want this
@@ -141,6 +152,9 @@ module Redcap
           # on the redcap_tag_select field type.
         end
 
+        ccf = field.field_choices&.choices_plain_text
+        next unless ccf.present?
+
         # Create a field for each multiple choice value
         ccf.each do |arr|
           fname = arr.first
@@ -152,6 +166,9 @@ module Redcap
           @show_if_condition_strings[ccffn.to_sym] = bl_condition_string if bl_condition_string.present?
         end
       end
+
+      # Add a disabled field if one is not present and we need to disable deleted records
+      @fields['disabled'] ||= { label: 'disabled' } if project_admin.data_options.handle_deleted_records == 'disabled'
 
       @fields
     end
@@ -211,6 +228,27 @@ module Redcap
       end
 
       @placeholder_fields
+    end
+
+    def extra_fields
+      return @extra_fields if @extra_fields
+
+      @extra_fields = []
+      @extra_fields << 'disabled' if project_admin.disable_deleted_records?
+
+      return @extra_fields unless project_admin.data_options.add_multi_choice_summary_fields
+
+      data_dictionary.all_fields.each do |_field_name, field|
+        next unless field.multiple_choice?
+
+        # Create a "chosen array" if the project configuration requires a summary field
+        # to capture all of the multiple choice values in one place
+        # But only do this if the number of choices is greater than 1, since we don't want this
+        # for standalone checkboxes
+        @extra_fields << field.chosen_array_field_name
+      end
+
+      @extra_fields
     end
 
     #

--- a/app/models/redcap/project_admin.rb
+++ b/app/models/redcap/project_admin.rb
@@ -50,6 +50,8 @@ module Redcap
 
     JobQueue = 'redcap'
 
+    ValidHandleDeletedRecordsValues = [nil, false, 'disable', 'ignore']
+
     has_one :redcap_data_dictionary,
             class_name: 'Redcap::DataDictionary',
             foreign_key: :redcap_project_admin_id,
@@ -201,10 +203,24 @@ module Redcap
     #
     # Specify options for the project.
     # add_multi_choice_summary_fields: automatically capture summary fields from checkbox fields with multiple responses
-    #                                  providing a single array result field that can more easily be used within SQL without
-    #                                  having to know each of the individual checkbox field columns in the database.
-    configure :data_options, with: %i[add_multi_choice_summary_fields]
+    #                                  providing a single array result field that can more easily be used within SQL
+    #                                  without having to know each of the individual checkbox field columns in
+    #                                  the database.
+    # handle_deleted_records: specify how to handle records deleted on Redcap that have already been transferred
+    #                         to the database. By default, the request fails. The options are:
+    #                         - false/null: (default) to prevent a request with deleted records
+    #                         - disable: set the disabled attribute for deleted records
+    #                         - ignore: skip any deleted records
+    #                         NOTE: with the *disabled* option, if a record subsequently "reappears" in Redcap
+    #                         then the existing DB record will be set to disabled = false and updated appropriately
+    configure :data_options, with: %i[add_multi_choice_summary_fields
+                                      handle_deleted_records]
 
+    validate :data_options, lambda {
+      return if data_options.handle_deleted_records.in?(ValidHandleDeletedRecordsValues)
+
+      errors.add(:data_options, "handle_deleted_records must be one of: #{ValidHandleDeletedRecordsValues}")
+    }
     #
     # A hash digest of the data dictionary, allowing any changes to indicate that an update is required
     configure_attributes :data_dictionary_version
@@ -312,12 +328,15 @@ module Redcap
 
     #
     # Compare the field lists for that required by storage against
-    # the actual dynamic model configuration
-    # @return [Array{storage fields, dynamic model fields}]
+    # the actual dynamic model configuration.
+    # Extra fields are those dependent on data_options, and will also appear in the storage fields list
+    # if present
+    # @return [Array{storage fields, dynamic model fields, extra fields}]
     def compare_storage_and_model_field_lists
-      fl = dynamic_storage.field_list # (no_placeholder_fields: true)
-      dmfl = dynamic_storage.dynamic_model.field_list
-      [fl, dmfl]
+      fl = dynamic_storage.field_list.split(' ')
+      extras = dynamic_storage.extra_fields
+      dmfl = dynamic_storage.dynamic_model.field_list.split(' ')
+      [fl, dmfl, extras]
     end
 
     #
@@ -326,11 +345,8 @@ module Redcap
     # Additional fields in the dynamic model are acceptable
     # @return [Boolean]
     def model_has_all_fields_for_storage?
-      storage, dm_fields = compare_storage_and_model_field_lists
-      storage_fields_a = storage&.split(' ')
-      dm_fields_a = dm_fields&.split(' ')
-
-      (storage_fields_a - dm_fields_a).empty?
+      storage_fields_a, dm_fields_a, extra_fields_a = compare_storage_and_model_field_lists
+      (storage_fields_a + extra_fields_a - dm_fields_a).empty?
     end
 
     def valid_metadata?
@@ -404,6 +420,18 @@ module Redcap
       dynamic_storage.create_dynamic_model
       record_job_request 'update_dynamic_model', result: { dynamic_model: dynamic_storage.dynamic_model.id }
       # dynamic_storage.add_user_access_control
+    end
+
+    def disable_deleted_records?
+      data_options.handle_deleted_records == 'disable'
+    end
+
+    def ignore_deleted_records?
+      data_options.handle_deleted_records == 'ignore'
+    end
+
+    def fail_on_deleted_records?
+      !data_options.handle_deleted_records
     end
 
     private

--- a/app/views/redcap/project_admins/_details_block.html.erb
+++ b/app/views/redcap/project_admins/_details_block.html.erb
@@ -44,28 +44,37 @@ end
   <span>not available</span>
 <% end %>
 </p>
+<% if object_instance.persisted? && object_instance.enabled? %>
+  <% if object_instance.dynamic_model_ready?%>
+    <p><label>database table</label>
+    <%= link_to link_label_open_in_new('search table data'), "/reports/reference_data__table_data?schema_name=#{dm.schema_name}&search_attrs%5B_blank%5D=true&search_attrs%5Bno_run%5D=true&table_name=#{dm.table_name}", 
+      target: '_blank' %></p>
+  <% end %>
+<% end %>  
+
+
 <%
-  if dm
-  
-    fl, dmfl = object_instance.compare_storage_and_model_field_lists
-
-    dmfla = dmfl&.split(' ')
-    fla = fl.split(' ')          
-
+  if dm  
+    fla, dmfla, exa = object_instance.compare_storage_and_model_field_lists
 %>
-<p><label>metadata and table fields</label> <span>
-
-  <% if !dmfl.present? || !fl.present? %>
-  <p>REDCap or table fields not set up</p>
-  <% elsif dmfl == fl %>
-  <p>REDCap fields match table</p>
+<p><label>metadata and table fields</label> 
+<span>
+  <% if !dmfla&.present? || !fla&.present? %>
+  <p class="info-danger">REDCap or table fields not set up</p>
+  <% elsif object_instance.model_has_all_fields_for_storage? %>
+  <p>REDCap fields match dynamic model table</p>
   <% else %>
   <p>REDCap fields don't match table</p>
-  <% if (fla - dmfla).present? %><p>- REDCap has additional fields (pull will fail): <%= "[#{(fla - dmfla).join(" ")}]" %><p><% end %>
-  <% if (dmfla - fla).present? %><p>- table has additional fields (pull will ignore them): <%= "[#{(dmfla - fla).join(" ")}]" %><p><% end %>
+  <ul>
+  <% rfs = (fla - exa - dmfla)
+     if rfs.present? %><li class="info-danger"><b>REDCap</b> has additional fields <b>(pull will fail)</b>: <%= "[#{rfs.join(" ")}]" %></li><% end %>
+  <% efs = (exa - dmfla)
+     if efs.present? %><li class="info-danger"><b>Options</b> specifies <code>data_options:</code> requiring extra fields <b>(pull will fail)</b>: <%= "[#{efs.join(" ")}]" %></li><% end %>
+  <% fs = (dmfla - fla)
+     if fs.present? %><li><b>Dynamic model</b> table has additional fields <b>(pull will ignore them)</b>: <%= "[#{fs.join(" ")}]" %></li><% end %>
   <% end %>  
-
-    </span></p>
+  </ul>
+  </span></p>
 <p><label>pull schedule</label>
   <span>
     <% if  object_instance.frequency.present? && object_instance.transfer_mode == 'scheduled' %>
@@ -84,12 +93,6 @@ end
 <% end %>
 <p><label>configuration updated at</label> <span><%=current_user_date_time( object_instance.updated_at) || '(not yet created)' %></span></p>
 <% if object_instance.persisted? && object_instance.enabled? %>
-  <hr/>
-  <% if object_instance.dynamic_model_ready?%>
-    <p><%= link_to link_label_open_in_new('search table data'), "/reports/reference_data__table_data?schema_name=#{dm.schema_name}&search_attrs%5B_blank%5D=true&search_attrs%5Bno_run%5D=true&table_name=#{dm.table_name}", 
-      target: '_blank' %></p>
-  <% end %>
-  <hr/>
   <div style="display: flex;">
     <div class="admin-info-col">
       <% if object_instance.dynamic_model_ready? %>
@@ -122,10 +125,20 @@ end
         method: :post %>
       </p>  
       <p>
-        <%= link_to 'force reconfiguration', force_reconfig_redcap_project_admin_path(object_instance), 
-        remote: true,
-        class: 'btn btn-danger btn-sm',
-        method: :post %>
+
+      <a class="btn btn-danger btn-sm show-in-modal" 
+         data-content-el="#dmdef-update-config-from-table-<%=object_instance.id%>" 
+         data-title="Force full reconfiguration">force reconfiguration</a>
+      <div id="dmdef-update-config-from-table-<%=object_instance.id%>" class="hidden">
+        <h2>This action may be destructive</h2>
+        <p>Click to continue if you are sure</p>
+        <p>
+          <%= link_to 'force reconfiguration', force_reconfig_redcap_project_admin_path(object_instance), 
+          remote: true,
+          class: 'btn btn-danger btn-sm',
+          method: :post %>
+        </p>
+      </div>      
       </p>
     </div>
   </div>

--- a/docs/admin_reference/project_admins/0_introduction.md
+++ b/docs/admin_reference/project_admins/0_introduction.md
@@ -1,0 +1,21 @@
+# REDCap: Project Transfer
+
+## Introduction
+
+**REDCap: Project Transfer** provides configuration of REDCap data transfer processes. Each project configured corresponds with a project deployed on a REDCap server, providing:
+
+- Capture of the REDCap project:
+  - configuration information
+  - data dictionary
+  - definitions of drop-downs, checkboxes and radio buttons
+  - list of data collection instruments
+  - users assigned to the project
+- Transfer of record data into the local database
+- Capture of the full project XML file
+
+Administration is provided in [REDCap: Project Transfer](/redcap/project_admins)
+
+## Contents
+
+- [Detailed Options](detailed_options.md)
+- [Action Buttons](action_buttons.md)

--- a/docs/admin_reference/project_admins/action_buttons.md
+++ b/docs/admin_reference/project_admins/action_buttons.md
@@ -1,0 +1,38 @@
+# REDCap Project Transfer: Action Buttons
+
+The information panel on the right-hand side of a REDCap project definition appear when the project has been set up.
+
+## refresh
+
+Simply refreshes the information in the admin panel to match the current state of the project and any actions that have been requested. The **Requests** tab will be updated to show any requests to the remote REDCap server made in the background or according to a timed schedule.
+
+## retrieve records
+
+Schedule an immediate transfer of all records from the REDCap project. After a little time, click the [refresh](#refresh) button then select the **Requests** tab to check that the retrieval has completed.
+
+## retrieve user list
+
+Fetch the list of users assigned to the REDCap project.
+
+## retrieve data collection instruments list
+
+Fetch the list of data collection instruments configured for the REDCap project.
+
+## dump project archive to filestore
+
+This pulls the full XML project archive and stores it as a file. This can be accessed in the **Files** tab.
+
+## update dynamic model
+
+In the configuration information that appears in the main section, a label **metadata and table fields** should show one of the following:
+
+- REDCap fields match dynamic model table
+- Dynamic model table has additional fields (pull will ignore them)
+
+If this is not the case and a status appears highlighted red and ending with the text **(pull will fail)**, then action must be taken for a transfer to be successful. This typically happens if one of the **Options** `data_options:` settings has been changed, or fields have been added to the REDCap server's project definition.
+
+Typically running the **update dynamic model** action is sufficient to rectify the situation and set up the new fields that are required.
+
+## force reconfiguration
+
+This action will perform an extensive reconfiguration of the definitions set locally. This may be destructive to configurations and should not be used unless an admin can validate the results. Typically this actions should not be required.

--- a/docs/admin_reference/project_admins/detailed_options.md
+++ b/docs/admin_reference/project_admins/detailed_options.md
@@ -1,0 +1,44 @@
+# REDCap Project Transfer: Detailed Options
+
+!defs(project_admin_field_defs.yaml)
+
+---
+
+## Options
+
+Options are set with reasonable defaults when a project is first saved.
+
+```yaml
+records_request_options:
+  exportSurveyFields: |
+    The admin must set this value based on the 
+    actual configuration of the REDCap project. 
+    If surveys are enabled for the project, set 
+    this value to **true** otherwise leave it 
+    blank or **false**.
+  returnMetadataOnly:
+  exportDataAccessGroups:
+  returnFormat:
+metadata_request_options:
+  returnFormat:
+data_options:
+  add_multi_choice_summary_fields: |
+    If *true*, Adds an extra array field to the
+    database for checkbox fields, providing
+    a single field summarizing all selected 
+    checkboxes for a single REDCap field.
+    By default (*false* or blank) only the 
+    individual checkbox fields for each option will
+    be added, as 
+    `<field_name>___1`, `<field_name>___2`,...
+  handle_deleted_records: |
+    one of
+      - disable
+      - ignore
+      - (blank)
+      - null
+      - false
+data_dictionary_version: |
+  do not change - a hash generated internally to 
+  identify whether the data dictionary has changed
+```

--- a/spec/migrations/20210215184600_create_rc_sample_responses_qoezsq.rb
+++ b/spec/migrations/20210215184600_create_rc_sample_responses_qoezsq.rb
@@ -7,7 +7,7 @@ class CreateRcSampleResponsesQoezsq < ActiveRecord::Migration[5.2]
     self.table_name = 'rc_sample_responses'
     self.fields = %i[record_id dob current_weight smoketime___pnfl smoketime___dnfl smoketime___anfl smoke_start
                      smoke_stop smoke_curr demog_date ncmedrec_add ladder_wealth ladder_comm born_address twelveyrs_address othealth___complete othealth_date q2_survey_complete
-                     sdfsdaf___0 sdfsdaf___1 sdfsdaf___2 rtyrtyrt___0 rtyrtyrt___1 rtyrtyrt___2 test_field test_phone i57 f57 dd yes_or_no test_complete]
+                     sdfsdaf___0 sdfsdaf___1 sdfsdaf___2 rtyrtyrt___0 rtyrtyrt___1 rtyrtyrt___2 test_field test_phone i57 f57 dd yes_or_no test_complete disabled]
     self.table_comment = 'Dynamicmodel: Rc Sample Response'
     self.fields_comments = {}
     self.db_configs = {

--- a/spec/models/redcap/data_records_repeat_instrument_spec.rb
+++ b/spec/models/redcap/data_records_repeat_instrument_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Redcap::DataRecords, type: :model do
     rc = @project_admin_metadata
     rc.reload
     rc.current_admin = @admin
+    rc.api_key = @metadata_project[:api_key]
     pi = rc.captured_project_info
     expect(pi).to be_a Hash
     expect(pi[:has_repeating_instruments_or_events]).to eq 1
@@ -96,6 +97,130 @@ RSpec.describe Redcap::DataRecords, type: :model do
     expect(dr.errors).to be_empty
     expect(dr.created_ids.sort).to be_empty
     expect(dr.updated_ids).to be_empty
+
+    # Now add a record by hand and repeat the run to simulate the deletion of redcap record
+    newrec = dm.new varname: 'birthwt', redcap_repeat_instrument: 'visitspecific_information', redcap_repeat_instance: '2', current_user: @admin.matching_user
+    newrec.force_save!
+    newrec.save!
+
+    dr = Redcap::DataRecords.new(rc, dm.name)
+    dr.retrieve
+    dr.summarize_fields
+    expect { dr.validate }.to raise_error(FphsException, 'Redcap::DataRecords retrieved fewer records (8) than expected (9)')
+  end
+
+  it 'cleanly deleted repeat instrument fields in records' do
+    setup_repeat_instrument_fields
+    rc = @project_admin_metadata
+    rc.reload
+    rc.current_admin = @admin
+    rc.api_key = @metadata_project[:api_key]
+    rc.data_options.handle_deleted_records = 'disable'
+    rc.save!
+    rc.reload
+    rc.api_key = @metadata_project[:api_key]
+    pi = rc.captured_project_info
+    c = rc.dynamic_storage.dynamic_model.implementation_class
+    # Fake a disabled attribute
+    c.attr_accessor :disabled
+
+    c.define_method(:saved_change_to_disabled?) do
+      true
+    end
+
+    c.define_method(:disabled?) do
+      !!disabled
+    end
+
+    expect(pi).to be_a Hash
+    expect(pi[:has_repeating_instruments_or_events]).to eq 1
+
+    expect(rc.repeating_instruments?).to be true
+
+    dd = rc.redcap_data_dictionary
+    repeat_fields = dd.all_fields_of_type(:repeat)
+
+    # The repeat fields are not in the form, instead are at the top project level
+    expect(repeat_fields.keys).to eq []
+
+    @dm_sf = dm = rc.dynamic_storage.dynamic_model.implementation_class
+    dm = rc.dynamic_storage.dynamic_model.implementation_class
+    expect(dm.attribute_names.include?('varname')).to be true
+    expect(dm.attribute_names.include?('redcap_repeat_instrument')).to be true
+    expect(dm.attribute_names.include?('redcap_repeat_instance')).to be true
+
+    dr = Redcap::DataRecords.new(rc, dm.name)
+    dr.retrieve
+    dr.summarize_fields
+    expect { dr.validate }.not_to raise_error
+
+    dr.store
+
+    expect(dr.errors).to be_empty
+    expect(dr.created_ids[0..5]).to eq [
+      {
+        redcap_repeat_instance: '',
+        redcap_repeat_instrument: '',
+        varname: 'abnormal_eps'
+      },
+      {
+        redcap_repeat_instance: 1,
+        redcap_repeat_instrument: 'visitspecific_information',
+        varname: 'abnormal_eps'
+      },
+      {
+        redcap_repeat_instance: '',
+        redcap_repeat_instrument: '',
+        varname: 'birthwt'
+      },
+      {
+        redcap_repeat_instance: 1,
+        redcap_repeat_instrument: 'visitspecific_information',
+        varname: 'birthwt'
+      },
+      {
+        redcap_repeat_instance: '',
+        redcap_repeat_instrument: '',
+        varname: 'birthwt_epq'
+      },
+      {
+        redcap_repeat_instance: 1,
+        redcap_repeat_instrument: 'visitspecific_information',
+        varname: 'birthwt_epq'
+      }
+
+    ]
+    expect(dr.updated_ids).to be_empty
+
+    expect(@dm_sf.where(varname: 'birthwt').count).to eq 2
+    expect(@dm_sf.where(varname: 'birthwt', redcap_repeat_instance: 1).first.redcap_repeat_instrument).to eq 'visitspecific_information'
+
+    dr = Redcap::DataRecords.new(rc, dm.name)
+    dr.retrieve
+    dr.summarize_fields
+    expect { dr.validate }.not_to raise_error
+
+    dr.store
+
+    expect(dr.errors).to be_empty
+    expect(dr.created_ids.sort).to be_empty
+    expect(dr.updated_ids).to be_empty
+
+    # Now add a record by hand and repeat the run to simulate the deletion of redcap record
+    newrec = dm.new varname: 'birthwt', redcap_repeat_instrument: 'visitspecific_information', redcap_repeat_instance: '2', current_user: @admin.matching_user
+    newrec.force_save!
+    newrec.save!
+
+    dr = Redcap::DataRecords.new(rc, dm.name)
+    dr.retrieve
+    dr.summarize_fields
+    expect { dr.validate }.not_to raise_error
+
+    dr.store
+
+    expect(dr.errors).to be_empty
+    expect(dr.created_ids.sort).to be_empty
+    expect(dr.updated_ids).to eq [{ redcap_repeat_instance: '2', redcap_repeat_instrument: 'visitspecific_information', varname: 'birthwt' }]
   end
 
   after :all do

--- a/spec/models/redcap/data_records_spec.rb
+++ b/spec/models/redcap/data_records_spec.rb
@@ -470,7 +470,7 @@ RSpec.describe Redcap::DataRecords, type: :model do
       dr.summarize_fields
       expect do
         dr.validate
-      end.to raise_error(FphsException, 'Redcap::DataRecords existing records were not in the retrieved records: 4')
+      end.to raise_error(FphsException, 'Redcap::DataRecords existing records were not in the retrieved records: {:record_id=>"4"}')
     end
   end
 
@@ -525,7 +525,7 @@ RSpec.describe Redcap::DataRecords, type: :model do
       dr.summarize_fields
       expect do
         dr.validate
-      end.not_to raise_error(FphsException, 'Redcap::DataRecords existing records were not in the retrieved records: 4')
+      end.not_to raise_error
 
       dr.store
       expect(dr.errors).to be_empty
@@ -567,7 +567,7 @@ RSpec.describe Redcap::DataRecords, type: :model do
       dr.summarize_fields
       expect do
         dr.validate
-      end.not_to raise_error(FphsException, 'Redcap::DataRecords existing records were not in the retrieved records: 4')
+      end.not_to raise_error
 
       dr.store
 

--- a/spec/models/redcap/dynamic_storage_spec.rb
+++ b/spec/models/redcap/dynamic_storage_spec.rb
@@ -132,6 +132,8 @@ RSpec.describe Redcap::DynamicStorage, type: :model do
     it 'allows a configuration to include an array column for each checkbox field group, in addition to individual boolean choice fields' do
       rc = Redcap::ProjectAdmin.active.first
       rc.current_admin = @admin
+      rc.data_options.add_multi_choice_summary_fields = true
+      rc.save
 
       ds = Redcap::DynamicStorage.new(rc, 'redcap_test.temp_mcf')
 

--- a/spec/support/redcap/redcap_support.rb
+++ b/spec/support/redcap/redcap_support.rb
@@ -464,7 +464,7 @@ module Redcap
     # Set up the appropriate dynamic model for the narrow record data.
     # The spec/migrations/20210212065538_create_rc_sample_responses_qoezsq.rb migration
     # handles the creation of the table
-    def create_dynamic_model_for_sample_response(survey_fields: nil)
+    def create_dynamic_model_for_sample_response(survey_fields: nil, disable: nil)
       j = {
         default: {
           db_configs: {
@@ -514,6 +514,9 @@ module Redcap
         tn = 'rc_sample_sf_responses'
       end
 
+      field_list = data_sample_response_fields(type).dup
+      field_list << 'disabled' if disable
+
       options = YAML.dump j.deep_stringify_keys
 
       @dynamic_model = DynamicModel.create! current_admin: @admin,
@@ -522,7 +525,7 @@ module Redcap
                                             primary_key_name: :id,
                                             foreign_key_name: nil,
                                             category: :test,
-                                            field_list: data_sample_response_fields(type).join(' '),
+                                            field_list: field_list.join(' '),
                                             options: options
     end
 


### PR DESCRIPTION
Fixes #94 
- Added the ability to ignore or disable deleted Redcap records
- Added documentation for Redcap project admin
- Changed handling of data_options.add_multi_choice_summary_fields Improved presentation of Redcap project admin details block 
- Changed "force reconfiguration" action to warn users that it is destructive and provide a confirmation to continue