### PR TITLE
Hms fixes 3 comb

### DIFF
--- a/app-scripts/parallel_test.sh
+++ b/app-scripts/parallel_test.sh
@@ -7,6 +7,11 @@ echo > tmp/working_failing_specs.log
 unset QUICK
 unset RUBY_DEBUG_OPEN
 
+if [ ! "${USE_PG_HOST}" ]; then
+  echo "sudo is required to clean the database. Enter your password if prompted"
+  sudo whoami
+fi
+
 # Ensure the tests run cleanly
 export DISABLE_SPRING=1
 spring stop

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -37,7 +37,7 @@ class ApplicationJob < ActiveJob::Base
       job_id = job.id if job.respond_to? :id
       nj = FailureMailer.notify_job_failure(
         job_id,
-        JSON.parse(job.to_json(force_plain_json: true)).to_yaml,
+        job.inspect.gsub(' @', "\n@"),
         exception.to_s
       )
 
@@ -48,7 +48,9 @@ class ApplicationJob < ActiveJob::Base
       end
       DateTime.now.to_s
     end
-  rescue StandardError => e
+  rescue Exception => e
+    puts e
+    puts e.backtrace.join("\n")
     Rails.logger.error "Failed to send notify_failure: #{e}"
     Rails.logger.error e.backtrace.join("\n")
   end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -35,7 +35,12 @@ class ApplicationJob < ActiveJob::Base
   def self.notify_failure(job, exception = nil)
     Rails.cache.fetch('delayed_job-failure-notification', expires_in: 1.hour) do
       job_id = job.id if job.respond_to? :id
-      nj = FailureMailer.notify_job_failure(job_id, JSON.parse(job.to_json).to_yaml, exception.to_s)
+      nj = FailureMailer.notify_job_failure(
+        job_id,
+        JSON.parse(job.to_json(force_plain_json: true)).to_yaml,
+        exception.to_s
+      )
+
       if Rails.env.test?
         nj.deliver_now
       else

--- a/app/mailers/failure_mailer.rb
+++ b/app/mailers/failure_mailer.rb
@@ -13,6 +13,11 @@ class FailureMailer < ActionMailer::Base
   #                       typically do something like job.to_yaml to avoid calling with types that
   #                       a background job can't handle
   def notify_job_failure(job_id, job_yaml, exception = nil)
+    if Settings::FailureNotificationsToEmail.blank?
+      Rails.logger.warn 'Settings::FailureNotificationsToEmail is blank - no notify_job_failure will be sent'
+      return
+    end
+
     view_job = "View job at: #{Settings::BaseUrl}/admin/job_reviews?filter[id]=#{job_id}" if job_id
     body = <<~END_TEXT
       A failure occurred running a delayed_job on server #{Settings::EnvironmentName}.

--- a/app/mailers/failure_mailer.rb
+++ b/app/mailers/failure_mailer.rb
@@ -13,11 +13,6 @@ class FailureMailer < ActionMailer::Base
   #                       typically do something like job.to_yaml to avoid calling with types that
   #                       a background job can't handle
   def notify_job_failure(job_id, job_yaml, exception = nil)
-    if Settings::FailureNotificationsToEmail.blank?
-      Rails.logger.warn 'Settings::FailureNotificationsToEmail is blank - no notify_job_failure will be sent'
-      return
-    end
-
     view_job = "View job at: #{Settings::BaseUrl}/admin/job_reviews?filter[id]=#{job_id}" if job_id
     body = <<~END_TEXT
       A failure occurred running a delayed_job on server #{Settings::EnvironmentName}.
@@ -29,6 +24,12 @@ class FailureMailer < ActionMailer::Base
       #{job_yaml}"
     END_TEXT
 
