### PR TITLE
Hms save trigger enh

### DIFF
--- a/app/models/admin/defs/extra_options_defs.yaml
+++ b/app/models/admin/defs/extra_options_defs.yaml
@@ -284,34 +284,38 @@
 
   save_trigger:
     on_create: &trigger_tasks
-      add_tracker: 
+      # Each trigger definition is run in order within the list
+      # simpler definitions may not use a list, and just specify a hash of key value pairs, run in order
+      # noting that this only allows a single configuration of each type of trigger
+
+      - add_tracker: 
 #!defs(save_triggers_add_tracker_options_defs.yaml)
 
-      create_master: 
+      - create_master: 
 #!defs(save_triggers_create_master_options_defs.yaml)
 
-      create_reference: 
+      - create_reference: 
 #!defs(save_triggers_create_reference_options_defs.yaml)
 
-      change_user_roles:
+      - change_user_roles:
 #!defs(save_triggers_change_user_roles_options_defs.yaml)
 
-      create_filestore_container: 
+      - create_filestore_container: 
 #!defs(save_triggers_create_filestore_container_options_defs.yaml)
 
-      notify: 
+      - notify: 
 #!defs(save_triggers_notify_options_defs.yaml)
 
-      pull_external_data: 
+      - pull_external_data: 
 #!defs(save_triggers_pull_external_data_options_defs.yaml)
 
-      set_item_flags:
+      - set_item_flags:
 #!defs(save_triggers_set_item_flags_options_defs.yaml)
 
-      update_reference: 
+      - update_reference: 
 #!defs(save_triggers_update_reference_options_defs.yaml)
 
-      update_this: 
+      - update_this: 
 #!defs(save_triggers_update_this_options_defs.yaml)
 
       - each:

--- a/app/models/dynamic/implementation_handler.rb
+++ b/app/models/dynamic/implementation_handler.rb
@@ -224,6 +224,7 @@ module Dynamic
     def handle_record_batch_trigger(alt_user: nil)
       as_user = alt_user || user
       self.current_user = as_user
+      self.save_trigger_results ||= {}
       option_type_config&.calc_batch_trigger self
     end
 

--- a/app/models/save_triggers/create_master.rb
+++ b/app/models/save_triggers/create_master.rb
@@ -31,6 +31,8 @@ class SaveTriggers::CreateMaster < SaveTriggers::SaveTriggersBase
     config = @config
     vals = {}
 
+    @item.save_trigger_results['created_masters'] ||= []
+
     if config[:if]
       ca = ConditionalActions.new config[:if], @item
       return unless ca.calc_action_if
@@ -54,6 +56,8 @@ class SaveTriggers::CreateMaster < SaveTriggers::SaveTriggersBase
       @item.save_trigger_results['created_master'] =
         @new_master =
           Master.create_master_record @item.current_user, empty: true, extra_ids: vals
+
+      @item.save_trigger_results['created_masters'] << @new_master
 
       if move_this
         new_master_id = @new_master.id

--- a/app/models/save_triggers/create_reference.rb
+++ b/app/models/save_triggers/create_reference.rb
@@ -77,7 +77,20 @@ class SaveTriggers::CreateReference < SaveTriggers::SaveTriggersBase
             when 'master_with_reference'
               ModelReference.create_from_master_with in_master, new_item, force_create:
             else
-              raise FphsException, "Unknown 'in' value in create_reference"
+
+              unless create_in.is_a?(Hash) && create_in[:specific_record]
+                raise FphsException,
+                      "Unknown 'in' value in create_reference"
+              end
+
+              # A specific instance is the target for the reference from_record
+              # Include return: return_result to return the actual instance
+              ca = ConditionalActions.new create_in[:specific_record], @item
+              ci = ca.get_this_val
+              puts ci
+              raise FphsException, "Result for 'in' hash is not an instance" unless ci.is_a? UserBase
+
+              ModelReference.create_with ci, new_item, force_create:
             end
 
           @item.save_trigger_results['created_references'] << res

--- a/app/models/save_triggers/create_reference.rb
+++ b/app/models/save_triggers/create_reference.rb
@@ -12,8 +12,8 @@ class SaveTriggers::CreateReference < SaveTriggers::SaveTriggersBase
   def perform
     @model_defs = [@model_defs] unless @model_defs.is_a? Array
 
-    @item.save_trigger_results['created_references'] = []
-    @item.save_trigger_results['created_items'] = []
+    @item.save_trigger_results['created_references'] ||= []
+    @item.save_trigger_results['created_items'] ||= []
 
     @model_defs.each do |model_def|
       model_def.each do |model_name, config|

