### PR TITLE
Hms redcap use fkey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ Note that not every tagged version may be suitable for production use. A Github 
 
 Since [version 8.4.0](#840---2024-01-10) the convention is that releases made within forked repositories should be up-versioned with a patch release, *x.y.z+1*. When changes are incorporated back into the primary repo [consected/restructure](https://github.com/consected/restructure) a new minor release will be created, *x.y+1,0*.
 
+## Unreleased
+
+- [Fixed] viewing a master record with category of redcap dynamic models (which show in a default panel) loads all entries in the database - fixes #370
+- [Added] redcap project option set_master_id_using_association, which adds a master_id to the underlying table and sets it automatically from the external id association - closes #369
+- [Added] ability for redcap project associate_master_through_external_identifer to match on external identifiers with integer external ids, by adding an integer redcap_survey_identifier_id field to the dynamic model
+- [Added] better information around missing fields and mismatched in the redcap project
+- [Added] the ability to retrieve the latest redcap configuration within the redcap project, so field configurations can be correctly validated
+- [Added] redcap project run_jobs_as_user and run_jobs_as_app_type options to ensure background jobs run consistently
+- [Fixed] dynamic models with foreign keys breaking the admin sample form view
+- [Fixed] Redcap project reconfigures dynamic model with new one if the category of the DM has changed - fixes #365
+- [Added] redcap project admin option associate_master_through_external_identifer: [external identifier] to automatically allow connection of redcap_survey_identifier to a master record through a matching external id - closes #369
+- [Added] estimated record count and new config checks to redcap project admin details panel
+- [Added] checking of tracker protocol updates in dynamic definitions details panels
+- [Added] _configurations.foreign_key_through_external_id to associate a dynamic model back to a master record through an external id field, rather than master_id or crosswalk attribute.
+
+## [8.8.2] - 2024-08-12
+
+- [Build] FPHS version
+
 ## [8.8.1] - 2024-08-12
 
 ### From FPHS - PR 363

--- a/app/controllers/concerns/master_handler.rb
+++ b/app/controllers/concerns/master_handler.rb
@@ -341,7 +341,7 @@ module MasterHandler
   # is not used repetitively (potentially breaking the current_user functionality and poor performance)
   def set_me_and_master
     if UseMasterParam.include?(action_name)
-      @master = Master.find(params[:master_id]) unless primary_model.no_master_association
+      @master = Master.find(params[:master_id]) unless primary_model.no_master_association && !params[:master_id]
     else
       object = primary_model.find(params[:id])
       set_object_instance object

--- a/app/controllers/concerns/master_handler.rb
+++ b/app/controllers/concerns/master_handler.rb
@@ -303,7 +303,7 @@ module MasterHandler
 
   def check_creatable?
     handle_option_type_config if action_name == 'new' && respond_to?(:handle_option_type_config, true)
-    return if object_instance.allows_current_user_access_to?(:create) || current_admin_sample
+    return if current_admin_sample || object_instance.allows_current_user_access_to?(:create)
 
     not_creatable
     nil
@@ -438,6 +438,7 @@ module MasterHandler
       # to ensure we have associations back the the master record set up correctly,
       # or to set other attributes required for validation.
       setup_default_build_params
+      set_master_on_build = !!params[:master_id]
     end
 
     begin
@@ -446,6 +447,11 @@ module MasterHandler
       logger.warn("set_instance_from_build: #{e}")
     end
     set_object_instance @master_objects.build(build_with)
+
+    if set_master_on_build
+      object_instance.master = @master
+      object_instance.current_user = current_user
+    end
 
     object_instance.item_id = @item_id if @item && object_instance.respond_to?(:item_id) && !object_instance.item_id
   end

--- a/app/controllers/dynamic_model/dynamic_models_controller.rb
+++ b/app/controllers/dynamic_model/dynamic_models_controller.rb
@@ -97,6 +97,13 @@ class DynamicModel::DynamicModelsController < UserBaseController
     @implementation_class ||= implementation_class
     resname = param_set_name
     params[resname] ||= {}
+
+    if current_admin_sample
+      @master.current_user = current_user
+      params[resname].merge!(master_id: @master&.id)
+      return
+    end
+
     params[resname].merge! @implementation_class.foreign_key_name => external_id
   end
 end

--- a/app/controllers/redcap/project_admins_controller.rb
+++ b/app/controllers/redcap/project_admins_controller.rb
@@ -72,7 +72,7 @@ class Redcap::ProjectAdminsController < AdminController
     @redcap__project_admin.data_dictionary_version = nil
     @redcap__project_admin.update!(captured_project_info: nil, transfer_mode: 'none')
 
-    msg = "Reconfiguration requested at #{DateTime.now}"
+    msg = "Reconfiguration requested at #{DateTime.now} - wait a few seconds then click the *refresh* button to review the changes"
     render json: { message: msg }, status: 200
   end
 
@@ -81,7 +81,7 @@ class Redcap::ProjectAdminsController < AdminController
     @redcap__project_admin.current_admin ||= current_admin
     @redcap__project_admin.update_dynamic_model
 
-    msg = "Reconfiguration requested at #{DateTime.now}"
+    msg = "Reconfiguration requested at #{DateTime.now} - wait a few seconds then click the *refresh* button to review the changes"
     render json: { message: msg }, status: 200
   end
 

--- a/app/controllers/redcap/project_admins_controller.rb
+++ b/app/controllers/redcap/project_admins_controller.rb
@@ -9,6 +9,18 @@ class Redcap::ProjectAdminsController < AdminController
 
   helper_method :transfer_mode_options, :notes_editor, :hide_edit_fields
 
+  def request_latest_rc_configs
+    set_instance_from_id
+
+    @redcap__project_admin.current_admin ||= current_admin
+    @redcap__project_admin.request_latest_config = true
+    @redcap__project_admin.updated_at = Time.now
+    @redcap__project_admin.save!
+
+    msg = "Latest configurations requested at #{DateTime.now}"
+    render json: { message: msg }, status: 200
+  end
+
   def request_records
     set_instance_from_id
     if @redcap__project_admin.dynamic_model_table.blank?

--- a/app/jobs/redcap/capture_data_collection_instruments_job.rb
+++ b/app/jobs/redcap/capture_data_collection_instruments_job.rb
@@ -7,10 +7,9 @@ module Redcap
     #
     # Download the list of data collection instruments.
     # @param [Redcap::ProjectAdmin] project_admin
-    # @param [Admin] current_admin
     # @return [Boolean] success
-    def perform(project_admin, current_admin)
-      setup_with project_admin, current_admin: current_admin
+    def perform(project_admin)
+      setup_with project_admin
 
       Redcap::DataCollectionInstrument.retrieve_and_store project_admin
     rescue StandardError => e

--- a/app/jobs/redcap/capture_project_archive_job.rb
+++ b/app/jobs/redcap/capture_project_archive_job.rb
@@ -8,10 +8,9 @@ module Redcap
     # Download the full XML project archive, and store it to the file_store container.
     # The stored file record is returned if successful.
     # @param [Redcap::ProjectAdmin] project_admin
-    # @param [User] current_user
     # @return [NfsStore::Manage::StoredFile]
-    def perform(project_admin, current_admin)
-      setup_with project_admin, current_admin: current_admin
+    def perform(project_admin)
+      setup_with project_admin
 
       container = project_admin.file_store
       raise FphsException, 'Project archive not downloaded - no file store set up' unless container
@@ -25,8 +24,8 @@ module Redcap
       NfsStore::Import.import_file(container.id,
                                    filename,
                                    temp_file.path,
-                                   project_admin.current_user,
-                                   path: path,
+                                   project_admin.job_user,
+                                   path:,
                                    replace: true)
     rescue StandardError => e
       create_failure_record(e, 'capture project archive job', project_admin)

--- a/app/jobs/redcap/capture_project_users_job.rb
+++ b/app/jobs/redcap/capture_project_users_job.rb
@@ -7,10 +7,9 @@ module Redcap
     #
     # Download the list of project users.
     # @param [Redcap::ProjectAdmin] project_admin
-    # @param [Admin] current_admin
     # @return [Boolean] success
-    def perform(project_admin, current_admin)
-      setup_with project_admin, current_admin: current_admin
+    def perform(project_admin)
+      setup_with project_admin
 
       pu = Redcap::ProjectUsers.new project_admin
       pu.retrieve_validate_store

--- a/app/jobs/redcap/redcap_job_handler.rb
+++ b/app/jobs/redcap/redcap_job_handler.rb
@@ -17,9 +17,13 @@ module Redcap
       project_admin.current_user.app_type = project_admin.job_app_type
       project_admin.in_background_job = true
 
-      raise FphsException, 'RedcapJobHandler: job admin is not set' unless project_admin.current_admin
-      raise FphsException, 'RedcapJobHandler: job user is not set' unless project_admin.current_user
-      raise FphsException, 'RedcapJobHandler: job user app type is not set' unless project_admin.current_user.app_type
+      raise FphsException, 'RedcapJobHandler: job admin is not set' unless project_admin.current_admin.is_a?(Admin)
+      raise FphsException, 'RedcapJobHandler: job user is not set' unless project_admin.current_user.is_a?(User)
+
+      unless project_admin.current_user.app_type.is_a?(Admin::AppType)
+        raise FphsException,
+              'RedcapJobHandler: job user app type is not set'
+      end
 
       Rails.logger.info 'Running REDCap job with - ' \
                         "admin: #{project_admin.current_admin.email} - " \

--- a/app/jobs/redcap/redcap_job_handler.rb
+++ b/app/jobs/redcap/redcap_job_handler.rb
@@ -4,7 +4,7 @@
 # to the job and handling error reporting
 module Redcap
   module RedcapJobHandler
-    def setup_with(project_admin, current_admin: nil)
+    def setup_with(project_admin)
       # puts "Setup project admin in Job: #{self}"
       unless project_admin.is_a? ProjectAdmin
         raise FphsException,
@@ -12,8 +12,19 @@ module Redcap
       end
 
       # Use the supplied admin if requested or original admin
-      project_admin.current_admin ||= current_admin || project_admin.admin
-      project_admin.current_user ||= current_admin.matching_user
+      project_admin.current_admin = project_admin.job_admin
+      project_admin.current_user = project_admin.job_user
+      project_admin.current_user.app_type = project_admin.job_app_type
+      project_admin.in_background_job = true
+
+      raise FphsException, 'RedcapJobHandler: job admin is not set' unless project_admin.current_admin
+      raise FphsException, 'RedcapJobHandler: job user is not set' unless project_admin.current_user
+      raise FphsException, 'RedcapJobHandler: job user app type is not set' unless project_admin.current_user.app_type
+
+      Rails.logger.info 'Running REDCap job with - ' \
+                        "admin: #{project_admin.current_admin.email} - " \
+                        "user #{project_admin.current_user.email} - " \
+                        "app type: #{project_admin.current_user.app_type.name}"
     end
 
     def create_failure_record(exception, action, project_admin)

--- a/app/models/activity_log.rb
+++ b/app/models/activity_log.rb
@@ -467,9 +467,7 @@ class ActivityLog < ActiveRecord::Base
     end
 
     # generate the basic activity log create / update records
-    track_name = full_item_type_name.singularize.humanize.downcase
-
-    Tracker.add_record_update_entries track_name, admin, 'record'
+    Tracker.add_record_update_entries tracker_name, admin, 'record'
 
     Classification::Protocol.enabled.each do |p|
       # logger.info "For protocol: #{p.id} #{p.name}"
@@ -494,6 +492,12 @@ class ActivityLog < ActiveRecord::Base
     Classification::Protocol.reset_memos
 
     true
+  end
+
+  #
+  # name for generating the basic activity log create / update records
+  def tracker_name
+    full_item_type_name.singularize.humanize.downcase
   end
 
   def check_item_type_and_rec_type

--- a/app/models/admin/app_type.rb
+++ b/app/models/admin/app_type.rb
@@ -103,6 +103,16 @@ class Admin
       user
     end
 
+    def self.find_active_by_name_or_id(name_or_id)
+      return if name_or_id.to_s.blank?
+
+      if name_or_id.is_a?(Integer) || name_or_id.to_i.to_s == name_or_id
+        Admin::AppType.active.find(name_or_id)
+      else
+        Admin::AppType.active.find_by_name(name_or_id)
+      end
+    end
+
     def active_on_server?
       self.class.active_app_types.include?(self) &&
         Admin::MigrationGenerator.current_search_paths.include?(default_schema_name)

--- a/app/models/concerns/handles_user_base.rb
+++ b/app/models/concerns/handles_user_base.rb
@@ -682,7 +682,7 @@ module HandlesUserBase
     mu = master_user
     unless mu.is_a?(User) && mu.persisted?
       master = '[not defined]' unless respond_to? :master
-      raise "bad user (for master #{master}) being pulled from master_user " \
+      raise "bad user (for master id: #{master&.id || 'nil'}) being pulled from master_user " \
       "(#{mu.class.name} #{mu.is_a?(User) ? '' : 'not a user'}#{mu && mu.persisted? ? '' : ' not persisted'})"
     end
 

--- a/app/models/concerns/nfs_store/for_admin_resources.rb
+++ b/app/models/concerns/nfs_store/for_admin_resources.rb
@@ -50,7 +50,7 @@ module NfsStore
     # Master record to be used to contain filestore containers
     # @return [Master]
     def master
-      Settings.admin_master
+      @master ||= Settings.admin_master
     end
 
     def master_id

--- a/app/models/concerns/nfs_store/for_admin_resources.rb
+++ b/app/models/concerns/nfs_store/for_admin_resources.rb
@@ -22,7 +22,7 @@ module NfsStore
       container = NfsStore::Manage::Container.create_in_current_app user: file_store_user,
                                                                     name: safe_name,
                                                                     extra_params: {
-                                                                      master: master,
+                                                                      master:,
                                                                       create_with_role: nfs_role
                                                                     }
       container.current_user = file_store_user
@@ -35,11 +35,15 @@ module NfsStore
     # Retrieve the file store container
     # @return [NfsStore::Manage::Container]
     def file_store
-      @file_store ||= NfsStore::Manage::Container.referenced_container self
+      @file_store ||= file_store_container
       return unless @file_store
 
       @file_store.current_user ||= file_store_user
       @file_store
+    end
+
+    def file_store_container
+      @file_store_container ||= NfsStore::Manage::Container.referenced_container self
     end
 
     #

--- a/app/models/concerns/nfs_store/has_current_user.rb
+++ b/app/models/concerns/nfs_store/has_current_user.rb
@@ -31,7 +31,8 @@ module NfsStore
 
           raise FsException::NoAccess,
                 'user does not have access to this container ' \
-                "(master #{container.master&.id} - parent #{cp.class} id: #{cp&.id} master: #{cpm})"
+                "(user #{container&.current_user&.email} - master #{container.master&.id} - #{container.class} " \
+                "- parent #{cp.class} id: #{cp&.id} master: #{cpm})"
         end
 
         container

--- a/app/models/concerns/standard_authentication.rb
+++ b/app/models/concerns/standard_authentication.rb
@@ -178,6 +178,16 @@ module StandardAuthentication
     def clean_memos
       @emails_by_id_memo = nil
     end
+
+    def find_active_by_email_or_id(email_or_id)
+      return if email_or_id.to_s.blank?
+
+      if email_or_id.is_a?(Integer) || email_or_id.to_i.to_s == email_or_id
+        active.find_by_id(email_or_id)
+      else
+        active.find_by_email(email_or_id)
+      end
+    end
   end
 
   def expires_in

--- a/app/models/concerns/user_handler.rb
+++ b/app/models/concerns/user_handler.rb
@@ -269,12 +269,12 @@ module UserHandler
   #
   # After a record has been saved, make a tracker entry for it
   # This only happens if the record was created or updated,
-  # is not marked `no_track` and it has a master association.
+  # is not marked `no_track` and it has a master association (with a master record set).
   # @return [Boolean | nil] representing success or failure
   def track_record_update
     # Don't do this if we have the configuration set to avoid tracking, or
     # if the record was not created or updated
-    return if no_track || !(@was_updated || @was_created) || self.class.no_master_association
+    return if no_track || !(@was_updated || @was_created) || self.class.no_master_association || !master
 
     @update_action = true
     Tracker.track_record_update self

--- a/app/models/dynamic/def_generator.rb
+++ b/app/models/dynamic/def_generator.rb
@@ -48,7 +48,7 @@ module Dynamic
         rescue Exception => e
           msg = "Failed to generate models. Hopefully this is only during a migration. \n***** #{e.inspect}"
           puts msg
-          puts e.backtrace.join("\n")
+          puts e.short_string_backtrace
           Rails.logger.warn msg
         end
       end

--- a/app/models/dynamic/def_handler.rb
+++ b/app/models/dynamic/def_handler.rb
@@ -302,6 +302,12 @@ module Dynamic
       @secondary_key = configurations && configurations[:secondary_key]
     end
 
+    #
+    # name for generating the basic activity log create / update records
+    def tracker_name
+      table_name.singularize
+    end
+
     def use_current_version
       return @use_current_version if @use_current_version_set
 

--- a/app/models/dynamic/model_generator.rb
+++ b/app/models/dynamic/model_generator.rb
@@ -83,7 +83,10 @@ module Dynamic
       end
 
       fla = field_list.split
-      if fla.include?('master_id')
+
+      # Remove master_id from the list and make it the foreign key name, only if
+      # the foreign_key_name was not already set or was set to master_id already
+      if fla.include?('master_id') && (foreign_key_name.blank? || foreign_key_name == 'master_id')
         foreign_key_name = 'master_id'
         @field_list = fla.select { |f| f != 'master_id' }.join(' ')
       end

--- a/app/models/dynamic/model_generator.rb
+++ b/app/models/dynamic/model_generator.rb
@@ -130,7 +130,7 @@ module Dynamic
 
       schema_name = [nil, ''] if schema_name.blank?
 
-      attrs = { table_name:, category:, schema_name: }
+      attrs = { table_name:, schema_name: }
       dms = DynamicModel.active.where(attrs)
 
       if dms.length > 1

--- a/app/models/dynamic_model.rb
+++ b/app/models/dynamic_model.rb
@@ -375,6 +375,12 @@ class DynamicModel < ActiveRecord::Base
             get "#{pg_name}/:id/template_config", to: "#{pg_name}#template_config"
           end
 
+          if dm.foreign_key_through_external_id
+            namespace :dynamic_model do
+              resources short_pg_name, only: %i[show new index]
+            end
+          end
+
         else
 
           resources short_pg_name, except: [:destroy], controller: pg_name

--- a/app/models/dynamic_model.rb
+++ b/app/models/dynamic_model.rb
@@ -201,7 +201,7 @@ class DynamicModel < ActiveRecord::Base
   def update_tracker_events
     return unless name && !disabled
 
-    Tracker.add_record_update_entries table_name.singularize, current_admin, 'record'
+    Tracker.add_record_update_entries tracker_name, current_admin, 'record'
     Classification::Protocol.reset_memos
   end
 

--- a/app/models/external_identifier.rb
+++ b/app/models/external_identifier.rb
@@ -252,7 +252,7 @@ class ExternalIdentifier < ActiveRecord::Base
   def update_tracker_events
     return unless label && !disabled
 
-    Tracker.add_record_update_entries name.singularize, current_admin, 'record'
+    Tracker.add_record_update_entries tracker_name, current_admin, 'record'
     Classification::Protocol.reset_memos
     # flag items are added when item flag names are added to the list
     # Tracker.add_record_update_entries self.name.singularize, current_admin, 'flag'

--- a/app/models/nfs_store/manage/container.rb
+++ b/app/models/nfs_store/manage/container.rb
@@ -74,7 +74,7 @@ module NfsStore
         app_type = user.app_type
         raise FsException::NoAccess, "User has no access to this container's app-type" unless user.app_type_valid?
 
-        where app_type: app_type
+        where app_type:
       end
 
       # Create a container record in the current app. After creation, #create_in_nfs_store is called by a callback
@@ -89,7 +89,7 @@ module NfsStore
           FsException::Action.new "Cannot create a container with app_type: #{app_type_id}, user: #{user&.id}, name: #{name}"
         end
 
-        create! extra_params.merge(app_type_id: app_type_id, name: name, current_user: user)
+        create! extra_params.merge(app_type_id:, name:, current_user: user)
       end
 
       #
@@ -175,7 +175,7 @@ module NfsStore
         res = nil
         Group.role_names_for(user).each do |role_name|
           if Filesystem.test_dir role_name, self, :read
-            res = File.stat(path_for(role_name: role_name)).gid
+            res = File.stat(path_for(role_name:)).gid
             break if res
           end
         end
@@ -196,7 +196,7 @@ module NfsStore
       # parent_sub_dir has not been overridden
       # @return [String]
       def path_to_parent_dir_for(role_name: nil)
-        parts = path_for(role_name: role_name).split('/')
+        parts = path_for(role_name:).split('/')
         parts.pop if parent_sub_dir.present?
         File.join parts
       end
@@ -322,7 +322,7 @@ module NfsStore
         current_user_role_names.each do |role_name|
           next unless Filesystem.test_dir role_name, self, :read
 
-          p = path_for role_name: role_name
+          p = path_for(role_name:)
           # Don't use Regex - it breaks if there are special characters
           paths = Dir.glob("#{p}/**/*").reject do |f|
             Pathname.new(f).directory?
@@ -376,7 +376,8 @@ module NfsStore
 
         raise FsException::NoAccess,
               'User does not have access to this container ' \
-              "(master #{master&.id} - parent #{cp.class} id: #{cp&.id} master: #{cpm})"
+              "(user #{current_user&.email} - master #{master&.id} - class #{self.class} " \
+              "- parent #{cp.class} id: #{cp&.id} master: #{cpm})"
       end
 
       def raise_if_action_not_authorized!(for_action)

--- a/app/models/redcap/data_collection_instrument.rb
+++ b/app/models/redcap/data_collection_instrument.rb
@@ -20,7 +20,7 @@ module Redcap
       jobs = ProjectAdmin.existing_jobs(jobclass, project_admin)
       return if jobs.count > 0
 
-      Redcap::CaptureDataCollectionInstrumentsJob.perform_later(project_admin, project_admin.current_admin)
+      Redcap::CaptureDataCollectionInstrumentsJob.perform_later(project_admin)
       project_admin.record_job_request('setup job: instruments')
     end
 
@@ -39,8 +39,8 @@ module Redcap
           name = record[:instrument_name]
           label = record[:instrument_label]
 
-          res = project_admin.redcap_data_collection_instruments.active.find_or_create_by(name: name)
-          res.update!(label: label, current_admin: project_admin.current_admin) if res.label != label
+          res = project_admin.redcap_data_collection_instruments.active.find_or_create_by(name:)
+          res.update!(label:, current_admin: project_admin.current_admin) if res.label != label
           item_ids << res.id
         end
 

--- a/app/models/redcap/data_dictionaries/field_type.rb
+++ b/app/models/redcap/data_dictionaries/field_type.rb
@@ -38,6 +38,7 @@ module Redcap
         form_complete: 'redcap status', # This is not a real REDCap type, but is used as a lookup
         form_timestamp: 'redcap completion timestamp', # This is not a real REDCap type, but is used as a lookup
         survey_identifier: 'survey identifier', # This is not a real REDCap type, but is used as a lookup
+        integer_survey_identifier: 'integer survey identifier', # This is not a real REDCap type, but is used as a lookup
         repeat: 'repeat instrument' # This is not a real REDCap type, but is used as a lookup
       }.freeze
 