+    if Settings::FailureNotificationsToEmail.blank?
+      Rails.logger.warn "Settings::FailureNotificationsToEmail is blank - no notify_job_failure will be sent.\n#{body}"
+      return
+    end
+
+    Rails.logger.info "Sending job failure message:\n#{body}"
     options = {
       body:,
       subject: 'delayed_job failure'

--- a/app/models/activity_log.rb
+++ b/app/models/activity_log.rb
@@ -69,7 +69,7 @@ class ActivityLog < ActiveRecord::Base
   def self.all_valid_item_and_rec_types
     Classification::GeneralSelection
       .selector_collection(['item_type like ?', '%_type'])
-      .map { |i| [i[:item_type].sub(/(_rec)?_type$/, '').singularize, i.value].join('_') } +
+      .map { |i| [i[:item_type].sub(/(_rec)?_type$/, '').singularize, i[:value]].join('_') } +
       use_with_class_names
   end
 

--- a/app/models/admin/defs/extra_options_defs.yaml
+++ b/app/models/admin/defs/extra_options_defs.yaml
@@ -128,9 +128,15 @@
         NOTE this is set in the form fields UI only if the item has been created and the current value is blank.
         It is not set before building the instances, so will not be available for data conditions.
       preset_value: |
-        default value | now() | today() 
+        default value | now() | today() | \{\{substitutions\}\}
         
         NOTE this is set when building the instances and may be used to drive logic like an embed_resource_name field
+      blank_preset_value: |
+        default value | now() | today() | \{\{substitutions\}\}
+        
+        NOTE this is set only if the attribute is blank when building the instances 
+        and may be used to drive logic like an embed_resource_name field
+
       no_downcase: true - to prevent downcasing of the attribute when stored to the database
       view_original_case: true - to prevent the UI capitalizing downcased fields
       format: plain | markdown - for free text editor fields such as notes and description

--- a/app/models/admin/migration_generator.rb
+++ b/app/models/admin/migration_generator.rb
@@ -270,7 +270,7 @@ class Admin::MigrationGenerator
   #                               such as 'app-export'
   def add_schema(export_type = nil)
     mig_text = schema_generator_script(db_migration_schema, 'create')
-    write_db_migration mig_text, "#{db_migration_schema}_schema", export_type: export_type
+    write_db_migration mig_text, "#{db_migration_schema}_schema", export_type:
   end
 
   #
@@ -542,7 +542,7 @@ class Admin::MigrationGenerator
           self.table_name = '#{table_name}'
           self.class_name = '#{class_name}'
           self.fields = %i[#{migration_fields_array.join(' ')}]
-          self.table_comment = '#{tcs[:table]}'
+          self.table_comment = #{tcs[:table].to_json}
           self.fields_comments = #{(tcs[:fields] || {}).to_h}
           self.db_configs = #{(db_configs || {}).to_h}
           self.no_master_association = #{!!no_master_association}

--- a/app/models/concerns/admin_handler.rb
+++ b/app/models/concerns/admin_handler.rb
@@ -233,7 +233,7 @@ module AdminHandler
   # Invalidate the cache and latest update value
   # @return [<Type>] <description>
   def invalidate_cache
-    logger.info "User Access Control added or updated (#{self.class.name}). Invalidating cache."
+    logger.info "Admin record added or updated (#{self.class.name}). Invalidating cache"
 
     # Allows caching in other classes to reset
     self.class.reset_latest_update

--- a/app/models/concerns/general_data_concerns.rb
+++ b/app/models/concerns/general_data_concerns.rb
@@ -119,7 +119,7 @@ module GeneralDataConcerns
                                 TrackerHistory
                                   .where(item_id: id,
                                          item_type: self.class.name,
-                                         master_id: master_id)
+                                         master_id:)
                                   .order(id: :asc)
                               end
   end
@@ -226,7 +226,9 @@ module GeneralDataConcerns
 
   def as_json(extras = {})
     self.current_user ||= extras[:current_user] if extras[:current_user]
-    if allows_current_user_access_to?(:access)
+    if extras[:force_plain_json]
+      extras = {}
+    elsif allows_current_user_access_to?(:access)
 
       extras[:include] ||= {}
       extras[:methods] ||= []

--- a/app/models/concerns/selector_cache.rb
+++ b/app/models/concerns/selector_cache.rb
@@ -115,7 +115,7 @@ module SelectorCache
       ckey = "#{collection_cache_key}#{conditions}"
 
       Rails.cache.fetch(ckey) do
-        enabled.where(conditions).map(&:attributes)
+        enabled.where(conditions).map { |i| i.attributes.with_indifferent_access }
       end
     end
 

--- a/app/models/redcap/client_request.rb
+++ b/app/models/redcap/client_request.rb
@@ -18,5 +18,9 @@ module Redcap
     attr_accessor :disabled
 
     scope :limited_index, -> { limit 1000 }
+
+    def invalidate_cache
+      logger.debug "Not invalidating cache (#{self.class.name})"
+    end
   end
 end

--- a/app/models/redcap/project_admin.rb
+++ b/app/models/redcap/project_admin.rb
@@ -377,8 +377,8 @@ module Redcap
     # @param [Admin::AdminBase] ref_record
     # @return [ActiveRecord::Relation]
     def self.existing_jobs(job_class, ref_record)
-      Delayed::Job.lookup_jobs_by job_class: job_class,
-                                  ref_record: ref_record,
+      Delayed::Job.lookup_jobs_by job_class:,
+                                  ref_record:,
                                   queue: ProjectAdmin::JobQueue,
                                   failed: false
     end
@@ -393,12 +393,12 @@ module Redcap
       result ||= { requested: true }
 
       curr_job_requests[action] =
-        Redcap::ClientRequest.create current_admin: current_admin || admin,
-                                     action: action,
-                                     server_url: server_url,
-                                     name: name,
+        Redcap::ClientRequest.create(current_admin: current_admin || admin,
+                                     action:,
+                                     server_url:,
+                                     name:,
                                      redcap_project_admin: self,
-                                     result: result
+                                     result:)
     end
 
     #
@@ -413,7 +413,7 @@ module Redcap
       return unless res
 
       res.update current_admin: current_admin || admin,
-                 result: result
+                 result:
     end
 
     #
@@ -461,6 +461,10 @@ module Redcap
       data_options.prefix_dynamic_model_config_library.blank? || dynamic_storage&.dynamic_model_config_library_added?
     end
 
+    def invalidate_cache
+      logger.debug "Not invalidating cache (#{self.class.name})"
+    end
+
     private
 
     #
@@ -483,13 +487,13 @@ module Redcap
     end
 
     def reset_field_metadata
-      redcap_data_dictionary&.update!(captured_metadata: nil, field_count: nil, current_admin: current_admin)
+      redcap_data_dictionary&.update!(captured_metadata: nil, field_count: nil, current_admin:)
     end
 
     #
     # Capture the data dictionary metadata from REDCap and store to table
     def capture_data_dictionary
-      dd = redcap_data_dictionary || create_redcap_data_dictionary(current_admin: current_admin)
+      dd = redcap_data_dictionary || create_redcap_data_dictionary(current_admin:)
 
       res = dd.capture_data_dictionary
       dd.reload
@@ -561,7 +565,7 @@ module Redcap
     def set_data_dictionary_version
       self.data_dictionary_version = redcap_data_dictionary.captured_metadata_digest
       save_options
-      update_columns(options: options)
+      update_columns(options:)
     end
 
     #
@@ -581,9 +585,9 @@ module Redcap
       curr_job_requests[action] ||=
         Redcap::ClientRequest
         .where(
-          action: action,
-          server_url: server_url,
-          name: name,
+          action:,
+          server_url:,
+          name:,
           redcap_project_admin_id: id
         )
         .order(

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -273,7 +273,7 @@ class Report < ActiveRecord::Base
   end
 
   def invalidate_cache
-    logger.info 'Not invalidating cache for report'
+    logger.debug "Not invalidating cache (#{self.class.name})"
   end
 
   def options_valid?

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -102,9 +102,9 @@ class Report < ActiveRecord::Base
   # @param name [String] full name of the report
   # @return [String] short_name for the report
   def self.resource_name_for_named_report(name, item_type = nil)
-    res = Report.active.where(name: name)
+    res = Report.active.where(name:)
 
-    res = res.where(item_type: item_type) if item_type
+    res = res.where(item_type:) if item_type
 
     res.order(updated_at: :desc).first&.alt_resource_name
   end
@@ -247,7 +247,7 @@ class Report < ActiveRecord::Base
 
   # Validate the generated resource_name is not a duplicate
   def valid_resource_name?
-    test = { short_name: short_name, item_type: item_type }
+    test = { short_name:, item_type: }
 
     res = self.class.active.where(test)
     return if (res.pluck(:id) - [id]).empty?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -217,6 +217,11 @@ class User < ActiveRecord::Base
   def send_reset_password_instructions
     return if a_template_or_batch_user? || !allow_users_to_register?
 
+    if disabled
+      raise FphsGeneralError,
+            'User profile does not exist or was disabled - contact an administrator to reset the password'
+    end
+
     if do_not_email
       raise FphsGeneralError,
             "User profile set to 'no email' - contact an administrator to reset the password"

--- a/app/views/page_layouts/_show_row.html.erb
+++ b/app/views/page_layouts/_show_row.html.erb
@@ -90,7 +90,7 @@
       col_footer = Formatter::Substitution.substitute(col_footer, data: sub_data, tag_subs: nil).html_safe
 
   %>
-    <% if !@master_id %>
+    <% if !@master_id && !col_url %>
     <%= render partial: 'layouts/error_page_block', locals: {error_title: 'Not Found', text: 'The requested resource was not found' } %>
     <% elsif inner_rows %>
     <div class="standalone-page-col-with-rows <%=col_classes%>" id="<%=col_block_id%>">

--- a/config/initializers/app_settings.rb
+++ b/config/initializers/app_settings.rb
@@ -3,7 +3,7 @@
 class Settings
   LogLevel = DefaultSettings::LogLevel
   DefaultMigrationSchema = DefaultSettings::DefaultMigrationSchema
-  DefaultSchemaOwner = ENV['FPHS_DEFAULT_SCHEMA_OWNER'] || DefaultSettings::DefaultSchemaOwner
+  DefaultSchemaOwner = ENV['FPHS_DEFAULT_SCHEMA_OWNER'].presence || DefaultSettings::DefaultSchemaOwner
 
   # Does not set the prefix, just specifies what we search by in jobs
   GlobalIdPrefix = DefaultSettings::GlobalIdPrefix
@@ -18,8 +18,8 @@ class Settings
   YearFieldPattern = '\\d{4,4}'
 
   # Inactivity timeouts for user / admin sessions
-  UserTimeout = (ENV['USER_TIMEOUT_MINS'] || 30).to_i.minutes.freeze
-  AdminTimeout = (ENV['ADMIN_TIMEOUT_MINS'] || 30).to_i.minutes.freeze
+  UserTimeout = (ENV['USER_TIMEOUT_MINS'].presence || 30).to_i.minutes.freeze
+  AdminTimeout = (ENV['ADMIN_TIMEOUT_MINS'].presence || 30).to_i.minutes.freeze
 
   OsWordsFile = '/usr/share/dict/words'
   # Setup information for the StrongPassword::StrengthChecker and
@@ -38,7 +38,7 @@ class Settings
     regex_requirements: ENV['PW_REGEX_REQ']
   }.freeze
 
-  PasswordUnlockTimeMins = (ENV['PW_UNLOCK_TIME_MINS'] || 60).to_i.freeze
+  PasswordUnlockTimeMins = (ENV['PW_UNLOCK_TIME_MINS'].presence || 60).to_i.freeze
 
   # Default logo filename. Can be overridden on an app by app basis with the "logo filename" app configuration.
   # The logo file itself should be placed in `app/assets/images` or directly in `public/``. Alternatively, place it in
@@ -50,13 +50,13 @@ class Settings
   # which may fail on some email servers if the domain name does not match
   # a verified domain name.
   # This must be set if user self registration is enabled.
-  NotificationsFromEmail = ENV['FPHS_FROM_EMAIL'] || ENV['FROM_EMAIL'] || DefaultSettings::NotificationsFromEmail
+  NotificationsFromEmail = ENV['FPHS_FROM_EMAIL'].presence || ENV['FROM_EMAIL'].presence || DefaultSettings::NotificationsFromEmail.presence
   # Email address for admin contact
-  AdminEmail = ENV['FPHS_ADMIN_EMAIL'] || DefaultSettings::AdminEmail
+  AdminEmail = ENV['FPHS_ADMIN_EMAIL'].presence || DefaultSettings::AdminEmail.presence
   # Email address that identifies the batch user profile. Defaults to the user that matches the AdminEmail
-  BatchUserEmail = ENV['FPHS_BATCH_USER_EMAIL'] || AdminEmail
+  BatchUserEmail = ENV['FPHS_BATCH_USER_EMAIL'].presence || AdminEmail.presence
   # Provide an email address for a technical admin to receive failure notifications
-  FailureNotificationsToEmail = ENV['FAIL_TO_EMAIL'] || ENV['FAIL_FROM_EMAIL'] || DefaultSettings::FailureNotificationsToEmail || Settings::AdminEmail
+  FailureNotificationsToEmail = ENV['FAIL_TO_EMAIL'].presence || ENV['FAIL_FROM_EMAIL'].presence || DefaultSettings::FailureNotificationsToEmail.presence || Settings::AdminEmail.presence
 
   # Set the max number of recipients for a message, to avoid an unexpected nasty error spamming the whole organization
   MaxNotificationRecipients = ENV['FPHS_MAX_NOTIFY_RECIPS']&.to_i || 200
@@ -66,35 +66,35 @@ class Settings
   TwoFactorAuthDisabledForAdmin = ENV['FPHS_2FA_AUTH_DISABLED'].in?(['true', 'admin'])
 
   # App name that appears within 2FA authenticator app
-  TwoFactorAuthIssuer = ENV['FPHS_2FA_APP'] || DefaultSettings::TwoFactorAuthIssuer
+  TwoFactorAuthIssuer = ENV['FPHS_2FA_APP'].presence || DefaultSettings::TwoFactorAuthIssuer
   # Number of seconds to use for 2FA token drift (the older it is allowed to be and still be valid)
-  TwoFactorAuthDrift = (ENV['FPHS_2FA_DRIFT'] || 30).to_i
+  TwoFactorAuthDrift = (ENV['FPHS_2FA_DRIFT'].presence || 30).to_i
 
   # Check number of previous passwords back to check for new password repeating an old one
-  CheckPrevPasswords = (ENV['FPHS_CHECK_PREV_PASSWORDS'] || (Rails.env.development? ? 0 : 5)).to_i
+  CheckPrevPasswords = (ENV['FPHS_CHECK_PREV_PASSWORDS'].presence || (Rails.env.development? ? 0 : 5)).to_i
   # Expire the password after a number of days
-  PasswordAgeLimit = (ENV['FPHS_PASSWORD_AGE_LIMIT'] || 90).to_i
+  PasswordAgeLimit = (ENV['FPHS_PASSWORD_AGE_LIMIT'].presence || 90).to_i
   # Number of days before a password expires to remind a user by email
-  PasswordReminderDays = (ENV['FPHS_PASSWORD_REMINDER_DAYS'] || 15).to_i
+  PasswordReminderDays = (ENV['FPHS_PASSWORD_REMINDER_DAYS'].presence || 15).to_i
   # Repeat the reminder every number of days until the password is updated or it expires
-  PasswordReminderRepeatDays = (ENV['FPHS_PASSWORD_REMINDER_REPEAT_DAYS'] || 4).to_i
+  PasswordReminderRepeatDays = (ENV['FPHS_PASSWORD_REMINDER_REPEAT_DAYS'].presence || 4).to_i
   # Maximum password attempts before account is locked
-  PasswordMaxAttempts = (ENV['FPHS_PASSWORD_MAX_ATTEMPTS'] || 3).to_i
+  PasswordMaxAttempts = (ENV['FPHS_PASSWORD_MAX_ATTEMPTS'].presence || 3).to_i
 
   # email = Sends an unlock link to the user email
   # time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # both  = Enables both strategies
   # none  = No unlock strategy. You should handle unlocking by yourself.
-  PasswordUnlockStrategy = (ENV['FPHS_PASSWORD_UNLOCK_STRATEGY'] || 'time').to_sym
+  PasswordUnlockStrategy = (ENV['FPHS_PASSWORD_UNLOCK_STRATEGY'].presence || 'time').to_sym
 
   # Used to identify the environment this application server belongs to. Also available in
   # text substitution as curly substitution {{environment_name}}
-  EnvironmentName = ENV['FPHS_ENV_NAME'] || 'App'
+  EnvironmentName = ENV['FPHS_ENV_NAME'].presence || 'App'
   # Allow text substitutions for messages, etc to provide a base URL for the app, accessible
   # using the curly substitution {{base_url}}
-  BaseUrl = ENV['BASE_URL'] || DefaultSettings::BaseUrl
+  BaseUrl = ENV['BASE_URL'].presence || DefaultSettings::BaseUrl
   # title tag page title, appears in tab or browser heading
-  PageTitle = ENV['PAGE_TITLE'] || DefaultSettings::PageTitle
+  PageTitle = ENV['PAGE_TITLE'].presence || DefaultSettings::PageTitle
 
   # Registration Settings
   # Since passwords have generated upon user creation, we must suppress generating a password
@@ -102,11 +102,11 @@ class Settings
   # For feature tests, set AllowUsersToRegister to true. Change it to false during testing where necessary.
   AllowUsersToRegister = Rails.env.test? || (ENV['ALLOW_USERS_TO_REGISTER'].to_s.downcase == 'true')
   # Admin assigned to newly created user through the user registration feature
-  RegistrationAdminEmail = ENV['REGISTRATION_ADMIN_EMAIL'] || AdminEmail
+  RegistrationAdminEmail = ENV['REGISTRATION_ADMIN_EMAIL'].presence || AdminEmail.presence
   # Template user for creating new users. The roles from this user are copied to the new user.
-  DefaultUserTemplateEmail = ENV['DEFAULT_USER_TEMPLATE_EMAIL'] || 'registration@template'
+  DefaultUserTemplateEmail = ENV['DEFAULT_USER_TEMPLATE_EMAIL'].presence || 'registration@template'
   # Require an invitation code to be used to register
-  InvitationCode = ENV['INVITATION_CODE']
+  InvitationCode = ENV['INVITATION_CODE'].presence
   # Add a reCAPTCHA v3 to the registration form - if not added, no reCAPTCHA will be used
   ReCaptchaSiteKey = ENV['RECAPTCHA_SITE_KEY'].presence
   ReCaptchaSecret = ENV['RECAPTCHA_SECRET'].presence
@@ -115,8 +115,8 @@ class Settings
   AllowAdminsToManageAdmins = (ENV['ALLOW_ADMINS_TO_MANAGE_ADMINS'].to_s.downcase == 'true')
 
   # Notify the NotifyEmailOnRegistration when a new admin or user is registered (notify on 'admin', 'user' or 'admin,user')
-  NotifyOnRegistration = ENV['NOTIFY_ON_REGISTRATION']
-  NotifyEmailOnRegistration = ENV['NOTIFY_EMAIL_ON_REGISTRATION'] || RegistrationAdminEmail
+  NotifyOnRegistration = ENV['NOTIFY_ON_REGISTRATION'].presence
+  NotifyEmailOnRegistration = ENV['NOTIFY_EMAIL_ON_REGISTRATION'].presence || RegistrationAdminEmail.presence
 
   # URL to appear on home page for users with login issues to contact
   DefaultLoginIssuesUrl = AllowUsersToRegister ? '/users/password/new' : "mailto: #{AdminEmail}?subject=Login%20Issues"
@@ -129,7 +129,7 @@ class Settings
   # Block to appear at top of login page as a user message
   LoginMessage = ENV['LOGIN_MESSAGE']
   # Maximum limit on master search results
-  SearchResultsLimit = ENV['FPHS_RESULT_LIMIT']
+  SearchResultsLimit = ENV['FPHS_RESULT_LIMIT'].presence
 
   #
   # Limit the app types an application server delivers.
@@ -189,9 +189,9 @@ class Settings
   # Length of a short code
   ShortcodeLength = 6
   # Website enabled public bucket for shortlink files
-  DefaultShortLinkS3Bucket = ENV['FPHS_SHORTLINK_BUCKET'] || DefaultSettings::DefaultShortLinkS3Bucket
+  DefaultShortLinkS3Bucket = ENV['FPHS_SHORTLINK_BUCKET'].presence || DefaultSettings::DefaultShortLinkS3Bucket
   # Log bucket for link clicks to be recorded and retrieved for analytics
-  DefaultShortLinkLogS3Bucket = ENV['FPHS_SHORTLINK_LOG_BUCKET'] || DefaultSettings::DefaultShortLinkLogS3Bucket
+  DefaultShortLinkLogS3Bucket = ENV['FPHS_SHORTLINK_LOG_BUCKET'].presence || DefaultSettings::DefaultShortLinkLogS3Bucket
   LogBucketPrefix = 'access/'
 
   # Default table names (and associated configs) for the primary CRM (Zeus) app
@@ -206,8 +206,8 @@ class Settings
 
   # Encryption key and salt for attribute encryption
   # @see Utilities::Encryption
-  EncryptionSecretKeyBase = ENV['FPHS_ENC_SECRET_KEY_BASE'] || (Rails.env.production? ? nil : 'test')
-  EncryptionSalt = ENV['FPHS_ENC_SALT'] || (Rails.env.production? ? nil : 'test-salt')
+  EncryptionSecretKeyBase = ENV['FPHS_ENC_SECRET_KEY_BASE'].presence || (Rails.env.production? ? nil : 'test')
+  EncryptionSalt = ENV['FPHS_ENC_SALT'].presence || (Rails.env.production? ? nil : 'test-salt')
 
   # Dynamic models create their own migrations during configuration, if this is set
   AllowDynamicMigrations = ENV['FPHS_ALLOW_DYN_MIGRATIONS'] == 'true' || Rails.env.development?
@@ -237,30 +237,31 @@ class Settings
   # ISO3166::Country.find_country_by_iso_short_name('united states of america').alpha2 == 'US'
   # If setting more than one country, separate them with a blank-space.
   # For example, PRIORITY_TIMEZONE_COUNTRY_CODES='us gb au'
-  CountryCodesForTimezones = (ENV['PRIORITY_TIMEZONE_COUNTRY_CODES']&.split || %w[us ie gb de gr au nz]).freeze
+  DefaultCountryCodesForTimezones = %w[us ie gb de gr au nz]
+  CountryCodesForTimezones = (ENV['PRIORITY_TIMEZONE_COUNTRY_CODES'].presence&.split || DefaultCountryCodesForTimezones).freeze
 
   # Use the timezone name or identifier. For example, "London" or "Eastern Time (US & Canada)".
   # To obtain the timezone identifiers, execute ActiveSupport::TimeZone.country_zones(<country alpha2 code>)
   # For example, ActiveSupport::TimeZone.country_zones('GB').map(&:name) == ["Edinburgh", "London"]
-  DefaultUserTimezone = (ENV['DEFAULT_TIMEZONE'] || 'Eastern Time (US & Canada)').freeze
+  DefaultUserTimezone = (ENV['DEFAULT_TIMEZONE'].presence || 'Eastern Time (US & Canada)').freeze
 
   # Date, Time and DateTime formats
   #
   # Set DEFAULT_DATE_FORMAT to mm/dd/yyyy or dd/mm/yyyy.
-  DefaultDateFormat = (ENV['DEFAULT_DATE_FORMAT'] || 'mm/dd/yyyy').freeze
+  DefaultDateFormat = (ENV['DEFAULT_DATE_FORMAT'].presence || 'mm/dd/yyyy').freeze
 
   # Set DEFAULT_DATE_TIME_FORMAT to:
   #   mm/dd/yyyy hh:mm am/pm
   #   mm/dd/yyyy 24h:mm
   #   dd/mm/yyyy hh:mm am/pm
   #   dd/mm/yyyy 24h:mm
-  DefaultDateTimeFormat = (ENV['DEFAULT_DATE_TIME_FORMAT'] || 'mm/dd/yyyy hh:mm am/pm').freeze
+  DefaultDateTimeFormat = (ENV['DEFAULT_DATE_TIME_FORMAT'].presence || 'mm/dd/yyyy hh:mm am/pm').freeze
 
   # Set DEFAULT_TIME_FORMAT to hh:mm am/pm or 24h:mm.
-  DefaultTimeFormat = (ENV['DEFAULT_TIME_FORMAT'] || 'hh:mm am/pm').freeze
+  DefaultTimeFormat = (ENV['DEFAULT_TIME_FORMAT'].presence || 'hh:mm am/pm').freeze
 
   # Set the priority listing for the country select
-  DefaultCountrySelect = (ENV['DEFAULT_COUNTRY_SELECT']&.split || %w[US CA DE]).freeze
+  DefaultCountrySelect = (ENV['DEFAULT_COUNTRY_SELECT'].presence&.split || %w[US CA DE]).freeze
 
   # Countries for which GDPR specific terms of use should be shown
   GdprCountryCodes = %w[AT BE BG HR CY CZ DK EE FI FR DE GR HU IE IT LV LT LU MT NL PL PT RO SE SK SI ES SE GB].freeze

--- a/spec/models/calc_actions/calculate_spec.rb
+++ b/spec/models/calc_actions/calculate_spec.rb
@@ -1265,10 +1265,10 @@ RSpec.describe 'Calculate conditional actions', type: :model do
     conf = setup_config(confy)
 
     return_failures = {}
-    res = ConditionalActions.new conf, @al, return_failures: return_failures
+    res = ConditionalActions.new(conf, @al, return_failures:)
     cai = res.calc_action_if
-    expect(cai).to be(true), "calc_action_if failed #{ { return_failures: return_failures,
-                                                         confy: confy,
+    expect(cai).to be(true), "calc_action_if failed #{ { return_failures:,
+                                                         confy:,
                                                          al: @al,
                                                          al1: @al1,
                                                          zip: "#{a1.zip} for #{a1}" } }"