--- a/app/models/save_triggers/update_reference.rb
+++ b/app/models/save_triggers/update_reference.rb
@@ -32,6 +32,8 @@ class SaveTriggers::UpdateReference < SaveTriggers::SaveTriggersBase
   def perform
     @model_defs = [@model_defs] unless @model_defs.is_a? Array
 
+    @item.save_trigger_results['updated_items'] = []
+
     @model_defs.each do |model_def|
       model_def.each do |_model_name, config|
         vals = {}
@@ -62,6 +64,7 @@ class SaveTriggers::UpdateReference < SaveTriggers::SaveTriggersBase
           res.ignore_configurable_valid_if = true if config[:force_not_valid]
           res.force_save! if config[:force_not_editable_save]
           res.update! vals.merge(current_user: @item.current_user || @item.user)
+          @item.save_trigger_results['updated_items'] << res
         end
       end
     end

--- a/app/models/save_triggers/update_reference.rb
+++ b/app/models/save_triggers/update_reference.rb
@@ -32,7 +32,7 @@ class SaveTriggers::UpdateReference < SaveTriggers::SaveTriggersBase
   def perform
     @model_defs = [@model_defs] unless @model_defs.is_a? Array
 
-    @item.save_trigger_results['updated_items'] = []
+    @item.save_trigger_results['updated_items'] ||= []
 
     @model_defs.each do |model_def|
       model_def.each do |_model_name, config|

--- a/spec/models/save_triggers/create_reference_spec.rb
+++ b/spec/models/save_triggers/create_reference_spec.rb
@@ -151,4 +151,40 @@ RSpec.describe SaveTriggers::CreateReference, type: :model do
     expect(mr.to_record_master_id).to eq pc.master_id
     expect(mr.from_record_master_id).to eq pc.master_id
   end
+
+  it 'creates a reference in a specific record' do
+    pn = random_phone_number
+
+    config = {
+      if: { always: true }
+    }
+
+    al_alt = create_item master: @master
+
+    config = {
+      player_contact: {
+        in: {
+          specific_record: {
+            activity_log__player_contact_phones: {
+              id: al_alt.id,
+              return: 'return_result'
+            }
+          }
+        },
+        with: { data: pn, rec_type: :phone, rank: 5 }
+      }
+    }
+    @trigger = SaveTriggers::CreateReference.new(config, @al)
+    @trigger.perform
+
+    pc = PlayerContact.find_by(data: pn)
+    expect(pc).not_to be nil
+    expect(pc.master_id).to eq @al.master.id
+
+    mr = ModelReference.last&.reload
+    expect(mr.to_record_id).to eq pc.id
+    expect(mr.to_record_master_id).to eq pc.master_id
+    expect(mr.from_record_master_id).to eq pc.master_id
+    expect(mr.from_record_id).to eq al_alt.id
+  end
 end

--- a/spec/models/save_triggers/save_triggers_base_spec.rb
+++ b/spec/models/save_triggers/save_triggers_base_spec.rb
@@ -59,6 +59,48 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
                   with:
                     select_who: 'updated value2'
 
+        save_trigger_test_3:
+          label: Save Trigger Test 3
+          fields:
+            - select_call_direction
+            - notes
+
+          field_options:
+            select_who:
+              blank_preset_value: 'from preset value - {{select_call_direction}}'
+
+          save_trigger:
+            on_update:
+              - update_this:
+                  one:
+                    with:
+                      select_who: 'updated value2'
+              - create_reference:
+                  player_contact:
+                    in: master
+                    with:
+                      rank: 10
+                      rec_type: email
+                      data: test@test.tst
+              - update_this:
+                  one:
+                    with:
+                      notes: 'this was updated with player contact {{player_contact_emails.first.data}}'
+              - create_reference:
+                  player_contact:
+                    in: master
+                    with:
+                      rank: 10
+                      rec_type: phone
+                      data: (617) 794 2300
+
+              - update_this:
+                  one:
+                    with:
+                      notes: |
+                        - {{notes}}
+                        - this was updated with player contact phone {{player_contact_phones.first.data}}
+
       ENDDEF
 
       al_def.extra_log_types = config
@@ -80,6 +122,7 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
       setup_access :activity_log__player_contact_phone__primary, resource_type: :activity_log_type, access: :create, user: @user
       setup_access :activity_log__player_contact_phone__save_trigger_test_1, resource_type: :activity_log_type, access: :create, user: @user
       setup_access :activity_log__player_contact_phone__save_trigger_test_2, resource_type: :activity_log_type, access: :create, user: @user