@@ -81,6 +82,7 @@ module Redcap
         form_complete: 'status', # This is not a real REDCap type, but is used as a lookup
         form_timestamp: 'completion_timestamp', # This is not a real REDCap type, but is used as a lookup
         survey_identifier: 'survey_identifier', # This is not a real REDCap type, but is used as a lookup
+        integer_survey_identifier: 'integer_survey_identifier', # This is not a real REDCap type, but is used as a lookup
         repeat: 'repeat_instrument' # This is not a real REDCap type, but is used as a lookup
       }.freeze
 
@@ -117,7 +119,8 @@ module Redcap
         'date time' => :to_datetime,
         'time' => :to_time,
         'redcap status' => :to_i,
-        'redcap completion timestamp' => :to_datetime_or_null
+        'redcap completion timestamp' => :to_datetime_or_null,
+        'integer survey identifier' => :to_i
       }.freeze
 
       # Non-string database types
@@ -131,7 +134,8 @@ module Redcap
         'date time' => :timestamp,
         'time' => :time,
         'redcap status' => :integer,
-        'redcap completion timestamp' => :timestamp
+        'redcap completion timestamp' => :timestamp,
+        'integer survey identifier' => :integer
       }.freeze
 
       # Types that are array fields

--- a/app/models/redcap/data_dictionaries/special_fields.rb
+++ b/app/models/redcap/data_dictionaries/special_fields.rb
@@ -42,6 +42,14 @@ module Redcap
       end
 
       #