@@ -1507,7 +1507,7 @@ RSpec.describe 'Calculate conditional actions', type: :model do
 
     a = res.calc_action_if
     expect(a).to be(false),
-                 "calc_action_if failed - #{{ confy: confy, city: @al.master.addresses.first.city, data: @al.master.player_contacts.first.data }}"
+                 "calc_action_if failed - #{{ confy:, city: @al.master.addresses.first.city, data: @al.master.player_contacts.first.data }}"
   end
 
   it 'handles deep references' do
@@ -2726,7 +2726,7 @@ RSpec.describe 'Calculate conditional actions', type: :model do
       m.current_user = @user
       data = "(516)123-7612-#{DateTime.now.to_f}"
       @pc = m.player_contacts.first
-      @pc.update! data: data, rec_type: 'phone', rank: 10, source: 'nflpa'
+      @pc.update! data:, rec_type: 'phone', rank: 10, source: 'nflpa'
 
       expect(@new_al.extra_log_type).not_to be nil
       expect(m.activity_log__player_contact_phones.where(extra_log_type: 'primary').count).to be > 0
@@ -3028,7 +3028,7 @@ RSpec.describe 'Calculate conditional actions', type: :model do
       m.current_user = @user
       data = "(516)123-7612-#{DateTime.now.to_f}"
       @pc = m.player_contacts.first
