### PR TITLE
Added _configurations.foreign_key_through_external_id to associate a …

### DIFF
--- a/app/controllers/concerns/dynamic_model_controller_handler.rb
+++ b/app/controllers/concerns/dynamic_model_controller_handler.rb
@@ -1,15 +1,10 @@
 module DynamicModelControllerHandler
-
   extend ActiveSupport::Concern
 
-
   class_methods do
-
-
     def model_class_name
       @model_class_name = definition.model_class_name
     end
-
   end
 
   def edit_form
@@ -17,11 +12,10 @@ module DynamicModelControllerHandler
   end
 
   def implementation_class
+    return @implementation_class if @implementation_class
+
     cn = self.class.model_class_name
     cnf = "DynamicModel::#{cn}"
-    cnf.constantize
+    @implementation_class = cnf.constantize
   end
-
-
-
 end

--- a/app/controllers/concerns/master_handler.rb
+++ b/app/controllers/concerns/master_handler.rb
@@ -30,16 +30,16 @@ module MasterHandler
   # so simply add a parameter like :cache_version => current timestamp to force new data
   def index
     index_res = if params[:cache_result].present?
-      response.headers['Cache-Control'] = 'max-age=30'
-      response.headers.delete 'Expires'
-      return unless stale?(etag: index_cache_key)
+                  response.headers['Cache-Control'] = 'max-age=30'
+                  response.headers.delete 'Expires'
+                  return unless stale?(etag: index_cache_key)
 
-      Rails.cache.fetch(index_cache_key) do
-        retrieve_index.as_json
-      end
-    else
-      retrieve_index.as_json
-    end
+                  Rails.cache.fetch(index_cache_key) do
+                    retrieve_index.as_json
+                  end
+                else
+                  retrieve_index.as_json
+                end
 
     render json: index_res
   end
@@ -432,6 +432,13 @@ module MasterHandler
 
     set_item if defined? set_item
     build_with = nil
+
+    if defined?(setup_default_build_params)
+      # We may need to set default parameters before the build
+      # to ensure we have associations back the the master record set up correctly,
+      # or to set other attributes required for validation.
+      setup_default_build_params
+    end
 
     begin
       build_with = secure_params

--- a/app/models/admin/defs/extra_options_top_level_options_defs.yaml
+++ b/app/models/admin/defs/extra_options_top_level_options_defs.yaml
@@ -54,6 +54,27 @@ _configurations:
     # NOTE: searches through the UI against the external ID (using the default capabilities)
     # may now return multiple results, since there is currently no way to specify the other fields that make up a unique search.
   can_change_master: allow assigned external identifiers to be moved to a different master record
+  foreign_key_through_external_id: external identifier resource name to join to master through when the *foreign key name* is defined
+    # Allows a dynamic model to be have a master association without a master_id (or other crosswalk attribute) column configured on the
+    # table. Instead, the column name specified in the *foreign key name* definition name the field this model, the value
+    # of which is then used to look up the external identifier record of type defined in this configuration. This then makes the connection
+    # back to the master record.
+    # The inverse of this is that the master record can create one of these dynamic models if an external identifier of this type has been created.
+    # If multiple external ids are associated with this master record, the most recent one will be used.
+    #
+    # For example, a dynamic model definition could look like this:
+    #   *Foreign key name*
+    #     alt_id
+    #   *Field list*
+    #     notes alt_id
+    #   *Options*
+    #     _configurations:
+    #       foreign_key_through_external_id: ipa_assignments
+    # This would then use the value of alt_id in the dynamic model record to find its associated master through a
+    # ipa_assignments external identifier associated with the master record.
+    #
+    # Another common use case might be to have the *Foreign key name* set to "redcap_survey_identifier" and the
+    # *foreign_key_through_external_id:* configuration would specify the external identifier type to use to lookup the associated master.
 
 # To add a table or view to the data dictionary, add the _data_dictionary: with
 # the essential keys, study: and domain:, plus any others that are required.

--- a/app/models/concerns/handles_user_base.rb
+++ b/app/models/concerns/handles_user_base.rb
@@ -683,7 +683,7 @@ module HandlesUserBase
     unless mu.is_a?(User) && mu.persisted?
       master = '[not defined]' unless respond_to? :master
       raise "bad user (for master #{master}) being pulled from master_user " \
