### PR TITLE
41 client request filter

### DIFF
--- a/app/controllers/concerns/admin_controller_handler.rb
+++ b/app/controllers/concerns/admin_controller_handler.rb
@@ -12,7 +12,7 @@ module AdminControllerHandler
                   :objects_instance, :human_name, :no_edit, :primary_model,
                   :view_path, :extra_field_attributes, :admin_links, :view_embedded?, :hide_app_type?,
                   :help_section, :help_subsection, :title, :no_create, :show_head_info, :view_folder,
-                  :no_options_field, :admin_labels
+                  :no_options_field, :admin_labels, :filters_prevent_disabled
   end
 
   def index
@@ -128,6 +128,12 @@ module AdminControllerHandler
 
   def filters_on
     []
+  end
+
+  #
+  # Override to prevent filters showing "disabled" option
+  def filters_prevent_disabled
+    false
   end
 
   #

--- a/app/controllers/concerns/filter_utils.rb
+++ b/app/controllers/concerns/filter_utils.rb
@@ -120,22 +120,25 @@ module FilterUtils
   # NOTE: Intentionally not memoized - this breaks things
   # @return [Hash] a hash that can safely be used in redirects and link_to
   def filter_params
+    # Set up filter_params_permitted
+    fpp = filter_params_permitted
+
     if has_disabled_field && (
         filter_params_permitted.blank? ||
         (filter_params_permitted.is_a?(Array) && filter_params_permitted[0].blank?)
       )
 
-      @filter_params_permitted = { disabled: 'enabled' }
+      fpp = { disabled: 'enabled' }
     end
 
-    unless @filter_params_permitted
+    unless fpp
       @filter_params = {}
       return @filter_params
     end
 
-    @filter_params_permitted[:disabled] ||= 'enabled' if has_disabled_field
+    fpp[:disabled] ||= 'enabled' if has_disabled_field
 
-    res = @filter_params_permitted || {}
+    res = fpp || {}
     res = filter_defaults.merge(res)
 
     num_to_clear_ids = 1

--- a/app/controllers/redcap/client_requests_controller.rb
+++ b/app/controllers/redcap/client_requests_controller.rb
@@ -2,6 +2,24 @@
 
 # View Redcap API client request log
 class Redcap::ClientRequestsController < AdminController
+  protected
+
+  def filters
+    {
+      action: Redcap::ClientRequest.pluck(:action).uniq.compact.reject(&:blank?),
+      name: Redcap::ClientRequest.pluck(:name).uniq.compact.reject(&:blank?),
+      server_url: Redcap::ClientRequest.pluck(:server_url).uniq.reject(&:blank?)
+    }
+  end
+
+  def filters_on
+    %i[action name server_url]
+  end
+
+  def filters_prevent_disabled
+    true
+  end
+
   private
 
   def no_edit

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -69,6 +69,10 @@ module AdminHelper
     return if view_embedded?
     return unless respond_to?(:filters) && filters
 
+    hdf = respond_to?(:has_disabled_field) && has_disabled_field
+
+    show_disabled_filter = hdf && (!respond_to?(:filters_prevent_disabled) || !filters_prevent_disabled)
+
     these_filters = filters.dup
 
     filters_on_multiple = false
@@ -83,7 +87,7 @@ module AdminHelper
 
     these_filters = { filters_on => these_filters } if these_filters.is_a? Array
 
-    if current_admin
+    if current_admin && show_disabled_filter
       these_filters[:disabled] = %w[disabled enabled]
       fo << :disabled
     end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -69,9 +69,7 @@ module AdminHelper
     return if view_embedded?
     return unless respond_to?(:filters) && filters
 
-    hdf = respond_to?(:has_disabled_field) && has_disabled_field
-
-    show_disabled_filter = hdf && (!respond_to?(:filters_prevent_disabled) || !filters_prevent_disabled)
+    show_disabled_filter = (!respond_to?(:filters_prevent_disabled) || !filters_prevent_disabled)
 
     these_filters = filters.dup
 

--- a/app/views/redcap/project_admins/_requests_block.html.erb
+++ b/app/views/redcap/project_admins/_requests_block.html.erb
@@ -1,5 +1,5 @@
 <h4>Latest Requests</h4>
-
+<p><%= link_to 'view all', redcap_client_requests_path(filter: {name: object_instance.name, server_url: object_instance.server_url}), target: '_blank' %>
 <table class="table"><thead><tr><th>action</th><th>admin</th><th>created</th><th>result</th></tr></thead>
 <tbody>
 <% object_instance.redcap_client_requests.order(id: :desc).limit(10).each do |cr| %>
@@ -13,4 +13,5 @@
 <% end %>
 </tbody>
 </table>
+
 


### PR DESCRIPTION
Fixes #41 

- [Fixed] filter_params when there is no disabled field
- [Added] the ability to hide "disabled" filter in admin pages if it is not needed
- [Added] ability to filter client requests, and linked this from the redcap project requests summary panel