-      @pc.update! data: data, rec_type: 'phone', rank: 10, source: 'nflpa'
+      @pc.update! data:, rec_type: 'phone', rank: 10, source: 'nflpa'
       @pc.master.player_contacts.where.not(id: @pc.id).update_all(master_id: @junk_master)
 
       expect(@new_al.extra_log_type).not_to be nil
@@ -3688,6 +3688,28 @@ RSpec.describe 'Calculate conditional actions', type: :model do
       expect(res).to eq @m2.id
     end
 
+    it 'finds a master record from a crosswalk field' do
+      ms = Master.where.not(msid: nil).limit(3)
+      msid = ms[1].msid
+      mid = ms[1].id
+
+      expect(ms.length).to eq 3
+      expect(msid).not_to be nil
+      expect(ms.pluck(:msid).uniq.length).to eq 3
+
+      conf = {
+        masters: {
+          msid:,
+          id: 'return_value'
+        }
+      }
+
+      ca = ConditionalActions.new conf, @al
+
+      res = ca.get_this_val
+      expect(res).to eq mid
+    end
+
     it 'returns a player record from another master record' do
       conf = {
         masters: {},
@@ -3749,7 +3771,7 @@ RSpec.describe 'Calculate conditional actions', type: :model do
       }
 
       return_failures = {}