-      "(#{mu.is_a?(User) ? '' : 'not a user'}#{mu && mu.persisted? ? '' : ' not persisted'})"
+      "(#{mu.class.name} #{mu.is_a?(User) ? '' : 'not a user'}#{mu && mu.persisted? ? '' : ' not persisted'})"
     end
 
     write_attribute :user_id, mu.id

--- a/app/models/dynamic/def_handler.rb
+++ b/app/models/dynamic/def_handler.rb
@@ -7,7 +7,7 @@ module Dynamic
     included do
       after_save :force_option_config_parse
       after_save :handle_batch_schedule
-      attr_accessor :configurations, :data_dictionary, :options_constants
+      attr_accessor :configurations, :data_dictionary, :options_constants, :foreign_key_through_external_id
     end
 
     class_methods do
@@ -468,6 +468,11 @@ module Dynamic
     # The name of the association within the Master class
     def model_association_name
       full_implementation_class_name.pluralize.ns_underscore.to_sym
+    end
+
+    # Association name where for a parent has one of this type
+    def one_of_this_association_name
+      model_association_name.to_s.singularize.to_sym
     end
 
     # Full namespaced item type name, underscored with double underscores

--- a/app/models/dynamic/dynamic_model_implementer.rb
+++ b/app/models/dynamic/dynamic_model_implementer.rb
@@ -48,16 +48,9 @@ module Dynamic
         true
       end
 
+      # TODO: check if this is always overridden by UserHandler
       def assoc_inverse
         @assoc_inverse = definition.model_association_name
-      end
-
-      def foreign_key_name
-        @foreign_key_name = definition.foreign_key_name.blank? ? nil : definition.foreign_key_name.to_sym
-      end
-
-      def primary_key_name
-        @primary_key_name = definition.primary_key_name.to_sym
       end
 
       # Override the primary_key definition for a model, to ensure

--- a/app/models/master.rb
+++ b/app/models/master.rb
@@ -185,6 +185,14 @@ class Master < ActiveRecord::Base
   # The main set of has_many associations that represents the primary data objects that can belong to a master record
   PrimaryAssociations = get_all_associations
 
+  # ExternalIdentifier associations take the form:
+  #    master.scantrons
+  # i.e. the underscored pluralized name
+  # This is placed here, since there is a dependency on MasterSearchHandler
+  # It also precedes the DynamicModel activation, since "has may through" associations made later
+  # may rely on the ExternalIdentifier associations.
+  ExternalIdentifier.enable_active_configurations
+
   # DynamicModel associations take the form:
   #     master.player_contact_histories
   # i.e. the pluralized table name
@@ -198,12 +206,6 @@ class Master < ActiveRecord::Base
   #   master.activity_log__player_contact_phones
   # Notice the double underscore which represents the Module::Class delimiter
   ActivityLog.enable_active_configurations
-
-  # ExternalIdentifier associations take the form:
-  #    master.scantrons
-  # i.e. the underscored pluralized name
-  # This is placed here, since there is a dependency on MasterSearchHandler
-  ExternalIdentifier.enable_active_configurations
 
   if attribute_names.include? 'created_by_user_id'
     # NOTE: a belongs_to association can't include a scope definition and be used in a join

--- a/app/models/view_handlers/subject.rb
+++ b/app/models/view_handlers/subject.rb
@@ -14,7 +14,7 @@ module ViewHandlers
       # subject info to be requested for a Master. Substitutions for example use this to get
       # subject_info.last_name as opposed to subject_infos.last_name
       if respond_to? :definition
-        Master.has_one definition.model_association_name.to_s.singularize.to_sym,
+        Master.has_one one_of_this_association_name,
                        -> { order(Master.subject_info_rank_order_clause) },
                        class_name: "DynamicModel::#{definition.model_class_name}",
                        foreign_key: definition.foreign_key_name,

