### PR TITLE
Hms fixes 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ Since [version 8.4.0](#840---2024-01-10) the convention is that releases made wi
 
 ## Unreleased
 
+- [Added] new check in Redcap project to ensure user has access to the associated external id table, if specified
+- [Added] ability for report edit table name and fields to be specified as {{table_name}} and {{table_fields}} to allow editing of arbitrary tables in the generic report
+- [Added] RedcapJobUserEmail setting to be viewed in server info
+- [Fixed] user creating an external identifier with additional fields loses their value - fixes #307
+- [Changed] external identifier details panel to add "search data" link - especially helpful if the user can edit the results for example to add other field entries to external id records
+- [Changed] specification of Redcap project run_jobs_in_app_type to only use the current user's app type if the configuration is not specified (it previously ignored a specified app not being found)
+- [Added] exceptions to make it clear if a master id was not found through an external id for various reasons
+- [Fixed] incorrect error message
+
+## [8.8.4] - 2024-08-27
+
+- [Added] save trigger create_reference, update_reference and update_this to accept embedded_item hash to create or update the appropriate item automatically
+
+## [8.8.3] - 2024-08-22
+
 - [Fixed] viewing a master record with category of redcap dynamic models (which show in a default panel) loads all entries in the database - fixes #370
 - [Added] redcap project option set_master_id_using_association, which adds a master_id to the underlying table and sets it automatically from the external id association - closes #369
 - [Added] ability for redcap project associate_master_through_external_identifer to match on external identifiers with integer external ids, by adding an integer redcap_survey_identifier_id field to the dynamic model

--- a/app/controllers/concerns/master_handler.rb
+++ b/app/controllers/concerns/master_handler.rb
@@ -104,7 +104,7 @@ module MasterHandler
       if object_instance.update(secure_params)
         reload_objects
         handle_additional_updates :update
-        if object_instance.has_multiple_results
+        if object_instance.has_multiple_results && !@assigning_master_to_existing_instance
           @master_objects = object_instance.multiple_results
           index
         else
@@ -344,6 +344,10 @@ module MasterHandler
       @master = Master.find(params[:master_id]) unless primary_model.no_master_association && !params[:master_id]
     else
       object = primary_model.find(params[:id])
+      unless primary_model.no_master_association || object.master_id
+        @assigning_master_to_existing_instance = true
+        object.master = Master.find(params[:master_id])
+      end
       set_object_instance object
       @master = object.master unless primary_model.no_master_association
       @id = object.id

--- a/app/controllers/external_identifier/external_identifier_controller.rb
+++ b/app/controllers/external_identifier/external_identifier_controller.rb
@@ -31,7 +31,11 @@ class ExternalIdentifier::ExternalIdentifierController < UserBaseController
     field_list = [:master_id] + defn.field_list_array
 
     res = params.require(controller_name.singularize.to_sym).permit(field_list)
-    res[implementation_class.external_id_attribute.to_sym] = nil if implementation_class.allow_to_generate_ids?
+    attr_ext_id = implementation_class.external_id_attribute
+    attr_ext_id_val = res[attr_ext_id.to_sym]
+    if implementation_class.allow_to_generate_ids? && object_instance.id && object_instance[attr_ext_id].to_s != attr_ext_id_val.to_s
+      res[attr_ext_id] = nil
+    end
     @secure_params = res
   end
 

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -14,7 +14,7 @@ module ReportsHelper
   def report_edit_btn(id)
     return unless id
 
-    rp = edit_report_path(id, report_id: @report.id, filter: filter_params_permitted)
+    rp = edit_report_path(id, report_id: @report.id, filter: filter_params_permitted, table_name: params[:table_name])
     link_to '',
             rp,
             remote: true,

--- a/app/models/admin/user_action_log.rb
+++ b/app/models/admin/user_action_log.rb
@@ -5,7 +5,7 @@ class Admin::UserActionLog < ActiveRecord::Base
 
   attr_accessor :no_master_association
 
-  validates :master_id, presence: true, unless: -> { item_type == 'masters' || item_type == 'reports' || no_master_association }
+  # validates :master_id, presence: true, unless: -> { item_type == 'masters' || item_type == 'reports' || no_master_association }
   validates :user_id, presence: true
   validates :app_type_id, presence: true
 end

--- a/app/models/concerns/general_data_concerns.rb
+++ b/app/models/concerns/general_data_concerns.rb
@@ -111,7 +111,7 @@ module GeneralDataConcerns
   def tracker_histories
     return @memo_tracker_histories if @memo_tracker_histories
 
-    return unless respond_to?(:master_id) && !self.class.no_master_association
+    return unless respond_to?(:master_id) && !allow_no_master_and_not_set?
 
     # Check for the existence of tracker_histories in the super class. If it
     # already exists, it is an association that we should not be overriding
@@ -167,7 +167,7 @@ module GeneralDataConcerns
   # Returns a simple hash alternative ids accessible by the current user
   # @return [Hash]
   def ids
-    master.alternative_ids
+    master&.alternative_ids
   end
 
   #
@@ -295,7 +295,7 @@ module GeneralDataConcerns
       extras[:methods] << :def_version
       extras[:methods] << :vdef_version
 
-      if respond_to?(:master) && !self.class.no_master_association && !is_a?(TrackerHistory) && !is_a?(Tracker)
+      if respond_to?(:master) && !allow_no_master_and_not_set? && !is_a?(TrackerHistory) && !is_a?(Tracker)
         extras[:methods] << :ids
       end
 

--- a/app/models/concerns/handles_user_base.rb
+++ b/app/models/concerns/handles_user_base.rb
@@ -48,6 +48,8 @@ module HandlesUserBase
     # Used primarily by #model_references to calculate ConditionalAction#calc_reference_if
     attr_accessor :reference, :embedded_item
 
+    NotPermittedParams = %i[user_id created_at updated_at tracker_id tracker_history_id admin_id disabled].freeze
+
     # Setup alternative id field methods
     Master.setup_resource_alternative_id_fields self unless no_master_association
 
@@ -80,7 +82,7 @@ module HandlesUserBase
     end
 
     def external_identifier?
-      false
+      (self < Dynamic::ExternalIdentifierBase)
     end
 
     #
@@ -89,6 +91,14 @@ module HandlesUserBase
     # configurations
     def no_master_association
       false
+    end
+
+    #
+    # No master association or if this is an external identifier, masters may be nil
+    # until they are assigned to a participant
+    # @return [true|false]
+    def no_master_or_optional?
+      !!(no_master_association || external_identifier?)
     end
 
     #
@@ -178,8 +188,7 @@ module HandlesUserBase
     # configured attributes, minus some standard fields. They are then refined
     # to access arrays if needed
     def permitted_params
-      res = attribute_names.map(&:to_sym) - %i[disabled user_id created_at updated_at tracker_id tracker_history_id
-                                               admin_id]
+      res = attribute_names.map(&:to_sym) - NotPermittedParams
       refine_permitted_params res
     end
 
@@ -353,7 +362,7 @@ module HandlesUserBase
   def def_version; end
 
   def master_user
-    return current_user if self.class.no_master_association
+    return current_user if allow_no_master_and_not_set?
 
     if respond_to?(:master) && master
       master.current_user
@@ -410,7 +419,7 @@ module HandlesUserBase
   end
 
   def allows_current_user_access_to?(perform, _with_options = nil)
-    no_ma = self.class.no_master_association
+    no_ma = allow_no_master_and_not_set?
     curr_user = if no_ma
                   current_user
                 else
@@ -625,7 +634,7 @@ module HandlesUserBase
   # field in Master through a DB trigger after the ProInfo record has been persisted. Checking
   # the crosswalk field would fail, because the master record has not been updated at this point.
   def check_crosswalk
-    return if self.class.no_master_association
+    return if allow_no_master_and_not_set?
 
     check_attrs = Master.crosswalk_attrs - (self.class.prevent_crosswalk_check || [])
     check_attrs.each do |attr|
@@ -663,16 +672,23 @@ module HandlesUserBase
   end
 
   #
+  # Return true if there is no master association, or if the master is optional
+  # i.e. this is an external identifier that has not yet been assigned to a participant
+  # @return [true|false] <description>
+  def allow_no_master_and_not_set?
+    !!(self.class.no_master_association || self.class.external_identifier? && !master)
+  end
+
+  #
   # Typically the user_id is not written to directly, and has been overriden to avoid
   # accidental changes. This method allows the model to write the user_id based on the
   # current user for the master that this object belongs to.
   def force_write_user
     return true if no_user_validation
 
-    # Special handling for editable reports and dynamic models with no_master_association set
-    if respond_to?(:user_id) && respond_to?(:current_user) && (
-      !self.class.respond_to?(:no_master_association) || self.class.no_master_association
-    )
+    # Special handling for editable reports and dynamic models with no_master_association or
+    # external identifiers that have not been assigned a master.
+    if respond_to?(:user_id) && respond_to?(:current_user) && allow_no_master_and_not_set?
       return write_attribute :user_id, current_user.id
     end
 
@@ -697,9 +713,8 @@ module HandlesUserBase
     return true if attributes['created_by_user_id']
 
     # Special handling for editable reports and dynamic models with no_master_association set
-    if respond_to?(:user_id) && respond_to?(:current_user) && (
-      !self.class.respond_to?(:no_master_association) || self.class.no_master_association
-    )
+    # or external identifiers that have not been assigned a master
+    if respond_to?(:user_id) && respond_to?(:current_user) && allow_no_master_and_not_set?
       return unless current_user
 
       cuid = if current_user.is_a? Integer

--- a/app/models/concerns/user_handler.rb
+++ b/app/models/concerns/user_handler.rb
@@ -99,8 +99,9 @@ module UserHandler
       r = { inverse_of: assoc_inverse }
       r[:foreign_key] = foreign_key_name if foreign_key_name && foreign_key_name != :master_id
       r[:primary_key] = primary_key_name if primary_key_name && primary_key_name != :id
-      r[:optional] = true if defined?(no_master_association) && no_master_association
-
+      if defined?(no_master_association) && no_master_association || (self < Dynamic::ExternalIdentifierBase)
+        r[:optional] = true
+      end
       r
     end
 

--- a/app/models/redcap/data_records.rb
+++ b/app/models/redcap/data_records.rb
@@ -392,13 +392,27 @@ module Redcap
     def handle_setting_master_id(update_record, retrieved_record)
       return unless do_handle_setting_master_id
 
+      isi = retrieved_record[integer_survey_identifier_field_name]
+      recid = retrieved_record.first.last
+      unless isi
+        raise FphsException,
+              "Integer survey identifier field is empty, can't set master id, for record #{recid}"
+      end
+
       # Start by setting the integer survey identifier field, so the association can get the master with the new value
-      update_record[integer_survey_identifier_field_name] = retrieved_record[integer_survey_identifier_field_name]
+      update_record[integer_survey_identifier_field_name] = isi
 
       # Retrieve the master_id from the record (which goes through the association), then set the value returned
       # on the actual underlying attribute. Although this looks like it is assigning the same value, this is not
       # actually what is happening.
-      update_record.master_id = update_record.master_id
+      res = update_record.master_id = update_record.master_id
+
+      unless res
+        raise FphsException,
+              "Redcap pull failed to get master id through association, for record #{recid} with survey identifier #{isi}"
+      end
+
+      res
     end
 
     #

--- a/app/models/redcap/project_admin.rb
+++ b/app/models/redcap/project_admin.rb
@@ -548,8 +548,12 @@ module Redcap
       return @job_app_type if @job_app_type
 
       ja = data_options.run_jobs_in_app_type
-      res = Admin::AppType.find_active_by_name_or_id(ja)
-      @job_app_type = res || current_user.app_type
+      res = if ja
+              Admin::AppType.find_active_by_name_or_id(ja)
+            else
+              current_user.app_type
+            end
+      @job_app_type = res
     end
 
     def invalidate_cache

--- a/app/models/reports/report_editing.rb
+++ b/app/models/reports/report_editing.rb
@@ -36,6 +36,15 @@ module Reports
       editable_data?
     end
 
+    def substitute_table_name_and_fields(params)
+      self.edit_model = params[:table_name] if edit_model == '{{table_name}}'
+      emc = edit_model_class
+      return unless emc
+
+      flist = emc.attribute_names - ReportsController::NotPermittedParams.map(&:to_s)
+      self.edit_field_names = flist.join(',') if edit_field_names == '{{table_fields}}'
+    end
+
     # If the results can be edited, what class represents each result
     def edit_model_class
       return unless editable_data?

--- a/app/views/admin/external_identifiers/_def_details.html.erb
+++ b/app/views/admin/external_identifiers/_def_details.html.erb
@@ -15,9 +15,10 @@
   <code><%= object_instance.all_implementation_fields.join("</code> <code>").html_safe %></code>
   </p>
 
-  <label>assigned identifiers</label>
-  <p><%=link_to link_label_open_in_new('details'), "/admin/external_identifier_details/#{object_instance.id}", target: '_blank' %></p>
-
+  <label>identifier records</label>
+  <p><%=link_to link_label_open_in_new('create identifiers and view counts'), "/admin/external_identifier_details/#{object_instance.id}", target: '_blank' %></p>
+  <p><%= link_to link_label_open_in_new('search data'), "/reports/reference_data__table_data?schema_name=#{object_instance.schema_name}&search_attrs%5B_blank%5D=true&search_attrs%5Bno_run%5D=true&table_name=#{object_instance.table_name}", 
+                target: '_blank' %></p>
   <%= render partial: 'admin/dynamic_models/est_record_count' %>
   <%= render partial: 'admin/dynamic_models/check_tracker_updates' %>
 

--- a/app/views/redcap/project_admins/_details_block.html.erb
+++ b/app/views/redcap/project_admins/_details_block.html.erb
@@ -129,8 +129,12 @@ if req&.result
   in app type <%= link_to link_label_open_in_new(object_instance.job_app_type&.name), admin_app_types_path(filter: {id: object_instance.job_app_type&.id}), target: '_blank' %>
     <% if !object_instance.job_app_type %>
     <p class="info-danger"><code>run_jobs_as_app_type</code> configuration is not set to an active app type</p>
-    <% elsif object_instance.job_user.accessible_app_type_ids.include?(object_instance.job_app_type&.id) %>
-    <p class="info-danger"><code>run_jobs_as_user</code> configuration is not set to a real user</p>
+    <% elsif !object_instance.job_user.accessible_app_type_ids.include?(object_instance.job_app_type&.id) %>
+    <p class="info-danger"><code>run_jobs_as_user</code> is not permitted to access app type <code><%=object_instance.job_app_type&.name%> (<%= object_instance.job_app_type&.id %>)</code></p>
+    <% end %>
+    <% am = object_instance.associate_master_through_external_id_resource_name
+       if am && !object_instance.job_user&.has_access_to?(:access, :table, am, alt_app_type_id: object_instance.job_app_type&.id, force_reset: true ) %>
+    <p class="info-danger"><code><%=object_instance.job_user&.email%></code> is not permitted to access external identifier <code><%=am%></code> in <code><%=object_instance.job_app_type&.name%></code></p>         
     <% end %>
   <% else %>
   <span>bad configuration</span>

--- a/app/views/reports/_edit_form.html.erb
+++ b/app/views/reports/_edit_form.html.erb
@@ -16,6 +16,7 @@
           <%= render partial: 'form_errors' %>
           <td class="report-el report-edit-btn-cell report-edit-btn-cell-editing">
             <%= hidden_filter_fields %>
+            <%= params[:table_name].present? ? hidden_field_tag(:table_name, params[:table_name]) : '' %>
             <%= report_edit_cancel %><button class="btn btn-primary report-edit-submit"><i class="glyphicon glyphicon-ok"></i></button>
           </td>
           <% if object_instance.respond_to?(:id) %>

--- a/config/initializers/app_settings.rb
+++ b/config/initializers/app_settings.rb
@@ -281,7 +281,7 @@ class Settings
     OnlyLoadAppTypes
     DefaultMigrationSchema DefaultSchemaOwner StartYearRange EndYearRange AgeRange CareerYearsRange
     UserTimeout AdminTimeout OsWordsFile PasswordConfig
-    NotificationsFromEmail AdminEmail BatchUserEmail FailureNotificationsToEmail
+    NotificationsFromEmail AdminEmail BatchUserEmail FailureNotificationsToEmail RedcapJobUserEmail
     TwoFactorAuthDisabledForUser TwoFactorAuthDisabledForAdmin TwoFactorAuthIssuer TwoFactorAuthDrift
     CheckPrevPasswords PasswordAgeLimit PasswordReminderDays PasswordMaxAttempts PasswordUnlockStrategy
     LoginIssuesUrl LoginMessage


### PR DESCRIPTION
- [Added] new check in Redcap project to ensure user has access to the associated external id table, if specified
- [Added] ability for report edit table name and fields to be specified as {{table_name}} and {{table_fields}} to allow editing of arbitrary tables in the generic report
- [Added] RedcapJobUserEmail setting to be viewed in server info
- [Fixed] user creating an external identifier with additional fields loses their value - fixes #307
- [Changed] external identifier details panel to add "search data" link - especially helpful if the user can edit the results for example to add other field entries to external id records
- [Changed] specification of Redcap project run_jobs_in_app_type to only use the current user's app type if the configuration is not specified (it previously ignored a specified app not being found)
- [Added] exceptions to make it clear if a master id was not found through an external id for various reasons
- [Fixed] incorrect error message in Redcap project admin details panel