-      res = ConditionalActions.new conf, @al, return_failures: return_failures
+      res = ConditionalActions.new(conf, @al, return_failures:)
       expect(res.calc_action_if).to be true
       expect(return_failures).to be_empty
     end
@@ -3764,7 +3786,7 @@ RSpec.describe 'Calculate conditional actions', type: :model do
       }
 
       return_failures = {}
-      res = ConditionalActions.new conf, @al, return_failures: return_failures
+      res = ConditionalActions.new(conf, @al, return_failures:)
       expect(res.calc_action_if).to be false
       expect(return_failures).to eq({ all: { this: { user_id: -999 } } })
     end
@@ -3782,7 +3804,7 @@ RSpec.describe 'Calculate conditional actions', type: :model do
       }
 
       return_failures = {}
-      res = ConditionalActions.new conf, @al, return_failures: return_failures
+      res = ConditionalActions.new(conf, @al, return_failures:)
       expect(res.calc_action_if).to be true
 
       conf = {
@@ -3799,7 +3821,7 @@ RSpec.describe 'Calculate conditional actions', type: :model do
       }
 
       return_failures = {}
-      res = ConditionalActions.new conf, @al, return_failures: return_failures
+      res = ConditionalActions.new(conf, @al, return_failures:)
       expect(res.calc_action_if).to be true
     end
 
