### PR TITLE
Hms save cond

### DIFF
--- a/app/assets/javascripts/app/_fpa_utils.js
+++ b/app/assets/javascripts/app/_fpa_utils.js
@@ -490,17 +490,20 @@ _fpa.utils.pretty_print = function (stre, options_hash) {
           //stre = Handlebars.Utils.escapeExpression(stre);
           stre = _fpa.utils.capitalize(stre);
           if (options_hash.remove_tags) stre = _fpa.utils.remove_tags(stre);
-          return stre;
         } else {
           stre = _fpa.utils.nl2br(stre);
           if (options_hash.remove_tags) stre = _fpa.utils.remove_tags(stre);
-          return stre;
         }
       } else {
         stre = _fpa.utils.nl2br(stre);
         if (options_hash.remove_tags) stre = _fpa.utils.remove_tags(stre);
-        return stre;
       }
+
+      if (options_hash.view_with_formats) {
+        var formatters = options_hash.view_with_formats
+        stre = _fpa.tag_formatter.format_all(stre, formatters, '', {})
+      }
+      return stre;
     } else {
       return null;
     }

--- a/app/assets/stylesheets/admin/activity_list.scss
+++ b/app/assets/stylesheets/admin/activity_list.scss
@@ -1,5 +1,6 @@
 .activity-list-section,
 .activity-list-references,
+.activity-list-embeds,
 .activity-list-libraries,
 .activity-list-file-filters,
 .activity-list-dialogs {

--- a/app/assets/stylesheets/admin/admin.scss
+++ b/app/assets/stylesheets/admin/admin.scss
@@ -171,3 +171,7 @@ div#creddocframe {
   font-style: italic;
 
 }
+
+a.link-disabled {
+  color: gray;
+}

--- a/app/controllers/concerns/embedded_item_handler.rb
+++ b/app/controllers/concerns/embedded_item_handler.rb
@@ -32,6 +32,7 @@ module EmbeddedItemHandler
 
     return unless @embedded_item
 
+    @embedded_item.force_preset_values
     case action_name
     when 'new'
       set_embedded_item_optional_params

--- a/app/models/activity_log.rb
+++ b/app/models/activity_log.rb
@@ -390,7 +390,7 @@ class ActivityLog < ActiveRecord::Base
   def self.routes_load
     mn = nil
     begin
-      m = enabled
+      m = active
       return if m.empty?
 
       Rails.application.routes.draw do

--- a/app/models/activity_log.rb
+++ b/app/models/activity_log.rb
@@ -737,6 +737,15 @@ class ActivityLog < ActiveRecord::Base
     full_item_type_name.ns_hyphenate
   end
 
+  def default_embed_table_name(extra_log_type)
+    sname = process_name || [item_type, rec_type].compact.join('_')
+    [category, sname, extra_log_type, 'recs'].compact.join('_')
+  end
+
+  def default_embed_resource_name(extra_log_type)
+    "dynamic_model__#{default_embed_table_name(extra_log_type)}"
+  end
+
   # Override to enable extra log types to also be added to Resouces::Models
   def add_model_to_list(m)
     # Clean up before re-adding

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -44,7 +44,7 @@ class Admin < ActiveRecord::Base
   # Get the user that corresponds to this admin
   # @return [User | nil]
   def matching_user
-    User.active.where(email: email).first
+    User.active.find_by(email:)
   end
 
   # Get the current app type for the user that corresponds to this admin

--- a/app/models/admin/app_type.rb
+++ b/app/models/admin/app_type.rb
@@ -274,19 +274,27 @@ class Admin
                   )
             ms << res if res
           end
-          c.save_trigger.each do |_d, st|
-            ns = st[:notify] || []
-            ns = [ns] if ns.is_a? Hash
+          c.save_trigger.each do |_d, sts|
+            sts = [sts] unless sts.is_a? Array
+            sts.each do |stconfig|
+              stsconfigs = stconfig.dig(:each, :do) || stconfig
+              stsconfigs = [stsconfigs] unless stsconfigs.is_a? Array
 
-            ns.each do |v|
-              lt = v[:layout_template]
-              ct = v[:content_template]
-              mt = v[:type]
+              stsconfigs.each do |st|
+                ns = st[:notify] || []
+                ns = [ns] if ns.is_a? Hash
 
-              res = Admin::MessageTemplate.active.find_by(name: lt, message_type: mt, template_type: 'layout')
-              ms << res if res
-              res = Admin::MessageTemplate.active.find_by(name: ct, message_type: mt, template_type: 'content')
-              ms << res if res
+                ns.each do |v|
+                  lt = v[:layout_template]
+                  ct = v[:content_template]
+                  mt = v[:type]
+
+                  res = Admin::MessageTemplate.active.find_by(name: lt, message_type: mt, template_type: 'layout')
+                  ms << res if res
+                  res = Admin::MessageTemplate.active.find_by(name: ct, message_type: mt, template_type: 'content')
+                  ms << res if res
+                end
+              end
             end
           end
         end

--- a/app/models/admin/app_type_export.rb
+++ b/app/models/admin/app_type_export.rb
@@ -39,25 +39,37 @@ module Admin::AppTypeExport
       options.delete :main_components
     end
 
+    excl = if options[:exclude_components]
+             options.delete :exclude_components
+           else
+             []
+           end
+
     options[:root] = true
     options[:methods] ||= []
     options[:include] ||= {}
 
     options[:methods] << :app_configurations
-    options[:methods] << :valid_user_access_controls unless main_components
+    unless main_components || excl.include?(:valid_user_access_controls)
+      options[:methods] << :valid_user_access_controls
+    end
     options[:methods] << :valid_associated_activity_logs
     options[:methods] << :associated_dynamic_models
     options[:methods] << :associated_external_identifiers
     options[:methods] << :associated_reports
-    options[:methods] << :associated_general_selections unless main_components
+    unless main_components || excl.include?(:associated_general_selections)
+      options[:methods] << :associated_general_selections
+    end
     options[:methods] << :page_layouts
-    options[:methods] << :user_roles unless main_components
+    options[:methods] << :user_roles unless main_components || excl.include?(:user_roles)
     options[:methods] << :role_descriptions
     options[:methods] << :associated_message_templates
     options[:methods] << :associated_config_libraries
     options[:methods] << :associated_protocols
-    options[:methods] << :associated_sub_processes unless main_components
-    options[:methods] << :associated_protocol_events unless main_components
+    options[:methods] << :associated_sub_processes unless main_components || excl.include?(:associated_sub_processes)
+    unless main_components || excl.include?(:associated_protocol_events)
+      options[:methods] << :associated_protocol_events
+    end
     options[:methods] << :associated_item_flag_names
     options[:methods] << :nfs_store_filters
 

--- a/app/models/admin/app_type_import.rb
+++ b/app/models/admin/app_type_import.rb
@@ -15,7 +15,7 @@ class Admin
     # @param [String] config_text - YAML or JSON text
     # @param [Admin] admin - admin profile performing import
     # @param [String] name - optionally override the name of the app type at import
-    # @param [Symbol] format - :json (default) or :yaml
+    # @param [Symbol] format - :json (default), :yaml, :raw (a hash)
     # @param [:force|:changed|nil] force_update - optionally force updated configuration items to current timestamp
     #                                  allowing previously failed imports to be overwritten
     #                                  or set to :changed to update changes, regardless of updated_at timestamp
@@ -184,6 +184,8 @@ class Admin
         config = JSON.parse(config_text)
       elsif format == :yaml
         config = YAML.safe_load(config_text)
+      elsif format == :raw
+        config = config_text.deep_stringify_keys
       else
         raise FphsException, 'specify app type import format as one of :json or :yaml'
       end

--- a/app/models/admin/defs/conditions_defs.yaml
+++ b/app/models/admin/defs/conditions_defs.yaml
@@ -46,6 +46,13 @@
           model_table_name:
             field_name: 'any conditional value must be false'
 
+        # Only creatable if this extra log type hasn't already been performed
+        # `definition_resources` resolves to the definition activity log association for an activity log
+        # or the dynamic model / external identifier association otherwise
+        not_any_completed:
+          definition_resources:
+            extra_log_type: '{{extra_log_type}}''
+
         any_return_an_embedded_item:
           embedded_item:
             return: return_result

--- a/app/models/admin/defs/conditions_defs.yaml
+++ b/app/models/admin/defs/conditions_defs.yaml
@@ -23,8 +23,20 @@
         any:
           model_table_name:
             field_name: 'any conditional value must be true'
-            
-        
+          model_table_name2:
+            # Get an array of ids for a specified set of "from" items
+            # where the items reference a "target" item, based on a filter
+            # This is different from `this_references` since "from" is unrelated
+            # to the current instance
+            id:
+              ids_referencing:
+                target:
+                  external_items:
+                    rec_type: val
+                from:
+                  activity_log_items:
+                    extra_log_type: act1
+                    return: return_all_results
         not_any:
           model_table_name:
             field_name: 'all conditional values must be false'
@@ -88,7 +100,7 @@
               condition: |
                 "one of:"
                 - 'IS NOT NULL', 'IS NULL'
-                - '=', '<', '>', '<>', '<=', '>=', 'LIKE', 'ILIKE', '~', '~*', 'in?'
+                - '=', '<', '>', '<>', '<=', '>=', 'LIKE', 'ILIKE', '~', '~*', 'in?, 'include?'
                 - '= ANY' -  The value of this field (must be scalar) matches any value from the retrieved array field
                 - '= ANY REV' -  Reverse the operator order
                 - '<> ANY' -  The value of this field (must be scalar) must not match any value from the retrieved array field

--- a/app/models/admin/defs/conditions_defs.yaml
+++ b/app/models/admin/defs/conditions_defs.yaml
@@ -88,7 +88,7 @@
               condition: |
                 "one of:"
                 - 'IS NOT NULL', 'IS NULL'
-                - '=', '<', '>', '<>', '<=', '>=', 'LIKE', 'ILIKE', '~', '~*'
+                - '=', '<', '>', '<>', '<=', '>=', 'LIKE', 'ILIKE', '~', '~*', 'in?'
                 - '= ANY' -  The value of this field (must be scalar) matches any value from the retrieved array field
                 - '= ANY REV' -  Reverse the operator order
                 - '<> ANY' -  The value of this field (must be scalar) must not match any value from the retrieved array field

--- a/app/models/admin/defs/conditions_defs.yaml
+++ b/app/models/admin/defs/conditions_defs.yaml
@@ -54,6 +54,27 @@
           embedded_item:
             some_field: return_value
 
+        any_calculation:
+          this:
+            calculate:
+              # Returns value
+              (sum|min|max):
+                attributes:
+                  - attr1
+                  - attr2
+
+        any_comparison_using_a_calculation:
+          this:
+            field_name:
+              # Returns a result if it matches
+              calculate:
+                (sum|min|max):
+                  attributes:
+                    - attr1
+                    - attr2
+              
+                                    
+
         all - users not related to master:
           # if the first key is 'users' then the query will return against all users rather than current master record
           users:

--- a/app/models/admin/defs/conditions_defs.yaml
+++ b/app/models/admin/defs/conditions_defs.yaml
@@ -1,7 +1,7 @@
 # Conditions Definitions
 
         all:
-          'model_table_name | this | this_references | parent_references | parent_or_this_references | referring_record (the record referring to this one)':
+          'model_table_name | this | embedded_item| this_references | parent_references | parent_or_this_references | referring_record (the record referring to this one)':
             field_name: 'all conditional values must be true in model_table_name (any matching record unless id or other filters specified separately) or this (this record)'
             field_name_2: 'literal value | null'
             field_name_3: 
@@ -45,7 +45,15 @@
         not_all:
           model_table_name:
             field_name: 'any conditional value must be false'
-          
+
+        any_return_an_embedded_item:
+          embedded_item:
+            return: return_result
+        
+        any_return_attribute_from_an_embedded_item:
+          embedded_item:
+            some_field: return_value
+
         all - users not related to master:
           # if the first key is 'users' then the query will return against all users rather than current master record
           users:

--- a/app/models/admin/defs/config_trigger_options_defs.yaml
+++ b/app/models/admin/defs/config_trigger_options_defs.yaml
@@ -1,0 +1,30 @@
+# Config Trigger options      
+      create_defaults:
+      # Specify one or more of the following options to automatically set them up during definition
+        user_access_control:
+        # Create default user controls (and role for this admin user) to allow this resource
+        # and any embed to be created
+        embed:
+        # Create a default embed dynamic model. No fields need to be specified.
+          fields:
+            - status
+            - notes
+        page_layout:
+        # Create a master page layout for this definition resource.
+      create_configs:
+      # Create configs for any type of additional definition. This follows the format of an app type export.
+        associated_general_selections:
+          - name: Not Started
+            value: not started
+            item_type: '{{default_embed_resource_name}}_status'
+            position: 1600
+          - name: Pending
+            value: pending
+            item_type: #{rn}_status
+            position: 1601
+          - name: In Progress
+            value: in progress
+            item_type: #{rn}_status
+            position: 1602
+
+        

--- a/app/models/admin/defs/extra_options_defs.yaml
+++ b/app/models/admin/defs/extra_options_defs.yaml
@@ -139,6 +139,8 @@
 
       no_downcase: true - to prevent downcasing of the attribute when stored to the database
       view_original_case: true - to prevent the UI capitalizing downcased fields
+      view_with_formats: |
+        list of formatters to apply to a string field when being viewed
       format: plain | markdown - for free text editor fields such as notes and description
       config:
         _comment: additional configurations for editor fields

--- a/app/models/admin/defs/extra_options_defs.yaml
+++ b/app/models/admin/defs/extra_options_defs.yaml
@@ -212,7 +212,11 @@
         
       on_create:                  
       on_update:
-  embed:
+
+  # embed can be defined in one of two styles:
+  embed: default_embed_resource # simply embeds the dynamic model matching the default_embed_resource_name for this activity
+
+  embed(form 2):
     resource_name: resource name for the item to embed
     resource_id: |
       (optional) literal integer or a named attribute on the resource to use as an id of the embedded item
@@ -352,4 +356,7 @@
       <<: *trigger_tasks
 
 
- 
+  config_trigger:
+    on_define:
+      # Add default configurations and extra detailed configurations when a dynamic definition configuration is saved or updated
+#!defs(config_trigger_options_defs.yaml)