+      # Add an integer survey identifier field to the hash of fields in this form
+      # @param [Hash] fields <description>
+      # @param [Redcap::DataDictionary] in_form
+      def self.add_integer_survey_identifier_field(fields, data_dictionary)
+        fields[integer_survey_identifier_field_name] = integer_survey_identifier_field(data_dictionary)
+      end
+
+      #
       # Add summary fields for multiple choice checkbox field definition
       # @param [Hash] fields
       # @param [Redcap::DataDictionaries::Form] form
@@ -59,6 +67,13 @@ module Redcap
         :redcap_survey_identifier
       end
 
+      # The full record may have a redcap_survey_identifier field if project admin
+      # attribute #records_request_options has exportSurveyFields: true
+      # @return [Symbol]
+      def self.integer_survey_identifier_field_name
+        :redcap_survey_identifier_id
+      end
+
       #
       # A redcap_survey_identifier field representation to support the
       # identifer field if survey fields are requested
@@ -70,7 +85,21 @@ module Redcap
           field_type: 'survey_identifier',
           text_validation_type_or_show_slider_number: 'string'
         }
-        Field.new(nil, field_metadata, data_dictionary: data_dictionary)
+        Field.new(nil, field_metadata, data_dictionary:)
+      end
+
+      #
+      # A redcap_survey_identifier_id field representation to support the
+      # identifer field if survey fields are requested
+      # @param [Redcap::DataDictionary] data_dictionary
+      # @return [Redcap::DataDictionaries::Field]
+      def self.integer_survey_identifier_field(data_dictionary)
+        field_metadata = {
+          field_name: integer_survey_identifier_field_name,
+          field_type: 'integer_survey_identifier',
+          text_validation_type_or_show_slider_number: 'integer'
+        }
+        Field.new(nil, field_metadata, data_dictionary:)
       end
 
       # Each form may have a <form name>_timestamp field if project admin
@@ -130,7 +159,7 @@ module Redcap
           field_name: :redcap_repeat_instrument,
           field_type: 'repeat'
         }
-        Field.new(nil, field_metadata, data_dictionary: data_dictionary)
+        Field.new(nil, field_metadata, data_dictionary:)
       end
 
       #
@@ -143,7 +172,7 @@ module Redcap
           field_name: :redcap_repeat_instance,
           field_type: 'repeat'
         }
-        Field.new(nil, field_metadata, data_dictionary: data_dictionary)
+        Field.new(nil, field_metadata, data_dictionary:)
       end
 
       #

--- a/app/models/redcap/dynamic_storage.rb
+++ b/app/models/redcap/dynamic_storage.rb
@@ -7,6 +7,11 @@ module Redcap
   class DynamicStorage
     include Dynamic::ModelGenerator
 
+    ExtraFieldTypes = {
+      disabled: 'boolean',
+      master_id: 'integer'
+    }.freeze
+
     attr_accessor :project_admin, :qualified_table_name, :category
 
     def self.default_category
@@ -54,11 +59,7 @@ module Redcap
 
       extra_fields&.each do |ef|
         ef = ef.to_sym
-        ft = if ef == :disabled
-               'boolean'
-             else
-               'string'
-             end
+        ft = ExtraFieldTypes[ef] || 'string'
         @field_types[ef] = ft.to_s
       end
 
@@ -66,7 +67,7 @@ module Redcap
     end
 
     #
-    # Return a hash of all fields, with a value true if they are to berepresented as an array
+    # Return a hash of all fields, with a value true if they are to be represented as an array
     # in the database. Used alongside #field_types a full definition of the field can be made
     # for migrations.
     # @return [Hash]
@@ -80,7 +81,8 @@ module Redcap
 
       extra_fields&.each do |ef|
         ef = ef.to_sym
-        ft = (ef != :disabled)
+        # Assume it is an array if it isn't one of the predefined extra fields
+        ft = !ExtraFieldTypes.keys.include?(ef)
         @array_fields[ef] = ft
       end
 
@@ -237,6 +239,7 @@ module Redcap
 
       @extra_fields = []
       @extra_fields << 'disabled' if project_admin.disable_deleted_records?
+      @extra_fields << 'master_id' if project_admin.data_options.set_master_id_using_association
 
       return @extra_fields unless project_admin.data_options.add_multi_choice_summary_fields
 

--- a/app/models/redcap/dynamic_storage.rb
+++ b/app/models/redcap/dynamic_storage.rb
@@ -316,6 +316,24 @@ module Redcap
     end
 
     #
+    # Specifies the external identifier resource name from associate_master_through_external_identifer
+    def associate_master_through_external_id_resource_name
+      res = project_admin.data_options.associate_master_through_external_identifer
+      return unless res.present?
+
+      res.split(' ')[0]
+    end
+
+    #
+    # Specifies the foreign key name from associate_master_through_external_identifer
+    def associate_master_through_external_id_fkey_name
+      res = project_admin.data_options.associate_master_through_external_identifer
+      return unless res.present?
+
+      res.split(' ')[1] || project_admin.survey_identifier_field
+    end
+
+    #
     # Add default user access control for the current admin
     # matching user
     def add_user_access_control

--- a/app/models/redcap/dynamic_storage.rb
+++ b/app/models/redcap/dynamic_storage.rb
@@ -318,19 +318,13 @@ module Redcap
     #
     # Specifies the external identifier resource name from associate_master_through_external_identifer
     def associate_master_through_external_id_resource_name
-      res = project_admin.data_options.associate_master_through_external_identifer
-      return unless res.present?
-
-      res.split(' ')[0]
+      project_admin.associate_master_through_external_id_resource_name
     end
 
     #
     # Specifies the foreign key name from associate_master_through_external_identifer
     def associate_master_through_external_id_fkey_name
-      res = project_admin.data_options.associate_master_through_external_identifer
-      return unless res.present?
-
-      res.split(' ')[1] || project_admin.survey_identifier_field
+      project_admin.associate_master_through_external_id_fkey_name
     end
 
     #

--- a/app/models/redcap/project_admin.rb
+++ b/app/models/redcap/project_admin.rb
@@ -224,6 +224,7 @@ module Redcap
                                       handle_deleted_records
                                       prefix_dynamic_model_config_library
                                       associate_master_through_external_identifer
+                                      set_master_id_using_association
                                       run_jobs_as_user
                                       run_jobs_in_app_type]
 
@@ -501,6 +502,10 @@ module Redcap
 
     def associate_master_through_external_id_valid?
       data_options.associate_master_through_external_identifer.blank? || dynamic_storage.dynamic_model_master_external_id_added?
+    end
+
+    def set_master_id_using_association_valid?
+      !data_options.set_master_id_using_association || data_options.associate_master_through_external_identifer.present?
     end
 
     #

--- a/app/models/redcap/project_users.rb
+++ b/app/models/redcap/project_users.rb
@@ -30,7 +30,7 @@ module Redcap
       jobs = Redcap::ProjectAdmin.existing_jobs(jobclass, project_admin)
       return if jobs.count > 0
 
-      jobclass.perform_later(project_admin, current_admin)
+      jobclass.perform_later(project_admin)
       project_admin.record_job_request('setup job: list project users')
     end
 
@@ -94,14 +94,14 @@ module Redcap
       end
 
       result = {
-        created_usernames: created_usernames,
-        updated_usernames: updated_usernames,
-        unchanged_usernames: unchanged_usernames,
-        disabled_usernames: disabled_usernames,
-        errors: errors
+        created_usernames:,
+        updated_usernames:,
+        unchanged_usernames:,
+        disabled_usernames:,
+        errors:
       }
 
-      project_admin.record_job_request('store project users', result: result)
+      project_admin.record_job_request('store project users', result:)
     end
 
     #
@@ -116,7 +116,7 @@ module Redcap
     # @return [Integer | false | nil]
     def create_or_update(record)
       username = record[:username]
-      existing_record = project_admin.redcap_project_users.active.where(username: username).first
+      existing_record = project_admin.redcap_project_users.active.where(username:).first
 
       if existing_record
         # Check if there is an exact match for the record. If so, we are done
@@ -131,7 +131,7 @@ module Redcap
           upserted_records << existing_record
           username
         else
-          errors << { username: username, errors: existing_record.errors, action: :update }
+          errors << { username:, errors: existing_record.errors, action: :update }
         end
       else
         new_record = ProjectUser.new(record.slice(*all_expected_field_names))

--- a/app/views/admin/activity_logs/_def_details.html.erb
+++ b/app/views/admin/activity_logs/_def_details.html.erb
@@ -26,6 +26,7 @@
   </p>
 
   <%= render partial: 'admin/dynamic_models/est_record_count' %>
+  <%= render partial: 'admin/dynamic_models/check_tracker_updates' %>
 
   <% unless object_instance.table_or_view_ready?%>
   <div class="help-block">

--- a/app/views/admin/dynamic_models/_check_tracker_updates.html.erb
+++ b/app/views/admin/dynamic_models/_check_tracker_updates.html.erb
@@ -1,0 +1,27 @@
+  <% if object_instance.persisted? && object_instance.enabled? && object_instance.table_or_view_ready? 
+       failed = false
+       begin
+          ts = Tracker.add_record_update_entries( object_instance.tracker_name, current_admin, 'record', no_create: true)
+          failed = !ts.uniq.first
+          pe = Tracker.sub_process_for('record')
+       rescue => e
+         failed = true
+       end
+       if failed
+  %>
+  <label>tracker protocol updates have not been created</label>
+  <div class="help-block">
+  <p>
+    The <%=link_to link_label_open_in_new("tracker updates protocol / sub process"), admin_protocol_sub_process_protocol_events_path(pe.protocol, pe), target: '_blank'%>
+    has not had records added for this dynamic definition.
+  </p>
+  <p> 
+    <code>created <%=object_instance.tracker_name.humanize%></code> and <code>updated <%=object_instance.tracker_name.humanize%></code> should exist
+  </p>
+  <p>
+     To correct this, try disabling then re-enabling the definition.
+  </p>
+  </div>
+  <%   end
+     end 
+  %>

--- a/app/views/admin/dynamic_models/_def_details.html.erb
+++ b/app/views/admin/dynamic_models/_def_details.html.erb
@@ -25,6 +25,7 @@
   </p>
 
   <%= render partial: 'admin/dynamic_models/est_record_count' %>
+  <%= render partial: 'admin/dynamic_models/check_tracker_updates' %>
 
   <% unless object_instance.table_or_view_ready?%>
   <div class="help-block">
@@ -70,6 +71,8 @@
   <p><%= "definition : table: +[#{(fields - table_cols).join(" ")}] -[#{(table_cols - fields).join(" ")}]" %><p>
   <% end %>  
 <% end %>
+
+
   <ul class="activity-list">
     <%= sortable_block "#dynamic_model_field_list", "li" %>
   </ul>

--- a/app/views/admin/dynamic_models/_est_record_count.html.erb
+++ b/app/views/admin/dynamic_models/_est_record_count.html.erb
@@ -1,7 +1,7 @@
   <% if object_instance.persisted? && object_instance.enabled? && object_instance.table_or_view_ready? %>
   <label>estimated record count</label>
-  <p class="dynamic-record-count">
+  <span class="dynamic-record-count">
   <%= object_instance.estimated_record_count || '(not found)' %>
-  </p>
+  </span>
   <% end %>
   

--- a/app/views/admin/external_identifiers/_def_details.html.erb
+++ b/app/views/admin/external_identifiers/_def_details.html.erb
@@ -19,6 +19,8 @@
   <p><%=link_to link_label_open_in_new('details'), "/admin/external_identifier_details/#{object_instance.id}", target: '_blank' %></p>
 
   <%= render partial: 'admin/dynamic_models/est_record_count' %>
+  <%= render partial: 'admin/dynamic_models/check_tracker_updates' %>
+
 
   <% unless object_instance.table_or_view_ready?%>
   <div class="help-block">

--- a/app/views/masters/_dynamic_model_blocks.html.erb
+++ b/app/views/masters/_dynamic_model_blocks.html.erb
@@ -39,9 +39,13 @@ category_models.each do |m|
     if force_load
       # Force the new dynamic models to load in the details panel, which they wouldn't do otherwise
 %>
+  <% if m.foreign_key_name.present? 
+        # Only show this if there is a master association. Otherwise we tend to load a full database of junk records.    
+  %>
     <div class="on-open-click hidden">