--- a/spec/migrations/20230328104402_create_test_no_master_dm_alt_id.rb
+++ b/spec/migrations/20230328104402_create_test_no_master_dm_alt_id.rb
@@ -1,0 +1,18 @@
+require 'active_record/migration/app_generator'
+class CreateTestNoMasterDmAltId < ActiveRecord::Migration[5.2]
+  include ActiveRecord::Migration::AppGenerator
+
+  def change
+    self.schema = 'test'
+    self.table_name = 'test_no_master_dm_alt_id_recs'
+    self.class_name = 'DynamicModel::TestNoMasterDmAltIdRec'
+    self.table_comment = 'Dynamicmodel: Test No Master Dm Rec Alt Id'
+    self.fields = %i[data info alt_id]
+    self.fields_comments = { data: 'Data', info: 'Information', alt_id: 'Alternative ID' }
+    self.db_configs = { data: { type: 'string' }, info: { type: 'string' }, alt_id: { type: 'integer' } }
+    self.no_master_association = true
+    self.resource_type = :dynamic_model
+    self.all_referenced_tables = []
+    create_dynamic_model_tables
+  end
+end

--- a/spec/models/dynamic/association_issues_spec.rb
+++ b/spec/models/dynamic/association_issues_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe 'ActiveRecord::HasManyThroughOrderError' do
+  describe '#has_many and has_one through' do
+    Rails.application.eager_load!
+
+    m = DynamicModel.active_model_configurations
+    m.map(&:implementation_class).each do |ic|
+      %i[has_one has_many].each do |association_kind|
+        has_through_associations = ic.descendants.reject(&:abstract_class?).each_with_object({}) do |ar_class, result|
+          has_through_associations = ar_class.reflect_on_all_associations(association_kind).select do |association|
+            association.options.key? :through
+          end
+          result[ar_class] = has_through_associations.map(&:name) if has_through_associations.any?
+        end
+        has_through_associations.each do |ar_class, association_names|
+          test_class = ar_class.new
+          association_names.each do |association_name|
+            context "loading #{ar_class}. #{association_name} should not raise an HasManyThroughOrderError" do
+              it 'should be a success' do
+                if association_kind == :has_one
+                  expect { test_class.send(association_name.to_sym) }.not_to raise_error
+                else
+                  expect { test_class.send(association_name.to_sym).first }.not_to raise_error
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/dynamic_model_spec.rb
+++ b/spec/models/dynamic_model_spec.rb
@@ -10,237 +10,269 @@ RSpec.describe 'Dynamic Model implementation', type: :model do
   include PlayerContactSupport
   include BulkMsgSupport
   include DynamicModelSupport
+  include TestNoMasterDmRecSupport
 
-  before :all do
-    expect(Admin::MigrationGenerator.view_definition('dynamic_test', 'test_views')).to be nil
-    generate_test_dynamic_view
-  rescue StandardError => e
-    puts e
-  end
+  describe 'dynamic models with foreign key as master_id' do
+    before :all do
+      expect(Admin::MigrationGenerator.view_definition('dynamic_test', 'test_views')).to be nil
+      generate_test_dynamic_view
+    rescue StandardError => e
+      puts e
+    end
 
-  before :example do
-    # Seeds.setup
+    before :example do
+      # Seeds.setup
 
-    @user0, = create_user
-    create_admin
-    create_user
-    setup_access :trackers
-    setup_access :tracker_history
+      @user0, = create_user
+      create_admin
+      create_user
+      setup_access :trackers
+      setup_access :tracker_history
 
-    import_bulk_msg_app
-    dm = DynamicModel::ZeusBulkMessage.definition
-    dm.current_admin = @admin
-    dm.update_tracker_events
+      import_bulk_msg_app
+      dm = DynamicModel::ZeusBulkMessage.definition
+      dm.current_admin = @admin
+      dm.update_tracker_events
 
-    @bulk_master = Master.find(-1)
-    @bulk_master.current_user = @user
+      @bulk_master = Master.find(-1)
+      @bulk_master.current_user = @user
 
-    @bms = DynamicModel::ZeusBulkMessageStatus.new
-    let_user_create :player_contacts
-    let_user_create :dynamic_model__zeus_bulk_message_recipients
-    let_user_create :dynamic_model__zeus_bulk_message_statuses
-    let_user_create :dynamic_model__zeus_bulk_messages
+      @bms = DynamicModel::ZeusBulkMessageStatus.new
+      let_user_create :player_contacts
+      let_user_create :dynamic_model__zeus_bulk_message_recipients
+      let_user_create :dynamic_model__zeus_bulk_message_statuses
+      let_user_create :dynamic_model__zeus_bulk_messages
 
