### PR TITLE
Hms rel 8619

### DIFF
--- a/app/assets/javascripts/app/_fpa_ajax_processors.js
+++ b/app/assets/javascripts/app/_fpa_ajax_processors.js
@@ -276,6 +276,9 @@ _fpa.postprocessors = {
 
   // On load of the full list of master records
   search_results_template: function (block, data) {
+
+    _fpa.postprocessors.setup_masters_state(data);
+
     // Ensure we format the viewed item on expanding it
     _fpa.masters.switch_id_on_click(block);
     if (data.masters && data.masters.length < 5) {
@@ -289,22 +292,6 @@ _fpa.postprocessors = {
       _fpa.postprocessors.tracker_events_handler(block, data);
       _fpa.postprocessors.extras_panel_handler(block);
       _fpa.postprocessors.configure_master_tabs(block);
-    }
-
-    // Capture the master data into state for later use around the application
-    // The layout of data is modelled partially on that provided by MessageTemplate.setup_data
-    // allowing caption-before to function in 'show' mode
-    if (data.masters && data.masters.length > 0) {
-      _fpa.state.masters = {};
-      data.masters.forEach(function (master) {
-        if (master && master.id) {
-          _fpa.state.masters[master.id] = Object.assign({}, master);
-          if (_fpa.state.masters[master.id].player_infos) {
-            _fpa.state.masters[master.id].player_info = _fpa.state.masters[master.id].player_infos[0];
-            _fpa.state.masters[master.id].item = _fpa.state.masters[master.id].embedded_item;
-          }
-        }
-      });
     }
 
     $('a.master-expander')
@@ -350,26 +337,31 @@ _fpa.postprocessors = {
     var master_id_list = $('#master_id_list').html();
 
     if ($('.no-search-in-master-record').length == 0) {
+      const prevent = _fpa.state.app_configs.prevent_reload_master_list;
       if (master_id_list && master_id_list.replace(/ /g, '').length > 1) {
         document.title = _fpa.env_name + ' results';
-        window.history.pushState(
-          { html: '/masters/search?utf8=✓&nav_q_id=' + master_id_list, pageTitle: document.title },
-          '',
-          '/masters/search?utf8=✓&nav_q_id=' + master_id_list
-        );
+
+        if (prevent)
+          window.history.pushState(
+            { html: '/masters/search?utf8=✓&nav_q_id=' + master_id_list, pageTitle: document.title },
+            '',
+            '/masters/search?utf8=✓&nav_q_id=' + master_id_list
+          );
       } else if (ext_id_field && ext_id_list && ext_id_list.length > 1) {
         document.title = _fpa.env_name + ' results';
-        window.history.pushState(
-          {
-            html: '/masters/search?utf8=✓&external_id[' + ext_id_field + ']=' + ext_id_list,
-            pageTitle: document.title,
-          },
-          '',
-          '/masters/search?utf8=✓&external_id[' + ext_id_field + ']=' + ext_id_list
-        );
+        if (prevent)
+          window.history.pushState(
+            {
+              html: '/masters/search?utf8=✓&external_id[' + ext_id_field + ']=' + ext_id_list,
+              pageTitle: document.title,
+            },
+            '',
+            '/masters/search?utf8=✓&external_id[' + ext_id_field + ']=' + ext_id_list
+          );
       } else {
         document.title = _fpa.env_name + ' results';
-        window.history.pushState({ html: '/masters/search', pageTitle: document.title }, '', '/masters/search');
+        if (prevent)
+          window.history.pushState({ html: '/masters/search', pageTitle: document.title }, '', '/masters/search');
       }
     }
   },
@@ -454,6 +446,25 @@ _fpa.postprocessors = {
   //   _fpa.form_utils.format_block(block);
 
   // },
+
+  // Capture the master data into state for later use around the application
+  // The layout of data is modelled partially on that provided by MessageTemplate.setup_data
+  // allowing caption-before to function in 'show' mode
+  setup_masters_state: function (data) {
+    if (!data.masters || data.masters.length <= 0) return;
+
+    _fpa.state.masters = {};
+    data.masters.forEach(function (master) {
+      if (master && master.id) {
+        _fpa.state.masters[master.id] = Object.assign({}, master);
+        if (_fpa.state.masters[master.id].player_infos) {
+          _fpa.state.masters[master.id].player_info = _fpa.state.masters[master.id].player_infos[0];
+          _fpa.state.masters[master.id].item = _fpa.state.masters[master.id].embedded_item;
+        }
+      }
+    });
+  },
+
 
   flash_template: function (block, data) {
     _fpa.timed_flash_fadeout();

--- a/app/assets/javascripts/app/_fpa_utils.js
+++ b/app/assets/javascripts/app/_fpa_utils.js
@@ -740,3 +740,50 @@ _fpa.utils.beep = function () {
   const snd = new Audio("data:audio/wav;base64,//uQRAAAAWMSLwUIYAAsYkXgoQwAEaYLWfkWgAI0wWs/ItAAAGDgYtAgAyN+QWaAAihwMWm4G8QQRDiMcCBcH3Cc+CDv/7xA4Tvh9Rz/y8QADBwMWgQAZG/ILNAARQ4GLTcDeIIIhxGOBAuD7hOfBB3/94gcJ3w+o5/5eIAIAAAVwWgQAVQ2ORaIQwEMAJiDg95G4nQL7mQVWI6GwRcfsZAcsKkJvxgxEjzFUgfHoSQ9Qq7KNwqHwuB13MA4a1q/DmBrHgPcmjiGoh//EwC5nGPEmS4RcfkVKOhJf+WOgoxJclFz3kgn//dBA+ya1GhurNn8zb//9NNutNuhz31f////9vt///z+IdAEAAAK4LQIAKobHItEIYCGAExBwe8jcToF9zIKrEdDYIuP2MgOWFSE34wYiR5iqQPj0JIeoVdlG4VD4XA67mAcNa1fhzA1jwHuTRxDUQ//iYBczjHiTJcIuPyKlHQkv/LHQUYkuSi57yQT//uggfZNajQ3Vmz+Zt//+mm3Wm3Q576v////+32///5/EOgAAADVghQAAAAA//uQZAUAB1WI0PZugAAAAAoQwAAAEk3nRd2qAAAAACiDgAAAAAAABCqEEQRLCgwpBGMlJkIz8jKhGvj4k6jzRnqasNKIeoh5gI7BJaC1A1AoNBjJgbyApVS4IDlZgDU5WUAxEKDNmmALHzZp0Fkz1FMTmGFl1FMEyodIavcCAUHDWrKAIA4aa2oCgILEBupZgHvAhEBcZ6joQBxS76AgccrFlczBvKLC0QI2cBoCFvfTDAo7eoOQInqDPBtvrDEZBNYN5xwNwxQRfw8ZQ5wQVLvO8OYU+mHvFLlDh05Mdg7BT6YrRPpCBznMB2r//xKJjyyOh+cImr2/4doscwD6neZjuZR4AgAABYAAAABy1xcdQtxYBYYZdifkUDgzzXaXn98Z0oi9ILU5mBjFANmRwlVJ3/6jYDAmxaiDG3/6xjQQCCKkRb/6kg/wW+kSJ5//rLobkLSiKmqP/0ikJuDaSaSf/6JiLYLEYnW/+kXg1WRVJL/9EmQ1YZIsv/6Qzwy5qk7/+tEU0nkls3/zIUMPKNX/6yZLf+kFgAfgGyLFAUwY//uQZAUABcd5UiNPVXAAAApAAAAAE0VZQKw9ISAAACgAAAAAVQIygIElVrFkBS+Jhi+EAuu+lKAkYUEIsmEAEoMeDmCETMvfSHTGkF5RWH7kz/ESHWPAq/kcCRhqBtMdokPdM7vil7RG98A2sc7zO6ZvTdM7pmOUAZTnJW+NXxqmd41dqJ6mLTXxrPpnV8avaIf5SvL7pndPvPpndJR9Kuu8fePvuiuhorgWjp7Mf/PRjxcFCPDkW31srioCExivv9lcwKEaHsf/7ow2Fl1T/9RkXgEhYElAoCLFtMArxwivDJJ+bR1HTKJdlEoTELCIqgEwVGSQ+hIm0NbK8WXcTEI0UPoa2NbG4y2K00JEWbZavJXkYaqo9CRHS55FcZTjKEk3NKoCYUnSQ0rWxrZbFKbKIhOKPZe1cJKzZSaQrIyULHDZmV5K4xySsDRKWOruanGtjLJXFEmwaIbDLX0hIPBUQPVFVkQkDoUNfSoDgQGKPekoxeGzA4DUvnn4bxzcZrtJyipKfPNy5w+9lnXwgqsiyHNeSVpemw4bWb9psYeq//uQZBoABQt4yMVxYAIAAAkQoAAAHvYpL5m6AAgAACXDAAAAD59jblTirQe9upFsmZbpMudy7Lz1X1DYsxOOSWpfPqNX2WqktK0DMvuGwlbNj44TleLPQ+Gsfb+GOWOKJoIrWb3cIMeeON6lz2umTqMXV8Mj30yWPpjoSa9ujK8SyeJP5y5mOW1D6hvLepeveEAEDo0mgCRClOEgANv3B9a6fikgUSu/DmAMATrGx7nng5p5iimPNZsfQLYB2sDLIkzRKZOHGAaUyDcpFBSLG9MCQALgAIgQs2YunOszLSAyQYPVC2YdGGeHD2dTdJk1pAHGAWDjnkcLKFymS3RQZTInzySoBwMG0QueC3gMsCEYxUqlrcxK6k1LQQcsmyYeQPdC2YfuGPASCBkcVMQQqpVJshui1tkXQJQV0OXGAZMXSOEEBRirXbVRQW7ugq7IM7rPWSZyDlM3IuNEkxzCOJ0ny2ThNkyRai1b6ev//3dzNGzNb//4uAvHT5sURcZCFcuKLhOFs8mLAAEAt4UWAAIABAAAAAB4qbHo0tIjVkUU//uQZAwABfSFz3ZqQAAAAAngwAAAE1HjMp2qAAAAACZDgAAAD5UkTE1UgZEUExqYynN1qZvqIOREEFmBcJQkwdxiFtw0qEOkGYfRDifBui9MQg4QAHAqWtAWHoCxu1Yf4VfWLPIM2mHDFsbQEVGwyqQoQcwnfHeIkNt9YnkiaS1oizycqJrx4KOQjahZxWbcZgztj2c49nKmkId44S71j0c8eV9yDK6uPRzx5X18eDvjvQ6yKo9ZSS6l//8elePK/Lf//IInrOF/FvDoADYAGBMGb7FtErm5MXMlmPAJQVgWta7Zx2go+8xJ0UiCb8LHHdftWyLJE0QIAIsI+UbXu67dZMjmgDGCGl1H+vpF4NSDckSIkk7Vd+sxEhBQMRU8j/12UIRhzSaUdQ+rQU5kGeFxm+hb1oh6pWWmv3uvmReDl0UnvtapVaIzo1jZbf/pD6ElLqSX+rUmOQNpJFa/r+sa4e/pBlAABoAAAAA3CUgShLdGIxsY7AUABPRrgCABdDuQ5GC7DqPQCgbbJUAoRSUj+NIEig0YfyWUho1VBBBA//uQZB4ABZx5zfMakeAAAAmwAAAAF5F3P0w9GtAAACfAAAAAwLhMDmAYWMgVEG1U0FIGCBgXBXAtfMH10000EEEEEECUBYln03TTTdNBDZopopYvrTTdNa325mImNg3TTPV9q3pmY0xoO6bv3r00y+IDGid/9aaaZTGMuj9mpu9Mpio1dXrr5HERTZSmqU36A3CumzN/9Robv/Xx4v9ijkSRSNLQhAWumap82WRSBUqXStV/YcS+XVLnSS+WLDroqArFkMEsAS+eWmrUzrO0oEmE40RlMZ5+ODIkAyKAGUwZ3mVKmcamcJnMW26MRPgUw6j+LkhyHGVGYjSUUKNpuJUQoOIAyDvEyG8S5yfK6dhZc0Tx1KI/gviKL6qvvFs1+bWtaz58uUNnryq6kt5RzOCkPWlVqVX2a/EEBUdU1KrXLf40GoiiFXK///qpoiDXrOgqDR38JB0bw7SoL+ZB9o1RCkQjQ2CBYZKd/+VJxZRRZlqSkKiws0WFxUyCwsKiMy7hUVFhIaCrNQsKkTIsLivwKKigsj8XYlwt/WKi2N4d//uQRCSAAjURNIHpMZBGYiaQPSYyAAABLAAAAAAAACWAAAAApUF/Mg+0aohSIRobBAsMlO//Kk4soosy1JSFRYWaLC4qZBYWFRGZdwqKiwkNBVmoWFSJkWFxX4FFRQWR+LsS4W/rFRb/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////VEFHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAU291bmRib3kuZGUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMjAwNGh0dHA6Ly93d3cuc291bmRib3kuZGUAAAAAAAAAACU=");
   snd.play();
 }
+
+// Return a hash of params, from the Rails format (or a literal value if a simple param requested)
+// If there are no matching items, an empty hash is returned.
+// ?key1=va11 - call with key1 only returns a simple result: val1
+// ?key1[key2]=val12 - call with key1 only returns {key2 => val12}
+// ?key1[key2]=val12 - call with key1 and key2 returns {}
+// ?key1[key2][others]=val100 - call with key1 and key2 returns {others => val100}
+// Use `full_key` if a full Rails style param is to be returned
+// ?key1[key2]=val12 - call with key1 only returns {key1[key2] => val12}
+_fpa.utils.get_params = function (key1, key2, full_key) {
+  const params = new URLSearchParams(window.location.search);
+  var data = {};
+
+  var r;
+  var get_match_i;
+  if (key1 && !key2) {
+    const got_simple_param = params.get(key1);
+    if (got_simple_param) return got_simple_param;
+
+    r = new RegExp(`^${key1}\\[(.+)\\]`)
+    get_match_i = 2;
+  }
+  else if (key1 && key2) {
+    r = new RegExp(`^${key1}\\[${key2}\\]\\[(.+)\\]`)
+    get_match_i = 3;
+  }
+
+  if (full_key)
+    var retkeyi = 0
+  else
+    retkeyi = get_match_i - 1;
+
+  for (const pair of params) {
+    const key = pair[0];
+    const val = pair[1];
+
+    res = key.match(r);
+    if (!res) continue;
+
+    var retkey = res[retkeyi];
+    data[retkey] = val;
+  }
+
+  if (Object.keys(data).length === 0) return;
+
+  return data;
+}

--- a/app/assets/javascripts/app/handlebars-helpers.js
+++ b/app/assets/javascripts/app/handlebars-helpers.js
@@ -639,6 +639,39 @@
     return res;
   });
 
+  Handlebars.registerHelper('length', function (val) {
+    if (!val) return;
+
+    return Object.keys(val).length;
+  });
+
+  Handlebars.registerHelper('params_to_query', function (key1, key2) {
+    const params = new URLSearchParams(window.location.search);
+    var data = {};
+
+    var r;
+    var get_match_i;
+    if (key1 && !key2) {
+      r = new RegExp(`^${key1}\\[(.+)\\]`)
+      get_match_i = 2;
+    }
+    else if (key1 && key2) {
+      r = new RegExp(`^${key1}\\[${key2}\\]\\[(.+)\\]`)
+      get_match_i = 3;
+    }
+    for (const pair of params) {
+      const key = pair[0];
+      const val = pair[1];
+
+      res = key.match(r);
+      if (!res) continue;
+      data[key] = val;
+    }
+
+    return $.param(data);
+  });
+
+
   Handlebars.registerHelper('in', function (context, key, items, options) {
 
     var ins = items.split(',');

--- a/app/assets/javascripts/app/handlebars-helpers.js
+++ b/app/assets/javascripts/app/handlebars-helpers.js
@@ -645,28 +645,34 @@
     return Object.keys(val).length;
   });
 
-  Handlebars.registerHelper('params_to_query', function (key1, key2) {
-    const params = new URLSearchParams(window.location.search);
-    var data = {};
+  Handlebars.registerHelper('params', function (key1, key2, key3) {
+    if (key2 && key2.hash) key2 = null;
+    if (key3 && key3.hash) key3 = null;
 
-    var r;
-    var get_match_i;
     if (key1 && !key2) {
-      r = new RegExp(`^${key1}\\[(.+)\\]`)
-      get_match_i = 2;
-    }
-    else if (key1 && key2) {
-      r = new RegExp(`^${key1}\\[${key2}\\]\\[(.+)\\]`)
-      get_match_i = 3;
-    }
-    for (const pair of params) {
-      const key = pair[0];
-      const val = pair[1];
+      var data = _fpa.utils.get_params(key1);
 
-      res = key.match(r);
-      if (!res) continue;
-      data[key] = val;
+      return data;
     }
+    if (key2 && !key3) {
+      var data = _fpa.utils.get_params(key1);
+      return data && data[key2];
+    }
+    else if (key3) {
+      var data = _fpa.utils.get_params(key1, key2);
+      return data && data[key3];
+    }
+  });
+
+  Handlebars.registerHelper('params_to_hash', function (key1, key2) {
+    if (key2 && key2.hash) key2 = null;
+    return _fpa.utils.get_params(key1, key2);
+  });
+
+  Handlebars.registerHelper('params_to_query', function (key1, key2) {
+    if (key2 && key2.hash) key2 = null;
+    const data = _fpa.utils.get_params(key1, key2, true);
+    if (!data) return;
 
     return $.param(data);
   });

--- a/app/controllers/concerns/app_type_change.rb
+++ b/app/controllers/concerns/app_type_change.rb
@@ -115,7 +115,7 @@ module AppTypeChange
   end
 
   def all_user_app_type_ids
-    @all_user_app_type_ids ||= Admin::AppType.all_ids_available_to(current_user)
+    Admin::AppType.all_ids_available_to(current_user)
   end
 
   #

--- a/app/controllers/concerns/master_handler.rb
+++ b/app/controllers/concerns/master_handler.rb
@@ -149,7 +149,7 @@ module MasterHandler
   # Retrieve the index action JSON from master objects and extended data
   # @return [String] JSON
   def retrieve_index
-    s = { objects_name => filter_records.as_json(current_user: current_user), multiple_results: objects_name }
+    s = { objects_name => filter_records.as_json(current_user:), multiple_results: objects_name }
 
     set_objects_instance(@master_objects) # re add_trackers collection
     s.merge!(extend_result)
@@ -563,11 +563,14 @@ module MasterHandler
 
     requested_filtered_ids = pfilter[:resource_id]
     secondary_key_filtered_ids = pfilter[:secondary_key]
+    attr_filter = pfilter[@master_objects.klass.resource_name.to_sym]
     if requested_filtered_ids.present?
       requested_filtered_ids = requested_filtered_ids.split(',').map { |i| i.strip.to_i }
       @master_objects = @master_objects.where(id: requested_filtered_ids)
     elsif secondary_key_filtered_ids.present?
       @master_objects = @master_objects.find_all_by_secondary_key(secondary_key_filtered_ids)
+    elsif attr_filter.present?
+      @master_objects = @master_objects.where(@master_objects.klass.table_name => attr_filter.to_unsafe_h)
     else
       @master_objects
     end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -138,7 +138,7 @@ module AdminHelper
 
     res = <<~END_HTML
       <span class="hidden">#{list_item.updated_at}</span>
-      <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip"  title="last updated by: #{list_item.admin&.email} at #{list_item.updated_at}"></span>
+      <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip"  title="last updated by: #{list_item.admin_email} at #{list_item.updated_at}"></span>
     END_HTML
 
     res.html_safe

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -217,8 +217,8 @@ module ApplicationHelper
 
   #
   # Cache key for pregenerated partials
-  def partial_cache_key(partial)
-    u = current_user || current_admin
+  def partial_cache_key(partial, force_user_or_admin: nil)
+    u = force_user_or_admin || current_user || current_admin
     auth_type = u.class.name
     if u.is_a? User
       apptype = u.app_type_id

--- a/app/models/admin/app_type.rb
+++ b/app/models/admin/app_type.rb
@@ -72,7 +72,11 @@ class Admin
 
       atavail = []
       olat = Settings::OnlyLoadAppTypes
-      active.each do |a|
+
+      use_ats = active
+      use_ats = use_ats.where(id: olat) if olat.present?
+
+      use_ats.each do |a|
         hat = user.has_access_to?(:access, :general, :app_type, alt_app_type_id: a.id)
         atavail << hat.app_type if hat && (!olat || hat.app_type_id.in?(olat))
       end

--- a/app/models/admin/defs/app_configuration_defs.yaml
+++ b/app/models/admin/defs/app_configuration_defs.yaml
@@ -77,7 +77,7 @@ notes field caption: |
 notes field format: |
   Default notes field format for this app. Defaults to plain text. Set value "markdown" for rich text editor
 no search in master record: |
-  Do not show search tabs or a search panel when linked followed to a single master record
+  Do not show search tabs or a search panel when link followed to a single master record
 open panels: |
   List of panels to open automatically when the master record is displayed. 
   Comma separated list of default panel names or resource names for 

--- a/app/models/admin/defs/page_layout_options_defs.yaml
+++ b/app/models/admin/defs/page_layout_options_defs.yaml
@@ -35,6 +35,13 @@ view_options:
   hide_sublist_controls:              # hide the sublist controls (filter, sort) in dynamic item panel
   hide_activity_logs_header:          # hide the activity logs header including + buttons
   close_others:                       # when clicked to expand this tab, others will be closed
+  show_for_single_master_only:        # Only show panel if a single master result is presented
+  show_for_multi_master_only:         # Only show panel if a multiple master results are presented
+  filter_items:                       # set to 'using params' to use URL params passed to the page within
+                                      # filter[<resource_name>][<param_name>]=<param_value>&...
+                                      # or set a series of hashes (keyed by resource name) representing params
+                                      # For example:
+                                      # { <resource_name>: { <param_name>: <param_value>, ...}, ... }
 
 list_options:
   hide_in_list: false (default) | true

--- a/app/models/admin/page_layout.rb
+++ b/app/models/admin/page_layout.rb
@@ -68,7 +68,8 @@ class Admin::PageLayout < Admin::AdminBase
   #   find_with: the alternative id (crosswalk or external id) to search for the master record with for standalone pages
   configure :view_options,
             with: %i[initial_show orientation add_item_label limit find_with hide_sublist_controls
-                     hide_activity_logs_header close_others]
+                     hide_activity_logs_header close_others
+                     show_for_single_master_only show_for_multi_master_only filter_items]
 
   # List options for dashboards list
   configure :list_options, with: %i[hide_in_list]
@@ -178,14 +179,14 @@ class Admin::PageLayout < Admin::AdminBase
   # Active standalone layouts for the specified app type
   # @return [ActiveRecord::Relation] standalone page layouts
   def self.app_standalone_layouts(app_type_id)
-    Admin::PageLayout.active.standalone.where(app_type_id: app_type_id)
+    Admin::PageLayout.active.standalone.where(app_type_id:)
   end
 
   #
   # Active view or standalone layouts for the specified app type
   # @return [ActiveRecord::Relation] all active layout types for app
   def self.app_show_layouts(app_type_id)
-    Admin::PageLayout.active.showable.where(app_type_id: app_type_id)
+    Admin::PageLayout.active.showable.where(app_type_id:)
   end
 
   def self.position_attribute
@@ -193,7 +194,7 @@ class Admin::PageLayout < Admin::AdminBase
   end
 
   def position_group
-    { app_type_id: app_type_id, layout_name: layout_name }
+    { app_type_id:, layout_name: }
   end
 
   def standalone?

--- a/app/models/admin/user_access_control.rb
+++ b/app/models/admin/user_access_control.rb
@@ -197,7 +197,7 @@ class Admin::UserAccessControl < Admin::AdminBase
   end
 
   def self.cache_key_for_access_for(*args)
-    "access-for--#{args.join('-')}-#{latest_update}-#{Settings::OnlyLoadAppTypes.join(',')}"
+    "access-for--#{args.join('-')}-#{latest_update}-#{Settings::OnlyLoadAppTypes}"
   end
 
   #

--- a/app/models/admin/user_access_control.rb
+++ b/app/models/admin/user_access_control.rb
@@ -197,7 +197,7 @@ class Admin::UserAccessControl < Admin::AdminBase
   end
 
   def self.cache_key_for_access_for(*args)
-    "access-for--#{args.join('-')}-#{latest_update}"
+    "access-for--#{args.join('-')}-#{latest_update}-#{Settings::OnlyLoadAppTypes.join(',')}"
   end
 
   #

--- a/app/models/concerns/admin_handler.rb
+++ b/app/models/concerns/admin_handler.rb
@@ -112,7 +112,11 @@ module AdminHandler
   def admin_name
     return unless admin_id
 
-    Admin.emails_by_id[user_id]
+    Admin.emails_by_id[admin_id]
+  end
+
+  def admin_email
+    admin_name
   end
 
   def admin=(_new_admin)

--- a/app/models/concerns/user_access_handler.rb
+++ b/app/models/concerns/user_access_handler.rb
@@ -49,7 +49,7 @@ module UserAccessHandler
       force_reset = true
     end
 
-    ckey = "has_access_to--#{perform}-#{resource_type}-#{named}-#{with_options}-#{alt_app_type_id || app_type_id}"
+    ckey = "has_access_to--#{perform}-#{resource_type}-#{named}-#{with_options}-#{alt_app_type_id || app_type_id}-#{Settings::OnlyLoadAppTypes}"
     return @has_access_to[ckey] if @has_access_to.key?(ckey) && !force_reset
 
     @has_access_to[ckey] =

--- a/app/models/concerns/user_and_roles.rb
+++ b/app/models/concerns/user_and_roles.rb
@@ -53,7 +53,7 @@ module UserAndRoles
         rn = [rn] unless rn.is_a? Array
         app_type_role_names = rn.map { |v| [app_type_id, v] }
       elsif user
-        app_type_role_names = user.app_type_role_names
+        app_type_role_names = user.app_type_role_names(app_type_id: app_type)
       end
 
       if app_type_role_names&.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -204,14 +204,24 @@ class User < ActiveRecord::Base
     Admin::AppType.all_available_to(self)
   end
 
+  #
+  # Get the role names for the user in the current app type, or if
+  # conditions specifies :app_type_id, use that instead
+  # @param [<Type>] conditions <description>
+  # @option conditions [<Type>] :<key> <description>
+  # @option conditions [<Type>] :<key> <description>
+  # @option conditions [<Type>] :<key> <description>
+  # @return [<Type>] <description>
   def app_type_role_names(conditions = {})
     @app_type_role_names = {} if user_roles_updated? || user_access_controls_updated?
     @app_type_role_names ||= {}
 
+    alt_app_type_id = conditions[:app_type_id] || app_type_id
+
     got = @app_type_role_names[conditions]
     return got if got
 
-    @app_type_role_names[conditions] = Admin::UserRole.active_app_roles(self, app_type: [app_type_id, nil])
+    @app_type_role_names[conditions] = Admin::UserRole.active_app_roles(self, app_type: [alt_app_type_id, nil])
                                                       .select('app_type_id, role_name').distinct.order(app_type_id: :asc)
                                                       .pluck(:app_type_id, :role_name)
   end

--- a/app/views/masters/_search_results_master_tabs_item.html.erb
+++ b/app/views/masters/_search_results_master_tabs_item.html.erb
@@ -6,9 +6,17 @@
   resources = panel.contains&.resources
   initial_show = panel.view_options&.initial_show
   close_others = panel.view_options&.close_others
+  show_for_single_master_only = panel.view_options&.show_for_single_master_only
+  show_for_multi_master_only = panel.view_options&.show_for_multi_master_only
+  filter_items = panel.view_options&.filter_items
   limit = panel.view_options&.limit
   default_panels = app_config_items(:open_panels)
   %>
+  <% if show_for_single_master_only %> 
+  {{#is (or num_masters (length (fpa_state_item 'masters'))) '===' 1 }}
+  <% elsif show_for_multi_master_only %>
+  {{#is (or num_masters (length (fpa_state_item 'masters'))) '>' 1}}
+  <% end %>
   <% if categories && categories.include?('trackers')
 
     if default_panels.length > 0
@@ -41,12 +49,28 @@
       end
 
       path = resource.gsub('__', '/').pluralize
+      extra_params = ''
+      using_params = ''
+      if filter_items
+        rparams = filter_items[resource.pluralize]
+        if rparams.is_a? Hash
+          rparams = rparams.to_unsafe_h if rparams.respond_to? :to_unsafe_h
+          extra_params = "&#{rparams.to_query}"
+          using_params = 'page-layout'
+        elsif rparams == 'using params'
+          using_params = 'page'
+        end
+      end
+
       extra_classes = "#{close_others ? 'tabs-close-others' : ''} #{initial_show ? 'on-open-click' : ''}"
   %>
-  <li role="presentation" class="<%= extra_classes %>">
-    <a id="tab-activity-log-<%= panel_name %>" href="/masters/{{id}}/<%= path %>?limit=<%=limit%>"  data-panel-tab="<%=resource%>" data-remote="true" data-prevent-on-collapse="true" data-toggle="collapse" data-target="#<%= resource.hyphenate %>-{{id}}" aria-expanded="false" class="scroll-to-expanded  collapsed"  data-result-target="#<%= resource.hyphenate %>-{{id}}" data-template="<%= resource.hyphenate %><%= template_postfix %>"><%= panel_label %></a>
+  <li role="presentation" class="<%= extra_classes %> initial_show_value-<%=initial_show%>-<%=default_panels.length%>">
+    <a id="tab-activity-log-<%= panel_name %>" href="/masters/{{id}}/<%= path %>?limit=<%=limit%><%extra_params%>&{{params_to_query 'filter' '<%=resource.pluralize%>'}}" data-using-params="<%= using_params %>" data-panel-tab="<%=resource%>" data-remote="true" data-prevent-on-collapse="true" data-toggle="collapse" data-target="#<%= resource.hyphenate %>-{{id}}" aria-expanded="false" class="scroll-to-expanded  collapsed"  data-result-target="#<%= resource.hyphenate %>-{{id}}" data-template="<%= resource.hyphenate %><%= template_postfix %>"><%= panel_label %></a>
   </li>
   <%
     end
   end
-%>
+  %>
+  <% if show_for_single_master_only || show_for_multi_master_only %> 
+  {{/is}}
+  <% end %>

--- a/app/views/masters/_search_results_master_tabs_item.html.erb
+++ b/app/views/masters/_search_results_master_tabs_item.html.erb
@@ -24,10 +24,11 @@
     end
     extra_classes = "#{close_others ? 'tabs-close-others' : ''} #{initial_show ? 'on-open-click' : ''}"
   %>
+  {{#if (or (not (params 'only_tabs')) (params 'only_tabs' 'trackers')) }}
   <li role="presentation" class="<%= extra_classes %>">
     <a href="/masters/{{id}}/trackers" data-panel-tab="trackers" data-toggle="collapse" data-target="#trackers-{{id}}" data-remote="true" aria-expanded="false" class="scroll-to-expanded open-tracker collapsed">tracker <span data-sub-for-root="master_id" data-sub-id="{{id}}" data-sub-item="trackers" data-template="tracker-badge-template" class="tracker-count">{{>tracker_badge master_id=id}}</span></a>
   </li>
-
+  {{/if}}
   <% elsif categories
 
     if default_panels.length > 0
@@ -35,9 +36,11 @@
     end
     extra_classes = "#{close_others ? 'tabs-close-others' : ''} #{initial_show ? 'on-open-click' : ''}"
   %>
+  {{#if (or (not (params 'only_tabs')) (params 'only_tabs' 'categories')) }}
   <li role="presentation" class="category-tab <%= extra_classes %>">
     <a href="#" data-panel-tab="<%= panel_name_us %>" data-toggle="collapse" data-target="#<%= panel_name%>-{{id}}" aria-expanded="false" class="scroll-to-expanded  collapsed"><%= panel_label %></a>
   </li>
+  {{/if}}
 
   <% elsif resources
     resources.each do |resource|
@@ -64,9 +67,11 @@
 
       extra_classes = "#{close_others ? 'tabs-close-others' : ''} #{initial_show ? 'on-open-click' : ''}"
   %>
+  {{#if (or (not (params 'only_tabs')) (params 'only_tabs' '<%=resource.pluralize%>')) }}
   <li role="presentation" class="<%= extra_classes %> initial_show_value-<%=initial_show%>-<%=default_panels.length%>">
     <a id="tab-activity-log-<%= panel_name %>" href="/masters/{{id}}/<%= path %>?limit=<%=limit%><%extra_params%>&{{params_to_query 'filter' '<%=resource.pluralize%>'}}" data-using-params="<%= using_params %>" data-panel-tab="<%=resource%>" data-remote="true" data-prevent-on-collapse="true" data-toggle="collapse" data-target="#<%= resource.hyphenate %>-{{id}}" aria-expanded="false" class="scroll-to-expanded  collapsed"  data-result-target="#<%= resource.hyphenate %>-{{id}}" data-template="<%= resource.hyphenate %><%= template_postfix %>"><%= panel_label %></a>
   </li>
+  {{/if}}
   <%
     end
   end

--- a/app/views/pages/_index_admin.html.erb
+++ b/app/views/pages/_index_admin.html.erb
@@ -28,8 +28,8 @@
   <div class="panel-body">
     <div class="row">
       <div class="col-sm-6">
-        <% begin %>
-        <%= render partial: 'admin/app_types/components' %>
+        <% begin %>        
+        <%= Rails.cache.fetch(partial_cache_key('index_admin_components', force_user_or_admin: current_admin)) { render partial: 'admin/app_types/components' } %>
         <% rescue StandardError => e
             logger.warn 'Failed to load admin components panel'
             logger.warn e


### PR DESCRIPTION
### From FPHS

- [Added] ability to only show listed tabs using `<uri>?only_tabs[<resource_name>]=true&...` or `?only_tabs[categories]=true&...`
- [Added] master panel options to page layouts to allow filtering of resource items by configured filter, or by page URL query params
- [Added] master panel options to "show for single master only" and "show for multi master only" so different panels can be shown for different UI states
- [Fixed] caching of apps available to users
- [Fixed] masters index history being pushed if the aim is to not prevent a reload
- [Fixed] available app type lookup for a user - role names where only being checked in the current app, not for the app being tested
- [Added] cache to admin index page to speed things up
- [Fixed] admin email lookup in admin info icons