@@ -3816,7 +3838,7 @@ RSpec.describe 'Calculate conditional actions', type: :model do
       }
 
       return_failures = {}
-      res = ConditionalActions.new conf, @al, return_failures: return_failures
+      res = ConditionalActions.new(conf, @al, return_failures:)
       b = res.calc_action_if
       expect(b).to be false
       expect(return_failures.dig(:all, :this, :user_id)).to eq(invalid_error_message: 'The user had a bad ID')
@@ -3836,7 +3858,7 @@ RSpec.describe 'Calculate conditional actions', type: :model do
 
       return_failures = {}
 
-      res = ConditionalActions.new conf, @al, return_failures: return_failures
+      res = ConditionalActions.new(conf, @al, return_failures:)
       b = res.calc_action_if
       expect(b).to be false
       expect(return_failures).to eq({ all: { this: { id: { invalid_error_message: 'Something was bad' } } } })
@@ -3855,7 +3877,7 @@ RSpec.describe 'Calculate conditional actions', type: :model do
       }
 
       return_failures = {}
-      res = ConditionalActions.new conf, @al, return_failures: return_failures
+      res = ConditionalActions.new(conf, @al, return_failures:)
       b = res.calc_action_if
       expect(b).to be false
       expect(return_failures).to eq({ all: { this: { id: { invalid_error_message: 'Something was bad' }, user_id: { invalid_error_message: 'The user had a bad ID' } } } })