-    @bulk_master.dynamic_model__zeus_bulk_message_recipients.update_all(response: nil)
-  end
+      @bulk_master.dynamic_model__zeus_bulk_message_recipients.update_all(response: nil)
+    end
 
-  it 'implements a dynamic model that can be disabled' do
-    # Since recipients can be disabled, the class should provide a scope that allows just active recipients to be selected
-    expect(DynamicModel::ZeusBulkMessageRecipient).to respond_to :active
-  end
+    it 'implements a dynamic model that can be disabled' do
+      # Since recipients can be disabled, the class should provide a scope that allows just active recipients to be selected
+      expect(DynamicModel::ZeusBulkMessageRecipient).to respond_to :active
+    end
 
-  it 'implements a dynamic model that can store data' do
-    pcs = []
-    max_num = 3
+    it 'implements a dynamic model that can store data' do
+      pcs = []
+      max_num = 3
 
-    recips = []
+      recips = []
 
-    zbmsg = @bulk_master.dynamic_model__zeus_bulk_messages.create!(status: 'sent', name: 'test', channel: 'sms', message: 'message', send_date: DateTime.now, send_time: Time.now - 10.minutes)
-    2.times do |n|
-      m = create_master
-      # We need a range of timestamps
-      sleep 1.2 if n == max_num - 1 || n == max_num
-      pcs << m.player_contacts.create(data: "(123)123-123#{n}", rank: 10, rec_type: :phone)
-      pc = pcs[n]
-      restext = "[{\"aws_sns_sms_message_id\":\"#{rand(199_999_999_999)}\"}]"
+      zbmsg = @bulk_master.dynamic_model__zeus_bulk_messages.create!(status: 'sent', name: 'test', channel: 'sms', message: 'message', send_date: DateTime.now, send_time: Time.now - 10.minutes)
+      2.times do |n|
+        m = create_master
+        # We need a range of timestamps
+        sleep 1.2 if n == max_num - 1 || n == max_num
+        pcs << m.player_contacts.create(data: "(123)123-123#{n}", rank: 10, rec_type: :phone)
+        pc = pcs[n]
+        restext = "[{\"aws_sns_sms_message_id\":\"#{rand(199_999_999_999)}\"}]"
 
