### PR TITLE
Hms fixes 6

### DIFF
--- a/app/assets/javascripts/app/_fpa_ajax_processors_reports.js
+++ b/app/assets/javascripts/app/_fpa_ajax_processors_reports.js
@@ -270,7 +270,9 @@ _fpa.postprocessors_reports = {
         if ($edit_cell.length) return;
 
         const $newel = $this.clone();
-        $newel.appendTo($edit_row);
+
+        var $replace_cell = $edit_row.find(`td.report-el-edit-disabled-cell-${dct}`)
+        $replace_cell.replaceWith($newel);
 
         // If the field contains a canvas element, make sure it is set up
         const $canvas = $newel.find('canvas');

--- a/app/assets/javascripts/app/_fpa_show_if.js
+++ b/app/assets/javascripts/app/_fpa_show_if.js
@@ -160,6 +160,7 @@ _fpa.show_if.methods = {
             var exp_field_value = data[cond_field];
             if (typeof exp_field_value == 'number') exp_field_value = exp_field_value.toString();
             if (typeof exp_field_value == 'undefined') exp_field_value = null;
+            if (exp_field_value === true || exp_field_value === false) exp_value = (exp_value === '1' ? [true, 'yes', 1, '1'] : [false, 'no', 0, '0']);
 
             // to have value
 
@@ -172,15 +173,19 @@ _fpa.show_if.methods = {
             else if (typeof exp_value == 'string')
               exp_value = [exp_value];
             else if (typeof exp_value == 'boolean') {
-              exp_value = [exp_value, (exp_value ? 'yes' : 'no')];
+              // Allow boolean fields to match on true/false, yes/no, '1'/'0' values
+              exp_value = [exp_value, (exp_value ? 'yes' : 'no'), (exp_value ? '1' : '0')];
             }
             else if (typeof exp_value == 'number') {
               exp_value = [exp_value.toString()];
             }
             else if (typeof exp_value == 'object') {
               for (var i = 0; i < exp_value.length; i++) {
+                // Allow boolean fields to match on true/false, yes/no, '1'/'0' values
                 if (exp_value[i] === true && exp_value.indexOf('yes') == -1) exp_value.push('yes');
                 if (exp_value[i] === false && exp_value.indexOf('no') == -1) exp_value.push('no');
+                if (exp_value[i] === true && exp_value.indexOf('1') == -1) exp_value.push('1');
+                if (exp_value[i] === false && exp_value.indexOf('0') == -1) exp_value.push('0');
                 if (typeof exp_value[i] == 'number') exp_value[i] = exp_value[i].toString();
               }
             }

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -212,6 +212,14 @@ class ReportsController < UserBaseController
 
     if @report_item.respond_to?(:master) && !@report_item.class.no_master_association
       @master = @report_item.master
+
+      # Specifically, if an edited report item did not previously have a master_id set, but now will have,
+      # ensure the current user can be set appropriately.
+      if !@master && secure_params[:master_id].present?
+        @report_item.master_id = secure_params[:master_id]
+        @master = @report_item.master
+      end
+
       @master.current_user = current_user if @master
     elsif @report_item.respond_to? :current_user
       @report_item.current_user = current_user

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -14,7 +14,8 @@ module ReportsHelper
   def report_edit_btn(id)
     return unless id
 
-    rp = edit_report_path(id, report_id: @report.id, filter: filter_params_permitted, table_name: params[:table_name])
+    rp = edit_report_path(id, report_id: @report.id, filter: filter_params_permitted, table_name: params[:table_name],
+                              runner_hash: @report.runner.runner_hash)
     link_to '',
             rp,
             remote: true,

--- a/app/models/admin/defs/extra_options_defs.yaml
+++ b/app/models/admin/defs/extra_options_defs.yaml
@@ -116,7 +116,9 @@
       include_blank: |
         true or false to force a drop down field to include a selectable
         blank
-      pattern: provide a mask for a text field
+      pattern: '.+\\d{3}-\\D{1-4}.*'
+        # provide a mask for a text field using basic regex
+        # This example accepts one or more characters of any type, 3 digits, a hyphen, 1 to 4 letters and any number of final characters
       value: |
         default value | now() | today() 
         

--- a/app/models/dynamic/implementation_handler.rb
+++ b/app/models/dynamic/implementation_handler.rb
@@ -244,6 +244,8 @@ module Dynamic
       fo.each do |name, config|
         next unless config.key?(:preset_value) || config.key?(:blank_preset_value)
 
+        next unless attribute_names.include?(name.to_s)
+
         init_value = config[:preset_value]
         if init_value
           res = FieldDefaults.calculate_default self, init_value

--- a/app/models/redcap/project_admin.rb
+++ b/app/models/redcap/project_admin.rb
@@ -219,6 +219,26 @@ module Redcap
     #                      Specify an external identifier resource name to use to look up the master record each
     #                      stored record is associated with. By default, "redcap_survey_identifier_id" is used as the
     #                      foreign key field used to look up the the external id. Optionally specify an alternative field name.
+    # set_master_id_using_association: true|false
+    #     If option `associate_master_through_external_identifer` is set, the ability to retrieve the master record
+    #     can be used to set a `master_id` field directly on the dynamic model. Setting this option to *true* will
+    #     add a `master_id` field automatically, and ensure it is set when records are retrieved from REDCap.
+    #     NOTE: for large datasets that change regularly, this may slow down record retrieval significantly.
+    # skip_store_if_no_survey_identifier: <Integer id> | nil
+    #                      If we are using an association to match a redcap survey identifier to a master record
+    #                      it won't be found if the public survey link was used and no survey identifier was populated.
+    #                      This option allows the record to be skipped when pulling, allowing other records to be retrieved
+    # run_jobs_as_user: <username>
+    #     Sets the admin and matching user that will be used to run background jobs,
+    #     such as getting project metadata or retrieving records from REDCap.
+    #     New projects set this to the email address or id in settings `RedcapJobUserEmail`, which may be set by
+    #     the environment variable `FPHS_RC_JOB_USER_EMAIL` or will default to the setting `BatchUserEmail`.
+    #     If left blank in earlier projects or explicitly set to blank, the user matching the project's current admin will be used.
+    # run_jobs_in_app_type: <app type name or id>
+    #     Sets the app type that will be set on the `run_as_jobs_user`, effectively setting the
+    #     access controls that authorize actions performed in background jobs such as retrieving records.
+    #     This avoids an arbitrary app type being set, especially where the dynamic model being stored to has save triggers
+    #     specified that may depend on access to specific resources.
 
     configure :data_options, with: %i[add_multi_choice_summary_fields
                                       handle_deleted_records
@@ -226,7 +246,8 @@ module Redcap
                                       associate_master_through_external_identifer
                                       set_master_id_using_association
                                       run_jobs_as_user
-                                      run_jobs_in_app_type]
+                                      run_jobs_in_app_type
+                                      skip_store_if_no_survey_identifier]
 
     validate :data_options, lambda {
       return if data_options.handle_deleted_records.in?(ValidHandleDeletedRecordsValues)

--- a/app/models/reports/report_editing.rb
+++ b/app/models/reports/report_editing.rb
@@ -73,7 +73,7 @@ module Reports
 
     # Edit fields that can be updated in a record
     def edit_fields
-      all_configured_edit_fields - search_reports_fields
+      all_configured_edit_fields - search_reports_fields - [:id]
     end
 
     # List any search_reports_ fields that represent criteria to feed to another report in the UI

--- a/app/views/reports/_edit_form.html.erb
+++ b/app/views/reports/_edit_form.html.erb
@@ -22,47 +22,55 @@
           <% if object_instance.respond_to?(:id) %>
             <td class="report-el report-el-object-id"><%= object_instance.id %></td>
           <% end %>
-          <% (@report.all_configured_edit_fields - [:id]).each do |field_name_sym| %>
-            <%
-          form_object_instance = object_instance
-          form_object_item_type_us = form_object_instance.item_type_us
-          label_redefined = false
+          <%             
+            cached_result_fields = Reports::Runner.cached_fields(params[:runner_hash])
+            raise FphsException, "Results are out of date. Re-run the report before attempting to edit it."  unless cached_result_fields
 
-          field_name = field_name_sym.to_s
-          col = form_object_instance.class.columns_hash[field_name]
-          # raise FphsException.new "Column #{field_name_sym} does not appear in the columns #{form_object_instance.class.columns_hash.map{|k,v| k}}" unless col
-          # External IDs and master crosswalk ids (msid) do not feature in the item. Ignore if they appear
-          column_type = :string
-          column_type = col.type if col
+            cached_result_fields = cached_result_fields - [:id]
 
-          local_vars = {
-            form: f,
-            field_name_sym: field_name_sym,
-            field_name: field_name,
-            column_type: column_type,
-            general_selection_name: general_selection_prefix_name(form_object_instance),
-            form_object_instance: form_object_instance,
-            form_object_item_type_us: form_object_item_type_us,
-            caption_before: {},
-            labels: labels
-          }
-          local_vars[:locals] = local_vars
+            edit_fields = @report.edit_fields
+            cached_result_fields.each do |field_name_sym| %>
 
-          # One time only, redefine the label method for this specific form fields instance
-          unless label_redefined
-            def f.label *args
-              return super if args.last.is_a?(Hash) && args.last[:force_show]
-              ""
+            <% if edit_fields.include?(field_name_sym) %>
+              <%
+            form_object_instance = object_instance
+            form_object_item_type_us = form_object_instance.item_type_us
+            label_redefined = false
+
+            field_name = field_name_sym.to_s
+            col = form_object_instance.class.columns_hash[field_name]
+            # raise FphsException.new "Column #{field_name_sym} does not appear in the columns #{form_object_instance.class.columns_hash.map{|k,v| k}}" unless col
+            # External IDs and master crosswalk ids (msid) do not feature in the item. Ignore if they appear
+            column_type = :string
+            column_type = col.type if col
+
+            local_vars = {
+              form: f,
+              field_name_sym: field_name_sym,
+              field_name: field_name,
+              column_type: column_type,
+              general_selection_name: general_selection_prefix_name(form_object_instance),
+              form_object_instance: form_object_instance,
+              form_object_item_type_us: form_object_item_type_us,
+              caption_before: {},
+              labels: labels
+            }
+            local_vars[:locals] = local_vars
+
+            # One time only, redefine the label method for this specific form fields instance
+            unless label_redefined
+              def f.label *args
+                return super if args.last.is_a?(Hash) && args.last[:force_show]
+                ""
+              end
+              label_redefined = true
             end
-            label_redefined = true
-          end
-        %>
-            <% if @report.edit_fields.include?(field_name_sym) %>
+          %>
               <td class="report-el report-el-edit-cell report-el-edit-<%=field_name_sym%> report-el-edit-type-<%=column_type%>" data-col-type="<%=field_name_sym%>" data-col-var-type="<%=column_type%>">
                 <%= edit_form_field(**local_vars) %>
               </td>
             <% else%>
-              <td class="report-el report-el-edit-cell report-el-disabled">
+              <td class="report-el report-el-edit-cell report-el-disabled report-el-edit-disabled-cell-<%=field_name_sym%>">
                 &nbsp;
               </td>
             <% end %>

--- a/docs/admin_reference/project_admins/detailed_options.md
+++ b/docs/admin_reference/project_admins/detailed_options.md
@@ -55,6 +55,10 @@ data_options:
     # can be used to set a `master_id` field directly on the dynamic model. Setting this option to *true* will
     # add a `master_id` field automatically, and ensure it is set when records are retrieved from REDCap.
     # NOTE: for large datasets that change regularly, this may slow down record retrieval significantly.  
+  skip_store_if_no_survey_identifier: true | nil
+    # If we are using an association to match a redcap survey identifier to a master record
+    # it won't be found if the public survey link was used and no survey identifier was populated.
+    # This option allows the record to be skipped when pulling, allowing other records to be retrieved
   run_jobs_as_user: <username>
     # Sets the admin and matching user that will be used to run background jobs, 
     # such as getting project metadata or retrieving records from REDCap.

--- a/spec/models/save_triggers/save_triggers_base_spec.rb
+++ b/spec/models/save_triggers/save_triggers_base_spec.rb
@@ -110,6 +110,8 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
           field_options:
             select_who:
               blank_preset_value: 'a,b,c'
+            bad_field_name_test_preset_value:
+              blank_preset_value: 'should not break'
 
           save_trigger:
             on_update:

--- a/spec/models/save_triggers/update_reference_spec.rb
+++ b/spec/models/save_triggers/update_reference_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe SaveTriggers::UpdateReference, type: :model do
       create_user
       @master = create_master
 
-      setup_access :player_contacts
-      setup_access :addresses
-      setup_access :activity_log__player_contact_phones
+      setup_access :player_contacts, user: @user
+      setup_access :addresses, user: @user
+      setup_access :activity_log__player_contact_phones, user: @user
 
       @activity_log = al = ActivityLog.active.where(name: al_name).first
       @working_data = '(111)222-3333 ext 12312312'

--- a/spec/models/save_triggers/update_this_spec.rb
+++ b/spec/models/save_triggers/update_this_spec.rb
@@ -57,9 +57,9 @@ RSpec.describe SaveTriggers::UpdateThis, type: :model do
       create_user
       @master = create_master
 
-      setup_access :player_contacts
-      setup_access :addresses
-      setup_access :activity_log__player_contact_phones
+      setup_access :player_contacts, user: @user
+      setup_access :addresses, user: @user
+      setup_access :activity_log__player_contact_phones, user: @user
 
       @activity_log = al = ActivityLog.active.where(name: al_name).first
       @working_data = '(111)222-3333 ext 12312312'


### PR DESCRIPTION
### From FPHS

- [Added] skip_store_if_no_survey_identifier option to redcap projects
- [Changed] handling of report record editing to correctly handle columns not editable or not configured to edit
- [Fixed] editing a report table item (external identifier model) and adding a master id fails - fixes #376
- [Fixed] Dynamic::ImplementationHandler#force_preset_values should only operate on model attributes, not every preset_value definition - fixes #380
- [Fixed] pattern documentation
- [Fixed] show if comparisons for Redcap when the condition is based on a boolean field - fixes #381
