### PR TITLE
Viva fixes 2

### DIFF
--- a/app/assets/javascripts/app/_fpa_ajax_processors_help.js
+++ b/app/assets/javascripts/app/_fpa_ajax_processors_help.js
@@ -123,7 +123,7 @@ _fpa.postprocessors_help = {
           var changed = true;
         }
 
-        if (href.indexOf('./') == 0 || href.indexOf('../') == 0 || href.indexOf('/') < 0) {
+        if ((href.indexOf('./') == 0 || href.indexOf('../') == 0 || href.indexOf('/') < 0) && href.indexOf('mailto:') != 0) {
           href = href.replace(/^\.\//, '');
           href = `${orig_subpath}/${href}#open-in-sidebar`;
           var changed = true;

--- a/app/assets/javascripts/app/_fpa_ajax_processors_reports.js
+++ b/app/assets/javascripts/app/_fpa_ajax_processors_reports.js
@@ -64,8 +64,8 @@ _fpa.postprocessors_reports = {
     block.removeClass('use-secure-view-on-links-setup');
     if (data) {
       // Update the search form results count bar manually
-      var c = $('.result-count').html();
-      var table_count = $('.count-only td[data-col-type="result_count"]').not('.report-el-was-from-new');
+      var c = block.find('.result-count').html();
+      var table_count = block.find('.count-only td[data-col-type="result_count"]').not('.report-el-was-from-new');
       var h;
       if (table_count.length === 1) {
         c = table_count.html();
@@ -75,7 +75,7 @@ _fpa.postprocessors_reports = {
 
       if (_fpa.templates['search-count-template']) {
         var h = _fpa.templates['search-count-template'](data);
-        $('.search_count_reports').html(h);
+        block.find('.search_count_reports').html(h);
       }
     }
 
@@ -96,23 +96,23 @@ _fpa.postprocessors_reports = {
         if (!by_auto_search) return;
       }
 
-      $('td a.edit-entity').click(function () {
-        $('.item-selected').removeClass('item-selected');
-        $(this).parents('tr').first().addClass('item-selected');
+      block.find('td a.edit-entity').click(function () {
+        block.find('.item-selected').removeClass('item-selected');
+        block.find(this).parents('tr').first().addClass('item-selected');
       });
-      $('td[data-col-type="master_id"]').on('click', function () {
+      block.find('td[data-col-type="master_id"]').on('click', function () {
         window.open('/masters/' + $(this).html().trim(), "_blank");
-        $('.item-selected').removeClass('item-selected');
+        block.find('.item-selected').removeClass('item-selected');
         $(this).addClass('item-selected');
       }).addClass('hover-link');
 
       for (var i in _fpa.state.alternative_id_fields) {
         var field = _fpa.state.alternative_id_fields[i];
 
-        $('td[data-col-type="' + field + '"]').on('click', function () {
+        block.find('td[data-col-type="' + field + '"]').on('click', function () {
           window.open('/masters/' + $(this).html().trim() + '?type=' + $(this).attr('data-col-type'), "_blank");
-          $('.item-selected').removeClass('item-selected');
-          $(this).addClass('item-selected');
+          block.find('.item-selected').removeClass('item-selected');
+          block.find(this).addClass('item-selected');
         }).addClass('hover-link');
       }
 
@@ -120,7 +120,7 @@ _fpa.postprocessors_reports = {
         if (table_cell_types.hasOwnProperty(t)) {
           var table = table_cell_types[t];
 
-          if ($('td[data-col-table="' + t + '"]').length > 0) {
+          if (block.find('td[data-col-table="' + t + '"]').length > 0) {
             for (var i in table) {
 
               if (table.hasOwnProperty(i)) {
@@ -129,7 +129,7 @@ _fpa.postprocessors_reports = {
                 var idname = col_types[i];
                 _fpa.cache.get_definition(i, function () {
                   var pe = _fpa.cache.fetch(i);
-                  var cells = $('td[data-col-table="' + t + '"][data-col-type="' + idname + '"]');
+                  var cells = block.find('td[data-col-table="' + t + '"][data-col-type="' + idname + '"]');
                   cells.each(function () {
                     var cell = $(this);
                     var d = cell.html();

--- a/app/assets/javascripts/app/_fpa_utils.js
+++ b/app/assets/javascripts/app/_fpa_utils.js
@@ -673,8 +673,17 @@ _fpa.utils.html_to_markdown = function (obj) {
     $(this).find('p, h1, h2, h3, h4').contents().unwrap().append('<br/>');
   });
 
-  $html.find('p, h1, h2, h3, h4, span').has(':empty').remove();
-  $html.find('p, h1, h2, h3, h4, span').has(':empty').remove();
+  for (let i = 0; i < 2; i++) {
+    $html.find('p, h1, h2, h3, h4, span').has(':empty').each(
+      function () {
+        if ($(this).find('img, hr').length == 0) {
+          $(this).addClass('cleanup-remove');
+        }
+      }
+    );
+  }
+
+  $html.find('.cleanup-remove').remove();
 
   obj.html = $html.html();
 

--- a/app/assets/javascripts/app/report_criteria.js
+++ b/app/assets/javascripts/app/report_criteria.js
@@ -136,6 +136,9 @@ _fpa.report_criteria = class {
       $dfs.on('change', function () {
         var fts = $(this).attr('data-filter-selector')
         _fpa.form_utils.select_filtering_changed($(this).val(), `[name="search_attrs[${fts}]"]`)
+      }).each(function () {
+        var fts = $(this).attr('data-filter-selector')
+        _fpa.form_utils.select_filtering_changed($(this).val(), `[name="search_attrs[${fts}]"]`)
       });
 
       _fpa.form_utils.setup_chosen_groups($dfs);

--- a/app/assets/javascripts/app/reports.js
+++ b/app/assets/javascripts/app/reports.js
@@ -179,6 +179,8 @@ _fpa.reports = {
     var dct;
     var dct_parts;
 
+    var $outer = block.parents('.modal-body, body').first().parent();
+
     block.find('td[data-col-type^="chart:"]').not('.attached_report_chart').each(function () {
 
       var row = $(this).parent();
@@ -235,7 +237,7 @@ _fpa.reports = {
       var ctx = $(this).find('canvas');
       var myPieChart = new Chart(ctx, value);
 
-      var head = $('th[data-col-type="' + chart_dct + '"]').not('.added-chart-legend');
+      var head = $outer.find('th[data-col-type="' + chart_dct + '"]').not('.added-chart-legend');
       if (head.length > 0) {
         var headp = head.find('p.table-header-col-type');
         headp.html(name);
@@ -295,7 +297,7 @@ _fpa.reports = {
       var extra_val = dct_parts[2].trim();
     }
 
-    var report_id = $('.report-container').attr('data-report-id');
+    var report_id = $outer.find('.report-container').first().attr('data-report-id');
 
 
     if (dct_action == 'download files') {
@@ -311,7 +313,7 @@ _fpa.reports = {
     else if (dct_action == 'remove from list') {
       var $f = $(`<form id="itemselection-for-report" method="post" action="/reports/${report_id}/remove_from_list.json" class="report-remove-from-list" data-remote="true"><input type="hidden" name="remove_from_list[list_name]" value="${extra_val}"></form>`);
 
-      var cblock = $('[data-result="#report-embedded"]');
+      var cblock = $outer.find('[data-result="#report-embedded"]').first();
       if (cblock.length == 0) cblock = $('body');
 
       cblock.find('#report_query_form').addClass('keep-notices');
@@ -320,15 +322,15 @@ _fpa.reports = {
       });
 
     }
-    var $fsels = $('.report-file-selector');
+    var $fsels = $outer.find('.report-file-selector');
     var all_selected = ($fsels.filter(':checked').length > 0);
     var checked_attr = all_selected ? 'checked' : '';
     var init_label = all_selected ? 'unselect all' : 'select all'
 
     var b = `<span class="report-files-actions"><a id="report-select-all-files" data-select-all="select">select all</a> / <a id="report-unselect-all-files" data-select-all="unselect">unselect all</a></span><span class="report-files-actions-btn"><input id="submit-report-selections" type="submit" value="${dct_action}" class="btn btn-primary rep-sel-action-${dct_action.replace(' ', '-')}"/></span>`;
-    var $t = $('table.report-table, .report-list[data-results-count]');
+    var $t = $outer.find('table.report-table, .report-list[data-results-count]');
     $f.insertBefore($t);
-    $t.appendTo($('#itemselection-for-report'));
+    $t.appendTo($outer.find('#itemselection-for-report'));
 
     // On select all / unselect all
     // check or uncheck all the entries.
@@ -379,7 +381,7 @@ _fpa.reports = {
 
     // Add a default item that will allow all items to be removed if needed. Without this, there must always be at least one
     // result sent.
-    var $el = $('#seicb-0').clone();
+    var $el = $outer.find('#seicb-0').clone();
     $el.prop('id', 'seicb-default');
     var defval = JSON.parse($el.val());
     defval.id = null;
@@ -389,7 +391,7 @@ _fpa.reports = {
     $el.attr('class', 'report-file-selector-default')
     $el.hide();
     console.log($el);
-    $('.report-files-actions').append($el);
+    $outer.find('.report-files-actions').append($el);
 
 
   },

--- a/app/assets/javascripts/app/reports_custom_impl_expand_all_tree.js
+++ b/app/assets/javascripts/app/reports_custom_impl_expand_all_tree.js
@@ -7,11 +7,12 @@ _fpa.reports_custom_handling.add_handler_implementation('expand_all_tree', funct
     $a.text('...');
 
     window.setTimeout(function () {
-      $('td[data-col-type="id0"] img[id="state"], td[data-col-type="id1"] img[id="state"]').click()
       if (orig_text == 'expand all') {
+        $('tr[data-tt-id]').each(function () { $(this)[0].trExpand(true) })
         $a.text('shrink all')
       }
       else {
+        $('tr[data-tt-id]').each(function () { $(this)[0].trCollapse(true) })
         $a.text('expand all')
       }
     });

--- a/app/assets/javascripts/app/reports_custom_impl_expand_subitems_tree.js
+++ b/app/assets/javascripts/app/reports_custom_impl_expand_subitems_tree.js
@@ -1,0 +1,14 @@
+_fpa.reports_custom_handling.add_handler_implementation('expand_subitems_tree', function () {
+  $('table').not('.added-expand_subitems_tree').on('click', 'td[data-col-type="id0"] img[id="state"]', function () {
+    const $tr = $(this).parents('tr').first();
+    var ttid = $tr.attr('data-tt-id');
+    console.log(ttid);
+    console.log($tr[0].trChildrenVisible);
+    if (!$tr[0].trChildrenVisible) return
+
+    $(`tr[data-tt-parent-id="${ttid}"]`).each(function () {
+      const tr = $(this)[0];
+      tr.trExpand(true)
+    })
+  }).addClass('added-expand_subitems_tree');
+});  

--- a/app/assets/javascripts/app/reports_custom_impl_pre_fully_expanded.js
+++ b/app/assets/javascripts/app/reports_custom_impl_pre_fully_expanded.js
@@ -1,0 +1,3 @@
+_fpa.reports_custom_handling.add_handler_implementation('pre_fully_expanded', function () {
+  $('table pre.expandable').removeClass('expandable');
+});  

--- a/app/assets/stylesheets/app/report_tree.scss
+++ b/app/assets/stylesheets/app/report_tree.scss
@@ -2,10 +2,32 @@ table.table.tree-table {
 
   border: 1px solid gray;
   margin: 0 auto;
-  opacity: 0.10;
+  tbody, thead {
+    opacity: 0.10;
+  }
+
+  &:before {
+    content: "loading...";
+    opacity: 1;
+    color: gray;
+    text-align: left;
+    margin: 0 auto;
+    width: auto;
+    position: absolute;
+    left: 46%;
+    font-size: 41px;
+    font-weight: bold;
+    display: block;
+  }
 
   &.jsTT {
-    opacity: 1
+    tbody, thead {
+      opacity: 1
+    }
+  }
+
+  &.jsTT:before {
+    display: none;
   }
 
   thead tr th.is-parent-col {


### PR DESCRIPTION
### From Viva

- [Changed] display of tree report loading
- [Fixed] tree embedded report when there is a report in the underlying page (embedded in a placeholder for example)
- [Added] report results handler to force all \<pre> elements to be fully expanded
- [Fixed] mailto links breaking in sidebar when content is a portal page
- [Fixed] editor html cleanup losing images and horizonal rule
- [Fixed] tree expander implementations
- [Fixed] report criteria drop down selector filters not loading when default criteria passed through URL