-      recips << @bulk_master.dynamic_model__zeus_bulk_message_recipients.create!(record_id: pc.id, data: pc.data, rank: pc.rank, response: restext, zeus_bulk_message_id: zbmsg.id)
+        recips << @bulk_master.dynamic_model__zeus_bulk_message_recipients.create!(record_id: pc.id, data: pc.data, rank: pc.rank, response: restext, zeus_bulk_message_id: zbmsg.id)
+      end
+    end
+
+    it "saves the current user's user_id if the created_by_user_id field is present" do
+      generate_test_dynamic_model
+
+      rec = @master.dynamic_model__test_created_by_recs.create! test1: 'abc'
+      expect(rec).to be_a DynamicModel::TestCreatedByRec
+
+      rec = DynamicModel::TestCreatedByRec.find rec.id
+      expect(rec).to be_persisted
+      expect(rec.user_id).to eq @user.id
+      # Expect the created_by_user_id field value to match the current user
+      expect(rec.created_by_user_id).to eq @user.id
+
+      rec.update!(current_user: @user0, test2: 'def')
+      rec = DynamicModel::TestCreatedByRec.find rec.id
+
+      expect(rec.user_id).to eq @user0.id
+      # Expect the created_by_user_id field value to be unchanged
+      expect(rec.created_by_user_id).to eq @user.id
+
+      expect(rec).to respond_to :created_by_user_name
+      expect(rec.created_by_user_name).to eq @user.email
+    end
+
+    it 'creates a view using supplied SQL' do
+      Admin::MigrationGenerator.view_definition 'dynamic_test', 'test_views'
+    end
+
+    it 'sets an initial config if the table already exists' do
+      unless Admin::MigrationGenerator.table_exists? 'test_created_by_recs'
+        TableGenerators.dynamic_models_table('test_created_by_recs', :create_do, 'test1', 'test2', 'created_by_user_id')
+      end
+
+      table_comment = 'a test table'
+      test2_comment = 'test2 column comment'
+
+      Admin::MigrationGenerator.connection.execute <<~END_SQL
+        comment on table test_created_by_recs is '#{table_comment}';
+        comment on column test_created_by_recs.test2 is '#{test2_comment}';
+      END_SQL
+
+      dm = DynamicModel.create! current_admin: @admin,
+                                name: 'test created by',
+                                table_name: 'test_created_by_recs',
+                                schema_name: 'ml_app',
+                                category: :test
+
+      dm.current_admin = @admin
+      dm.update_tracker_events
+
+      expect(dm).to be_a ::DynamicModel
+      # The field list has been set up
+      expect(dm.field_list).to eq 'test1 test2 created_by_user_id'
+      # The keys have been set up automatically
+      expect(dm.foreign_key_name).to eq 'master_id'
+      expect(dm.primary_key_name).to eq 'id'
+      # A baseline set of comments have been set up
+      tcs = dm.table_comments
+      # The default comment 'Dynamicmodel: Test Created By' should not be used
+      expect(tcs[:table]).to eq table_comment
+      expect(tcs[:fields][:test2]).to eq test2_comment
+
+      ol = dm.options.dup
+      # now update the config and check the options haven't changed again
+      dm.update!(name: 'updated test created by', current_admin: @admin)
+
+      dm.reload
+      expect(dm.options).to eq ol
+    end
+
+    it 'pulls the current configuration from a table' do
+      unless Admin::MigrationGenerator.table_exists? 'test_created_by_recs'
+        TableGenerators.dynamic_models_table('test_created_by_recs', :create_do, 'test1', 'test2', 'created_by_user_id')
+      end
+
+      table_comment = 'a test table'
+      test2_comment = 'test2 column comment'
+
+      new_table_comment = 'a test table new comment'
+      new_test1_comment = 'new test1 column comment'
+      new_test2_comment = 'new test2 column comment'
+
+      Admin::MigrationGenerator.connection.execute <<~END_SQL
+        comment on table test_created_by_recs is '#{table_comment}';
+        comment on column test_created_by_recs.test2 is '#{test2_comment}';
+      END_SQL
+
+      dm = DynamicModel.create! current_admin: @admin,
+                                name: 'test created by',
+                                table_name: 'test_created_by_recs',
+                                schema_name: 'ml_app',
+                                category: :test
+
+      dm.current_admin = @admin
+      dm.update_tracker_events
+
+      expect(dm).to be_a ::DynamicModel
+      # The field list has been set up
+      expect(dm.field_list).to eq 'test1 test2 created_by_user_id'
+      # The keys have been set up automatically
+      expect(dm.foreign_key_name).to eq 'master_id'
+      expect(dm.primary_key_name).to eq 'id'
+
+      # A baseline set of comments have been set up
+      tcs = dm.table_comments
+      # The default comment 'Dynamicmodel: Test Created By' should not be used
+      expect(tcs[:table]).to eq table_comment
+      expect(tcs[:fields][:test2]).to eq test2_comment
+
+      # Make changes to the comments and see them reflected in the options after the next save
+      Admin::MigrationGenerator.connection.execute <<~END_SQL
+        comment on table test_created_by_recs is '#{new_table_comment}';
+        comment on column test_created_by_recs.test1 is '#{new_test1_comment}';
+        comment on column test_created_by_recs.test2 is '#{new_test2_comment}';
+      END_SQL
+
+      # Force a full reload
+      dm = DynamicModel.find(dm.id)
+      dm.current_admin = @admin
+
+      dm.update_config_from_table
+      dm.save!
+
+      dm = DynamicModel.find(dm.id)
+      dm.option_configs force: true
+      expect(dm).to be_a ::DynamicModel
+      # The field list has been set up
+      expect(dm.field_list).to eq 'test1 test2 created_by_user_id'
+      # The keys have been set up automatically
+      expect(dm.foreign_key_name).to eq 'master_id'
+      expect(dm.primary_key_name).to eq 'id'
+
+      # A new set of comments have been set up
+      tcs = dm.table_comments
+      # The default comment 'Dynamicmodel: Test Created By' should not be used
+      expect(tcs[:table]).to eq new_table_comment
+      expect(tcs[:fields][:test1]).to eq new_test1_comment
+      expect(tcs[:fields][:test2]).to eq new_test2_comment
+    end
+
+    it 'sets up a data dictionary if the appropriate config is specified' do
+      unless Admin::MigrationGenerator.table_exists? 'test_created_by_recs'
+        TableGenerators.dynamic_models_table('test_created_by_recs', :create_do, 'test1', 'test2', 'created_by_user_id')
+      end
+
+      options = <<~END_OPTIONS
+        _data_dictionary:
+          study: Test Study
+          domain: Test
+          source_type: test database
+      END_OPTIONS
+
+      name = 'test created by 2'
+      res = Dynamic::DatadicVariable.find_by_identifiers source_name: name,
+                                                         source_type: 'test database',
+                                                         form_name: nil,
+                                                         variable_name: 'test1'
+
+      expect(res.first).to be nil
+
+      dm = DynamicModel.create!(current_admin: @admin,
+                                name:,
+                                table_name: 'test_created_by_recs',
+                                schema_name: 'ml_app',
+                                category: :test,
+                                options:)
+
+      expect(dm.data_dictionary_handler).not_to be nil
+
+      res = Dynamic::DatadicVariable.find_by_identifiers source_name: name,
+                                                         source_type: 'test database',
+                                                         form_name: nil,
+                                                         variable_name: 'test1'
+
+      expect(res.first).to be_a Datadic::Variable
     end
   end
 