-      <a href="<% if m.foreign_key_name.present? %>/masters/{{id}}<% end %>/dynamic_model/<%=m.implementation_model_name.pluralize%>" data-result-target="#<%=m.full_item_types_name%>-{{id}}-" data-template="<%=m.implementation_model_name.hyphenate.pluralize%>-list-template" data-remote="true"  data-open-priority="<%= force_load == true ? 1000 : force_load %>"><%=m.name%></a>
+      <a href="/masters/{{id}}/dynamic_model/<%=m.implementation_model_name.pluralize%>" data-result-target="#<%=m.full_item_types_name%>-{{id}}-" data-template="<%=m.implementation_model_name.hyphenate.pluralize%>-list-template" data-remote="true"  data-open-priority="<%= force_load == true ? 1000 : force_load %>"><%=m.name%></a>
     </div>
+  <% end %>    
 <%  end
   end
 end

--- a/app/views/redcap/project_admins/_details_block.html.erb
+++ b/app/views/redcap/project_admins/_details_block.html.erb
@@ -1,18 +1,20 @@
 <h4><%= object_instance.name %></h4>
+<% if object_instance.persisted? %>
+  <p><%= link_to 'refresh', edit_redcap_project_admin_path(object_instance), 
+  data: {
+    remote: true, 
+    target: "##{object_instance.resource_name.hyphenate}--",
+    'result-target': "##{object_instance.resource_name.hyphenate}--",
+    'result-target-force': "true"
+  },
+  class: 'btn btn-primary btn-sm' %>
+  </p>
+<% end %>
 <% if current_admin&.matching_user_app_type&.name != 'ref-data' %>
   <h4>Important - switch to app ref-data to review and update Redcap information</h4>
 <% end%>
-<p><label>status</label> <span><%= object_instance.status %></span>&nbsp;
-  <% if object_instance.persisted? %>
-        <%= link_to 'refresh', edit_redcap_project_admin_path(object_instance), 
-        data: {
-          remote: true, 
-          target: "##{object_instance.resource_name.hyphenate}--",
-          'result-target': "##{object_instance.resource_name.hyphenate}--",
-          'result-target-force': "true"
-        },
-        class: 'btn btn-primary btn-sm' %>
-  <% else %>
+<p><label>record retrieval status</label> <span><%= object_instance.status %></span>&nbsp;
+  <% unless object_instance.persisted? %>        
   new
   <% end %>
 </p>
@@ -23,11 +25,22 @@ if req&.result
   if !got_error && req.result['errors']&.present?
     got_error = req.result['errors'].join(' | ')
   end
-end
-%>
+  %>
 <p><label>latest request</label>
-  <pre><%= got_error || 'no error' %></pre>
+<i>at <%=current_user_date_time req.created_at%></i>
+  <% if got_error %>
+    <pre><%= got_error %></pre>
+  <% else %>
+    <span>no error</span>
+  <% end %>
 </p>
+<% end %>
+<% if got_error&.include?('Redcap::DataRecords::ModelMissingFields') || got_error&.include?('Redcap::DataRecords::MismatchFields') %>
+<div class="help-block">
+  <p>To get more information, click the <strong>retrieve latest redcap configuration</strong> button below. 
+  When it has completed (may take several seconds) click the <strong>refresh</strong> button.</p>
+</div>
+<% end %>
 <% if object_instance.captured_project_info.present?%>
   <p><label>project info</label> metadata available</p>
 <% else %>
@@ -49,7 +62,7 @@ end
     <p><label>database table</label>
     <%= link_to link_label_open_in_new('search table data'), "/reports/reference_data__table_data?schema_name=#{dm.schema_name}&search_attrs%5B_blank%5D=true&search_attrs%5Bno_run%5D=true&table_name=#{dm.table_name}", 
       target: '_blank' %></p>
-      <%= render partial: 'admin/dynamic_models/est_record_count', locals: {object_instance: dm} %>
+    <p><%= render partial: 'admin/dynamic_models/est_record_count', locals: {object_instance: dm} %></p>
   <% end %>
 <% end %>  
 
@@ -63,12 +76,12 @@ end
     %>
     <p class="info-danger">Failed to compare REDCap and table fields</p>
     <% end %>
-<p><label>metadata and table fields</label></p>
+<p><label>metadata and table fields</label>
 <span>
   <% if !dmfla&.present? || !fla&.present? %>
-  <p class="info-danger">REDCap or table fields not set up</p>
+  <span class="info-danger">REDCap or table fields not set up</span>
   <% elsif object_instance.model_has_all_fields_for_storage? %>
-  <p>REDCap fields match dynamic model table</p>
+  <span>REDCap fields match dynamic model table</span>
   <% else %>
   <p>REDCap fields don't match table</p>
   <ul>
@@ -78,24 +91,48 @@ end
       if efs.present? %><li class="info-danger"><b>Options</b> specifies <code>data_options:</code> requiring extra fields <b>(pull will fail)</b>: <%= "[#{efs.join(" ")}]" %></li><% end %>
   <%  fs = (dmfla - fla)
       if fs.present? %><li><b>Dynamic model</b> table has additional fields <b>(pull will ignore them)</b>: <%= "[#{fs.join(" ")}]" %></li><% end %>
+  <%  if rfs.present? || efs.present? %>
+        <div class="help-block">
+          <p>To add the additional fields to the dynamic model database table, click the <strong>update dynamic model</strong> button.</p>
+          <p><i>NOTE:</i> Updating the dynamic model can have side-effects. If changes have been made to the dynamic model options directly, these
+          will be overwritten. Also, the next time records are retrieved from REDCap, and save triggers defined on the dynamic model will be fired.
+          </p>
+        </div>
+    <% end %>
   <% end %>
   </ul>
 </span>
-<% unless object_instance.dynamic_model_config_library_valid? %>
-<p class="info-danger">Dynamic model config library has not been added</p>
-<% end %>
-<% unless object_instance.associate_master_through_external_id_valid? %>
-<p class="info-danger">Dynamic model _configurations.foreign_key_through_external_id has not been added</p>
-<% end %>
+</p>
+  <% unless object_instance.dynamic_model_config_library_valid? %>
+  <p class="info-danger">Dynamic model config library has not been added</p>
+  <% end %>
+  <% unless object_instance.associate_master_through_external_id_valid? %>
+  <p class="info-danger">Dynamic model _configurations.foreign_key_through_external_id has not been added</p>
+  <% end %>
 <p><label>pull schedule</label>
   <span>
-    <% if  object_instance.frequency.present? && object_instance.transfer_mode == 'scheduled' %>
-      every <%= object_instance.frequency %> - next run at 
-      <%= current_user_date_time(object_instance.task_schedule&.run_at) || '(no task scheduled)' %>
-    <% elsif object_instance.transfer_mode == 'manual' %>manual
-    <% else %>none
-    <% end %>
+  <% if  object_instance.frequency.present? && object_instance.transfer_mode == 'scheduled' %>
+    every <%= object_instance.frequency %> - next run at 
+    <%= current_user_date_time(object_instance.task_schedule&.run_at) || '(no task scheduled)' %>
+  <% elsif object_instance.transfer_mode == 'manual' %>manual
+  <% else %>none
+  <% end %>
   </span>
+</p>
+
+<p><label>run requests as</label>
+  <% if object_instance.job_user %>
+  <%= link_to link_label_open_in_new(object_instance.job_user&.email), admin_manage_users_path(filter: {id: object_instance.job_user&.id}), target: '_blank' %> 
+  in app type <%= link_to link_label_open_in_new(object_instance.job_app_type&.name), admin_app_types_path(filter: {id: object_instance.job_app_type&.id}), target: '_blank' %>
+    <% if !object_instance.job_app_type %>
+    <p class="info-danger"><code>run_jobs_as_app_type</code> configuration is not set to an active app type</p>
+    <% elsif object_instance.job_user.accessible_app_type_ids.include?(object_instance.job_app_type&.id) %>
+    <p class="info-danger"><code>run_jobs_as_user</code> configuration is not set to a real user</p>
+    <% end %>
+  <% else %>
+  <span>bad configuration</span>
+  <p class="info-danger"><code>run_jobs_as_user</code> configuration is not set to a real user</p>
+  <% end %>
 </p>
 <% end %>
 <% if object_instance.dynamic_model_ready? && object_instance.file_store %>
@@ -112,6 +149,10 @@ end
               method: :post, 
               remote: true, 
               class: 'btn btn-warning btn-sm' %></p>
+        <p><%= link_to 'retrieve latest redcap configuration', request_latest_rc_configs_redcap_project_admin_path(id: object_instance.id), 
+              method: :post, 
+              remote: true, 
+              class: 'btn btn-warning btn-sm' %></p>              
         <p><%= link_to 'retrieve user list', request_users_redcap_project_admin_path(id: object_instance.id), 
               method: :post, 
               remote: true, 
@@ -131,13 +172,22 @@ end
     <div class="admin-info-col">
 
       <p>
-        <%= link_to 'update dynamic model', update_dynamic_model_redcap_project_admin_path(object_instance), 
-        remote: true,
-        class: 'btn btn-danger btn-sm',
-        method: :post %>
-      </p>  
-      <p>
+      <a class="btn btn-danger btn-sm show-in-modal" 
+         data-content-el="#dmdef-update-dm-config-from-table-<%=object_instance.id%>" 
+         data-title="Update dynamic model and database">update dynamic model</a>
+      <div id="dmdef-update-dm-config-from-table-<%=object_instance.id%>" class="hidden">
+        <h2>This action may be have side-effects</h2>
+        <p>Click to continue if you are sure</p>
+        <p>
+          <%= link_to 'update dynamic model', update_dynamic_model_redcap_project_admin_path(object_instance), 
+          remote: true,
+          class: 'btn btn-danger btn-sm',
+          method: :post %>
+        </p>  
+      </div>      
+      </p>
 
+      <p>
       <a class="btn btn-danger btn-sm show-in-modal" 
          data-content-el="#dmdef-update-config-from-table-<%=object_instance.id%>" 
          data-title="Force full reconfiguration">force reconfiguration</a>

--- a/app/views/redcap/project_admins/_details_block.html.erb
+++ b/app/views/redcap/project_admins/_details_block.html.erb
@@ -109,6 +109,9 @@ if req&.result
   <% unless object_instance.associate_master_through_external_id_valid? %>
   <p class="info-danger">Dynamic model _configurations.foreign_key_through_external_id has not been added</p>
   <% end %>
+  <% unless object_instance.set_master_id_using_association_valid? %>
+  <p class="info-danger">Option set_master_id_using_association requires associate_master_through_external_identifer to be set</p>
+  <% end %>  
 <p><label>pull schedule</label>
   <span>
   <% if  object_instance.frequency.present? && object_instance.transfer_mode == 'scheduled' %>

--- a/app/views/redcap/project_admins/_details_block.html.erb
+++ b/app/views/redcap/project_admins/_details_block.html.erb
@@ -49,6 +49,7 @@ end
     <p><label>database table</label>
     <%= link_to link_label_open_in_new('search table data'), "/reports/reference_data__table_data?schema_name=#{dm.schema_name}&search_attrs%5B_blank%5D=true&search_attrs%5Bno_run%5D=true&table_name=#{dm.table_name}", 
       target: '_blank' %></p>
+      <%= render partial: 'admin/dynamic_models/est_record_count', locals: {object_instance: dm} %>
   <% end %>
 <% end %>  
 
@@ -82,6 +83,9 @@ end
 </span>
 <% unless object_instance.dynamic_model_config_library_valid? %>
 <p class="info-danger">Dynamic model config library has not been added</p>
+<% end %>
+<% unless object_instance.associate_master_through_external_id_valid? %>
+<p class="info-danger">Dynamic model _configurations.foreign_key_through_external_id has not been added</p>
 <% end %>
 <p><label>pull schedule</label>
   <span>

--- a/config/initializers/app_settings.rb
+++ b/config/initializers/app_settings.rb
@@ -55,6 +55,8 @@ class Settings
   AdminEmail = ENV['FPHS_ADMIN_EMAIL'].presence || DefaultSettings::AdminEmail.presence
   # Email address that identifies the batch user profile. Defaults to the user that matches the AdminEmail
   BatchUserEmail = ENV['FPHS_BATCH_USER_EMAIL'].presence || AdminEmail.presence