@@ -3874,7 +3896,7 @@ RSpec.describe 'Calculate conditional actions', type: :model do
       }
 
       return_failures = {}
-      res = ConditionalActions.new conf, @al, return_failures: return_failures
+      res = ConditionalActions.new(conf, @al, return_failures:)
       b = res.calc_action_if
       expect(b).to be true
 
@@ -3892,7 +3914,7 @@ RSpec.describe 'Calculate conditional actions', type: :model do
       }
 
       return_failures = {}
-      res = ConditionalActions.new conf, @al, return_failures: return_failures
+      res = ConditionalActions.new(conf, @al, return_failures:)
       b = res.calc_action_if
       expect(b).to be true
     end
@@ -3912,7 +3934,7 @@ RSpec.describe 'Calculate conditional actions', type: :model do
 
       return_failures = {}
 
-      res = ConditionalActions.new conf, @al, return_failures: return_failures
+      res = ConditionalActions.new(conf, @al, return_failures:)
       b = res.calc_action_if
       expect(b).to be false
       expect(return_failures).to eq({ any: { this: { id: { invalid_error_message: 'All were bad' } } } })
@@ -3932,7 +3954,7 @@ RSpec.describe 'Calculate conditional actions', type: :model do
 
       return_failures = {}
 
-      res = ConditionalActions.new conf, @al, return_failures: return_failures
+      res = ConditionalActions.new(conf, @al, return_failures:)
       b = res.calc_action_if
       expect(b).to be false
       expect(return_failures).to eq({ any: { this: { user_id: { invalid_error_message: 'The user had a bad ID' } } } })