-  it "saves the current user's user_id if the created_by_user_id field is present" do
-    generate_test_dynamic_model
+  describe 'no foreign key' do
+    before :example do
+      # Seeds.setup
 
-    rec = @master.dynamic_model__test_created_by_recs.create! test1: 'abc'
-    expect(rec).to be_a DynamicModel::TestCreatedByRec
-
-    rec = DynamicModel::TestCreatedByRec.find rec.id
-    expect(rec).to be_persisted
-    expect(rec.user_id).to eq @user.id
-    # Expect the created_by_user_id field value to match the current user
-    expect(rec.created_by_user_id).to eq @user.id
-
-    rec.update!(current_user: @user0, test2: 'def')
-    rec = DynamicModel::TestCreatedByRec.find rec.id
-
-    expect(rec.user_id).to eq @user0.id
-    # Expect the created_by_user_id field value to be unchanged
-    expect(rec.created_by_user_id).to eq @user.id
-
-    expect(rec).to respond_to :created_by_user_name
-    expect(rec.created_by_user_name).to eq @user.email
-  end
-
-  it 'creates a view using supplied SQL' do
-    Admin::MigrationGenerator.view_definition 'dynamic_test', 'test_views'
-  end
-
-  it 'sets an initial config if the table already exists' do
-    unless Admin::MigrationGenerator.table_exists? 'test_created_by_recs'
-      TableGenerators.dynamic_models_table('test_created_by_recs', :create_do, 'test1', 'test2', 'created_by_user_id')
+      @user0, = create_user
+      create_admin
+      create_user
+      setup_access :trackers
+      setup_access :tracker_history
+      @ext = ExternalIdentifier.active.first.implementation_class
+      @dm = setup_test_no_master_dm_rec_dynamic_model_alt_id @ext.resource_name
     end
 
-    table_comment = 'a test table'
-    test2_comment = 'test2 column comment'
+    it 'uses a foreign key through an external id to get the master record' do
+      stids = [123_456, 678_901, 345_617]
+      @sts = []
+      stids.each do |stid|
+        m = create_master
+        @sts << @ext.create(@ext.external_id_attribute => stid, master: m)
+      end
 
-    Admin::MigrationGenerator.connection.execute <<~END_SQL
-      comment on table test_created_by_recs is '#{table_comment}';
-      comment on column test_created_by_recs.test2 is '#{test2_comment}';
-    END_SQL
+      expect(@user).to be_a User
+      rec = create_test_no_master_dm_alt_id_rec(alt_id: stids[1])
 