+  # Email address that identifies the Redcap job user profile. Defaults to the BatchUserEmail
+  RedcapJobUserEmail = ENV['FPHS_RC_JOB_USER_EMAIL'].presence || BatchUserEmail.presence
   # Provide an email address for a technical admin to receive failure notifications
   FailureNotificationsToEmail = ENV['FAIL_TO_EMAIL'].presence || ENV['FAIL_FROM_EMAIL'].presence || DefaultSettings::FailureNotificationsToEmail.presence || Settings::AdminEmail.presence
 
@@ -224,6 +226,10 @@ class Settings
   # }
   RedcapRecordsRequestOptions = Rails.env.test? ? nil : { exportSurveyFields: true }
   RedcapMetadataRequestOptions = nil
+  RedcapDataOptions = {
+    run_jobs_as_user: RedcapJobUserEmail,
+    run_jobs_in_app_type: 'ref-data'
+  }
 
   # Alternative to blindly using inflector acronyms.
   # This array of acronyms will be enforced for titleize only, avoiding

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,7 @@ Rails.application.routes.draw do
   namespace :redcap do
     resources :project_admins, except: %i[show destroy] do
       member do
+        post :request_latest_rc_configs
         post :request_records
         post :request_archive
         post :request_users

--- a/docs/admin_reference/project_admins/detailed_options.md
+++ b/docs/admin_reference/project_admins/detailed_options.md
@@ -50,6 +50,11 @@ data_options:
     # When this is specified, and the project is set to `exportSurveyFields: true` then an additional
     # `redcap_survey_identifier_id` field is added to the dynamic model database table, defined as an
     # integer type. This allows it to be correctly joined to integer typed external id fields on other tables.
+  set_master_id_using_association: true|false
+    # If option `associate_master_through_external_identifer` is set, the ability to retrieve the master record
+    # can be used to set a `master_id` field directly on the dynamic model. Setting this option to *true* will
+    # add a `master_id` field automatically, and ensure it is set when records are retrieved from REDCap.
+    # NOTE: for large datasets that change regularly, this may slow down record retrieval significantly.  
   run_jobs_as_user: <username>
     # Sets the admin and matching user that will be used to run background jobs, 
     # such as getting project metadata or retrieving records from REDCap.

--- a/docs/admin_reference/project_admins/detailed_options.md
+++ b/docs/admin_reference/project_admins/detailed_options.md
@@ -43,6 +43,25 @@ data_options:
     # config library to be prefixed to the dynamic
     # model definition whenever it is updated.
     # For example: "redcap test_library"
+  associate_master_through_external_identifer: <external identifier> (optional: foreign key name)
+    # Specify an external identifier resource name to use to look up the master record each
+    # stored record is associated with. By default, "redcap_survey_identifier_id" is used as the
+    # foreign key name used to look up the the external id. Optionally specify an alternative field name.
+    # When this is specified, and the project is set to `exportSurveyFields: true` then an additional
+    # `redcap_survey_identifier_id` field is added to the dynamic model database table, defined as an
+    # integer type. This allows it to be correctly joined to integer typed external id fields on other tables.
+  run_jobs_as_user: <username>
+    # Sets the admin and matching user that will be used to run background jobs, 
+    # such as getting project metadata or retrieving records from REDCap.
+    # New projects set this to the email address or id in settings `RedcapJobUserEmail`, which may be set by
+    # the environment variable `FPHS_RC_JOB_USER_EMAIL` or will default to the setting `BatchUserEmail`.
+    # If left blank in earlier projects or explicitly set to blank, the user matching the project's current admin will be used.
+  run_jobs_in_app_type: <app type name or id>
+    # Sets the app type that will be set on the `run_as_jobs_user`, effectively setting the
+    # access controls that authorize actions performed in background jobs such as retrieving records.
+    # This avoids an arbitrary app type being set, especially where the dynamic model being stored to has save triggers
+    # specified that may depend on access to specific resources.
+
 data_dictionary_version: random hash
     # do not change - a hash generated internally to 
     # identify whether the data dictionary has changed

--- a/spec/fixtures/redcap/short_records_narrow-survey-fields.json
+++ b/spec/fixtures/redcap/short_records_narrow-survey-fields.json
@@ -1,7 +1,7 @@
 [
   {
     "record_id": "1",
-    "redcap_survey_identifier": "",
+    "redcap_survey_identifier": "121",
     "q2_survey_timestamp": "[not completed]",
     "dob": "",
     "current_weight": "",
@@ -37,7 +37,7 @@
   },
   {
     "record_id": "4",
-    "redcap_survey_identifier": "",
+    "redcap_survey_identifier": "124",
     "q2_survey_timestamp": "[not completed]",
     "dob": "1998-04-16",
     "current_weight": "",
@@ -73,7 +73,7 @@
   },
   {
     "record_id": "14",
-    "redcap_survey_identifier": "",
+    "redcap_survey_identifier": "1214",
     "q2_survey_timestamp": "[not completed]",
     "dob": "2019-08-02",
     "current_weight": "234",
@@ -109,7 +109,7 @@
   },
   {
     "record_id": "19",
-    "redcap_survey_identifier": "",
+    "redcap_survey_identifier": "1219",
     "q2_survey_timestamp": "[not completed]",
     "dob": "1971-02-17",
     "current_weight": "300",
@@ -145,7 +145,7 @@
   },
   {
     "record_id": "32",
-    "redcap_survey_identifier": "",
+    "redcap_survey_identifier": "1232",
     "q2_survey_timestamp": "[not completed]",
     "dob": "",
     "current_weight": "",

--- a/spec/fixtures/redcap/short_records_updated_records-survey-fields.json
+++ b/spec/fixtures/redcap/short_records_updated_records-survey-fields.json
@@ -1,7 +1,7 @@
 [
   {
     "record_id": "1",
-    "redcap_survey_identifier": "kjasdfkjh",
+    "redcap_survey_identifier": "21",
     "q2_survey_timestamp": "[not completed]",
     "dob": "",
     "current_weight": "",
@@ -37,7 +37,7 @@
   },
   {
     "record_id": "4",
-    "redcap_survey_identifier": "",
+    "redcap_survey_identifier": "124",
     "q2_survey_timestamp": "2020-02-01 12:45:00",
     "dob": "1998-04-16",
     "current_weight": "",
@@ -73,7 +73,7 @@
   },
   {
     "record_id": "14",
-    "redcap_survey_identifier": "",
+    "redcap_survey_identifier": "214",
     "q2_survey_timestamp": "[not completed]",
     "dob": "2019-08-02",
     "current_weight": "234",
@@ -109,7 +109,7 @@
   },
   {
     "record_id": "19",
-    "redcap_survey_identifier": "",
+    "redcap_survey_identifier": "219",
     "q2_survey_timestamp": "[not completed]",
     "dob": "1971-02-17",
     "current_weight": "300",
@@ -145,7 +145,7 @@
   },
   {
     "record_id": "32",
-    "redcap_survey_identifier": "",
+    "redcap_survey_identifier": "1232",
     "q2_survey_timestamp": "[not completed]",
     "dob": "",
     "current_weight": "",

--- a/spec/models/redcap/data_records_spec.rb
+++ b/spec/models/redcap/data_records_spec.rb
@@ -4,467 +4,525 @@ require 'rails_helper'
 require './db/table_generators/dynamic_models_table'
 
 RSpec.describe Redcap::DataRecords, type: :model do
+  include MasterSupport
   include ModelSupport
   include Redcap::RedcapSupport
+
+  def request_admin
+    res = Admin.find_active_by_email_or_id Settings::RedcapJobUserEmail
+    expect(res).to be_a Admin
+    res
+  end
+
+  def create_sid_scantrons
+    @record_ids = %w[1 4 14 19 32]
+    @int_survey_ids = @record_ids.map { |i| "12#{i}".to_i } + @record_ids.map { |i| "2#{i}".to_i }
+    @int_survey_ids.each do |sid|
+      master = create_master(@user)
+      master.current_user = @user
+      master.scantrons.create!(scantron_id: sid)
+    end
+  end
 
   def clean_file_fields_filesystem(container)
     FileUtils.rm_rf "#{NfsStore::Manage::Filesystem.nfs_store_directory}/gid601/app-type-#{container.app_type_id}/containers/#{container.id} -- q2_demo/redcap_test.test_file_field_recs/file-fields/"
   end
+  describe 'retrieving records and files' do
+    before :all do
+      @bad_admin, = create_admin
+      @bad_admin.update! disabled: true
+      create_admin
+      @projects = setup_redcap_project_admin_configs
+      @project = @projects.first
+      @metadata_project = @projects.find { |p| p[:name] == 'metadata' }
+      setup_file_fields
+    end
+
+    before :example do
+      @bad_admin, = create_admin
+      @bad_admin.update! disabled: true
+      create_admin
+      setup_file_store
+      @projects = setup_redcap_project_admin_configs
+      @project = @projects.first
+      reset_mocks
+    end
+
+    it 'has a valid model to store records to, which must be a subclass of Dynamic::DynamicModelBase' do
+      setup_file_fields
+
+      dmrec = DynamicModel.active.find_by(category: 'redcap')
+      dmrec.force_regenerate = true
+      dmrec.generate_model
+      DynamicModel.reset_active_model_configurations!
+
+      dm = dmrec.implementation_class
+      expect(dm < Dynamic::DynamicModelBase).to be true
+
+      rc = Redcap::ProjectAdmin.active.first
+      rc.current_admin = @admin
+      class_name = dm.name
+      dr = Redcap::DataRecords.new(rc, class_name)
+
+      expect { dr.send :model }.not_to raise_error
+
+      dr = Redcap::DataRecords.new(rc, 'Class')
+
+      expect { dr.send :model }.to raise_error(FphsException, 'Redcap::DataRecords model is not a valid type: Class')
+    end
+
+    it 'retrieves records from REDCap immediately' do
+      dm = create_dynamic_model_for_sample_response
+
+      rc = Redcap::ProjectAdmin.active.first
+      rc.current_admin = @admin
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+
+      res = dr.retrieve
+
+      expect(res).to be_a Array
+      expect(res.length).to eq 5
+      expect(res.first).to be_a Hash
+      expect(res.first.keys.first).to eq :record_id
+    end
+
+    it 'validates retrieved records' do
+      dm = create_dynamic_model_for_sample_response
+
+      # data_sample_response_fields
+
+      rc = Redcap::ProjectAdmin.active.first
+      rc.current_admin = @admin
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+
+      dr.retrieve
+      dr.summarize_fields
+      dr.handle_survey_identifier
+
+      expect { dr.validate }.not_to raise_error
+    end
+
+    it 'raises errors if retrieved records id is missing' do
+      dm = create_dynamic_model_for_sample_response
+
+      rc = Redcap::ProjectAdmin.active.first
+      rc.current_admin = @admin
+
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+      stub_request_records @project[:server_url], @project[:api_key], 'fail_record_id_nil'
+      dr.retrieve
+      dr.summarize_fields
+      dr.handle_survey_identifier
+      expect { dr.validate }.to raise_error(FphsException, 'Redcap::DataRecords retrieved data that has a nil record id')
+    end
+
+    it 'raises errors if retrieved records have missing fields' do
+      dm = create_dynamic_model_for_sample_response
+
+      rc = Redcap::ProjectAdmin.active.first
+      rc.current_admin = @admin
+
+      stub_request_records @project[:server_url], @project[:api_key], 'mismatch_fields'
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+      dr.retrieve
+      dr.summarize_fields
+      dr.handle_survey_identifier
+      expect do
+        dr.validate
+      end.to raise_error(FphsException,
+                         "Redcap::DataRecords::ModelMissingFields retrieved record fields are not present in the model:\nmismatch_field")
+    end
 
-  before :all do
-    @bad_admin, = create_admin
-    @bad_admin.update! disabled: true
-    create_admin
-    @projects = setup_redcap_project_admin_configs
-    @project = @projects.first
-    @metadata_project = @projects.find { |p| p[:name] == 'metadata' }
-    setup_file_fields
-  end
-
-  before :example do
-    @bad_admin, = create_admin
-    @bad_admin.update! disabled: true
-    create_admin
-    @projects = setup_redcap_project_admin_configs
-    @project = @projects.first
-    reset_mocks
-  end
+    it 'stores retrieved records' do
+      dm = create_dynamic_model_for_sample_response
 
-  it 'has a valid model to store records to, which must be a subclass of Dynamic::DynamicModelBase' do
-    setup_file_fields
-    dm = DynamicModel.active.where(category: 'redcap').first.implementation_class
-    expect(dm < Dynamic::DynamicModelBase).to be true
+      rc = Redcap::ProjectAdmin.active.first
+      rc.current_admin = @admin
 
-    rc = Redcap::ProjectAdmin.active.first
-    rc.current_admin = @admin
-    class_name = dm.name
-    dr = Redcap::DataRecords.new(rc, class_name)
-
-    expect { dr.send :model }.not_to raise_error
-
-    dr = Redcap::DataRecords.new(rc, 'Class')
-
-    expect { dr.send :model }.to raise_error(FphsException, 'Redcap::DataRecords model is not a valid type: Class')
-  end
-
-  it 'retrieves records from REDCap immediately' do
-    dm = create_dynamic_model_for_sample_response
+      stub_request_records @project[:server_url], @project[:api_key]
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+      dr.retrieve
+      dr.summarize_fields
+      dr.handle_survey_identifier
 
-    rc = Redcap::ProjectAdmin.active.first
-    rc.current_admin = @admin
-    dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+      expect { dr.validate }.not_to raise_error
 
-    res = dr.retrieve
-
-    expect(res).to be_a Array
-    expect(res.length).to eq 5
-    expect(res.first).to be_a Hash
-    expect(res.first.keys.first).to eq :record_id
-  end
-
-  it 'validates retrieved records' do
-    dm = create_dynamic_model_for_sample_response
-
-    # data_sample_response_fields
-
-    rc = Redcap::ProjectAdmin.active.first
-    rc.current_admin = @admin
-    dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
-
-    dr.retrieve
-    dr.summarize_fields
-
-    expect { dr.validate }.not_to raise_error
-  end
-
-  it 'raises errors if retrieved records id is missing' do
-    dm = create_dynamic_model_for_sample_response
-
-    rc = Redcap::ProjectAdmin.active.first
-    rc.current_admin = @admin
+      dr.store
 
-    dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
-    stub_request_records @project[:server_url], @project[:api_key], 'fail_record_id_nil'
-    dr.retrieve
-    dr.summarize_fields
-    expect { dr.validate }.to raise_error(FphsException, 'Redcap::DataRecords retrieved data that has a nil record id')
-  end
-
-  it 'raises errors if retrieved records have missing fields' do
-    dm = create_dynamic_model_for_sample_response
-
-    rc = Redcap::ProjectAdmin.active.first
-    rc.current_admin = @admin
-
-    stub_request_records @project[:server_url], @project[:api_key], 'mismatch_fields'
-    dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
-    dr.retrieve
-    dr.summarize_fields
-    expect do
-      dr.validate
-    end.to raise_error(FphsException,
-                       "Redcap::DataRecords retrieved record fields are not present in the model:\nmismatch_field")
-  end
-
-  it 'stores retrieved records' do
-    dm = create_dynamic_model_for_sample_response
-
-    rc = Redcap::ProjectAdmin.active.first
-    rc.current_admin = @admin
+      expect(dr.errors).to be_empty
+      expect(dr.created_ids.map { |r| r[:record_id] }.sort).to eq %w[1 4 14 19 32].sort
+      expect(dr.updated_ids).to be_empty
+    end
 
-    stub_request_records @project[:server_url], @project[:api_key]
-    dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
-    dr.retrieve
-    dr.summarize_fields
+    it "fails if survey fields are requested and the dynamic model doesn't expect them" do
+      dm = create_dynamic_model_for_sample_response
 
-    expect { dr.validate }.not_to raise_error
+      rc = Redcap::ProjectAdmin.active.first
+      rc.current_admin = @admin
+      rc.records_request_options.exportSurveyFields = true
 
-    dr.store
+      stub_request_records @project[:server_url], @project[:api_key]
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+      dr.retrieve
+      expect { dr.validate }.to raise_error FphsException,
+                                            "Redcap::DataRecords::ModelMissingFields retrieved record fields are not present in the model:\n" \
+                                            'redcap_survey_identifier q2_survey_timestamp test_timestamp'
+    end
 
-    expect(dr.errors).to be_empty
-    expect(dr.created_ids.map { |r| r[:record_id] }.sort).to eq %w[1 4 14 19 32].sort
-    expect(dr.updated_ids).to be_empty
-  end
+    it 'stores retrieved records even if the target has additional fields' do
+      dm = create_dynamic_model_for_sample_response
 
-  it "fails if survey fields are requested and the dynamic model doesn't expect them" do
-    dm = create_dynamic_model_for_sample_response
+      rc = Redcap::ProjectAdmin.active.first
+      rc.current_admin = @admin
 
-    rc = Redcap::ProjectAdmin.active.first
-    rc.current_admin = @admin
-    rc.records_request_options.exportSurveyFields = true
+      WebMock.reset!
 
-    stub_request_records @project[:server_url], @project[:api_key]
-    dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
-    dr.retrieve
-    expect { dr.validate }.to raise_error FphsException,
-                                          "Redcap::DataRecords retrieved record fields are not present in the model:\n" \
-                                          'redcap_survey_identifier q2_survey_timestamp test_timestamp'
-  end
+      mock_limited_requests
+      rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records)
+      rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records, rc.records_request_options)
 
-  it 'stores retrieved records even if the target has additional fields' do
-    dm = create_dynamic_model_for_sample_response
+      api_key = rc.api_key
+      rc.update! current_admin: @admin, disabled: true
+      rc = Redcap::ProjectAdmin.create! current_admin: @admin,
+                                        study: 'Q2',
+                                        name: 'q2_demo',
+                                        api_key:,
+                                        server_url: rc.server_url
 
-    rc = Redcap::ProjectAdmin.active.first
-    rc.current_admin = @admin
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+      dr.retrieve
+      dr.summarize_fields
+      dr.handle_survey_identifier
 
-    WebMock.reset!
+      expect { dr.validate }.not_to raise_error
 
-    mock_limited_requests
-    rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records)
-    rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records, rc.records_request_options)
+      dr.store
 