+      setup_access :activity_log__player_contact_phone__save_trigger_test_3, resource_type: :activity_log_type, access: :create, user: @user
       expect(@user.has_access_to?(:create, :activity_log_type, :activity_log__player_contact_phone__save_trigger_test_1)).to be_truthy
       al_def.add_master_association
 
@@ -130,6 +173,20 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
       al.skip_save_trigger = false
       al.update!(select_call_direction: 'make update')
       expect(al.select_who).to eq 'updated value2'
+    end
+
+    it 'runs a list of triggers in the desired order' do
+      al = @player_contact.activity_log__player_contact_phones.create!(select_call_direction: 'from player',
+                                                                       select_who: 'user',
+                                                                       extra_log_type: 'save_trigger_test_3')
+      expect(al.select_who).to eq 'user'
+      al.skip_save_trigger = false
+      al.update!(select_call_direction: 'to player')
+      expect(al.select_who).to eq 'updated value2'
+      expect(al.notes).to eq <<~END_TEXT
+        - this was updated with player contact test@test.tst
+        - this was updated with player contact phone (617)794-2300
+      END_TEXT
     end
   end
 
@@ -187,6 +244,40 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
                   with:
                     select_who: 'batch updated value 2'
 
+        batch_trigger_test_3:
+          label: Batch Trigger Test 3
+          fields:
+            - select_call_direction
+            - select_who
+          save_trigger:
+            on_create:
+              update_this:
+                one:
+                  with:
+                    select_who: 'created value'
+
+          batch_trigger:
+            on_record:
+              - update_this:
+                  one:
+                    force_not_editable_save: true
+                    with:
+                      select_who: 'batch updated value 3'
+              - create_reference:
+                  player_contact:
+                    in: master
+                    with:
+                      rec_type: email
+                      rank: 5
+                      data: test2@test.tst
+              - update_this:
+                  one:
+                    force_not_editable_save: true
+                    with:
+                      select_who: |
+                        - {{select_who}}
+                        - added {{player_contact_emails.first.data}}
+
       ENDDEF
 
       al_def.extra_log_types = config
@@ -208,6 +299,7 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
       setup_access :activity_log__player_contact_phone__primary, resource_type: :activity_log_type, access: :create, user: @user
       setup_access :activity_log__player_contact_phone__batch_trigger_test_1, resource_type: :activity_log_type, access: :create, user: @user
       setup_access :activity_log__player_contact_phone__batch_trigger_test_2, resource_type: :activity_log_type, access: :create, user: @user
+      setup_access :activity_log__player_contact_phone__batch_trigger_test_3, resource_type: :activity_log_type, access: :create, user: @user
       expect(@user.has_access_to?(:create, :activity_log_type, :activity_log__player_contact_phone__batch_trigger_test_1)).to be_truthy
       al_def.add_master_association
 
@@ -260,6 +352,38 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
       al2.reload
       expect(al.select_who).to eq 'batch updated value'
       expect(al2.select_who).to eq 'batch updated value 2'
+    end
+
+    it 'runs the the triggers in a list' do
+      al = @player_contact.activity_log__player_contact_phones.create!(select_call_direction: 'from player',
+                                                                       select_who: 'user',
+                                                                       extra_log_type: 'batch_trigger_test_3')
+      al2 = @player_contact.activity_log__player_contact_phones.create!(select_call_direction: 'from player',
+                                                                        select_who: 'user',
+                                                                        extra_log_type: 'batch_trigger_test_2')
+
+      expect(al.select_who).to eq 'created value'
+      expect(al2.select_who).to eq 'user'
+      all_recs = al.class.all.pluck(:id)
+
+      al.reload
+      al.skip_save_trigger = false
+      al.current_user = @master.current_user
+
+      al2.reload
+      al2.skip_save_trigger = false
+      al2.current_user = @master.current_user
+
+      res = al.class.trigger_batch_now
+      expect(res).to eq all_recs
+
+      al.reload
+      al2.reload
+      expect(al2.select_who).to eq 'batch updated value 2'
+      expect(al.select_who).to eq <<~END_TEXT
+        - batch updated value 3
+        - added test2@test.tst
+      END_TEXT
     end
   end
 


### PR DESCRIPTION
### From FPHS

- [Added] iteration through save triggers based on an array of values - closes #348
- [Added] save triggers definition as a list of triggers instead of a hash - closes #347
- [Added] updated_items element to save_trigger_results for update_reference trigger - fixes #345
- [Added] save trigger create_reference in a specific record - fixes #346