-    dm = DynamicModel.create! current_admin: @admin,
-                              name: 'test created by',
-                              table_name: 'test_created_by_recs',
-                              schema_name: 'ml_app',
-                              category: :test
-
-    dm.current_admin = @admin
-    dm.update_tracker_events
-
-    expect(dm).to be_a ::DynamicModel
-    # The field list has been set up
-    expect(dm.field_list).to eq 'test1 test2 created_by_user_id'
-    # The keys have been set up automatically
-    expect(dm.foreign_key_name).to eq 'master_id'
-    expect(dm.primary_key_name).to eq 'id'
-    # A baseline set of comments have been set up
-    tcs = dm.table_comments
-    # The default comment 'Dynamicmodel: Test Created By' should not be used
-    expect(tcs[:table]).to eq table_comment
-    expect(tcs[:fields][:test2]).to eq test2_comment
-
-    ol = dm.options.dup
-    # now update the config and check the options haven't changed again
-    dm.update!(name: 'updated test created by', current_admin: @admin)
-
-    dm.reload
-    expect(dm.options).to eq ol
-  end
-
-  it 'pulls the current configuration from a table' do
-    unless Admin::MigrationGenerator.table_exists? 'test_created_by_recs'
-      TableGenerators.dynamic_models_table('test_created_by_recs', :create_do, 'test1', 'test2', 'created_by_user_id')
+      expect(rec.master).not_to be nil
+      expect(rec.master_id).to eq @sts[1].master_id
     end
-
-    table_comment = 'a test table'
-    test2_comment = 'test2 column comment'
-
-    new_table_comment = 'a test table new comment'
-    new_test1_comment = 'new test1 column comment'
-    new_test2_comment = 'new test2 column comment'
-
-    Admin::MigrationGenerator.connection.execute <<~END_SQL
-      comment on table test_created_by_recs is '#{table_comment}';
-      comment on column test_created_by_recs.test2 is '#{test2_comment}';
-    END_SQL
-
-    dm = DynamicModel.create! current_admin: @admin,
-                              name: 'test created by',
-                              table_name: 'test_created_by_recs',
-                              schema_name: 'ml_app',
-                              category: :test
-
-    dm.current_admin = @admin
-    dm.update_tracker_events
-
-    expect(dm).to be_a ::DynamicModel
-    # The field list has been set up
-    expect(dm.field_list).to eq 'test1 test2 created_by_user_id'
-    # The keys have been set up automatically
-    expect(dm.foreign_key_name).to eq 'master_id'
-    expect(dm.primary_key_name).to eq 'id'
-
-    # A baseline set of comments have been set up
-    tcs = dm.table_comments
-    # The default comment 'Dynamicmodel: Test Created By' should not be used
-    expect(tcs[:table]).to eq table_comment
-    expect(tcs[:fields][:test2]).to eq test2_comment
-
-    # Make changes to the comments and see them reflected in the options after the next save
-    Admin::MigrationGenerator.connection.execute <<~END_SQL
-      comment on table test_created_by_recs is '#{new_table_comment}';
-      comment on column test_created_by_recs.test1 is '#{new_test1_comment}';
-      comment on column test_created_by_recs.test2 is '#{new_test2_comment}';
-    END_SQL
-
-    # Force a full reload
-    dm = DynamicModel.find(dm.id)
-    dm.current_admin = @admin
-
-    dm.update_config_from_table
-    dm.save!
-
-    dm = DynamicModel.find(dm.id)
-    dm.option_configs force: true
-    expect(dm).to be_a ::DynamicModel
-    # The field list has been set up
-    expect(dm.field_list).to eq 'test1 test2 created_by_user_id'
-    # The keys have been set up automatically
-    expect(dm.foreign_key_name).to eq 'master_id'
-    expect(dm.primary_key_name).to eq 'id'
-
-    # A new set of comments have been set up
-    tcs = dm.table_comments
-    # The default comment 'Dynamicmodel: Test Created By' should not be used
-    expect(tcs[:table]).to eq new_table_comment
-    expect(tcs[:fields][:test1]).to eq new_test1_comment
-    expect(tcs[:fields][:test2]).to eq new_test2_comment
-  end
-
-  it 'sets up a data dictionary if the appropriate config is specified' do
-    unless Admin::MigrationGenerator.table_exists? 'test_created_by_recs'
-      TableGenerators.dynamic_models_table('test_created_by_recs', :create_do, 'test1', 'test2', 'created_by_user_id')
-    end
-
-    options = <<~END_OPTIONS
-      _data_dictionary:
-        study: Test Study
-        domain: Test
-        source_type: test database
-    END_OPTIONS
-
-    name = 'test created by 2'
-    res = Dynamic::DatadicVariable.find_by_identifiers source_name: name,
-                                                       source_type: 'test database',
-                                                       form_name: nil,
-                                                       variable_name: 'test1'
-
-    expect(res.first).to be nil
-
-    dm = DynamicModel.create! current_admin: @admin,
-                              name: name,
-                              table_name: 'test_created_by_recs',
-                              schema_name: 'ml_app',
-                              category: :test,
-                              options: options
-
-    expect(dm.data_dictionary_handler).not_to be nil
-
-    res = Dynamic::DatadicVariable.find_by_identifiers source_name: name,
-                                                       source_type: 'test database',
-                                                       form_name: nil,
-                                                       variable_name: 'test1'
-
-    expect(res.first).to be_a Datadic::Variable
   end
 end