-    api_key = rc.api_key
-    rc.update! current_admin: @admin, disabled: true
-    rc = Redcap::ProjectAdmin.create! current_admin: @admin,
-                                      study: 'Q2',
-                                      name: 'q2_demo',
-                                      api_key:,
-                                      server_url: rc.server_url
+      expect(dr.errors).to be_empty
+      expect(dr.created_ids.map { |r| r[:record_id] }.sort).to eq %w[1 19 32 4 5].sort
+      expect(dr.updated_ids).to be_empty
+    end
 
-    dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
-    dr.retrieve
-    dr.summarize_fields
-    expect { dr.validate }.not_to raise_error
+    it 'raises an error if the retrieved fields are different from the expect fields' do
+    end
 
-    dr.store
+    it 'does nothing if the records all match' do
+      dm = create_dynamic_model_for_sample_response
 
-    expect(dr.errors).to be_empty
-    expect(dr.created_ids.map { |r| r[:record_id] }.sort).to eq %w[1 19 32 4 5].sort
-    expect(dr.updated_ids).to be_empty
-  end
+      rc = Redcap::ProjectAdmin.active.first
+      rc.current_admin = @admin
 
-  it 'raises an error if the retrieved fields are different from the expect fields' do
-  end
-
-  it 'does nothing if the records all match' do
-    dm = create_dynamic_model_for_sample_response
+      stub_request_records @project[:server_url], @project[:api_key]
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+      dr.retrieve
+      dr.summarize_fields
+      dr.handle_survey_identifier
 
-    rc = Redcap::ProjectAdmin.active.first
-    rc.current_admin = @admin
-
-    stub_request_records @project[:server_url], @project[:api_key]
-    dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
-    dr.retrieve
-    dr.summarize_fields
-    expect { dr.validate }.not_to raise_error
-
-    dr.store
-
-    expect(dr.errors).to be_empty
-    expect(dr.created_ids.map { |r| r[:record_id] }.sort).to eq %w[1 4 14 19 32].sort
-    expect(dr.updated_ids).to be_empty
-
-    dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
-    dr.retrieve
-    dr.summarize_fields
-    expect { dr.validate }.not_to raise_error
-
-    dr.store
-
-    expect(dr.errors).to be_empty
-    expect(dr.created_ids.sort).to be_empty
-    expect(dr.updated_ids).to be_empty
-  end
+      expect { dr.validate }.not_to raise_error
 
-  it 'does updates on records that have changed' do
-    dm = create_dynamic_model_for_sample_response(survey_fields: true)
+      dr.store
 
-    rc = Redcap::ProjectAdmin.active.first
-    rc.current_admin = @admin
-    rc.records_request_options.exportSurveyFields = true
+      expect(dr.errors).to be_empty
+      expect(dr.created_ids.map { |r| r[:record_id] }.sort).to eq %w[1 4 14 19 32].sort
+      expect(dr.updated_ids).to be_empty
 
-    stub_request_records @project[:server_url], @project[:api_key]
-    dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
-    dr.retrieve
-    dr.summarize_fields
-    expect { dr.validate }.not_to raise_error
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+      dr.retrieve
+      dr.summarize_fields
+      dr.handle_survey_identifier
 