--- a/app/models/admin/defs/extra_options_defs.yaml
+++ b/app/models/admin/defs/extra_options_defs.yaml
@@ -323,6 +323,7 @@
           do:
             - <trigger 1> # a trigger configuration such as update_this:
             - <trigger 2>
+          if: # optionally specify a condition to skip a whole iteration. Individual trigger ifs are still available.
           # The iterator index and value can be accessed inside the triggers with:
           # - {{save_trigger_results.iterator_index}}
           # - {{save_trigger_results.iterator_value}}

--- a/app/models/admin/defs/extra_options_top_level_options_defs.yaml
+++ b/app/models/admin/defs/extra_options_top_level_options_defs.yaml
@@ -48,6 +48,12 @@ _configurations:
     app_type: optionally specify an app_type id to force the use of a batch user when perfoming actions
     user: optionally specify a user id (or email) to force use of the specified user when perfoming actions
   tab_caption: a markdown string to be shown at the top of activity log panels (between header title and action buttons)
+  uniqueness_fields: check for uniqueness of an external identifier based on multiple fields, rather than the external id attribute alone
+    # Provide a list of fields (including the external id attribute name if required) to check uniqueness against. 
+    # If no uniqueness check is required, specify 'id'.
+    # NOTE: searches through the UI against the external ID (using the default capabilities)
+    # may now return multiple results, since there is currently no way to specify the other fields that make up a unique search.
+  can_change_master: allow assigned external identifiers to be moved to a different master record
 
 # To add a table or view to the data dictionary, add the _data_dictionary: with
 # the essential keys, study: and domain:, plus any others that are required.

--- a/app/models/admin/defs/save_triggers_create_master_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_create_master_options_defs.yaml
@@ -12,3 +12,5 @@
               field_name_4: 
                 reference_name:
                   field_name: return_value
+          # NOTE: this sets:
+          # - save_trigger_results.created_masters (with the master record created, if it was created)

--- a/app/models/admin/defs/save_triggers_create_reference_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_create_reference_options_defs.yaml
@@ -12,6 +12,20 @@
 
             force_create: 'true to force the creation of a reference and referenced object, independent of user access controls'
             force_not_valid: 'true to allow valid_if checks to be ignored'
+
+            with_result: 
+            # Map attributes from a related item to the target item.
+            # NOTE: with: fields override any specified here
+              from:
+                embedded_item:
+                  return: return_result
+              attributes:
+                receipt_date: event_date
+                receipt_time: event_time
+                received_by: received_by
+                select_facility: 'Lab: {{select_lab}}'
+                # Substitutions use data only from the "from:" item                
+
             with: 
               field_name: 'now()'
               field_name_2: 'literal value'

--- a/app/models/admin/defs/save_triggers_create_reference_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_create_reference_options_defs.yaml
@@ -24,4 +24,7 @@
 
             to_existing_record: # use an existing record of type "model_name", rather than creating a new one
               record_id: 'Hash with return_value, such as {model_name: {match: value, id: "return_value"\}\}'
-    
+          # NOTE: this sets:
+          # - save_trigger_results.created_references (list of model_reference items created - skipped if an item wasn't created)
+          # - save_trigger_results.created_items (list of created items - skipped if an item wasn't created)
+          # - save_trigger_results.created_results (list of results indicating if an item was created based on "if:" conditions)

--- a/app/models/admin/defs/save_triggers_update_reference_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_update_reference_options_defs.yaml
@@ -43,3 +43,6 @@
                   field_name: return_value
               field_name_5: '\{\{curly_tag\}\} - \{\{curly_tag2\}\}'
               field_name_6: '\{\{\{data.data_structure\}\}\}' # Get a data structure as original object, for JSON fields etc                  
+          # NOTE: this sets:
+          # - save_trigger_results.updated_items (list of updated items - skipped if an item wasn't updated)
+          # - save_trigger_results.updated_results (list of results indicating if an item was updated based on "if:" conditions)

--- a/app/models/admin/defs/save_triggers_update_reference_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_update_reference_options_defs.yaml
@@ -26,6 +26,20 @@
 
             force_not_editable_save: 'true allows the update to succeed even if the referenced item is set as not_editable'
             force_not_valid: 'true to allow valid_if checks to be ignored'
+
+            with_result: 
+            # Map attributes from a related item to the target item.
+            # NOTE: with: fields override any specified here
+              from:
+                embedded_item:
+                  return: return_result
+              attributes:
+                receipt_date: event_date
+                receipt_time: event_time
+                received_by: received_by
+                select_facility: 'Lab: {{select_lab}}'
+                # Substitutions use data only from the "from:" item                
+
             with: 
               field_name: 'now()'
               field_name_2: 'literal value'

--- a/app/models/admin/defs/save_triggers_update_this_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_update_this_options_defs.yaml
@@ -4,6 +4,20 @@
             if: if_extras
             force_not_editable_save: 'true allows the update to succeed even if the referenced item is set as not_editable'
             force_not_valid: 'true to allow valid_if checks to be ignored'
+
+            with_result: 
+            # Map attributes from a related item to the target item.
+            # NOTE: with: fields override any specified here
+              from:
+                embedded_item:
+                  return: return_result
+              attributes:
+                receipt_date: event_date
+                receipt_time: event_time
+                received_by: received_by
+                select_facility: 'Lab: {{select_lab}}'
+                # Substitutions use data only from the "from:" item                
+
             with:
               field_name: 'now()'
               field_name_2: 'literal value'

--- a/app/models/calc_actions/calculate.rb
+++ b/app/models/calc_actions/calculate.rb
@@ -30,7 +30,7 @@ module CalcActions
     include Common
 
     # We won't use a query join when referring to tables based on these keys
