### PR TITLE
118 redcap config library

### DIFF
--- a/app/models/dynamic/model_generator.rb
+++ b/app/models/dynamic/model_generator.rb
@@ -11,7 +11,7 @@ module Dynamic
     included do
       # :field_types is a Hash of field_name => field_type values, where the field_name
       # is a symbol and field_type is a valid DB migration data type (also a symbol)
-      attr_accessor :field_types, :array_fields
+      attr_accessor :field_types, :array_fields, :prefix_config_library
       attr_accessor :parent, :qualified_table_name, :category
     end
 
@@ -65,6 +65,13 @@ module Dynamic
       }.deep_stringify_keys!
 
       options = YAML.dump default_options
+
+      if prefix_config_library.present?
+        options = options.sub(
+          /^---/,
+          "---\n#{prefix_config_library_string}\n"
+        )
+      end
 
       fla = field_list.split
       if fla.include?('master_id')
@@ -147,6 +154,20 @@ module Dynamic
 
       dynamic_model.generate_model if dynamic_model&.ready_to_generate?
       dynamic_model.implementation_class_defined?(Object, fail_without_exception: true)
+    end
+
+    #
+    # String to form the library to prefix the options
+    # @return [String]
+    def prefix_config_library_string
+      "# @library #{prefix_config_library}"
+    end
+
+    #
+    # Check if the prefix config library has been added to the options
+    # @return [true|false]
+    def dynamic_model_config_library_added?
+      !!dynamic_model&.options&.index(/^#{prefix_config_library_string}$/)
     end
 
     #

--- a/app/models/dynamic/model_generator.rb
+++ b/app/models/dynamic/model_generator.rb
@@ -116,7 +116,17 @@ module Dynamic
       schema_name, table_name = schema_and_table_name
       name = table_name.singularize
 
-      @dynamic_model = DynamicModel.active.where(name: name, category: category, schema_name: schema_name).first
+      schema_name = [nil, ''] if schema_name.blank?
+
+      attrs = { name: name, category: category, schema_name: schema_name }
+      dms = DynamicModel.active.where(attrs)
+
+      if dms.length > 1
+        Rails.logger.warn "Multiple dynamic models were found for #{attrs}\n" \
+                          "The item with id #{dms.first.id} will be used"
+      end
+
+      @dynamic_model = dms.first
       return if !no_check && !dynamic_model_ready?
 
       @dynamic_model

--- a/app/models/option_configs/extra_options.rb
+++ b/app/models/option_configs/extra_options.rb
@@ -529,7 +529,7 @@ module OptionConfigs
         category = res[1].strip
         name = res[2].strip
         lib = Admin::ConfigLibrary.content_named category, name, format: :yaml
-        lib = lib.dup
+        lib = (lib || '').dup
         lib.gsub!(/^_definitions:.*/, "_definitions__#{category}_#{name}:")
         content_to_update.gsub!(res[0], lib)
         res = content_to_update.match reg

--- a/app/models/redcap/dynamic_storage.rb
+++ b/app/models/redcap/dynamic_storage.rb
@@ -308,6 +308,14 @@ module Redcap
     end
 
     #
+    # Specifies the "<category> <name>" part of the @library string to add automatically when
+    # generating the dynamic model
+    # @return [String]
+    def prefix_config_library
+      project_admin.data_options.prefix_dynamic_model_config_library
+    end
+
+    #
     # Add default user access control for the current admin
     # matching user
     def add_user_access_control

--- a/app/models/redcap/project_admin.rb
+++ b/app/models/redcap/project_admin.rb
@@ -213,8 +213,14 @@ module Redcap
     #                         - ignore: skip any deleted records
     #                         NOTE: with the *disabled* option, if a record subsequently "reappears" in Redcap
     #                         then the existing DB record will be set to disabled = false and updated appropriately
+    # prefix_dynamic_model_config_library: category name
+    #                      The "<category> <name>" string identifier for a
+    #                      config library to be prefixed to the dynamic
+    #                      model definition whenever it is updated.
+    #                      For example: "redcap test_library"
     configure :data_options, with: %i[add_multi_choice_summary_fields
-                                      handle_deleted_records]
+                                      handle_deleted_records
+                                      prefix_dynamic_model_config_library]
 
     validate :data_options, lambda {
       return if data_options.handle_deleted_records.in?(ValidHandleDeletedRecordsValues)
@@ -432,6 +438,14 @@ module Redcap
 
     def fail_on_deleted_records?
       !data_options.handle_deleted_records
+    end
+
+    #
+    # Returns true if the data_options.prefix_dynamic_model_config_library setting is blank
+    # or if the dynamic model has the specified library in its options
+    # @return [true|false]
+    def dynamic_model_config_library_valid?
+      data_options.prefix_dynamic_model_config_library.blank? || dynamic_storage&.dynamic_model_config_library_added?
     end
 
     private

--- a/app/views/redcap/project_admins/_details_block.html.erb
+++ b/app/views/redcap/project_admins/_details_block.html.erb
@@ -39,7 +39,7 @@ end
     dm = object_instance.dynamic_storage&.dynamic_model
     dm_path = admin_dynamic_models_path(filter: { table_name: dm.table_name, disabled: :enabled } )
 %>
-  <span><%= link_to link_label_open_in_new(dm.name), dm_path, target: '_blank' %> </span>
+  <span>(id: <%=dm.id%>) <%= link_to link_label_open_in_new(dm.name), dm_path, target: '_blank' %> </span>
 <% else %>
   <span>not available</span>
 <% end %>

--- a/app/views/redcap/project_admins/_details_block.html.erb
+++ b/app/views/redcap/project_admins/_details_block.html.erb
@@ -55,9 +55,9 @@ end
 
 <%
   if dm  
-    fla, dmfla, exa = object_instance.compare_storage_and_model_field_lists
+    fla, dmfla, exa = object_instance.compare_storage_and_model_field_lists    
 %>
-<p><label>metadata and table fields</label> 
+<p><label>metadata and table fields</label></p>
 <span>
   <% if !dmfla&.present? || !fla&.present? %>
   <p class="info-danger">REDCap or table fields not set up</p>
@@ -74,7 +74,10 @@ end
      if fs.present? %><li><b>Dynamic model</b> table has additional fields <b>(pull will ignore them)</b>: <%= "[#{fs.join(" ")}]" %></li><% end %>
   <% end %>  
   </ul>
-  </span></p>
+</span>
+<% unless object_instance.dynamic_model_config_library_valid? %>
+<p class="info-danger">Dynamic model config library has not been added</p>
+<% end %>
 <p><label>pull schedule</label>
   <span>
     <% if  object_instance.frequency.present? && object_instance.transfer_mode == 'scheduled' %>

--- a/docs/admin_reference/project_admins/detailed_options.md
+++ b/docs/admin_reference/project_admins/detailed_options.md
@@ -10,35 +10,40 @@ Options are set with reasonable defaults when a project is first saved.
 
 ```yaml
 records_request_options:
-  exportSurveyFields: |
-    The admin must set this value based on the 
-    actual configuration of the REDCap project. 
-    If surveys are enabled for the project, set 
-    this value to **true** otherwise leave it 
-    blank or **false**.
+  exportSurveyFields: true | false | (blank)
+    # The admin must set this value based on the 
+    # actual configuration of the REDCap project. 
+    # If surveys are enabled for the project, set 
+    # this value to **true** otherwise leave it 
+    # blank or **false**.
   returnMetadataOnly:
   exportDataAccessGroups:
   returnFormat:
 metadata_request_options:
   returnFormat:
 data_options:
-  add_multi_choice_summary_fields: |
-    If *true*, Adds an extra array field to the
-    database for checkbox fields, providing
-    a single field summarizing all selected 
-    checkboxes for a single REDCap field.
-    By default (*false* or blank) only the 
-    individual checkbox fields for each option will
-    be added, as 
-    `<field_name>___1`, `<field_name>___2`,...
-  handle_deleted_records: |
-    one of
-      - disable
-      - ignore
-      - (blank)
-      - null
-      - false
-data_dictionary_version: |
-  do not change - a hash generated internally to 
-  identify whether the data dictionary has changed
+  add_multi_choice_summary_fields: true | null | (blank)
+    # If *true*, Adds an extra array field to the
+    # database for checkbox fields, providing
+    # a single field summarizing all selected 
+    # checkboxes for a single REDCap field.
+    # By default (*false* or blank) only the 
+    # individual checkbox fields for each option will
+    # be added, as 
+    # `<field_name>___1`, `<field_name>___2`,...
+  handle_deleted_records: value
+    # one of
+    #   - disable
+    #   - ignore
+    #   - (blank)
+    #   - null
+    #   - false
+  prefix_dynamic_model_config_library: category name
+    # The "<category> <name>" string identifier for a
+    # config library to be prefixed to the dynamic
+    # model definition whenever it is updated.
+    # For example: "redcap test_library"
+data_dictionary_version: random hash
+    # do not change - a hash generated internally to 
+    # identify whether the data dictionary has changed
 ```


### PR DESCRIPTION
Added redcap project admin option to prefix a config library to the dynamic model, so it always appears after an update

Closes #118 