-    dr.store
-
-    expect(dr.errors).to be_empty
-    expect(dr.created_ids.map { |r| r[:record_id] }.sort).to eq %w[1 4 14 19 32].sort
-    expect(dr.updated_ids).to be_empty
-
-    WebMock.reset!
-    rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records)
-
-    rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records, rc.records_request_options)
-
-    stub_request_records @project[:server_url], @project[:api_key], 'updated_records'
-
-    Rails.cache.clear
-    dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
-    dr.retrieve
-    dr.summarize_fields
-    expect { dr.validate }.not_to raise_error
-    dr.store
-
-    expect(dr.errors).to be_empty
-    expect(dr.created_ids).to be_empty
-    expect(dr.updated_ids.map { |r| r[:record_id] }.sort).to eq %w[1 4 14 19].sort
-  end
-
-  it 'retrieves all records in the background' do
-    dm = create_dynamic_model_for_sample_response
-    rc = Redcap::ProjectAdmin.active.first
-    rc.current_admin = @admin
-    rc.dynamic_model_table = dm.implementation_class.table_name.to_s
-    rc.save # to ensure the background job works
-    dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
-
-    start_time = DateTime.now
-    expect(dm.implementation_class_defined?)
-
-    expect(dr.existing_records_length).to eq 0
-
-    dr.request_records
-
-    expect(dr.existing_records_length).to be > 0
-
-    cr = Redcap::ClientRequest.where(admin: @admin,
-                                     action: 'store records',
-                                     server_url: rc.server_url,
-                                     name: rc.name,
-                                     redcap_project_admin: rc)
-                              .where('created_at > :created_at', created_at: start_time)
-                              .last
-
-    expect(cr.result).to be_a Hash
-    expect(cr.result['count_created_ids']).to be > 0
-    expect(cr.result['count_updated_ids']).to eq 0
-    expect(cr.result['count_unchanged_ids']).to eq 0
-    expect(cr.result['errors']).to be_empty
-  end
-
-  it 'retrieves all records in the background if there are more model than storage fields' do
-    dm = create_dynamic_model_for_sample_response
-    rc = Redcap::ProjectAdmin.active.first
-    rc.current_admin = @admin
-    rc.dynamic_model_table = dm.implementation_class.table_name.to_s
-    rc.save # to ensure the background job works
-
-    WebMock.reset!
-
-    mock_limited_requests
-    rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records)
-    rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records, rc.records_request_options)
-    api_key = rc.api_key
-    rc.update! current_admin: @admin, disabled: true
-    rc = Redcap::ProjectAdmin.create! current_admin: @admin,
-                                      study: 'Q2',
-                                      name: 'q2_demo',
-                                      api_key:,
-                                      server_url: rc.server_url
-
-    rc.update! current_admin: @admin, dynamic_model_table: dm.implementation_class.table_name.to_s
-
-    dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
-
-    start_time = DateTime.now
-    expect(dm.implementation_class_defined?)
-
-    expect(dr.existing_records_length).to eq 0
-
-    dr.request_records
-
-    expect(dr.existing_records_length).to be > 0
-
-    cr = Redcap::ClientRequest.where(admin: @admin,
-                                     action: 'store records',
-                                     server_url: rc.server_url,
-                                     name: rc.name,
-                                     redcap_project_admin: rc)
-                              .where('created_at > :created_at', created_at: start_time)
-                              .last
-
-    expect(cr.result).to be_a Hash
-    expect(cr.result['count_created_ids']).to be > 0
-    expect(cr.result['count_updated_ids']).to eq 0
-    expect(cr.result['count_unchanged_ids']).to eq 0
-    expect(cr.result['errors']).to be_empty
-  end
-
-  it 'fails to start background request if model has missing fields' do
-    dm = create_dynamic_model_for_sample_response
-    rc = Redcap::ProjectAdmin.active.first
-    rc.current_admin = @admin
-    rc.dynamic_model_table = dm.implementation_class.table_name.to_s
-    rc.save # to ensure the background job works
-
-    WebMock.reset!
-
-    WebMock.reset!
-    mock_limited_requests
-    rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records)
-    rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records, rc.records_request_options)
-    stub_request_records @project[:server_url], @project[:api_key], 'missing_record'
-
-    api_key = rc.api_key
-    rc.update! current_admin: @admin, disabled: true
-    rc = Redcap::ProjectAdmin.create! current_admin: @admin,
-                                      study: 'Q2',
-                                      name: 'q2_demo',
-                                      api_key:,
-                                      server_url: rc.server_url
-
-    rc.update! current_admin: @admin, dynamic_model_table: dm.implementation_class.table_name.to_s
-
-    cr = Redcap::ClientRequest.where(admin: @admin,
-                                     action: 'store records',
-                                     server_url: rc.server_url,
-                                     name: rc.name,
-                                     redcap_project_admin: rc)
-                              .last
-
-    dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
-
-    start_time = Time.now
-    expect(dm.implementation_class_defined?)
-
-    expect(dr.existing_records_length).to eq 0
-
-    expect { dr.request_records }.to raise_error FphsException, /Redcap::DataRecords retrieved record fields don't match the data dictionary:/
-
-    expect(dr.existing_records_length).to eq 0
-
-    cr = Redcap::ClientRequest.where(admin: @admin,
-                                     action: 'store records',
-                                     server_url: rc.server_url,
-                                     name: rc.name,
-                                     redcap_project_admin: rc)
-                              .where('created_at > :created_at', created_at: start_time)
-                              .last
-
-    expect(cr.result['storage_stage']).to eq 'validate'
-
-    cr = Redcap::ClientRequest.where(admin: @admin,
-                                     action: 'capture records job',
-                                     server_url: rc.server_url,
-                                     name: rc.name,
-                                     redcap_project_admin: rc)
-                              .where('created_at > :created_at', created_at: start_time)
-                              .last
-    expect(cr.result['error']).to include "Redcap::DataRecords retrieved record fields don't match the data dictionary"
-  end
-
-  it 'downloads files' do
-    setup_file_fields
-    rc = @project_admin
-    rc.current_admin = @admin
-
-    dd = rc.redcap_data_dictionary
-    clean_file_fields_filesystem rc.file_store
-
-    dr = Redcap::DataRecords.new(rc, 'TestFileFieldRec')
-
-    expect(dr.send(:file_fields)).to eq %i[file1 signature]
-
-    dr.retrieve
-    expect(dr.records.length).to be > 0
-    puts dr.errors if dr.errors.present?
-    expect(dr.errors).not_to be_present
-
-    dr.send(:capture_files, dr.records[1])
-    puts dr.errors if dr.errors.present?
-    expect(dr.errors).not_to be_present
-
-    files = dr.imported_files
-    expect(files.count).to eq 2
-    expect(files.map { |f| "#{f.path}/#{f.file_name}" }.sort).to eq ["#{rc.dynamic_model_table}/file-fields/4/file1", "#{rc.dynamic_model_table}/file-fields/4/signature"]
-
-    # Repeat - should not update the files
-    Rails.cache.clear
-    dr = Redcap::DataRecords.new(rc, 'TestFileFieldRec')
-    dr.retrieve
-    dr.send(:capture_files, dr.records[1])
-    expect(dr.errors).not_to be_present
-    files = dr.imported_files
-    expect(files.count).to eq 0
-
-    # Reset with new file content
-    Rails.cache.clear
-    mock_file_field_requests
-    dr = Redcap::DataRecords.new(rc, 'TestFileFieldRec')
-    dr.retrieve
-    dr.send(:capture_files, dr.records[1])
-    expect(dr.errors).not_to be_present
-    files = dr.imported_files
-    expect(files.count).to eq 2
-  end
-
-  it 'downloads files in background' do
-    setup_file_fields
-    rc = @project_admin
-    rc.current_admin = @admin
-
-    expect(rc.dynamic_model_ready?).to be true
-
-    files = rc.file_store.stored_files
-    expect(files.count).to eq 0
-    clean_file_fields_filesystem rc.file_store
-
-    dd = rc.redcap_data_dictionary
-
-    dr = Redcap::DataRecords.new(rc, 'TestFileFieldRec')
-
-    dm = DynamicModel.active.find_by(table_name: 'test_file_field_recs')
-    puts rc.dynamic_storage.dynamic_model.implementation_class.table_name
-    puts DynamicModel.find_by(table_name: 'test_file_field_recs')&.attributes || 'no test_file_field_recs' unless dm
-    puts DynamicModel.active.to_a unless dm
-    expect(dm).to be_a DynamicModel
-
-    expect(dr.existing_records_length).to eq 0
-    dr.request_records
-    expect(dr.existing_records_length).to be > 0
-
-    puts dr.errors if dr.errors.present?
-    expect(dr.errors).not_to be_present
-
-    files = rc.file_store.stored_files.reload
-
-    expect(files.count).to eq 4
-    expect(files.map { |f| "#{f.path}/#{f.file_name}" }.sort)
-      .to eq ["#{rc.dynamic_model_table}/file-fields/4/file1", "#{rc.dynamic_model_table}/file-fields/4/signature", "#{rc.dynamic_model_table}/file-fields/19/signature", "#{rc.dynamic_model_table}/file-fields/32/file1"].sort
+      expect { dr.validate }.not_to raise_error
+
+      dr.store
+
+      expect(dr.errors).to be_empty
+      expect(dr.created_ids.sort).to be_empty
+      expect(dr.updated_ids).to be_empty
+    end
+
+    it 'does updates on records that have changed' do
+      dm = create_dynamic_model_for_sample_response(survey_fields: true)
+
+      rc = Redcap::ProjectAdmin.active.first
+      rc.current_admin = @admin
+      rc.records_request_options.exportSurveyFields = true
+
+      stub_request_records @project[:server_url], @project[:api_key]
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+      dr.retrieve
+      dr.summarize_fields
+      dr.handle_survey_identifier
+
+      expect { dr.validate }.not_to raise_error
+
+      dr.store
+
+      expect(dr.errors).to be_empty
+      expect(dr.created_ids.map { |r| r[:record_id] }.sort).to eq %w[1 4 14 19 32].sort
+      expect(dr.updated_ids).to be_empty
+
+      WebMock.reset!
+      rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records)
+
+      rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records, rc.records_request_options)
+
+      stub_request_records @project[:server_url], @project[:api_key], 'updated_records'
+
+      Rails.cache.clear
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+      dr.retrieve
+      dr.summarize_fields
+      dr.handle_survey_identifier
+
+      expect { dr.validate }.not_to raise_error
+      dr.store
+
+      expect(dr.errors).to be_empty
+      expect(dr.created_ids).to be_empty
+      expect(dr.updated_ids.map { |r| r[:record_id] }.sort).to eq %w[1 4 14 19].sort
+    end
+
+    it 'retrieves all records in the background' do
+      dm = create_dynamic_model_for_sample_response
+      rc = Redcap::ProjectAdmin.active.first
+      rc.current_admin = @admin
+      rc.dynamic_model_table = dm.implementation_class.table_name.to_s
+      rc.save # to ensure the background job works
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+
+      start_time = DateTime.now
+      expect(dm.implementation_class_defined?)
+
+      expect(dr.existing_records_length).to eq 0
+
+      dr.request_records
+
+      expect(dr.existing_records_length).to be > 0
+
+      cr = Redcap::ClientRequest.where(admin: @admin,
+                                       action: 'store records',
+                                       server_url: rc.server_url,
+                                       name: rc.name,
+                                       redcap_project_admin: rc)
+                                .where('created_at > :created_at', created_at: start_time)
+                                .last
+
+      expect(cr.result).to be_a Hash
+      expect(cr.result['count_created_ids']).to be > 0
+      expect(cr.result['count_updated_ids']).to eq 0
+      expect(cr.result['count_unchanged_ids']).to eq 0
+      expect(cr.result['errors']).to be_empty
+    end
+
+    it 'retrieves all records in the background if there are more model than storage fields' do
+      dm = create_dynamic_model_for_sample_response
+      rc = Redcap::ProjectAdmin.active.first
+      rc.current_admin = @admin
+      rc.dynamic_model_table = dm.implementation_class.table_name.to_s
+      rc.save # to ensure the background job works
+
+      WebMock.reset!
+
+      mock_limited_requests
+      rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records)
+      rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records, rc.records_request_options)
+      api_key = rc.api_key
+      rc.update! current_admin: @admin, disabled: true
+      rc = Redcap::ProjectAdmin.create! current_admin: @admin,
+                                        study: 'Q2',
+                                        name: 'q2_demo',
+                                        api_key:,
+                                        server_url: rc.server_url
+
+      rc.update! current_admin: @admin, dynamic_model_table: dm.implementation_class.table_name.to_s
+
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+
+      start_time = DateTime.now
+      expect(dm.implementation_class_defined?)
+
+      expect(dr.existing_records_length).to eq 0
+
+      dr.request_records
+
+      expect(dr.existing_records_length).to be > 0
+
+      cr = Redcap::ClientRequest.where(admin: request_admin,
+                                       action: 'store records',
+                                       server_url: rc.server_url,
+                                       name: rc.name,
+                                       redcap_project_admin: rc)
+                                .where('created_at > :created_at', created_at: start_time)
+                                .last
+
+      expect(cr.result).to be_a Hash
+      expect(cr.result['count_created_ids']).to be > 0
+      expect(cr.result['count_updated_ids']).to eq 0
+      expect(cr.result['count_unchanged_ids']).to eq 0
+      expect(cr.result['errors']).to be_empty
+    end
+
+    it 'fails to start background request if model has missing fields' do
+      dm = create_dynamic_model_for_sample_response
+      rc = Redcap::ProjectAdmin.active.first
+      rc.current_admin = @admin
+      rc.dynamic_model_table = dm.implementation_class.table_name.to_s
+      rc.save # to ensure the background job works
+
+      WebMock.reset!
+
+      WebMock.reset!
+      mock_limited_requests
+      rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records)
+      rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records, rc.records_request_options)
+      stub_request_records @project[:server_url], @project[:api_key], 'missing_record'
+
+      api_key = rc.api_key
+      rc.update! current_admin: @admin, disabled: true
+      rc = Redcap::ProjectAdmin.create! current_admin: @admin,
+                                        study: 'Q2',
+                                        name: 'q2_demo',
+                                        api_key:,
+                                        server_url: rc.server_url
+
+      rc.update! current_admin: @admin, dynamic_model_table: dm.implementation_class.table_name.to_s
+
+      cr = Redcap::ClientRequest.where(admin: request_admin,
+                                       action: 'store records',
+                                       server_url: rc.server_url,
+                                       name: rc.name,
+                                       redcap_project_admin: rc)
+                                .last
+
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+
+      start_time = Time.now
+      expect(dm.implementation_class_defined?)
+
+      expect(dr.existing_records_length).to eq 0
+
+      expect { dr.request_records }.to raise_error FphsException, /Redcap::DataRecords::MismatchFields retrieved record fields don't match the data dictionary:/
+
+      expect(dr.existing_records_length).to eq 0
+
+      cr = Redcap::ClientRequest.where(admin: request_admin,
+                                       action: 'store records',
+                                       server_url: rc.server_url,
+                                       name: rc.name,
+                                       redcap_project_admin: rc)
+                                .where('created_at > :created_at', created_at: start_time)
+                                .last
+
+      expect(cr.result['storage_stage']).to eq 'validate'
+
+      cr = Redcap::ClientRequest.where(admin: request_admin,
+                                       action: 'capture records job',
+                                       server_url: rc.server_url,
+                                       name: rc.name,
+                                       redcap_project_admin: rc)
+                                .where('created_at > :created_at', created_at: start_time)
+                                .last
+      expect(cr.result['error']).to include "Redcap::DataRecords::MismatchFields retrieved record fields don't match the data dictionary"
+    end
+
+    it 'downloads files' do
+      setup_file_fields
+      rc = @project_admin
+      rc.current_admin = @admin
+      setup_file_store
+
+      # expect(@admin.matching_user).to eq @user
+      expect(@user.has_access_to?(:edit, :table, rc.dynamic_storage.dynamic_model.resource_name))
+      expect(@user.role_names).to include(Settings.admin_nfs_role)
+      puts @user.email
+
+      dd = rc.redcap_data_dictionary
+      clean_file_fields_filesystem rc.file_store
+
+      dr = Redcap::DataRecords.new(rc, 'TestFileFieldRec')
+
+      expect(dr.send(:file_fields)).to eq %i[file1 signature]
+
+      dr.retrieve
+      expect(dr.records.length).to be > 0
+      puts dr.errors if dr.errors.present?
+      expect(dr.errors).not_to be_present
+
+      dr.send(:capture_files, dr.records[1])
+      puts dr.errors if dr.errors.present?
+      expect(dr.errors).not_to be_present
+
+      files = dr.imported_files
+      expect(files.count).to eq 2
+      expect(files.map { |f| "#{f.path}/#{f.file_name}" }.sort).to eq ["#{rc.dynamic_model_table}/file-fields/4/file1", "#{rc.dynamic_model_table}/file-fields/4/signature"]
+
+      # Repeat - should not update the files
+      Rails.cache.clear
+      dr = Redcap::DataRecords.new(rc, 'TestFileFieldRec')
+      dr.retrieve
+      dr.send(:capture_files, dr.records[1])
+      expect(dr.errors).not_to be_present
+      files = dr.imported_files
+      expect(files.count).to eq 0
+
+      # Reset with new file content
+      Rails.cache.clear
+      mock_file_field_requests
+      dr = Redcap::DataRecords.new(rc, 'TestFileFieldRec')
+      dr.retrieve
+      dr.send(:capture_files, dr.records[1])
+      expect(dr.errors).not_to be_present
+      files = dr.imported_files
+      expect(files.count).to eq 2
+    end
+
+    it 'downloads files in background' do
+      rc = @project_admin
+      rc.current_admin = @admin
+      setup_file_store rc.job_admin
+      setup_file_store
+
+      # expect(@admin.matching_user).to eq @user
+      expect(rc.job_user.has_access_to?(:edit, :table, rc.dynamic_storage.dynamic_model.resource_name)).to be_truthy
+      expect(@user.role_names).to include(Settings.admin_nfs_role)
+      expect(@user.has_access_to?(:create, :table, :nfs_store__manage__containers)).to be_truthy
+
+      expect(rc.job_user.has_access_to?(:create, :table, :nfs_store__manage__containers)).to be_truthy
+
+      puts @user.email
+
+      expect(rc.dynamic_model_ready?).to be true
+
+      files = rc.file_store.stored_files
+      expect(files.count).to eq 0
+      clean_file_fields_filesystem rc.file_store
+
+      mock_file_field_requests
+
+      rc.in_background_job = true
+      dd = rc.redcap_data_dictionary
+
+      dr = Redcap::DataRecords.new(rc, 'TestFileFieldRec')
+
+      dm = DynamicModel.active.find_by(table_name: 'test_file_field_recs')
+      puts rc.dynamic_storage.dynamic_model.implementation_class.table_name
+      puts DynamicModel.find_by(table_name: 'test_file_field_recs')&.attributes || 'no test_file_field_recs' unless dm
+      puts DynamicModel.active.to_a unless dm
+      expect(dm).to be_a DynamicModel
+
+      expect(dr.existing_records_length).to eq 0
+      dr.request_records
+      expect(dr.existing_records_length).to be > 0
+
+      puts dr.errors if dr.errors.present?
+      expect(dr.errors).not_to be_present
+
+      files = rc.file_store.stored_files.reload
+
+      expect(files.count).to eq 4
+      expect(files.map { |f| "#{f.path}/#{f.file_name}" }.sort)
+        .to eq ["#{rc.dynamic_model_table}/file-fields/4/file1", "#{rc.dynamic_model_table}/file-fields/4/signature", "#{rc.dynamic_model_table}/file-fields/19/signature", "#{rc.dynamic_model_table}/file-fields/32/file1"].sort
+    end
   end
 
   describe 'handling of deleted records prevents transfer' do