-    NonJoinTableNames = %i[this parent referring_record top_referring_record this_references parent_references
+    NonJoinTableNames = %i[this parent embedded_item referring_record top_referring_record this_references parent_references
                            parent_or_this_references user master condition value hide_error invalid_error_message
                            role_name reference ids_referencing].freeze
 
@@ -254,6 +254,9 @@ module CalcActions
 
         val = attribute_from_instance(from_instance, val_item_value)
 
+      elsif val_item_key == :embedded_item
+        from_instance = @current_instance.embedded_item
+        val = from_instance && attribute_from_instance(from_instance, val_item_value)
       elsif val_item_key == :referring_record && !val_item_value.is_a?(Hash)
         # Get a literal value from the current instance's referring_record.
         # This is a record referring to the current instance.

--- a/app/models/calc_actions/calculate.rb
+++ b/app/models/calc_actions/calculate.rb
@@ -556,7 +556,7 @@ module CalcActions
                               else
                                 @condition_config
                               end
-      self.top_level_error ||= iem
+      self.top_level_error = iem || top_level_error
 
       @non_query_conditions = NonQueryCondition.new(current_instance:,
                                                     condition_config: this_condition_config,

--- a/app/models/calc_actions/calculate.rb
+++ b/app/models/calc_actions/calculate.rb
@@ -652,7 +652,7 @@ module CalcActions
               next
             end
 
-            if val.is_a?(Hash) && !val.key?(:element)
+            if val.is_a?(Hash) && !val.key?(:element) && !val.key?(:calculate)
               # Since the conditional value is actually a hash, we need to
               # get the value to be matched from another referenced record (or this)
               # Generate the query condition to do this

--- a/app/models/calc_actions/calculate.rb
+++ b/app/models/calc_actions/calculate.rb
@@ -630,6 +630,7 @@ module CalcActions
       @sub_conditions = {}
 
       @condition_config.each do |c_table, t_conds|
+        c_table = @current_instance.class.definition.resource_name if c_table == :definition_resources
         join_table_name = c_table.to_sym
         table_name = ModelReference.record_type_to_table_name(c_table).to_sym
 

--- a/app/models/calc_actions/common.rb
+++ b/app/models/calc_actions/common.rb
@@ -20,7 +20,7 @@ module CalcActions
 
     BoolTypeString = '__!BOOL__'
     UnaryConditions = ['IS NOT NULL', 'IS NULL'].freeze
-    BinaryConditions = ['=', '<', '>', '<>', '<=', '>=', 'LIKE', 'ILIKE', '~*', '~'].freeze
+    BinaryConditions = ['=', '<', '>', '<>', '<=', '>=', 'LIKE', 'ILIKE', '~*', '~', 'in?', 'include?'].freeze
     ValidExtraConditions = (BinaryConditions + UnaryConditions).freeze
 
     attr_accessor :return_this, :top_level_error, :top_level_error_above, :skip_merge

--- a/app/models/calc_actions/common.rb
+++ b/app/models/calc_actions/common.rb
@@ -23,7 +23,7 @@ module CalcActions
     BinaryConditions = ['=', '<', '>', '<>', '<=', '>=', 'LIKE', 'ILIKE', '~*', '~'].freeze
     ValidExtraConditions = (BinaryConditions + UnaryConditions).freeze
 
-    attr_accessor :return_this
+    attr_accessor :return_this, :top_level_error, :top_level_error_above, :skip_merge
 
     #
     # Get an attribute from an instance, and ensure that a blank is
@@ -96,8 +96,12 @@ module CalcActions
       # Make sure we don't overwrite the actual results passed in, since these
       # can be the actual @condition_config or other objects that shouldn't be changed
       res_changes = {}
+      tl_changes = {}
       res_key = results.first.first
       res_conds = results.first.last.dup
+      return if res_conds.empty?
+
+      cond_changes = res_conds.dup
 
       res_conds.each do |t, res|
         field = res.first.first
@@ -105,9 +109,14 @@ module CalcActions
         val_msg = conf[field] if conf.is_a?(Hash)
         msg = val_msg[:invalid_error_message] if val_msg.is_a?(Hash)
         msg ||= condition_error_message
-        if msg
+        if @top_level_error
+          res = tl_changes[t] = { top_level_error: { invalid_error_message: @top_level_error } }
+          cond_changes.delete(t)
+          next
+        elsif msg.present?
           msg = { invalid_error_message: msg }
           res = res_changes[t] = { field => msg }
+          cond_changes.delete(t)
           next
         end
 
@@ -117,7 +126,14 @@ module CalcActions
           { field => new_validator(res_changes[:validate].first.first, nil, options: {}).message }
         next
       end
-      return_failures.deep_merge!(res_key => res_conds.merge(res_changes))
+
+      return if @top_level_error_above && @top_level_error_above == @top_level_error
+
+      return_failures.deep_merge!(res_key => tl_changes) if tl_changes.present?
+      return if @top_level_error_above
+
+      return_failures.deep_merge!(res_key => cond_changes) if cond_changes.present?
+      return_failures.deep_merge!(res_key => res_conds.merge(res_changes)) unless res_changes.empty?
     end
 
     #
@@ -126,8 +142,15 @@ module CalcActions
       return @condition_error_message if @got_condition_error_message
 
       @got_condition_error_message = true
-      @condition_error_message = @condition_config.respond_to?(:key?) &&
-                                 @condition_config.first.last[:invalid_error_message]
+      @top_level_error ||= false
+      return unless @condition_config.respond_to?(:key?)
+
+      @condition_error_message = if @condition_config.first.last.is_a?(Hash)
+                                   @condition_config.first.last[:invalid_error_message]
+                                 else
+                                   @top_level_error = true
+                                   @condition_config.first.last
+                                 end
     end
 
     #

--- a/app/models/calc_actions/non_query_condition.rb
+++ b/app/models/calc_actions/non_query_condition.rb
@@ -5,9 +5,10 @@ module CalcActions
   class NonQueryCondition
     include Common
 
-    NonQueryTableNames = %i[this user parent referring_record top_referring_record role_name reference].freeze
+    NonQueryTableNames = %i[this user parent referring_record top_referring_record embedded_item role_name
+                            reference].freeze
 
-    NonQueryNestedKeyNames = %i[this referring_record top_referring_record this_references parent_references
+    NonQueryNestedKeyNames = %i[this referring_record top_referring_record embedded_item this_references parent_references
                                 parent_or_this_references reference validate].freeze
 
     SimpleConditions = ['==', '=', '<', '>', '<>', '!=', '<=', '>=', '~*', '~', 'in?', 'include?'].freeze
@@ -303,6 +304,8 @@ module CalcActions
                                current_instance.top_referring_record
                              when :reference
                                current_instance.reference
+                             when :embedded_item
+                               current_instance.embedded_item
                              end
     end
 

--- a/app/models/calc_actions/non_query_condition.rb
+++ b/app/models/calc_actions/non_query_condition.rb
@@ -189,15 +189,16 @@ module CalcActions
         #### Handle a Nested Condition
         # If we have the field name key being all, any, etc, then run the nested conditions
         # with the current condition scope
+        # We set top_level_error_above since the all/any/not... indicates we are at a new level
         ca = ConditionalActions.new({ field_name => expected_val },
                                     in_instance,
                                     current_scope: @condition_scope,
                                     return_failures:,
                                     return_this:,
                                     top_level_error:,
-                                    top_level_error_above:)
+                                    top_level_error_above: top_level_error)
         res = ca.calc_action_if
-        @skip_merge = true
+
       elsif expected_val.keys.first == :validate
         #### Handle validate
         # take the validate definition and calculate the result
@@ -217,9 +218,7 @@ module CalcActions
         @skip_merge = true
         res = in_instance.attributes[field_name.to_s] == returned_value
       else
-        #### Handle a Nested Condition
-        # If we have the field name key being all, any, etc, then run the nested conditions
-        # with the current condition scope
+        #### Handle a previously unhandled nested condition
         ca = ConditionalActions.new({ all: { field_name => expected_val } },
                                     in_instance,
                                     current_scope: @condition_scope,

--- a/app/models/concerns/admin_handler.rb
+++ b/app/models/concerns/admin_handler.rb
@@ -110,9 +110,9 @@ module AdminHandler
   end
 
   def admin_name
-    return unless admin
+    return unless admin_id
 
-    admin.email
+    Admin.emails_by_id[user_id]
   end
 
   def admin=(_new_admin)
@@ -158,7 +158,9 @@ module AdminHandler
 
   # user email to allow simplified exports
   def user_email
-    user.email if respond_to?(:user) && user
+    return unless respond_to?(:user_id) && user_id
+
+    User.emails_by_id[user_id]
   end
 
   def _class_name

--- a/app/models/concerns/general_data_concerns.rb
+++ b/app/models/concerns/general_data_concerns.rb
@@ -66,8 +66,7 @@ module GeneralDataConcerns
   def user_name
     return unless respond_to?(:user_id) && user_id
 
-    @user_names_memo ||= {}
-    @user_names_memo[user_id] ||= user&.email
+    User.emails_by_id[user_id]
   end
 
   def user_email

--- a/app/models/concerns/handles_user_base.rb
+++ b/app/models/concerns/handles_user_base.rb
@@ -847,6 +847,7 @@ module HandlesUserBase
 
     @return_failures.each do |cond_type, c_vals|
       c_vals.each do |table, cond|
+        cond = { table => cond } unless cond.is_a? Hash
         cond.each do |k, v|
           v = v.present? ? v : '(blank)'
           if v.is_a? Hash

--- a/app/models/concerns/standard_authentication.rb
+++ b/app/models/concerns/standard_authentication.rb
@@ -33,6 +33,7 @@ module StandardAuthentication
     before_save :handle_password_change
     after_save :handle_password_reminder_setup, if: :set_reminder
     after_save :clear_plaintext_password
+    after_save :clean_memos
     after_create :notify_admin
     attr_accessor :new_two_factor_auth_code, :forced_password_reset, :new_password, :set_reminder
 
@@ -168,6 +169,14 @@ module StandardAuthentication
       end
 
       words
+    end
+
+    def emails_by_id
+      @emails_by_id_memo ||= all.pluck(:id, :email).to_h
+    end
+
+    def clean_memos
+      @emails_by_id_memo = nil
     end
   end
 
@@ -507,5 +516,9 @@ module StandardAuthentication
 
     Users::NewUserAdded.notify(self) if is_a?(Admin) && notify.include?('admin')
     Users::NewUserAdded.notify(self) if is_a?(User) && notify.include?('user')
+  end
+
+  def clean_memos
+    self.class.clean_memos
   end
 end

--- a/app/models/conditional_actions.rb
+++ b/app/models/conditional_actions.rb
@@ -4,12 +4,15 @@ class ConditionalActions
   include CalcActions::Calculate
   attr_accessor :current_instance, :action_conf, :return_failures, :current_scope, :condition_config
 
-  def initialize(action_conf, current_instance, return_failures: nil, current_scope: nil, return_this: nil)
+  def initialize(action_conf, current_instance, return_failures: nil, current_scope: nil, return_this: nil,
+                 top_level_error: nil, top_level_error_above: nil)
     action_conf = action_conf.symbolize_keys if action_conf.is_a?(Hash)
     @action_conf = action_conf
     @current_instance = current_instance
     @return_failures = return_failures
     @return_this ||= return_this || { value: nil }
+    @top_level_error = top_level_error
+    @top_level_error_above = top_level_error_above
 
     # For the lowest level, setup the query with the master record
     # If current_scope is specified, then we are at a sub condition level, and the
@@ -18,7 +21,7 @@ class ConditionalActions
                         current_instance.class.no_master_association
                        current_instance.class
                      else
-                       current_scope || Master.select(:id).where(id: current_instance.master.id)
+                       current_scope || Master.select(:id).where(id: current_instance.master_id)
                      end
   end
 

--- a/app/models/dynamic/activity_log_implementer.rb
+++ b/app/models/dynamic/activity_log_implementer.rb
@@ -369,7 +369,7 @@ module Dynamic
       return @can_create unless @can_create.nil?
 
       unless extra_log_type_config
-        msg = "can_create? does not have an extra_log_type_config for #{self}"
+        msg = "can_create? does not have an extra_log_type_config for #{self} -- #{extra_log_type}"
         Rails.logger.warn msg
         Rails.logger.warn "extra_log_type: #{extra_log_type}"
         Rails.logger.warn "option_configs_names: #{self.class.definition.option_configs_names}"

--- a/app/models/dynamic/def_config_triggers.rb
+++ b/app/models/dynamic/def_config_triggers.rb
@@ -1,0 +1,228 @@
+module Dynamic
+  #
+  # Handle the config_trigger options, which if defined are run when dynamic definitions are saved
+  class DefConfigTriggers
+    attr_accessor :dynamic_def, :dynamic_def_type, :current_admin, :admin_matching_user, :option_configs, :category,
+                  :app_type, :app_type_name, :default_role_name, :role_name, :access, :common_subname
+
+    def initialize(dynamic_def)
+      self.dynamic_def = dynamic_def
+      self.dynamic_def_type = dynamic_def.class.name.underscore.to_sym
+      self.current_admin = dynamic_def.current_admin
+      self.admin_matching_user = current_admin.matching_user&.id
+      self.option_configs = dynamic_def.option_configs
+      self.category = dynamic_def.category
+      self.app_type = current_admin.matching_user_app_type
+      self.app_type_name = app_type&.name&.downcase
+      self.common_subname = (category || app_type_name || 'app').downcase
+      self.default_role_name = "user - #{common_subname}"
+
+      unless admin_matching_user
+        Rails.logger.warn "There is no admin matching user (#{current_admin&.email}) - will not add default configs to dynamic def #{dynamic_def.name}"
+      end
+      unless app_type
+        Rails.logger.warn "There is no current app type - will not add default configs to dynamic def #{dynamic_def.name}"
+      end
+
+      nil
+    end
+
+    def self.process(dynamic_def)
+      return if dynamic_def.disabled? || !dynamic_def.ready_to_generate?
+
+      inst = new(dynamic_def)
+      inst.handle_all_option_configs
+
+      dynamic_def.force_option_config_parse
+    end
+
+    def handle_all_option_configs
+      option_configs.each do |option_config|
+        create_defaults(option_config)
+        create_configs(option_config)
+      end
+    rescue StandardError => e
+      raise FphsException,
+            "A failure occurred creating config for config trigger for: #{dynamic_def.model_association_name}.\n#{e}"
+    end
+
+    private
+
+    def create_defaults(option_config)
+      config_trigger = option_config&.config_trigger
+      return unless config_trigger
+
+      config = config_trigger.dig(:on_define, :create_defaults)
+      return unless config
+
+      raise FphsException, 'No app type set for create_defaults' unless app_type
+
+      setup config
+      create_role_for_admin_matching_user(config, option_config)
+      create_default_user_access_controls(config, option_config)
+      create_default_embed(config, option_config)
+      create_activity_log_page_layout(config, option_config)
+    end
+
+    def setup(config)
+      uac = config[:user_access_control] || {}
+
+      self.role_name = uac[:role_name] || default_role_name
+      self.access = uac[:access] || :create
+    end
+
+    #
+    # Create a role for the matching admin user only if the role hasn't already been created, even if it was disabled later.
+    # The aim is to allow the admin to override the user role by disabling it if necessary
+    def create_role_for_admin_matching_user(config, option_config)
+      cond = { app_type_id: app_type.id,
+               user_id: admin_matching_user,
+               role_name: }
+      exists = Admin::UserRole.find_by(cond)
+      return if exists
+
+      cond[:current_admin] = current_admin
+      Admin::UserRole.create!(cond)
+    end
+
+    def create_default_user_access_controls(config, option_config)
+      return unless config.has_key? :user_access_control
+
+      resource_type = :table
+
+      uac_cond = { role_name:,
+                   app_type:,
+                   resource_type:,
+                   resource_name: dynamic_def.resource_name,
+                   access: }
+      create_missing_user_access_control(uac_cond)
+
+      return unless dynamic_def_type == :activity_log
+
+      uac_cond = { role_name:,
+                   app_type:,
+                   resource_type: :activity_log_type,
+                   resource_name: option_config.resource_name,
+                   access: }
+      create_missing_user_access_control(uac_cond)
+    end
+
+    def create_default_embed(config, option_config)
+      return unless config.has_key?(:embed) && dynamic_def_type == :activity_log
+
+      # Create the corresponding dynamic model for embedding in the activity log
+      embed = config[:embed] || {}
+
+      return if option_config.name.in?(%w[primary blank_log])
+
+      tname = dynamic_def.default_embed_table_name(option_config.name.downcase)
+
+      fkey = dynamic_def.foreign_key_field_name
+      schema_name = dynamic_def.schema_name
+
+      emb_fields = "#{fkey} #{embed[:fields]&.join(' ')}"
+
+      # Check for a match purely on the table and schema name
+      emb_cond = {
+        table_name: tname,
+        schema_name:
+      }
+
+      exists = DynamicModel.find_by(table_name: tname)
+
+      emb_cond.merge!(
+        name: option_config.label,
+        primary_key_name: :id,
+        foreign_key_name: :master_id,
+        category:,
+        field_list: emb_fields
+      )
+
+      exists.current_admin = current_admin
+
+      if exists
+        exists.update!(emb_cond) unless attributes_equal(exists, emb_cond)
+      else
+        exists = DynamicModel.create!(emb_cond)
+      end
+
+      uac_cond = { role_name:,
+                   app_type:,
+                   resource_type: :table,
+                   resource_name: exists.resource_name,
+                   access: }
+
+      create_missing_user_access_control uac_cond
+    end
+
+    def create_activity_log_page_layout(config, option_config)
+      return unless config.has_key?(:page_layout) && dynamic_def_type == :activity_log
+
+      pl = config[:page_layout] || {}
+
+      cond = {
+        app_type_id: app_type.id,
+        panel_name: common_subname.id_hyphenate,
+        layout_name: 'master'
+      }
+
+      exist = Admin::PageLayout.find_by(cond)
+      return if exist
+
+      options_yaml = <<~END_YAML
+        contains:
+          resources:
+          - #{dynamic_def.resource_name}
+
+        view_options:
+          initial_show: true
+      END_YAML
+
+      cond.merge!(
+        panel_label: dynamic_def.name,
+        options: options_yaml,
+        panel_position: 100,
+        current_admin:
+      )
+
+      Admin::PageLayout.create! cond
+    end
+
+    def create_configs(option_config)
+      # create_config = option_configs&.dig(:on_define, :create_config)
+
+      # create_config&.each do |k, v|
+      #   ctype = v.first.first
+      #   cdefs = v.first.last
+      #   cdefs.each do |cdef|
+      #     cdef_name = cdef.first.first
+      #     cdef_val = cdef.first.last
+      #     cmake = "#{k.ns_camelize}::#{cdef_name}".constantize
+      #     exists = cmake.active.find_by(cdef_val)
+      #     next if exists
+
+      #     cmake.create! cdef_val
+      #   end
+      # end
+
+      #  create_embed = option_configs&.dig(:on_define, :create_embed)
+    end
+
+    def create_missing_user_access_control(uac_cond)
+      exists = Admin::UserAccessControl.active.find_by(uac_cond)
+      return if exists
+
+      uac_cond[:current_admin] = current_admin
+      newuac = Admin::UserAccessControl.create!(uac_cond)
+
+      Admin::UserAccessControl.active.reload
+      dynamic_def.class.active_model_configurations force_update: true
+      newuac
+    end
+
+    def attributes_equal(instance, match_attr)
+      sk_match_attr = match_attr.stringify_keys.transform_values { |v| v.is_a?(Symbol) ? v.to_s : v }
+      instance.attributes.slice(*sk_match_attr.keys) == sk_match_attr
+    end
+  end
+end

--- a/app/models/dynamic/def_generator.rb
+++ b/app/models/dynamic/def_generator.rb
@@ -43,7 +43,7 @@ module Dynamic
             # It is expected that this is mostly when originally seeding the database
             dm.current_admin ||= dm.admin
 
-            dm.update_tracker_events
+            # dm.update_tracker_events
           end
         rescue Exception => e
           msg = "Failed to generate models. Hopefully this is only during a migration. \n***** #{e.inspect}"

--- a/app/models/dynamic/def_generator.rb
+++ b/app/models/dynamic/def_generator.rb
@@ -199,10 +199,11 @@ module Dynamic
 
         # Check if it can be instantiated correctly - if it can't, allow it to raise an exception
         # since this is seriously unexpected
-        klass.new
+        klass.new(skip_presets: true)
       rescue Exception => e
         err = "Failed to instantiate the class #{icn} in parent #{parent_class}: #{e}"
         logger.warn err
+        logger.warn e.short_string_backtrace
         raise FphsException, err unless opt[:fail_without_exception]
 
         # By default, return false if an error occurred attempting the initialization.
@@ -440,6 +441,7 @@ module Dynamic
       rescue StandardError => e
         err = "Failed to instantiate the class #{full_implementation_class_name}: #{e}"
         logger.warn err
+        logger.warn e.short_string_backtrace
         errors.add :name, err
         # Force exit of callbacks
         raise FphsException, err

--- a/app/models/dynamic/def_generator.rb
+++ b/app/models/dynamic/def_generator.rb
@@ -470,6 +470,13 @@ module Dynamic
       ActiveRecord::Base.connection.schema_cache.clear!
     end
 
+    # Get a complete set of all tables to be accessed by embed configurations
+    def all_direct_embed_tables
+      option_configs.map(&:embed).compact.map do |oc|
+        oc.dup
+      end
+    end
+
     # Get a complete set of all tables to be accessed by model reference configurations,
     # with a value representing what they are associated from.
     def all_referenced_tables

--- a/app/models/dynamic/def_handler.rb
+++ b/app/models/dynamic/def_handler.rb
@@ -533,5 +533,18 @@ module Dynamic
 
       :view
     end
+
+    #
+    # Get an estimated count of records in the table. Cached for 15 minutes
+    # @return [Integer]
+    def estimated_record_count
+      ckey = "estimated_record_count--#{self.class.name}-#{id}-#{created_at}-#{updated_at}"
+      Rails.cache.fetch(ckey, expires_in: 15.minutes) do
+        implementation_class.count
+      rescue StandardError => e
+        Rails.logger.warn "Failed to get estimated record count for #{name}"
+        nil
+      end
+    end
   end
 end

--- a/app/models/dynamic/implementation_handler.rb
+++ b/app/models/dynamic/implementation_handler.rb
@@ -12,7 +12,7 @@ module Dynamic
 
       # skip_save_trigger: Prevent save triggers from running
       # save_trigger_results: Results from stored locally by save triggers
-      attr_accessor :skip_save_trigger, :save_trigger_results
+      attr_accessor :skip_save_trigger, :save_trigger_results, :skip_presets
     end
 
     class_methods do
@@ -236,6 +236,8 @@ module Dynamic
     # blank_preset_value: only sets the value if it was previously blank, so won't override values in #create! methods
     # By setting ahead of time, things like embed_resource_name can operate.
     def force_preset_values
+      return if skip_presets
+
       fo = option_type_config&.field_options
       return unless fo
 

--- a/app/models/external_identifier.rb
+++ b/app/models/external_identifier.rb
@@ -313,9 +313,9 @@ class ExternalIdentifier < ActiveRecord::Base
   end
 
   def config_uniqueness
-    res = self.class.active.where(name: name.downcase).where.not(id: id)
+    res = self.class.active.where(name: name.downcase).where.not(id:)
     errors.add :name, 'must be unique' if !disabled && !res.empty?
-    res = self.class.active.where(external_id_attribute: external_id_attribute.downcase).where.not(id: id)
+    res = self.class.active.where(external_id_attribute: external_id_attribute.downcase).where.not(id:)
     errors.add :external_id_attribute, 'must be unique' if !disabled && !res.empty?
   end
 
@@ -335,7 +335,7 @@ class ExternalIdentifier < ActiveRecord::Base
                      searchable: false,
                      current_admin: admin,
                      position: 100,
-                     sql: sql
+                     sql:
     end
 
     r = usage_report('Search', ReportItemSearchType)
@@ -359,7 +359,7 @@ class ExternalIdentifier < ActiveRecord::Base
                      searchable: true,
                      current_admin: admin,
                      position: 100,
-                     sql: sql,
+                     sql:,
                      search_attrs: sa
     end
 
@@ -379,6 +379,6 @@ class ExternalIdentifier < ActiveRecord::Base
                    searchable: false,
                    current_admin: admin,
                    position: 100,
-                   sql: sql
+                   sql:
   end
 end

--- a/app/models/formatter/substitution.rb
+++ b/app/models/formatter/substitution.rb
@@ -337,6 +337,7 @@ module Formatter
         tag = case tag
               when 'first' then '0'
               when 'last' then '-1'
+              else tag
               end
         orig_val = data[tag.to_i]
       else

--- a/app/models/master.rb
+++ b/app/models/master.rb
@@ -337,6 +337,8 @@ class Master < ActiveRecord::Base
       @current_user = user
     elsif user.is_a?(Integer)
       @current_user = User.find(user)
+    elsif user.nil?
+      raise 'Setting current_user to nil is not allowed'
     else
       raise 'Attempting to set current_user with non user: ' \
              "#{user} #{user.class.name} #{user.class.__id__} #{User.__id__}"

--- a/app/models/option_configs/extra_option_implementers/save_triggers.rb
+++ b/app/models/option_configs/extra_option_implementers/save_triggers.rb
@@ -113,6 +113,8 @@ module OptionConfigs
                           [nil]
                         end
 
+          raise FphsException, 'No iterator values were found for save trigger each' unless iter_values
+
           iter_values.each_with_index do |iter_value, iter_index|
             obj.save_trigger_results['iterator_index'] = iter_index
             obj.save_trigger_results['iterator_value'] = iter_value

--- a/app/models/option_configs/extra_option_implementers/save_triggers.rb
+++ b/app/models/option_configs/extra_option_implementers/save_triggers.rb
@@ -103,6 +103,8 @@ module OptionConfigs
           next unless configs
 
           iter_configs = configs[:each] || { do: configs }
+          # Assuming this is an each: definition, get an if: config
+          do_if = configs.dig(:each, :if)
 
           val_configs = iter_configs[:value]
           iter_values = if val_configs
@@ -114,6 +116,13 @@ module OptionConfigs
           iter_values.each_with_index do |iter_value, iter_index|
             obj.save_trigger_results['iterator_index'] = iter_index
             obj.save_trigger_results['iterator_value'] = iter_value
+
+            # Provide the ability to skip all triggers for this iteration
+            if do_if
+              ca = ConditionalActions.new do_if, obj
+              next unless ca.calc_action_if
+            end
+
             all_iter_configs = iter_configs[:do]
             all_iter_configs = [all_iter_configs] unless all_iter_configs.is_a? Array
             all_iter_configs.each do |iter_config|

--- a/app/models/option_configs/extra_options.rb
+++ b/app/models/option_configs/extra_options.rb
@@ -360,10 +360,17 @@ module OptionConfigs
       # Make save_trigger.on_save the default for on_create and on_update
       os = self.save_trigger[:on_save]
       if os
-        ou = self.save_trigger[:on_update] || {}
-        oc = self.save_trigger[:on_create] || {}
-        self.save_trigger[:on_update] = os.merge(ou)
-        self.save_trigger[:on_create] = os.merge(oc)
+        os = [os] if os.is_a?(Hash)
+
+        ou = self.save_trigger[:on_update]
+        oc = self.save_trigger[:on_create]
+        ou = [ou] if ou.is_a?(Hash)
+        oc = [oc] if oc.is_a?(Hash)
+
+        ou ||= []
+        oc ||= []
+        self.save_trigger[:on_update] = os + ou
+        self.save_trigger[:on_create] = os + oc
       end
 
       self.save_trigger[:on_upload] ||= {}

--- a/app/models/option_configs/extra_options.rb
+++ b/app/models/option_configs/extra_options.rb
@@ -73,6 +73,7 @@ module OptionConfigs
       clean_filestore_def
       clean_fields_def
       clean_field_options_def
+      clean_embed_def
       clean_references_def
       clean_save_triggers
       clean_batch_triggers
@@ -219,6 +220,23 @@ module OptionConfigs
       oc = self.valid_if[:on_create] || {}
       self.valid_if[:on_update] = os.merge(ou)
       self.valid_if[:on_create] = os.merge(oc)
+    end
+
+    def clean_embed_def
+      return unless embed
+
+      rn = embed[:resource_name]
+      resource = Resources::Models.find_by(resource_name: rn)
+      embed[:resource_model_def] = resource
+
+      return if resource && resource[:model]
+
+      Rails.logger.warn "embed for #{rn} does not exist as a class in #{name} / #{config_obj.name}"
+      # Log this as a warning, not an error, since we are not able to control the order of items being created
+      # in an app import, and many references to underlying definitions will not yet have been created
+      failed_config :embed,
+                    "embed for #{rn} does not exist as a class in #{name} / #{config_obj.name}",
+                    level: :warn
     end
 
     def clean_references_def

--- a/app/models/option_configs/template_option_mapping.rb
+++ b/app/models/option_configs/template_option_mapping.rb
@@ -21,6 +21,8 @@ module OptionConfigs
       can_create = current_user.has_access_to?(:create, :table, plural_name)
       can_edit = can_create || current_user.has_access_to?(:edit, :table, plural_name)
 
+      default_options = option_type_config
+      view_options = default_options.view_options
       {
         def_record:,
         def_version: def_record.def_version,
@@ -48,12 +50,12 @@ module OptionConfigs
         embed: direct_embed_type(def_record, option_type_config),
         extra_options_config: option_type_config,
         external_id_options: {
-          label: external_id_type.label,
+          label: default_options.label || external_id_type.label,
           formatter:,
           attribute: external_id_type.external_id_attribute.to_s
         },
         orientation: 'vertical',
-        add_item_label: external_id_type.label,
+        add_item_label: default_options.button_label || external_id_type.label,
         column_defs: def_record.model_class&.columns_hash
       }
     end

--- a/app/models/save_triggers/create_reference.rb
+++ b/app/models/save_triggers/create_reference.rb
@@ -25,6 +25,7 @@ class SaveTriggers::CreateReference < SaveTriggers::SaveTriggersBase
         create_in = config[:in]
         create_if = config[:if]
         create_with = config[:with]
+        with_result = config[:with_result]
 
         # We calculate the conditional if inside each item, rather than relying
         # on the outer processing in ActivityLogOptions#calc_save_trigger_if
@@ -37,6 +38,8 @@ class SaveTriggers::CreateReference < SaveTriggers::SaveTriggersBase
         end
 
         in_master = @master
+
+        handle_with_result with_result, vals
 
         create_with&.each do |fn, def_val|
           res = FieldDefaults.calculate_default @item, def_val

--- a/app/models/save_triggers/create_reference.rb
+++ b/app/models/save_triggers/create_reference.rb
@@ -14,6 +14,7 @@ class SaveTriggers::CreateReference < SaveTriggers::SaveTriggersBase
 
     @item.save_trigger_results['created_references'] ||= []
     @item.save_trigger_results['created_items'] ||= []
+    @item.save_trigger_results['created_results'] ||= []
 
     @model_defs.each do |model_def|
       model_def.each do |model_name, config|
@@ -29,7 +30,10 @@ class SaveTriggers::CreateReference < SaveTriggers::SaveTriggersBase
         # on the outer processing in ActivityLogOptions#calc_save_trigger_if
         if create_if
           ca = ConditionalActions.new create_if, @item
-          next unless ca.calc_action_if
+          unless ca.calc_action_if
+            @item.save_trigger_results['created_results'] << false
+            next
+          end
         end
 
         in_master = @master
@@ -50,8 +54,7 @@ class SaveTriggers::CreateReference < SaveTriggers::SaveTriggersBase
             to_record_id = to_existing_record[:record_id]
             raise FphsException, 'record_id must be set in to_existing_record' unless to_record_id
 
-            ca = ConditionalActions.new to_record_id, @item
-            to_existing_record_id = ca.get_this_val
+            to_existing_record_id = FieldDefaults.calculate_default @item, to_record_id
             new_item = new_type.find(to_existing_record_id)
           else
             new_item = new_type.new vals
@@ -62,8 +65,6 @@ class SaveTriggers::CreateReference < SaveTriggers::SaveTriggersBase
             end
             new_item.save!
           end
-
-          @item.save_trigger_results['created_items'] << new_item
 
           res =
             case create_in
@@ -85,15 +86,17 @@ class SaveTriggers::CreateReference < SaveTriggers::SaveTriggersBase
 
               # A specific instance is the target for the reference from_record
               # Include return: return_result to return the actual instance
-              ca = ConditionalActions.new create_in[:specific_record], @item
-              ci = ca.get_this_val
-              puts ci
+              # or use {{{triple curly substitution}}}
+              ci = FieldDefaults.calculate_default @item, create_in[:specific_record]
               raise FphsException, "Result for 'in' hash is not an instance" unless ci.is_a? UserBase
 
               ModelReference.create_with ci, new_item, force_create:
             end
 
           @item.save_trigger_results['created_references'] << res
+          @item.save_trigger_results['created_items'] << new_item
+          @item.save_trigger_results['created_results'] << true
+
           res
         end
       end

--- a/app/models/save_triggers/save_triggers_base.rb
+++ b/app/models/save_triggers/save_triggers_base.rb
@@ -38,5 +38,26 @@ class SaveTriggers::SaveTriggersBase
     ca.calc_action_if
   end
 
+  def handle_with_result(with_result, vals)
+    return unless with_result
+
+    ca = ConditionalActions.new with_result[:from], @item
+    source = ca.get_this_val
+
+    unless source
+      raise FphsException, 'with_result.from returns no result - check return: return_result has been specified'
+    end
+
+    with_result[:attributes].each do |to, from|
+      sval = if from.include? '{{'
+               FieldDefaults.calculate_default(source, from)
+             else
+               source.attributes[from.to_s]
+             end
+
+      vals[to] = sval
+    end
+  end
+
   def self.config_def(if_extras: nil); end
 end

--- a/app/models/save_triggers/update_reference.rb
+++ b/app/models/save_triggers/update_reference.rb
@@ -49,14 +49,11 @@ class SaveTriggers::UpdateReference < SaveTriggers::SaveTriggersBase
           end
         end
 
-        config[:with].each do |fn, def_val|
-          if def_val.is_a? Hash
-            ca = ConditionalActions.new def_val, @item
-            res = ca.get_this_val
-          else
-            res = FieldDefaults.calculate_default @item, def_val
-          end
+        with_result = config[:with_result]
+        handle_with_result with_result, vals
 
+        config[:with].each do |fn, def_val|
+          res = FieldDefaults.calculate_default @item, def_val
           vals[fn] = res
         end
 

--- a/app/models/save_triggers/update_this.rb
+++ b/app/models/save_triggers/update_this.rb
@@ -43,6 +43,9 @@ class SaveTriggers::UpdateThis < SaveTriggers::SaveTriggersBase
           next unless ca.calc_action_if
         end
 
+        with_result = config[:with_result]
+        handle_with_result with_result, vals
+
         config[:with].each do |fn, def_val|
           if def_val.is_a? Hash
             ca = ConditionalActions.new def_val, @item

--- a/app/models/view_handlers/address.rb
+++ b/app/models/view_handlers/address.rb
@@ -9,7 +9,7 @@ module ViewHandlers
     InactiveRank = 0
 
     included do
-      validates :zip, "validates/zip": true, allow_blank: true if attribute_names.include? :zip
+      validates :zip, "validates/zip": true, allow_blank: true if attribute_names.include? 'zip'
     end
 
     class_methods do

--- a/app/models/view_handlers/address.rb
+++ b/app/models/view_handlers/address.rb
@@ -9,7 +9,7 @@ module ViewHandlers
     InactiveRank = 0
 
     included do
-      validates :zip, "validates/zip": true, allow_blank: true
+      validates :zip, "validates/zip": true, allow_blank: true if attribute_names.include? :zip
     end
 
     class_methods do
@@ -37,31 +37,31 @@ module ViewHandlers
     end
 
     def state_name
-      self.class.get_state_name state
+      self.class.get_state_name state if respond_to? :state
     end
 
     def country_name
-      self.class.get_country_name country
+      self.class.get_country_name country if respond_to? :country
     end
 
     protected
 
     # Validate state and zip for US country and region / postal code for non-US
     def handle_country
-      if country
-        self.country = country.downcase
+      return unless respond_to?(:country) && country
 
-        if country.downcase == 'us'
-          self.region = nil
-          self.postal_code = nil
-        elsif region.blank? && postal_code.blank?
-          errors.add :country,
-                     'was not USA and province/county and postal code are blank. At least one must be entered for countries other than USA.'
-          throw(:abort)
-        else
-          self.state = nil
-          self.zip = nil
-        end
+      self.country = country.downcase
+
+      if country.downcase == 'us'
+        self.region = nil
+        self.postal_code = nil
+      elsif region.blank? && postal_code.blank?
+        errors.add :country,
+                   'was not USA and province/county and postal code are blank. At least one must be entered for countries other than USA.'
+        throw(:abort)
+      else
+        self.state = nil
+        self.zip = nil
       end
     end
   end

--- a/app/views/activity_logs/_common_search_results_template.html.erb
+++ b/app/views/activity_logs/_common_search_results_template.html.erb
@@ -109,7 +109,7 @@
     <ul class="list-group" data-item-id="{{id}}" data-item-rank="{{rank}}">
       <li class="list-group-item sub-list-data">
         <i class="glyphicon glyphicon-phone"></i>
-        <a data-on-click-call="activity_logs.selected_parent" data-on-click-show="activity_logs_<%=item_type_name%>_actions_block@#activity-log-{{master_id}}-initial-action" data-master-id="{{master_id}}" data-item-id="{{id}}" data-item-data="{{data}}" data-rec-type="{{rec_type}}">{{pretty_string data return_string="true" capitalize="true"}}</a>
+        <a data-on-click-call="activity_logs.selected_parent" data-on-click-show="activity_logs_<%=item_type_name%>_actions_block@#activity-log-{{master_id}}-initial-action" data-master-id="{{master_id}}" data-item-id="{{id}}" data-item-data="{{data}}" data-rec-type="{{rec_type}}">{{pretty_string data return_string="true"}}</a>
         <a data-toggle="scrollto-result" data-target-force="true" data-target="#activity-log-<%=item_type_name_hyphenated%>-sub-list-{{master_id}}-{{id}}" title="edit" class="edit-entity edit-activity-log-<%=item_type_name_hyphenated%> pull-right glyphicon glyphicon-edit small" href="/masters/{{master_id}}/<%=item_type.pluralize%>/{{id}}/edit" data-remote="true" data-<%=item_type_hyphenated%>-id="{{id}}" data-result-target=""></a>
         <span class="pull-right label label-info general-rank-{{rank}} <%=item_type_hyphenated%>-{{rank}}" style="margin-right:1em">{{#has 'rank'}}{{#if rank}}{{rank}} - {{rank_name}}{{else}}(no rank){{/if}}{{/has}}</span>
       </li>

--- a/app/views/admin/activity_logs/_def_details.html.erb
+++ b/app/views/admin/activity_logs/_def_details.html.erb
@@ -2,12 +2,12 @@
 <div class="al-details-section">
   <label>item type name</label>
   <p class="al-item-type">
-  <%= object_instance.full_item_type_name %>
+  <code><%= object_instance.full_item_type_name %></code>
   </p>
 
   <label>resource name</label>
   <p class="al-resource-name">
-  <%= object_instance.resource_name %>
+  <code><%= object_instance.resource_name %></code>
   </p>
 
   <label>database <%= object_instance.table_or_view || '<span class="info-danger">not defined</span>'.html_safe %></label>
@@ -45,6 +45,7 @@
   <% end %>
 
   <label>all fields</label>
+  <p>Set of all fields aggregated from all activities.</p>
   <p class="al-field-list">
   <ul class="activity-list">
     <li><%= object_instance.all_implementation_fields
@@ -57,6 +58,7 @@
 
 <div class="activity-list-section">
   <label>activities</label>
+  <p>Click an activity name to jump to its definition. Each activity shown lists the fields defined for it.</p>
   <ul class="activity-list">
   <% object_instance.option_configs_names&.each do |name| 
        conf = object_instance.option_type_config_for(name)
@@ -77,8 +79,45 @@
 <%= render partial: 'admin/common_templates/def_details_libraries', locals: {object_instance: object_instance} %>
 <%= render partial: 'admin/common_templates/def_details_dialogs', locals: {object_instance: object_instance} %>
 
+<div class="activity-list-embeds">
+  <label>embeds</label>
+  <p>Add <code>embed:</code> configurations to directly embed another dynamic definition. This uses database joins, 
+  rather than an intermediate model references to access embedded records.</p>
+  <ul class="al-reference-list al-embed-list">
+  <% shown_refs = []
+     object_instance.all_direct_embed_tables.each do |ref| 
+  
+      got = ref.dig(:resource_model_def, :resource_item_name)
+      unless shown_refs.include?(got)
+        shown_refs << got
+        to_table_name = ref.dig(:resource_model_def, :table_name)
+        type = ref.dig(:resource_model_def, :type)
+        link = case type  
+                when :dynamic_model then admin_dynamic_models_path(filter: { table_name: to_table_name, disabled: :enabled } )
+                when :activity_log then admin_activity_logs_path(filter: { table_name: to_table_name, disabled: :enabled } )
+                when :external_identifier then admin_external_identifiers_path(filter: { name: to_table_name, disabled: :enabled } )
+                end
+        if link
+  %>
+    <li>
+      <%= link_to(got, link, target: '_blank') %>
+      <ul>
+        <li>table: <%= to_table_name %></li>
+      </ul>
+  <%    else %>
+    <%= got %>
+  <%    end %>
+    </li>
+    <%  end %>
+  <% end %>
+  </ul>
+</div>
+
 <div class="activity-list-references">
   <label>references</label>
+  <p>Add <code>references:</code> configurations to connect to other dynamic definitions. This connects through
+  an intermediate `model_references` database table, allowing arbitrary connections to be made between records.</p>
+  
   <ul class="al-reference-list">
   <% shown_refs = []
      object_instance.all_referenced_tables.each do |ref| 
@@ -119,6 +158,7 @@
 
 <div class="activity-list-file-filters">
   <label>file filters</label>
+  <p>File containers use file filters to define which filenames can be viewed for a specific activity or default configuration.</p>
   <p>
   <%= link_to(link_label_open_in_new("edit"),
         admin_nfs_store_filter_filters_path(filter: {resource_name: "#{object_instance.full_item_type_name}__%"}),

--- a/app/views/admin/activity_logs/_def_details.html.erb
+++ b/app/views/admin/activity_logs/_def_details.html.erb
@@ -1,5 +1,10 @@
 <% if object_instance.persisted? && object_instance.enabled?%>
 <div class="al-details-section">
+  <% unless object_instance.implementation_class_defined?(::ActivityLog, fail_without_exception: true) %>
+    <label>implementation class not ready</label>
+    <p>Using this definition will fail</p>
+  <% end %>
+
   <label>item type name</label>
   <p class="al-item-type">
   <code><%= object_instance.full_item_type_name %></code>
@@ -19,6 +24,9 @@
                 "/reports/reference_data__table_data?schema_name=#{object_instance.schema_name}&search_attrs%5B_blank%5D=true&search_attrs%5Bno_run%5D=true&table_name=#{object_instance.table_name}", 
                 target: '_blank' %>
   </p>
+
+  <%= render partial: 'admin/dynamic_models/est_record_count' %>
+
   <% unless object_instance.table_or_view_ready?%>
   <div class="help-block">
   <p>Typically the database table or view associated with an activity log is created when the definition is first created (or prior to this if handled manually.)</p>

--- a/app/views/admin/app_types/_components.html.erb
+++ b/app/views/admin/app_types/_components.html.erb
@@ -1,18 +1,36 @@
 <%
   unless defined? main_components
-    main_components = true
+    main_components = nil
   end
+  
+  exclude_components = %i[associated_sub_processes associated_protocol_events]
+
+  options = {main_components: , exclude_components: }
 
   unless defined? open_in_new
     open_in_new = false
   end
+
+  active_or_all = 'active'
+
+  alt_names = {
+    general_selections: ['item_type'],
+    user_access_controls: ['resource_type', 'role_name'],
+    user_roles: ['role_name'],
+    app_configurations: ['name'],
+    sub_processes: ['protocol_name'],
+    protocol_events: ['protocol_name']
+  }
+
+  alt_links = alt_names.dup
 %>
-<div class="admin-panel-components">
+<div class="admin-panel-components" id="admin-panel-components">
   <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
     <% 
-    @app_type.as_json(main_components: main_components).first.last.each do |k, v_hash|        
+    @app_type.as_json(options).first.last.each do |k, v_hash|        
       v_class = nil
       if v_hash.respond_to?(:each) 
+        kclean = k.gsub(/^valid_|associated_/i, '').to_sym
         title = k.humanize.gsub(/^valid |associated /i, '').titleize
         title_hyph = title.id_hyphenate
         init_link_class = 'collapsed'
@@ -47,27 +65,45 @@
       <div id="<%="app-type-components-#{title_hyph}"%>" class="panel-collapse collapse <%=init_panel_class%>" role="tabpanel" aria-labelledby="<%="app-type-component-heading-#{title_hyph}"%>">
         <div class="panel-body">
           <ul>
-          <% all_vs = v_hash.map do |k2_hash| %>
-            <%
-              k2 = k2_hash['_class_name'].constantize.find(k2_hash['id'])
+          <%
+            constants = {}
+            results = {}
+            all_vs = v_hash.map do |k2_hash| %>
+            <%              
+              k2_cn = k2_hash['_class_name']
+              k2_const = constants[k2_cn] ||= k2_cn.constantize
+              k2_all = results["#{k2_cn}--all"] ||= k2_const.send(active_or_all)
+              k2_id = k2_hash['id']
+              next unless k2_id
+
+              k2 = k2_all.find { |r| r && r['id'] == k2_id }
+              next unless k2
+
               rn = k2.respond_to?(:alt_resource_name) && k2.alt_resource_name
               rn ||= k2.respond_to?(:resource_name) && k2.resource_name
-              path = send("#{base_path}_path", filter: {id: k2.id})
-              name = if k2.respond_to?(:name)
-                      k2.respond_to?(:category) ? "#{k2.category.present? ? k2.category : '(no category)'} / #{k2.name}" : k2.name
+              path = if alt_links[kclean]
+                       fs = alt_links[kclean].map {|l| [l, k2[l]]}.to_h
+                       send("#{base_path}_path", filter: fs)
+                     else
+                       send("#{base_path}_path", filter: {id: k2.id})
+                     end
+              name = if alt_names[kclean]
+                       alt_names[kclean].map {|ka| k2[ka] || k2.send(ka) }.join(" / ")
+                     elsif k2.respond_to?(:name)
+                       k2.respond_to?(:category) ? "#{k2.category.present? ? k2.category : '(no category)'} / #{k2.name}" : k2.name
                      else
                        rn
-                     end
+                     end              
 
-              { rn: rn, path: path, name: name }
+              { rn: kclean, path: path, name: name, disabled: k2.disabled }
             %>
           <% end %>
-          <% all_vs.sort {|vi, vk| vi[:name] <=> vk[:name] }.each do |vs| %>
+          <% all_vs.compact.uniq.sort {|vi, vk| vi[:name] <=> vk[:name] }.each do |vs| %>
             <li>
               <% if open_in_new %>              
-              <%= link_to link_label_open_in_new(vs[:name]), vs[:path], target: "adminres-#{vs[:rn]}" %>
+              <%= link_to link_label_open_in_new(vs[:name]), vs[:path], target: "adminres-#{vs[:rn]}", class: "link-#{vs[:disabled] ? 'disabled' : 'active'}" %>
               <% else %>
-              <%= link_to vs[:name], vs[:path] %>
+              <%= link_to vs[:name], vs[:path], class: "link-#{vs[:disabled] ? 'disabled' : 'active'}" %>
               <% end %>
             </li>
           <% end %>

--- a/app/views/admin/app_types/_config_notices.html.erb
+++ b/app/views/admin/app_types/_config_notices.html.erb
@@ -1,11 +1,32 @@
+
 <% if @config_notices.present? %>
+<p><a href="#admin-panel-components">jump to components</a></p>
 <div class="config-error-block">
-  <% @config_notices.each do |ce| %>
-      <div>
-        <h4><span class="activity-list-name"><%= ce[:name] %></span> - <%= ce[:type] %></h4>
-        <p><%= ce[:message] %></p>
-        <pre><%= ce[:config_def].to_yaml.sub("---\n",'') %></pre>
+  <div class="panel-group" id="accordion-notices" role="tablist" aria-multiselectable="true">
+  <% @config_notices.each do |ce| 
+    head_el_id = "app-type-config-notices-heading--#{ce[:name].id_hyphenate}-#{ce[:type].id_hyphenate}"
+    el_id = "app-type-config-notices-body--#{ce[:name].id_hyphenate}-#{ce[:type].id_hyphenate}"
+    title = "<span class=\"activity-list-name\">#{ce[:name]}</span> - #{ce[:type]}".html_safe
+  %>
+    <div class="panel panel-default">
+      <div class="panel-heading" role="tab" id="<%=head_el_id%>">
+        <h4 class="panel-title">
+           <%= link_to title, "\##{el_id}", 
+              role: "button", 
+              data: { toggle: "collapse", parent: "#accordion-notices" }, 
+              'aria-expanded' =>"true",
+              'aria-controls'=>"\##{el_id}",
+              class: 'app-type-config-notices-head-link' %> 
+          </h4>
       </div>
+      <div id="<%=el_id%>" class="panel-collapse collapse" role="tabpanel" aria-labelledby="<%=head_el_id%>">   
+        <div class="panel-body">
+          <p><%= ce[:message] %></p>
+          <pre><%= ce[:config_def].to_yaml.sub("---\n",'') %></pre>
+        </div>
+      </div>
+    </div>
   <% end %>
+  </div>
 </div>
 <% end %>

--- a/app/views/admin/dynamic_models/_def_details.html.erb
+++ b/app/views/admin/dynamic_models/_def_details.html.erb
@@ -1,5 +1,10 @@
 <div class="dynamic-details-section">
 <% if object_instance.persisted? %>
+  <% unless object_instance.implementation_class_defined?(::DynamicModel, fail_without_exception: true) %>
+    <label>implementation class not ready</label>
+    <p>Using this definition will fail</p>
+  <% end %>
+
   <label>item type name</label>
   <p class="dynamic-item-type">
   <%= object_instance.full_item_type_name %>
@@ -18,6 +23,9 @@
     <%= link_to link_label_open_in_new('search data'), "/reports/reference_data__table_data?schema_name=#{object_instance.schema_name}&search_attrs%5B_blank%5D=true&search_attrs%5Bno_run%5D=true&table_name=#{object_instance.table_name}", 
                 target: '_blank' %>
   </p>
+
+  <%= render partial: 'admin/dynamic_models/est_record_count' %>
+
   <% unless object_instance.table_or_view_ready?%>
   <div class="help-block">
   <p>Typically the database table or view associated with a dynamic model is created when the definition is first created (or prior to this if handled manually.)</p>

--- a/app/views/admin/dynamic_models/_est_record_count.html.erb
+++ b/app/views/admin/dynamic_models/_est_record_count.html.erb
@@ -1,0 +1,7 @@
+  <% if object_instance.persisted? && object_instance.enabled? && object_instance.table_or_view_ready? %>
+  <label>estimated record count</label>
+  <p class="dynamic-record-count">
+  <%= object_instance.estimated_record_count || '(not found)' %>
+  </p>
+  <% end %>
+  

--- a/app/views/admin/external_identifiers/_def_details.html.erb
+++ b/app/views/admin/external_identifiers/_def_details.html.erb
@@ -1,5 +1,10 @@
 <% if object_instance.persisted? && object_instance.enabled?%>
 <div class="dynamic-details-section">
+  <% unless object_instance.implementation_class_defined?(::ExternalIdentifier, fail_without_exception: true) %>
+    <label>implementation class not ready</label>
+    <p>Using this definition will fail</p>
+  <% end %>
+
   <label>item type name</label>
   <p class="dynamic-item-type">
   <%= object_instance.full_item_type_name %>
@@ -11,7 +16,9 @@
   </p>
 
   <label>assigned identifiers</label>
-  <p><%=link_to link_label_open_in_new('details'), "/admin/external_identifier_details/#{object_instance.id}", target: '_blank' %>
+  <p><%=link_to link_label_open_in_new('details'), "/admin/external_identifier_details/#{object_instance.id}", target: '_blank' %></p>
+
+  <%= render partial: 'admin/dynamic_models/est_record_count' %>
 
   <% unless object_instance.table_or_view_ready?%>
   <div class="help-block">

--- a/app/views/common_templates/_common_template_result.html.erb
+++ b/app/views/common_templates/_common_template_result.html.erb
@@ -107,7 +107,7 @@
         {{#is model_data_type 'external_identifier' }}
           {{#if external_id_options}}
           <h4 class="list-group-item-heading external-id-heading">
-            <span>{{external_id_options.label}}</span> <strong>{{#if external_id_options.formatter}}{{{format_with external_id_options.formatter (lookup result_data external_id_options.attribute)}}}{{else}}{{pretty_string (lookup result_data external_id_options.attribute) return_string="true"}}{{/if}} </strong>
+            <span>{{>show_result_caption result_data=result_data}}</span> <strong>{{#if external_id_options.formatter}}{{{format_with external_id_options.formatter (lookup result_data external_id_options.attribute)}}}{{else}}{{pretty_string (lookup result_data external_id_options.attribute) return_string="true"}}{{/if}} </strong>
           </h4>
           {{else}}
           <h4 class="list-group-item-heading">{{>show_result_caption result_data=result_data}}</h4>

--- a/app/views/common_templates/_common_template_result_fields.html.erb
+++ b/app/views/common_templates/_common_template_result_fields.html.erb
@@ -338,7 +338,7 @@
   {{else is this_value '===' null}}
 {{! #######  Default! }}
   {{else}}
-    <li class="{{> field_result_class}}" data-field-name="{{key}}" data-field-type="{{field_type}}" data-col-type="{{lookup field_types @key}}" data-field-val="{{this_value}}">{{> field_label labels=(concat 'labels_' (underscore name)) }} <strong>{{#if show_raw_text}}{{this_value}}{{else if (or (fpa_state_item 'template_config' (underscore name) vdef_version 'field_options' key 'no_downcase') (fpa_state_item 'template_config' (underscore name) vdef_version 'field_options' key 'view_original_case')) }}{{this_value}}{{else}}{{pretty_string this_value return_string="true" capitalize="true"}}{{/if}}</strong></li>
+    <li class="{{> field_result_class}}" data-field-name="{{key}}" data-field-type="{{field_type}}" data-col-type="{{lookup field_types @key}}" data-field-val="{{this_value}}">{{> field_label labels=(concat 'labels_' (underscore name)) }} <strong>{{#if show_raw_text}}{{this_value}}{{else if (or (fpa_state_item 'template_config' (underscore name) vdef_version 'field_options' key 'no_downcase') (fpa_state_item 'template_config' (underscore name) vdef_version 'field_options' key 'view_original_case')) }}{{this_value}}{{else}}{{pretty_string this_value return_string="true" capitalize="true" view_with_formats=(fpa_state_item 'template_config' (underscore name) vdef_version 'field_options' key 'view_with_formats')}}{{/if}}</strong></li>
   {{/is}}
   {{#if show_item_type_flags_after}}
   {{#is key item_flags_after}}

--- a/app/views/masters/_search_results_master_tabs_default.html.erb
+++ b/app/views/masters/_search_results_master_tabs_default.html.erb
@@ -56,7 +56,7 @@
     </li>
     <% end %>
 
-    <% ActivityLog.enabled.each do |a| %>
+    <% ActivityLog.active.each do |a| %>
       <% if master_viewables[a.full_item_types_name.to_sym]
         initial_show = (default_panels.length == 0 && app_config_text(:show_activity_log_panel) == a.item_type_name) || a.item_type_name.in?(default_panels)
       %>

--- a/app/views/masters/_search_results_template.html.erb
+++ b/app/views/masters/_search_results_template.html.erb
@@ -164,7 +164,7 @@
 
       <%= render partial: 'masters/search_results_category_panel', locals: {panel: nil, category: 'trackers', panel_name: 'trackers', panel_label: 'Tracker', initial_show: true} %>
 
-      <% ActivityLog.enabled.each do |a| %>
+      <% ActivityLog.active.each do |a| %>
         <% if master_viewables[a.full_item_types_name.to_sym] %>
         <div id="<%= a.full_item_types_name.hyphenate %>-{{id}}" class="activity-logs-generic-block <%= a.full_item_types_name.hyphenate %>-block collapse" data-sub-for-root="master_id" data-sub-id="{{id}}" data-sub-item="<%= a.full_item_types_name %>" data-template="<%= a.model_association_name.to_s.hyphenate %>-main-result-template"  >
             <div id="<%= a.full_item_types_name.hyphenate %>-inner-{{id}}" class="activity-logs-inner-block"></div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -132,7 +132,7 @@
       "check_name": "UnsafeReflection",
       "message": "Unsafe reflection method `constantize` called on model attribute",
       "file": "app/models/calc_actions/calculate.rb",
-      "line": 627,
+      "line": 702,
       "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
       "code": "Resources::Models.find_by(:resource_name => @join_tables.first).class_name.constantize",
       "render_path": null,
@@ -188,6 +188,29 @@
         "method": "update_table_name"
       },
       "user_input": "calc_trigger_fn_name(table_name)",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "400bb8ca8aa70318439abf6184505d97492cb3d1709f6acb834ee013df71dbee",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/admin/app_type.rb",
+      "line": 226,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Classification::GeneralSelection.active.where(\"item_type ~ '#{\"^(#{associated_table_names.map do\n \"#{tn.singularize}_|#{tn}_\"\n end.join(\"|\")})\"}'\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "AppType",
+        "method": "associated_general_selections"
+      },
+      "user_input": "associated_table_names.map do\n \"#{tn.singularize}_|#{tn}_\"\n end.join(\"|\")",
       "confidence": "Medium",
       "cwe_id": [
         89
@@ -270,7 +293,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/page_layouts/_show_row.html.erb",
-      "line": 114,
+      "line": 116,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "Formatter::Substitution.substitute(markdown_to_html((col[\"footer\"] or \"\")), :data => ((Master.find_with({ :id => params[:filters][:master_id], :type => (((active_layouts.find(params[:id]) or active_layouts.where(:panel_name => params[:id]).first).view_options.find_with or params[:filters][:master_type].hyphenate)) }, :access_by => current_user) or {})), :tag_subs => nil)",
       "render_path": [
@@ -298,7 +321,7 @@
         {
           "type": "template",
           "name": "page_layouts/_show_row",
-          "line": 97,
+          "line": 99,
           "file": "app/views/page_layouts/_show_row.html.erb",
           "rendered": {
             "name": "page_layouts/_show_row",
@@ -383,25 +406,6 @@
       "confidence": "High",
       "cwe_id": [
         89
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Unmaintained Dependency",
-      "warning_code": 123,
-      "fingerprint": "715ee6d743a8af33c7b930d728708ce19c765fb40e2ad9d2b974db04d92dc7d1",
-      "check_name": "EOLRuby",
-      "message": "Support for Ruby 3.0.6 ends on 2024-03-31",
-      "file": ".ruby-version",
-      "line": 1,
-      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
-      "code": null,
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "Weak",
-      "cwe_id": [
-        1104
       ],
       "note": ""
     },
@@ -866,7 +870,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/page_layouts/_show_row.html.erb",
-      "line": 105,
+      "line": 107,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "Formatter::Substitution.substitute(markdown_to_html((col[\"header\"] or \"\")), :data => ((Master.find_with({ :id => params[:filters][:master_id], :type => (((active_layouts.find(params[:id]) or active_layouts.where(:panel_name => params[:id]).first).view_options.find_with or params[:filters][:master_type].hyphenate)) }, :access_by => current_user) or {})), :tag_subs => nil)",
       "render_path": [
@@ -894,7 +898,7 @@
         {
           "type": "template",
           "name": "page_layouts/_show_row",
-          "line": 97,
+          "line": 99,
           "file": "app/views/page_layouts/_show_row.html.erb",
           "rendered": {
             "name": "page_layouts/_show_row",
@@ -914,6 +918,6 @@
       "note": ""
     }
   ],
-  "updated": "2024-02-13 12:56:34 +0000",
-  "brakeman_version": "6.1.1"
+  "updated": "2024-08-06 18:49:07 +0100",
+  "brakeman_version": "6.1.2"
 }

--- a/config/initializers/app_settings.rb
+++ b/config/initializers/app_settings.rb
@@ -164,7 +164,7 @@ class Settings
 
   # Initial configurations for the bulk messaging app
   def self.bulk_msg_app
-    Admin::AppType.active_app_types.where(name: 'bulk-msg').first
+    Admin::AppType.active_app_types.find_by(name: 'bulk-msg')
   end
 
   def self.bulk_msg_master
@@ -173,6 +173,7 @@ class Settings
 
   # Master record to use for admin features that need an underlying master, such as file store
   def self.admin_master
+    @admin_master = nil if Rails.env.development?
     @admin_master ||= Master.find(-2)
   end
 

--- a/docs/admin_reference/general/substitutions.md
+++ b/docs/admin_reference/general/substitutions.md
@@ -152,6 +152,14 @@ In addition to the attributes within the current record, the following are avail
   - data (data attribute)
   - class_name
   - save_trigger_results
+  - resource_name
+  - item_type_name
+  - table_name
+
+- Item definition details
+  - definition_resource_name
+  - definition_item_type_name
+  - default_embed_resource_name
 
 ### Server constants
 

--- a/spec/models/calc_actions/calculate_spec.rb
+++ b/spec/models/calc_actions/calculate_spec.rb
@@ -2799,6 +2799,53 @@ RSpec.describe 'Calculate conditional actions', type: :model do
       res = ca.get_this_val
       expect(res).to eq @alref
     end
+
+    it 'returns the embedded item' do
+      m = @al.master
+      m.current_user = @user
+
+      a1 = m.addresses.create! city: 'Portland',
+                               state: 'OR',
+                               zip: rand(99_999).to_s.rjust(5, '0').to_s,
+                               rank: 0,
+                               rec_type: 'home',
+                               source: 'nflpa'
+
+      @al.extra_log_type_config.references = {
+        address: {
+          address: {
+            from: 'master',
+            add: 'one_to_master'
+          }
+        }
+      }
+
+      ModelReference.create_with @al, a1, force_create: true
+
+      expect(@al.model_references.length).to eq 1
+
+      conf = {
+        embedded_item: {
+          update: 'return_result'
+        }
+      }
+
+      ca = ConditionalActions.new conf, @al
+
+      res = ca.get_this_val
+      expect(res).to eq a1
+
+      conf = {
+        embedded_item: {
+          zip: 'return_value'
+        }
+      }
+
+      ca = ConditionalActions.new conf, @al
+
+      res = ca.get_this_val
+      expect(res).to eq a1.zip
+    end
   end
 
   describe 'finding parent references' do

--- a/spec/models/calc_actions/calculate_spec.rb
+++ b/spec/models/calc_actions/calculate_spec.rb
@@ -2191,6 +2191,47 @@ RSpec.describe 'Calculate conditional actions', type: :model do
     expect(res.calc_action_if).to be true
   end
 
+  describe 'calculate functions' do
+    it 'calculates the sum of several attributes' do
+      al = create_item
+      al.update! select_who: '2', current_user: @user, master_id: al.master_id
+
+      conf = {
+        all: {
+          this: {
+            dummy: {
+              calculate: {
+                sum: {
+                  attributes: %w[id user_id]
+                }
+              }
+            }
+          }
+        }
+      }
+
+      ca = ConditionalActions.new conf, al
+      result = ca.calc_action_if
+      expect(result).to be false
+
+      conf = {
+        all: {
+          this: {
+            calculate: {
+              sum: {
+                attributes: %w[id user_id]
+              }
+            }
+          }
+        }
+      }
+
+      ca = ConditionalActions.new conf, al
+      result = ca.get_this_val
+      expect(result).to eq(@user.id + al.id)
+    end
+  end
+
   describe 'hash elements' do
     it 'compares a hash element' do
       al = create_item

--- a/spec/models/calc_actions/calculate_spec.rb
+++ b/spec/models/calc_actions/calculate_spec.rb
@@ -421,6 +421,21 @@ RSpec.describe 'Calculate conditional actions', type: :model do
     expect(res.calc_action_if).to be false
   end
 
+  it 'uses definition_resource as an identifier for an association' do
+    m = @al.master
+    m.current_user = @user
+
+    conf = {
+      all: {
+        definition_resources: {
+          extra_log_type: @al.extra_log_type
+        }
+      }
+    }
+    res = ConditionalActions.new conf, @al
+    expect(res.calc_action_if).to be true
+  end
+
   it 'checks if nested conditions work' do
     m = @al.master
     m.current_user = @user

--- a/spec/models/classification/selection_options_handler_spec.rb
+++ b/spec/models/classification/selection_options_handler_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Classification::SelectionOptionsHandler, type: :model do
     config0 = Classification::SelectionOptionsHandler.selector_with_config_overrides
 
     ::ActivityLog.define_models
-    @activity_log = al = ActivityLog.enabled.first
+    @activity_log = al = ActivityLog.active.first
 
     cleanup_matching_activity_logs(al.item_type, al.rec_type, al.process_name, excluding_id: al.id)
 

--- a/spec/models/dynamic/def_config_triggers_spec.rb
+++ b/spec/models/dynamic/def_config_triggers_spec.rb
@@ -129,4 +129,40 @@ RSpec.describe 'Dynamic Definition Generation', type: :model do
     embedded_item = al.embedded_item
     expect(embedded_item).to eq dm
   end
+
+  it 'add configurations using the app import format' do
+    rn = DynamicModel::SetupEmbedTestTest1Rec.resource_name
+    yaml = <<~END_YAML
+      test1:
+        config_trigger:
+          on_define:
+            create_defaults:
+              user_access_control:
+              embed:
+                fields:
+                  - status
+                  - notes
+              page_layout:
+            create_configs:
+              associated_general_selections:
+                - name: Not Started
+                  value: not started
+                  item_type: '{{default_embed_resource_name}}_status'
+                  position: 1600
+                - name: Pending
+                  value: pending
+                  item_type: #{rn}_status
+                  position: 1601
+                - name: In Progress
+                  value: in progress
+                  item_type: #{rn}_status
+                  position: 1602
+
+        embed: default_embed_resource
+    END_YAML
+
+    @al.update!(extra_log_types: yaml)
+    gs = Classification::GeneralSelection.where(item_type: "#{rn}_status")
+    expect(gs.length).to eq 3
+  end
 end

--- a/spec/models/dynamic/def_config_triggers_spec.rb
+++ b/spec/models/dynamic/def_config_triggers_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require './db/table_generators/dynamic_models_table'
+
+# Dynamic model implementation description using both imported apps and direct configurations
+RSpec.describe 'Dynamic Definition Generation', type: :model do
+  include MasterSupport
+  include ModelSupport
+  include PlayerContactSupport
+  include DynamicModelSupport
+
+  def generate_test_al(keep_def: nil)
+    create_user unless @user
+    @user.app_type ||= Admin::AppType.active.first
+    @user.email = @admin.email
+    @user.current_admin = @admin
+    @user.save
+    @app_type = @user.app_type
+
+    setup_access :masters, user: @user
+    @master = Master.create! current_user: @user
+    @master.current_user = @user
+
+    # Clean up old definition
+    @als = ActivityLog.active.where(
+      name: 'activity_log_player_contacts',
+      item_type: 'player_contact',
+      process_name: 'embed_test'
+    )
+
+    if keep_def
+      @al = @als.first
+      @al.updated_at = Time.now
+      @al.current_admin = @admin
+      @al.save!
+    else
+      @als.each do |al|
+        al.update! disabled: true, current_admin: @admin
+      end
+
+      yaml = <<~END_YAML
+        test1:
+          config_trigger:
+            on_define:
+              create_defaults:
+                user_access_control:
+                embed:
+                  fields:
+                    - status
+                    - notes
+                page_layout:
+          embed: default_embed_resource
+      END_YAML
+
+      al_att = {
+        name: 'activity_log_player_contacts',
+        item_type: 'player_contact',
+        process_name: 'embed_test',
+        schema_name: 'dynamic_test',
+        category: 'setup',
+        action_when_attribute: 'emailed_when',
+        current_admin: @admin,
+        extra_log_types: yaml
+      }
+      @al = ActivityLog.create! al_att
+    end
+
+    # setup_access :activity_log__player_contact_embed_tests
+    # setup_access :activity_log__player_contact_embed_test__test1, resource_type: :activity_log_type
+  end
+
+  before :all do
+    Settings::AllowDynamicMigrations = true
+    # SetupHelper.setup_al_player_contact_phones
+    # ::ActivityLog.define_models
+    create_user
+    setup_access :player_contacts
+    let_user_create_player_contacts
+    @player_contact = create_item(data: rand(10_000_000_000_000_000), rank: 10)
+    generate_test_al
+    Settings::AllowDynamicMigrations = nil
+  end
+
+  it 'creates an activity log with default user access control and embedded item' do
+    @master.current_user = @user
+
+    role_name = "user - #{@al.category || @app_type.name}"
+    expect(Admin::UserRole.active_app_roles(@user, app_type: @user.app_type).map(&:role_name)).to include role_name
+
+    expect(ActivityLog::PlayerContactEmbedTest.definition.option_configs.first.config_trigger[:on_define]).to be_present
+    al = ActivityLog::PlayerContactEmbedTest.create(master: @master, player_contact_id: @player_contact.id, extra_log_type: :test1)
+    expect { DynamicModel::SetupEmbedTestTest1Rec }.not_to raise_error
+    dm = DynamicModel::SetupEmbedTestTest1Rec.create(master: @master, @al.foreign_key_field_name => al.id, status: 'done')
+    expect(dm.persisted?).to be true
+
+    embedded_item = al.embedded_item
+    expect(embedded_item).to eq dm
+
+    expect(Admin::PageLayout.last.panel_name).to eq 'setup'
+  end
+
+  it 'will not break existing configurations when an activity log with config_trigger is rerun' do
+    role_name = "user - #{@al.category || @app_type.name}"
+    expect(Admin::UserRole.active_app_roles(@user, app_type: @user.app_type).map(&:role_name)).to include role_name
+    expect(ActivityLog::PlayerContactEmbedTest.definition.option_configs.first.config_trigger[:on_define]).to be_present
+    al = ActivityLog::PlayerContactEmbedTest.create(master: @master, player_contact_id: @player_contact.id, extra_log_type: :test1)
+    expect { DynamicModel::SetupEmbedTestTest1Rec }.not_to raise_error
+    dm = DynamicModel::SetupEmbedTestTest1Rec.create(master: @master, @al.foreign_key_field_name => al.id, status: 'done')
+    expect(dm.persisted?).to be true
+
+    generate_test_al
+    al = ActivityLog::PlayerContactEmbedTest.create(master: @master, player_contact_id: @player_contact.id, extra_log_type: :test1)
+    expect { DynamicModel::SetupEmbedTestTest1Rec }.not_to raise_error
+    dm = DynamicModel::SetupEmbedTestTest1Rec.create(master: @master, @al.foreign_key_field_name => al.id, status: 'done')
+    expect(dm.persisted?).to be true
+
+    # The generator doesn't add the user back into a role if the user role was previously disabled. The aim is to allow the admin to override this setting
+    ur = Admin::UserRole.active.find_by(role_name:, user_id: @user.id, app_type: @user.app_type)
+    ur.update!(disabled: true, current_admin: @admin)
+    generate_test_al
+    expect { ActivityLog::PlayerContactEmbedTest.create(master: @master, player_contact_id: @player_contact.id, extra_log_type: :test1) }.to raise_error(FphsException)
+    expect { DynamicModel::SetupEmbedTestTest1Rec }.not_to raise_error
+    expect { DynamicModel::SetupEmbedTestTest1Rec.create(master: @master, @al.foreign_key_field_name => al.id, status: 'done') }.to raise_error(FphsException)
+
+    ur.update!(disabled: false, current_admin: @admin)
+    al = ActivityLog::PlayerContactEmbedTest.create(master: @master, player_contact_id: @player_contact.id, extra_log_type: :test1)
+    dm = DynamicModel::SetupEmbedTestTest1Rec.create(master: @master, @al.foreign_key_field_name => al.id, status: 'done2')
+    embedded_item = al.embedded_item
+    expect(embedded_item).to eq dm
+  end
+end

--- a/spec/models/dynamic_model_extension/player_contact_phone_info_spec.rb
+++ b/spec/models/dynamic_model_extension/player_contact_phone_info_spec.rb
@@ -112,9 +112,9 @@ RSpec.describe 'DynamicModelExtension::PlayerContactPhoneInfo', type: :model do
     res = DynamicModel::PlayerContactPhoneInfo.update_opt_outs 1
     expect(res).to be > 0
 
-    study = Classification::Protocol.active.where(name: 'Study').first
+    study = Classification::Protocol.active.where(name: 'Study').reload.first
 
-    tracker = TrackerHistory.where(protocol_id: study.id).reorder('').last
+    tracker = TrackerHistory.where(protocol_id: study.id).reorder('').reload.last
 
     expect(old_tracker&.id || 0).to be < tracker.id
 

--- a/spec/models/external_identifier_spec.rb
+++ b/spec/models/external_identifier_spec.rb
@@ -18,141 +18,239 @@ RSpec.describe ExternalIdentifier, type: :model do
     uac.save!
   end
 
-  before :example do
+  def setup_ei_table(test_num)
     # Seeds.setup
-    r = 'test7'
-    @implementation_table_name = "test_external_#{r}_identifiers"
-    @implementation_attr_name = "test_#{r}_id"
+    @implementation_table_name = "test_external_#{test_num}_identifiers"
+    @implementation_attr_name = "test_#{test_num}_id"
 
     create_admin
     create_user
 
     ExternalIdentifier.define_models
-  end
-
-  it 'validates new configurations' do
-    # Check if a configured item does actually exist as a usable model
-    vals = list_valid_attribs.first
-
-    vals[:name] = @implementation_table_name
-    vals[:external_id_attribute] = @implementation_attr_name
-    e = create_item vals
-    expect(e.disabled).to be false
-
-    # No duplicate names
-    new_vals = list_valid_attribs.last.dup
-    new_vals[:name] = vals[:name]
-    new_vals[:disabled] = false
-
-    expect do
-      create_item new_vals, nil, true
-    end.to raise_error(ActiveRecord::RecordInvalid)
-
-    # No duplicate external_id_attribute
-    new_vals = list_valid_attribs.last.dup
 
     ActiveRecord::Base.connection.schema_cache.clear!
-    unless ActiveRecord::Base.connection.table_exists? new_vals[:name]
-      TableGenerators.external_identifiers_table(new_vals[:name], true, @implementation_attr_name)
+    unless ActiveRecord::Base.connection.table_exists? @implementation_table_name
+      TableGenerators.external_identifiers_table(@implementation_table_name, true, @implementation_attr_name)
     end
-    new_vals[:external_id_attribute] = vals[:external_id_attribute]
-    new_vals[:disabled] = false
-    expect do
-      create_item new_vals, nil, true
-    end.to raise_error(ActiveRecord::RecordInvalid)
+
+    ExternalIdentifier.define_models
   end
 
-  it 'has an implementation class for a created external model' do
-    ExternalIdentifier.active.each do |e|
-      e.disabled = true
-      e.current_admin = @admin
-      e.save!
+  describe 'external identifier implementation' do
+    before :example do
+      # Seeds.setup
+      r = 'test7'
+      @implementation_table_name = "test_external_#{r}_identifiers"
+      @implementation_attr_name = "test_#{r}_id"
+
+      create_admin
+      create_user
+
+      ExternalIdentifier.define_models
     end
-    # Check if a configured item does actually exist as a usable model
-    vals = list_valid_attribs.first
 
-    e = create_item vals
+    it 'validates new configurations' do
+      # Check if a configured item does actually exist as a usable model
+      vals = list_valid_attribs.first
 
-    res = nil
-    begin
-      res = e.implementation_class.new
-    rescue NoMethodError
-      puts "Implementation class doesn't appear to have been defined"
-    rescue NameError
-      puts "Implementation class doesn't appear to have been defined"
+      vals[:name] = @implementation_table_name
+      vals[:external_id_attribute] = @implementation_attr_name
+      e = create_item vals
+      expect(e.disabled).to be false
+
+      # No duplicate names
+      new_vals = list_valid_attribs.last.dup
+      new_vals[:name] = vals[:name]
+      new_vals[:disabled] = false
+
+      expect do
+        create_item new_vals, nil, true
+      end.to raise_error(ActiveRecord::RecordInvalid)
+
+      # No duplicate external_id_attribute
+      new_vals = list_valid_attribs.last.dup
+
+      ActiveRecord::Base.connection.schema_cache.clear!
+      unless ActiveRecord::Base.connection.table_exists? new_vals[:name]
+        TableGenerators.external_identifiers_table(new_vals[:name], true, @implementation_attr_name)
+      end
+      new_vals[:external_id_attribute] = vals[:external_id_attribute]
+      new_vals[:disabled] = false
+      expect do
+        create_item new_vals, nil, true
+      end.to raise_error(ActiveRecord::RecordInvalid)
     end
-    expect(res).not_to be nil
 
-    m = create_master
-    c = e.implementation_class
+    it 'has an implementation class for a created external model' do
+      ExternalIdentifier.active.each do |e|
+        e.disabled = true
+        e.current_admin = @admin
+        e.save!
+      end
+      # Check if a configured item does actually exist as a usable model
+      vals = list_valid_attribs.first
 
-    expect(@user.app_type_id).not_to be nil
-    allow_ext_id_create
-    expect(@user.has_access_to?(:create, :table, @implementation_table_name)).to be_truthy
+      e = create_item vals
 
-    eid = rand(9_999_999)
-    m.current_user = @user
-    res = c.new(c.external_id_attribute => eid, master: m)
+      res = nil
+      begin
+        res = e.implementation_class.new
+      rescue NoMethodError
+        puts "Implementation class doesn't appear to have been defined"
+      rescue NameError
+        puts "Implementation class doesn't appear to have been defined"
+      end
+      expect(res).not_to be nil
 
-    res.save
-    expect(res).to be_a c
-    expect(res.id).not_to be nil
-    expect(res.attributes[c.external_id_attribute]).to eq eid
+      m = create_master
+      c = e.implementation_class
 
-    # Ensure it fails if trying to add a bad ID
-    res = c.new(c.external_id_attribute => -1, master: m)
+      expect(@user.app_type_id).not_to be nil
+      allow_ext_id_create
+      expect(@user.has_access_to?(:create, :table, @implementation_table_name)).to be_truthy
 
-    expect(res.save).to be false
+      eid = rand(9_999_999)
+      m.current_user = @user
+      res = c.new(c.external_id_attribute => eid, master: m)
+
+      res.save
+      expect(res).to be_a c
+      expect(res.id).not_to be nil
+      expect(res.attributes[c.external_id_attribute]).to eq eid
+
+      # Ensure it fails if trying to add a bad ID
+      res = c.new(c.external_id_attribute => -1, master: m)
+
+      expect(res.save).to be false
+    end
   end
 
-  it 'allows player records to referenced using the external ID' do
-    ExternalIdentifier.active.each do |e|
-      e.disabled = true
-      e.current_admin = @admin
-      e.save!
+  describe 'external identifier actions' do
+    before :example do
+      setup_ei_table 'test8'
     end
-    # Create an external identifier implementation
-    vals = list_valid_attribs.first
-    e = create_item vals
 
-    # Create some master records to allow fair testing
-    create_master
-    m = create_master
-    create_master
+    it 'allows player records to referenced using the external ID' do
+      ExternalIdentifier.active.each do |e|
+        e.disabled = true
+        e.current_admin = @admin
+        e.save!
+      end
+      # Create an external identifier implementation
+      vals = list_valid_attribs.first
+      e = create_item vals
 
-    # Create an external identifier ID record
-    allow_ext_id_create
-    c = e.implementation_class
-    eid = rand(9_999_999)
-    m.current_user = @user
-    res = c.new(c.external_id_attribute => eid, master: m)
-    res.save
-    expect(res.id).not_to be nil
+      # Create some master records to allow fair testing
+      create_master
+      m = create_master
+      create_master
 
-    expect(@user.has_access_to?(:access, :table, c.resource_name))
+      # Create an external identifier ID record
+      allow_ext_id_create
+      c = e.implementation_class
+      eid = rand(9_999_999)
+      m.current_user = @user
+      res = c.new(c.external_id_attribute => eid, master: m)
+      res.save
+      expect(res.id).not_to be nil
 
-    # Attempt to find the master
-    found = Master.find_with_alternative_id(vals[:external_id_attribute], eid, @user)
-    expect(found).to eq m
+      expect(@user.has_access_to?(:access, :table, c.resource_name))
+
+      # Attempt to find the master
+      found = Master.find_with_alternative_id(vals[:external_id_attribute], eid, @user)
+      expect(found).to eq m
+    end
+
+    it 'creates an external ID automatically' do
+      create_master
+
+      ei = ExternalIdentifier.active.find_by name: :sage_assignments
+      unless ei
+        ei = ExternalIdentifier.find_by name: :sage_assignments
+        ei.current_admin = @admin
+        ei.disabled = false
+        ei.save!
+      end
+
+      setup_access :sage_assignments, user: @master.current_user
+      expect(SageAssignment.definition.pregenerate_ids).to be true
+
+      SageAssignment.generate_ids(@admin, 100)
+
+      res = @master.sage_assignments.create!
+      expect(res.sage_id).not_to be blank?
+    end
   end
 
-  it 'creates an external ID automatically' do
-    create_master
+  describe 'uniqueness checks' do
+    it 'validates an new external ID is unique' do
+      setup_ei_table 'unique1'
 
-    ei = ExternalIdentifier.active.find_by name: :sage_assignments
-    unless ei
-      ei = ExternalIdentifier.find_by name: :sage_assignments
-      ei.current_admin = @admin
-      ei.disabled = false
-      ei.save!
+      create_master
+
+      e = create_item name: @implementation_table_name,
+                      label: 'unique identifiers',
+                      external_id_attribute: @implementation_attr_name,
+                      min_id: 1,
+                      max_id: 99_999_999,
+                      disabled: false
+      c = e.implementation_class
+      allow_ext_id_create
+
+      expect(@user.has_access_to?(:access, :table, c.resource_name)).to be_truthy
+      res = c.create!(@implementation_attr_name => 123, master_id: @master.id, current_user: @master.current_user)
+      expect(res[@implementation_attr_name]).not_to be blank?
+
+      expect do
+        res = c.create!(@implementation_attr_name => 123, master_id: @master.id, current_user: @master.current_user)
+      end.to raise_error
+
+      expect do
+        res = c.create!(@implementation_attr_name => 124, master_id: @master.id, current_user: @master.current_user)
+      end.not_to raise_error
     end
 
-    setup_access :sage_assignments, user: @master.current_user
-    expect(SageAssignment.definition.pregenerate_ids).to be true
+    it 'validates an new external ID is unique with a uniqueness_fields configuration' do
+      setup_ei_table 'unique2'
+      create_master
 
-    SageAssignment.generate_ids(@admin, 100)
+      # Define the external identifier to be unique on master_id and the external id attribute
+      opt = <<~END_OPT
+        _configurations:
+          uniqueness_fields:
+            - master_id
+            - #{@implementation_attr_name}
+      END_OPT
 
-    res = @master.sage_assignments.create!
-    expect(res.sage_id).not_to be blank?
+      e = create_item name: @implementation_table_name,
+                      label: 'unique identifiers',
+                      external_id_attribute: @implementation_attr_name,
+                      min_id: 1,
+                      max_id: 99_999_999,
+                      disabled: false,
+                      options: opt
+
+      c = e.implementation_class
+      allow_ext_id_create
+
+      expect(@user.has_access_to?(:access, :table, c.resource_name)).to be_truthy
+      res = c.create!(@implementation_attr_name => 223, master_id: @master.id, current_user: @master.current_user)
+      res = c.create!(@implementation_attr_name => 224, master_id: @master.id, current_user: @master.current_user)
+
+      expect do
+        res = c.create!(@implementation_attr_name => 223, master_id: @master.id, current_user: @master.current_user)
+      end.to raise_error
+
+      create_master
+      expect do
+        res = c.create!(@implementation_attr_name => 223, master_id: @master.id, current_user: @master.current_user)
+      end.not_to raise_error
+
+      expect do
+        res = c.create!(@implementation_attr_name => 223, master_id: @master.id, current_user: @master.current_user)
+      end.to raise_error
+
+      res = c.create!(@implementation_attr_name => 224, master_id: @master.id, current_user: @master.current_user)
+    end
   end
 end

--- a/spec/models/option_configs/dynamic_model_options_spec.rb
+++ b/spec/models/option_configs/dynamic_model_options_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'Dynamic Model Options', type: :model do
 
   before :all do
     DynamicModel.active.where(table_name: 'test_created_by_recs').each { |dm| dm.disable!(@admin) }
+    DynamicModel.reset_active_model_configurations!
   end
 
   before :example do

--- a/spec/models/save_triggers/save_triggers_base_spec.rb
+++ b/spec/models/save_triggers/save_triggers_base_spec.rb
@@ -120,6 +120,14 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
                         List of results
               - each:
                   value: '{{{select_who::split_csv}}}'
+                  if:
+                    not_any:
+                      this:
+                        save_trigger_results:
+                          element: iterator_value
+                          value:
+                            - ''
+                            - null
                   do:
                     - update_this:
                         one:
@@ -223,17 +231,17 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
 
     it 'runs a list of triggers for each value specified' do
       al = @player_contact.activity_log__player_contact_phones.create!(select_call_direction: 'from player',
-                                                                       select_who: 'a,b,c',
+                                                                       select_who: '"",a,b,,c,',
                                                                        extra_log_type: 'save_trigger_test_4')
-      expect(al.select_who).to eq 'a,b,c'
+      expect(al.select_who).to eq '"",a,b,,c,'
       al.skip_save_trigger = false
       al.update!(select_call_direction: 'to player')
       expect(al.select_who).to eq 'an iterator'
       expect(al.notes).to eq <<~END_TEXT
         List of results
-        - 0 => a
-        - 1 => b
-        - 2 => c
+        - 1 => a
+        - 2 => b
+        - 4 => c
       END_TEXT
         .strip
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -208,6 +208,8 @@ RSpec.configure do |config|
       # Seeds::ActivityLogPlayerContactPhone.setup
       put_now 'setup_al_player_contact_emails'
       SetupHelper.setup_al_player_contact_emails
+      put_now 'setup_al_player_contact_embed_tests'
+      SetupHelper.setup_al_player_contact_embed_tests
       put_now 'Setup ext_identifier'
       SetupHelper.setup_ext_identifier
       put_now 'setup_test_app'

--- a/spec/setup_helper.rb
+++ b/spec/setup_helper.rb
@@ -192,6 +192,19 @@ module SetupHelper
     Rails.cache.clear
   end
 
+  def self.setup_al_player_contact_embed_tests
+    Rails.logger.info 'Setting up al player contact embed tests'
+    ActiveRecord::Base.connection.schema_cache.clear!
+
+    return if ActivityLog.connection.table_exists? 'activity_log_player_contact_embed_tests'
+
+    TableGenerators.activity_logs_table('activity_log_player_contact_embed_tests', 'player_contacts', true,
+                                        'data', 'select_email_direction', 'select_who',
+                                        'emailed_when', 'select_result', 'select_next_step', 'follow_up_when',
+                                        'protocol_id', 'notes', 'set_related_player_contact_rank')
+    Rails.cache.clear
+  end
+
   # Setup Activity Log Player Contact Phones
   def self.setup_al_player_contact_phones
     Rails.logger.info 'Setting up al player contact phones'

--- a/spec/support/activity_log_feature_support/activity_log_setup.rb
+++ b/spec/support/activity_log_feature_support/activity_log_setup.rb
@@ -1,32 +1,30 @@
 module ActivityLogSetup
-
   include ModelSupport
 
   # Most of the database items are set up in the DB seed. This method just allows for some additional
   # test specific items to be added
   def create_phone_log_config
-    admin, _ = create_admin
+    admin, = create_admin
 
     if Classification::GeneralSelection.enabled.where(item_type: 'activity_log__player_contact_phone_select_who').length >= 5
 
       gs = [
-        ["Rob Standish", "rob standish", "activity_log__player_contact_phone_select_who"],
-        ["Chris", "chris", "activity_log__player_contact_phone_select_who"],
-        ["P Smith", "p smith", "activity_log__player_contact_phone_select_who"],
-        ["Andy Morehouse", "andy morehouse", "activity_log__player_contact_phone_select_who"]
+        ['Rob Standish', 'rob standish', 'activity_log__player_contact_phone_select_who'],
+        ['Chris', 'chris', 'activity_log__player_contact_phone_select_who'],
+        ['P Smith', 'p smith', 'activity_log__player_contact_phone_select_who'],
+        ['Andy Morehouse', 'andy morehouse', 'activity_log__player_contact_phone_select_who']
       ]
       gs.each do |g|
-        Classification::GeneralSelection.create!(name: g[0], value: g[2], item_type: g[2], current_admin: admin, disabled: false, create_with: true, edit_always: false, lock: true )
+        Classification::GeneralSelection.create!(name: g[0], value: g[2], item_type: g[2], current_admin: admin, disabled: false, create_with: true, edit_always: false, lock: true)
       end
     end
 
     setup_access :player_infos
     setup_access :trackers
 
-    ActivityLog.enabled.each do |a|
+    ActivityLog.active.each do |a|
       a.current_admin = admin
       a.update_tracker_events
     end
-
   end
 end

--- a/spec/support/activity_log_feature_support/log_expectations.rb
+++ b/spec/support/activity_log_feature_support/log_expectations.rb
@@ -54,11 +54,11 @@ module LogExpectations
   end
 
   def expect_log_player_contact_to(values)
-    if values[:have_rank]
-      have_css("#{PhoneListActions::PhoneItemsCss}.selected-item")
-      rank_text = find("#{PhoneListActions::PhoneItemsCss}.selected-item span.label-info").text
-      expect(rank_text).to eq values[:have_rank]
-    end
+    return unless values[:have_rank]
+
+    have_css("#{PhoneListActions::PhoneItemsCss}.selected-item")
+    rank_text = find("#{PhoneListActions::PhoneItemsCss}.selected-item span.label-info").text
+    expect(rank_text).to eq values[:have_rank]
   end
 
   def expect_tracker_event_to_include(date, protocol, sp, pe = nil, index = 0)


### PR DESCRIPTION
### From FPHS

- [Changed] loading of associated model definitions, improving performance and presentation
- [Added] definition_resources as an alias resource name for consistent substitutions and conditions
- [Added] config_trigger.create_configs option to create related configurations using app import format
- [Added] config_trigger option to make building activity log processes easier
- [Added] calculated condition to calculate using a function such as sum, min, max - closes #308
- [Added] estimated record count to dynamic definitions - closes #265
- [Added] with_result to create/update... save triggers
- [Added] embedded_item option to conditional calculations
- [Added] ids_referencing condition and ability to get return_all_results from a condition
- [Fixed] condition negate and add include? condition
- [Fixed] incorrect handling of save trigger on_save option as an array when on_create is a hash (or vice versa)
- [Added] ability for extra_log_type to be used in creatable_if condition
- [Added] handling of invalid_error_message at top of an all/any/not... block to prevent invididual errors being recorded, allowing them all to roll up to a single result
- [Fixed] tag element array index retrieval
- [Fixed] handling of implementation class setup to avoid preset value definitions breaking the implementation
- [Added] view_with_formats to field_options, allowing a series of tag formatters to be applied when viewing the field
- [Fixed] embedded items not setting preset_value
- [Fixed] address view handler with no country field
- [Added] save trigger results for created and updated results
- [Fixed] use of view_options.header caption configuration in external id definitions
- [Added] embed definitions into the activity log details panel - fixes #19
- [Added] "in?" to the simple conditions that can be tested in non-query conditions
- [Added] non-query condition elements to specify last as well as first in the traversal of the dot separated list
- [Added] "if:" option to save trigger "each:" to avoid having to check the same "if" for every trigger
- [Added] ability to define external id configurations for uniqueness_fields, can_change_master and fix saving from a add item report
- [Changed] calling #enabled to #active for consistency
- [Fixed] curly substitutions to allow .last to appear on the end of a requested element