--- a/spec/models/redcap/data_records_spec.rb
+++ b/spec/models/redcap/data_records_spec.rb
@@ -232,6 +232,7 @@ RSpec.describe Redcap::DataRecords, type: :model do
 
     stub_request_records @project[:server_url], @project[:api_key], 'updated_records'
 
+    Rails.cache.clear
     dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
     dr.retrieve
     dr.summarize_fields
@@ -412,6 +413,7 @@ RSpec.describe Redcap::DataRecords, type: :model do
     expect(files.map { |f| "#{f.path}/#{f.file_name}" }.sort).to eq ["#{rc.dynamic_model_table}/file-fields/4/file1", "#{rc.dynamic_model_table}/file-fields/4/signature"]
 
     # Repeat - should not update the files
+    Rails.cache.clear
     dr = Redcap::DataRecords.new(rc, 'TestFileFieldRec')
     dr.retrieve
     dr.send(:capture_files, dr.records[1])
@@ -420,6 +422,7 @@ RSpec.describe Redcap::DataRecords, type: :model do
     expect(files.count).to eq 0
 
     # Reset with new file content
+    Rails.cache.clear
     mock_file_field_requests
     dr = Redcap::DataRecords.new(rc, 'TestFileFieldRec')
     dr.retrieve
@@ -511,6 +514,7 @@ RSpec.describe Redcap::DataRecords, type: :model do
       rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records, rc.records_request_options)
 
       stub_request_records @project[:server_url], @project[:api_key], 'missing_record'
+      Rails.cache.clear
       dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
       dr.retrieve
       dr.summarize_fields
@@ -566,6 +570,7 @@ RSpec.describe Redcap::DataRecords, type: :model do
       rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records, rc.records_request_options)
 
       stub_request_records @project[:server_url], @project[:api_key], 'missing_record'
+      Rails.cache.clear
       dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
       dr.retrieve
       dr.summarize_fields
@@ -608,6 +613,7 @@ RSpec.describe Redcap::DataRecords, type: :model do
       rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records, rc.records_request_options)
 
       stub_request_records @project[:server_url], @project[:api_key], 'missing_record'
+      Rails.cache.clear
       dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
       dr.retrieve
       dr.summarize_fields

--- a/spec/models/save_triggers/save_triggers_base_spec.rb
+++ b/spec/models/save_triggers/save_triggers_base_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
             - select_call_direction
             - extra_text
 
+          field_options:
+            select_who:
+              blank_preset_value: 'from preset value - {{select_call_direction}}'
+
           save_trigger:
             on_update:
               update_this:
@@ -87,6 +91,7 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
                                                                        select_who: 'user',
                                                                        extra_log_type: 'save_trigger_test_2')
       expect(al.select_who).to eq 'user'
+      expect(al.select_call_direction).to eq 'from player'
     end
 
     it 'runs the on_create trigger when an instance is created' do
@@ -116,6 +121,15 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
       al.current_user = @master.current_user
       al.update!(select_call_direction: 'to player')
       expect(al.select_who).to eq 'updated value'
+    end
+
+    it 'sets a preset value, which can be overridden in the on_update trigger' do
+      al = @player_contact.activity_log__player_contact_phones.create!(select_call_direction: 'from player',
+                                                                       extra_log_type: 'save_trigger_test_2')
+      expect(al.select_who).to eq 'from preset value - from player'
+      al.skip_save_trigger = false
+      al.update!(select_call_direction: 'make update')
+      expect(al.select_who).to eq 'updated value2'
     end
   end
 


### PR DESCRIPTION
### From FPHS

- [Fixed] password self-reset fails with exception if user is disabled - fixes #342
- [Added] field option for blank_preset_value and allow substitutions in preset_value - fixes #220
- [Fixed] issue in selector cache, where callers were sensitive to attributes with symbol or string keys
- [Changed] parallel tests to ask for sudo early in the process if needed
- [Added] spec for getting master id using MSID in conditions
- [Fixed] dashboard error not being to load report resources
- [Added] definition for multiple save buttons, with show_if control
- [Changed] settings to ensure proper nil results for empty environment variables
- [Added] edit_as options to select_user_with fields
- [Fixed] issue where table comments with apostrophes break the migration with a syntax error. Fixes #331 and #332
- [Changed] logging of job failure notification
- [Fixed] error reporting failed job
- [Changed] cache invalidation to avoid unnecessary requests to clear the cache
- [Fixed] spec to clear cache between requests