@@ -487,6 +545,12 @@ RSpec.describe Redcap::DataRecords, type: :model do
       expect(ds.dynamic_model_ready?).to be_truthy
     end
 
+    before :example do
+      create_admin
+      setup_file_store
+      reset_mocks
+    end
+
     it 'complains if records are missing and handle_deleted_records = nil' do
       dm = create_dynamic_model_for_sample_response
 
@@ -501,6 +565,8 @@ RSpec.describe Redcap::DataRecords, type: :model do
 
       dr.retrieve
       dr.summarize_fields
+      dr.handle_survey_identifier
+
       expect { dr.validate }.not_to raise_error
 
       dr.store
@@ -518,6 +584,8 @@ RSpec.describe Redcap::DataRecords, type: :model do
       dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
       dr.retrieve
       dr.summarize_fields
+      dr.handle_survey_identifier
+
       expect do
         dr.validate
       end.to raise_error(FphsException, 'Redcap::DataRecords existing records were not in the retrieved records: {:record_id=>"4"}')
@@ -543,6 +611,12 @@ RSpec.describe Redcap::DataRecords, type: :model do
       expect(ds.dynamic_model_ready?).to be_truthy
     end
 
+    before :example do
+      create_admin
+      setup_file_store
+      reset_mocks
+    end
+
     it 'ignores records if records are missing and handle_deleted_records = ignore' do
       dm = create_dynamic_model_for_sample_response
 
@@ -557,6 +631,8 @@ RSpec.describe Redcap::DataRecords, type: :model do
       dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
       dr.retrieve
       dr.summarize_fields
+      dr.handle_survey_identifier
+
       expect { dr.validate }.not_to raise_error
 
       dr.store
@@ -574,6 +650,8 @@ RSpec.describe Redcap::DataRecords, type: :model do
       dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
       dr.retrieve
       dr.summarize_fields
+      dr.handle_survey_identifier
+
       expect do
         dr.validate
       end.not_to raise_error
@@ -600,6 +678,8 @@ RSpec.describe Redcap::DataRecords, type: :model do
       dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
       dr.retrieve
       dr.summarize_fields
+      dr.handle_survey_identifier
+
       expect { dr.validate }.not_to raise_error
 
       dr.store
@@ -617,6 +697,8 @@ RSpec.describe Redcap::DataRecords, type: :model do
       dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
       dr.retrieve
       dr.summarize_fields
+      dr.handle_survey_identifier
+
       expect do
         dr.validate
       end.not_to raise_error
@@ -673,8 +755,9 @@ RSpec.describe Redcap::DataRecords, type: :model do
       dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
 
       dr.retrieve
-
       dr.summarize_fields
+      dr.handle_survey_identifier
+
       expect(dr.records.first.keys).to include(:smoketime_chosen_array)
 
       expect { dr.validate }.not_to raise_error
@@ -693,6 +776,80 @@ RSpec.describe Redcap::DataRecords, type: :model do
         exp_array = %w[pnfl dnfl anfl].map { |choice| r["smoketime___#{choice}"] && choice }.select { |item| item }
 
         expect(sa).to eq exp_array
+      end
+    end
+  end
+
+  describe 'project associating foreign key with external id' do
+    before :all do
+      @bad_admin, = create_admin
+      @bad_admin.update! disabled: true
+      create_admin
+      @projects = setup_redcap_project_admin_configs
+      @project = @projects.first
+
+      # Create the first DM with multiple choice summary fields
+      rc = Redcap::ProjectAdmin.active.first
+      rc.records_request_options.exportSurveyFields = true
+      rc.data_options.associate_master_through_external_identifer = 'scantrons'
+      rc.study = 'external-id-test'
+      rc.current_admin = @admin
+      rc.save!
+
+      rc.reload
+      expect(rc.data_options.associate_master_through_external_identifer).to eq 'scantrons'
+      puts "rc.id: #{rc.id}"
+
+      ds = Redcap::DynamicStorage.new rc, "redcap_test.test_rc#{rand 100_000_000_000_000}_recs"
+      ds.category = 'redcap-test-env'
+      @dm = ds.create_dynamic_model
+      expect(ds.dynamic_model_ready?).to be_truthy
+    end
+
+    before :example do
+      create_admin
+      setup_file_store
+      reset_mocks
+
+      # Set up scantrons to match to redcap_survey_identifiers
+      setup_access :scantrons unless @user.has_access_to? :create, :table, :scantrons
+
+      create_sid_scantrons
+    end
+
+    it 'saves records with integer survey identifiers' do
+      dm = @dm
+
+      rc = Redcap::ProjectAdmin.active.find_by(study: 'external-id-test')
+      rc.current_admin = @admin
+      rc.save!
+      expect(rc.data_options.associate_master_through_external_identifer).to eq 'scantrons'
+      dd = rc.redcap_data_dictionary
+      all_rf = dd.all_retrievable_fields
+      expect(all_rf[:redcap_survey_identifier_id].field_type.name).to eq :integer_survey_identifier
+
+      stub_request_records @project[:server_url], @project[:api_key]
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+
+      dr.retrieve
+      dr.summarize_fields
+      dr.handle_survey_identifier
+
+      expect(dr.records.first.keys).to include(:redcap_survey_identifier_id)
+
+      expect { dr.validate }.not_to raise_error
+      dr.store
+
+      expect(dr.errors).to be_empty
+      created_record_ids = dr.created_ids.map { |r| r[:record_id] }.sort
+      expect(created_record_ids).to eq @record_ids.sort
+      expect(dr.updated_ids).to be_empty
+
+      stored_recs = dm.implementation_class.where(record_id: created_record_ids)
+      stored_recs.each do |r|
+        sa = r.redcap_survey_identifier_id
+
+        expect(sa).to eq r.redcap_survey_identifier.to_i
       end
     end
   end

--- a/spec/models/redcap/project_admin_spec.rb
+++ b/spec/models/redcap/project_admin_spec.rb
@@ -107,8 +107,11 @@ RSpec.describe Redcap::ProjectAdmin, type: :model do
     rc.dynamic_model_table = 'test.test_file_field_sf_recs'
     rc.server_url = server_url('file_field')
     rc.records_request_options.exportSurveyFields = true
+    rc.data_options.run_jobs_as_user = @user.email
     puts "Project Name: #{rc.name}"
     rc.save
+    expect(rc.job_user).to eq @user
+    expect(rc.job_app_type).to eq @user.app_type
 
     rc.dump_archive
 

--- a/spec/support/dynamic_model_support.rb
+++ b/spec/support/dynamic_model_support.rb
@@ -20,13 +20,15 @@ module DynamicModelSupport
     @master = Master.create! current_user: @user
     @master.current_user = @user
 
-    DynamicModel.active.where(table_name: 'test_created_by_recs').each { |dm| dm.disable!(@admin) }
+    DynamicModel.active.where(table_name: 'test_created_by_recs').reload.each { |dm| dm.disable!(@admin) }
 
     dm = DynamicModel.create! current_admin: @admin, name: 'test created by', table_name: 'test_created_by_recs', primary_key_name: :id, foreign_key_name: :master_id, category: :test
     dm.current_admin = @admin
     dm.update_tracker_events
 
     expect(dm).to be_a ::DynamicModel
+    active_count = DynamicModel.active.where(table_name: 'test_created_by_recs').reload.count
+    expect(active_count).to eq 1
 
     setup_access :dynamic_model__test_created_by_recs, user: @user
     setup_access :dynamic_model__test_created_by_recs, user: @user0


### PR DESCRIPTION
- [Fixed] viewing a master record with category of redcap dynamic models (which show in a default panel) loads all entries in the database - fixes #370
- [Added] redcap project option set_master_id_using_association, which adds a master_id to the underlying table and sets it automatically from the external id association - closes #369
- [Added] ability for redcap project associate_master_through_external_identifer to match on external identifiers with integer external ids, by adding an integer redcap_survey_identifier_id field to the dynamic model
- [Added] better information around missing fields and mismatched in the redcap project
- [Added] the ability to retrieve the latest redcap configuration within the redcap project, so field configurations can be correctly validated
- [Added] redcap project run_jobs_as_user and run_jobs_as_app_type options to ensure background jobs run consistently
- [Fixed] dynamic models with foreign keys breaking the admin sample form view
- [Fixed] Redcap project reconfigures dynamic model with new one if the category of the DM has changed - fixes #365
- [Added] redcap project admin option associate_master_through_external_identifer: [external identifier] to automatically allow connection of redcap_survey_identifier to a master record through a matching external id - closes #369
- [Added] estimated record count and new config checks to redcap project admin details panel
- [Added] checking of tracker protocol updates in dynamic definitions details panels