--- a/spec/support/test_no_master_dm_rec_support.rb
+++ b/spec/support/test_no_master_dm_rec_support.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 module TestNoMasterDmRecSupport
+  def no_master_dm_table_name
+    'test_no_master_dm_recs'
+  end
+
   def setup_test_no_master_dm_rec_dynamic_model
-    dm = DynamicModel.create! current_admin: @admin, name: 'Test No Master Dm Rec', table_name: 'test_no_master_dm_recs', primary_key_name: :id, foreign_key_name: nil, category: :test
+    dm = DynamicModel.create! current_admin: @admin, name: 'Test No Master Dm Rec', table_name: no_master_dm_table_name, primary_key_name: :id, foreign_key_name: nil, category: :test
     dm.current_admin = @admin
     dm.update_tracker_events
 
@@ -10,6 +14,36 @@ module TestNoMasterDmRecSupport
 
     setup_access :dynamic_model__test_no_master_dm_recs, user: @user
     setup_access :dynamic_model__test_no_master_dm_recs, user: @user0
+    dm
+  end
+
+  def no_master_dm_table_name_alt_id
+    'test_no_master_dm_alt_id_recs'
+  end
+
+  def setup_test_no_master_dm_rec_dynamic_model_alt_id(extid_resource_name)
+    options = <<~END_OPTIONS
+      _configurations:
+        foreign_key_through_external_id: #{extid_resource_name}
+    END_OPTIONS
+
+    dm = DynamicModel.create!(
+      current_admin: @admin,
+      name: 'Test No Master Dm Rec Alt Id',
+      table_name: no_master_dm_table_name_alt_id,
+      primary_key_name: :id,
+      foreign_key_name: :alt_id,
+      category: :test,
+      options:
+    )
+
+    dm.current_admin = @admin
+    dm.update_tracker_events
+
+    expect(dm).to be_a ::DynamicModel
+
+    setup_access :dynamic_model__test_no_master_dm_alt_id_recs, user: @user
+    setup_access :dynamic_model__test_no_master_dm_alt_id_recs, user: @user0
     dm
   end
 
@@ -25,6 +59,15 @@ module TestNoMasterDmRecSupport
     att = att.dup
     att[:current_user] = @user
     DynamicModel::TestNoMasterDmRec.create! att
+  rescue StandardError => e
+    puts "attr for failure: #{att}"
+    raise e
+  end
+
+  def create_test_no_master_dm_alt_id_rec(att)
+    att = att.dup
+    att[:current_user] = @user
+    DynamicModel::TestNoMasterDmAltIdRec.create! att
   rescue StandardError => e
     puts "attr for failure: #{att}"
     raise e


### PR DESCRIPTION
[Added] _configurations.foreign_key_through_external_id to associate a dynamic model back to a master record through an external id field, rather than master_id or crosswalk attribute.