### PR TITLE
Hms fixes 9

### DIFF
--- a/app/assets/javascripts/app/_fpa_form_utils.js
+++ b/app/assets/javascripts/app/_fpa_form_utils.js
@@ -1681,7 +1681,7 @@ _fpa.form_utils = {
 
         if (href.indexOf('display_as=embedded') < 0) {
           let sym = href.indexOf('?') > 0 ? '&' : '?';
-          $(this).attr('href', `${href}${sym}display_as=embedded#open-in-sidebar`);
+          $(this).attr('href', `${href}${sym}display_as=embedded&display_embed_where=sidebar&#open-in-sidebar`);
         }
 
         $(this).click(function (ev) {

--- a/app/assets/stylesheets/admin/admin.scss
+++ b/app/assets/stylesheets/admin/admin.scss
@@ -53,6 +53,7 @@ a.collapsed > .caret {
 .admin-title {
   padding-left: 15px;
   padding-right: 15px;
+  margin-left: 47px;
 }
 
 .admin-help-icon {
@@ -175,3 +176,31 @@ div#creddocframe {
 a.link-disabled {
   color: gray;
 }
+
+
+.admin-action-page {
+  position: relative;
+  overflow: visible;
+}
+
+#components-menu-button {
+  top: 30px;
+  position: absolute;
+}
+
+.components-menu-block {
+  top: 103px;
+  position: absolute;
+  left: 0;
+}
+
+.components-menu {
+  max-width: 450px;
+  background: white;
+  padding: 4px;
+  position: absolute;
+  z-index: 2000;
+  min-width: 300px;
+  box-shadow: 0 4px 6px 4px rgba(0, 0, 0, 0.15);
+}
+

--- a/app/assets/stylesheets/app/help.scss
+++ b/app/assets/stylesheets/app/help.scss
@@ -24,7 +24,8 @@
 div.help-view-doc,
 .common-help-item,
 .md-formatted-block,
-#help-sidebar-body div.standalone-page-col.reset-row {
+#help-sidebar-body div.standalone-page-col.reset-row,
+#help-sidebar-body div.info-page.reset-row {
   font-family: Roboto, sans-serif;
 
   .common-help-item {

--- a/app/controllers/info_pages_controller.rb
+++ b/app/controllers/info_pages_controller.rb
@@ -6,11 +6,27 @@ class InfoPagesController < ActionController::Base
   before_action :setup_navs
   helper_method :body_class_list
 
-  # public page
+  #
+  # Show a public or internal page
+  # Public pages must have category 'public'
+  # Internal app pages will be used if a current user is authenticated and
+  # a category 'public' page is not found. In this case, the category will be based
+  # on the first portion of the supplied slug, appearing before a double underscore.
+  # For example some_study__info_page - some_study will be used as the category
   def show
     id = params[:id].gsub(/[^a-zA-Z0-9\-_]/, '')
     @content = Admin::MessageTemplate.generate_content content_template_name: id, category: :public,
                                                        allow_missing_template: true, markdown_to_html: true
+
+    if current_user && !@content
+      pre, page = id.split('__', 2)
+      raise FphsException, "Requested info page not valid for #{id}" unless pre.present? && page.present?
+
+      pre = "#{pre} - info-page"
+      @content = Admin::MessageTemplate.generate_content content_template_name: page, category: pre,
+                                                         allow_missing_template: true, markdown_to_html: true
+    end
+
     unless @content
       @content = '<h1>Page Not Found</h1>'.html_safe
       render :show, status: :not_found, layout: 'public_application'
@@ -22,7 +38,11 @@ class InfoPagesController < ActionController::Base
       @nav_right_plain = '<li><a href="/" class="btn btn-warning public-page-login-btn">login</a></li>'.html_safe
     end
 
-    render :show, layout: 'public_application'
+    if params[:display_as] == 'embedded' && params[:display_embed_where] == 'sidebar'
+      render partial: 'info_pages/show_in_sidebar'
+    else
+      render :show, layout: 'public_application'
+    end
   end
 
   private

--- a/app/controllers/info_pages_controller.rb
+++ b/app/controllers/info_pages_controller.rb
@@ -39,7 +39,7 @@ class InfoPagesController < ActionController::Base
     end
 
     if params[:display_as] == 'embedded' && params[:display_embed_where] == 'sidebar'
-      render partial: 'info_pages/show_in_sidebar'
+      render partial: 'info_pages/show_in_sidebar', content_type: 'text/html'
     else
       render :show, layout: 'public_application'
     end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -25,7 +25,7 @@ class PagesController < ApplicationController
   def index
     unless current_user && !current_admin
       @is_admin_index = true
-      @app_type = current_user&.app_type || current_admin.matching_user&.app_type || Admin::AppType.active.first
+      @app_type ||= helpers.admin_app_type
       @server_info = Admin::ServerInfo.new(current_admin)
 
       render 'index', layout: 'admin_application'

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -414,9 +414,9 @@ class ReportsController < UserBaseController
     id = params[:report_id]
     setup_report id
 
-    return if params[:id] == 'cancel' || params[:id].blank?
-
     @report.substitute_table_name_and_fields(params)
+
+    return if params[:id] == 'cancel' || params[:id].blank?
 
     id = params[:id]
     id = id.to_i

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -96,11 +96,16 @@ module AdminHelper
     res.html_safe
   end
 
+  def admin_app_type
+    @app_type ||= current_user&.app_type || current_admin.matching_user&.app_type || Admin::AppType.active.first
+  end
+
   def show_admin_heading(alt_title = nil)
     alt_title ||= title
     res = <<~END_HTML
       <div class="panel panel-default admin-action-page">
-        <div class="panel-heading">#{' '}
+        <div class="panel-heading">
+          #{render partial: 'admin/common_templates/app_components_dropdown'}
           <h1 class="admin-title">#{alt_title}
             #{ link_to(
               '',
@@ -117,7 +122,7 @@ module AdminHelper
                       'working-target': '#help-sidebar-body' }
             ) }
             #{render partial: 'admin_handler/status_bar'}
-          </h1>
+            </h1>
         </div>
       </div>
     END_HTML

--- a/app/models/admin/message_template.rb
+++ b/app/models/admin/message_template.rb
@@ -21,7 +21,7 @@ class Admin::MessageTemplate < ActiveRecord::Base
   # @param [String|Symbol|nil] type optionally the type to find
   # @return [Admin::MessageTemplate|nil] matching instance
   def self.named(name, type: nil)
-    res = where(name: name)
+    res = where(name:)
     res = res.where(message_type: type) if type
     res.first
   end
@@ -50,7 +50,7 @@ class Admin::MessageTemplate < ActiveRecord::Base
 
   # Simply calls {Formatter::Substitution.substitute}
   def substitute(all_content, data: {}, tag_subs: nil, ignore_missing: false)
-    Formatter::Substitution.substitute all_content, data: data, tag_subs: tag_subs, ignore_missing: ignore_missing
+    Formatter::Substitution.substitute all_content, data:, tag_subs:, ignore_missing:
   end
 
   #
@@ -65,20 +65,22 @@ class Admin::MessageTemplate < ActiveRecord::Base
   # @param [String] content_template_text raw text to use a template
   # @param [Hash] data simple Hash to pass to #substitute
   # @param [Boolean] ignore_missing defaults to false
+  # @param [Symbol|true|false] markdown_to_html - method to call to decide if markdown should be converted to html or literal value
   # @return [String] resulting text
-  def generate(content_template_name: nil, content_template_text: nil, data: {}, ignore_missing: false)
+  def generate(content_template_name: nil, content_template_text: nil, data: {}, ignore_missing: false,
+               markdown_to_html: :force_markdown_to_html)
     raise FphsException, 'Must use a layout template to generate from' unless layout_template?
 
     # Generate the content to be embedded, forcing the result to be converted from markdown to HTML
     # if the content template indicates that this is required by calling #force_markdown_to_html on itself
-    text = self.class.generate_content(content_template_name: content_template_name,
-                                       content_template_text: content_template_text,
-                                       data: data,
-                                       ignore_missing: ignore_missing,
+    text = self.class.generate_content(content_template_name:,
+                                       content_template_text:,
+                                       data:,
+                                       ignore_missing:,
                                        no_substitutions: true,
-                                       markdown_to_html: :force_markdown_to_html)
+                                       markdown_to_html:)
     all_content = template.sub('{{main_content}}', text)
-    substitute all_content, data: data, ignore_missing: ignore_missing
+    substitute all_content, data:, ignore_missing:
   end
 
   #

--- a/app/models/messaging/message_notification.rb
+++ b/app/models/messaging/message_notification.rb
@@ -94,10 +94,18 @@ module Messaging
         raise FphsException, 'Content template name or text must be set'
       end
 
-      self.generated_text = layout_template.generate content_template_name: content_template_name,
-                                                     content_template_text: content_template_text,
-                                                     data: data,
-                                                     ignore_missing: ignore_missing
+      # We need to prevent conversion to html for all SMS
+      markdown_to_html = if sms?
+                           false
+                         else
+                           :force_markdown_to_html
+                         end
+
+      self.generated_text = layout_template.generate(content_template_name:,
+                                                     content_template_text:,
+                                                     data:,
+                                                     ignore_missing:,
+                                                     markdown_to_html:)
 
       self.generated_content = generated_text
       save!
@@ -112,7 +120,7 @@ module Messaging
     def generate_view(ignore_missing: false)
       return generated_content if generated_content.present?
 
-      generate(ignore_missing: ignore_missing)
+      generate(ignore_missing:)
     rescue FphsException => e
       "EXCEPTION: #{e}"
     end
@@ -242,8 +250,8 @@ module Messaging
         NotificationMailer.send_message_notification(self).deliver_now
       elsif sms?
         sms = Messaging::NotificationSms.new
-        sms.send_now(self, recipient_sms_numbers: recipient_sms_numbers, generated_text: generated_text,
-                           importance: importance, logger: logger)
+        sms.send_now(self, recipient_sms_numbers:, generated_text:,
+                           importance:, logger:)
       else
         raise FphsException, "No recognized message type for message notification: #{message_type}"
       end
@@ -335,7 +343,7 @@ module Messaging
                                        default_country_code: rec[:default_country_code]
           recipient_sms_numbers = [pn]
           # Generate and send to this specific phone number with the data for this item
-          resp = generate_and_send recipient_sms_numbers: recipient_sms_numbers
+          resp = generate_and_send(recipient_sms_numbers:)
 
           list_item.set_response list_item.user, resp
           # Add the phone number to the recipient data hash

--- a/app/models/option_configs/extra_option_implementers/save_triggers.rb
+++ b/app/models/option_configs/extra_option_implementers/save_triggers.rb
@@ -113,7 +113,7 @@ module OptionConfigs
                           [nil]
                         end
 
-          raise FphsException, 'No iterator values were found for save trigger each' unless iter_values
+          raise FphsException, "No iterator values were found for save trigger each: #{iter_configs}" unless iter_values
 
           iter_values.each_with_index do |iter_value, iter_index|
             obj.save_trigger_results['iterator_index'] = iter_index

--- a/app/models/save_triggers/save_triggers_base.rb
+++ b/app/models/save_triggers/save_triggers_base.rb
@@ -15,8 +15,12 @@ class SaveTriggers::SaveTriggersBase
     item.save_trigger_results ||= {} if item.respond_to? :save_trigger_results
 
     if item.respond_to? :current_user
-      self.user = item.current_user
-      raise FphsException, 'save_trigger item master user must be set' unless user
+      cu = item.current_user
+      extra_detail = "master: #{master} item: #{item} / #{item.class.no_master_association}"
+      raise FphsException, "save_trigger item current user not set - #{extra_detail}" unless cu
+
+      self.user = cu
+      raise FphsException, "save_trigger item master user must be set - #{extra_detail}" unless user
     end
 
     self.model_defs = if config.is_a? Array

--- a/app/views/admin/app_types/_components.html.erb
+++ b/app/views/admin/app_types/_components.html.erb
@@ -27,7 +27,7 @@
 <div class="admin-panel-components" id="admin-panel-components">
   <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
     <% 
-    @app_type.as_json(options).first.last.each do |k, v_hash|        
+    admin_app_type.as_json(options).first.last.each do |k, v_hash|        
       v_class = nil
       if v_hash.respond_to?(:each) 
         kclean = k.gsub(/^valid_|associated_/i, '').to_sym
@@ -104,6 +104,7 @@
               <%= link_to link_label_open_in_new(vs[:name]), vs[:path], target: "adminres-#{vs[:rn]}", class: "link-#{vs[:disabled] ? 'disabled' : 'active'}" %>
               <% else %>
               <%= link_to vs[:name], vs[:path], class: "link-#{vs[:disabled] ? 'disabled' : 'active'}" %>
+              <%= link_to link_label_open_in_new(''), vs[:path], target: "adminres-#{vs[:rn]}", class: "link-#{vs[:disabled] ? 'disabled' : 'active'}" %>
               <% end %>
             </li>
           <% end %>

--- a/app/views/admin/common_templates/_app_components_dropdown.html.erb
+++ b/app/views/admin/common_templates/_app_components_dropdown.html.erb
@@ -1,0 +1,15 @@
+<a class="glyphicon glyphicon-th-large btn btn-default" id="components-menu-button" data-toggle="collapse" aria-controls="admin-panel-components" aria-expanded="false" href="#components-menu"></a>
+<div class="components-menu-block">
+  <div id="components-menu" class="components-menu collapse" aria-labelledby="components-menu-button">
+  <% begin %>        
+          <%= Rails.cache.fetch(partial_cache_key('index_admin_components', force_user_or_admin: current_admin)) { render partial: 'admin/app_types/components' } %>
+          <% rescue StandardError => e
+              logger.warn 'Failed to load admin components panel'
+              logger.warn e
+              logger.warn e.backtrace.join("\n")
+          %>
+          <p>Failed to load components</p>
+          <p><%=e%></p>
+          <% end %>
+  </div>
+</div>

--- a/app/views/admin/dynamic_models/_est_record_count.html.erb
+++ b/app/views/admin/dynamic_models/_est_record_count.html.erb
@@ -1,7 +1,9 @@
   <% if object_instance.persisted? && object_instance.enabled? && object_instance.table_or_view_ready? %>
+  <div>
   <label>estimated record count</label>
   <span class="dynamic-record-count">
   <%= object_instance.estimated_record_count || '(not found)' %>
   </span>
+  </div>
   <% end %>
   

--- a/app/views/info_pages/_show_in_sidebar.erb
+++ b/app/views/info_pages/_show_in_sidebar.erb
@@ -1,0 +1,15 @@
+<div>
+  <div class="help-view-doc" data-result="help-doc-content-result">
+    <div class="help-doc-header">
+      <%#= render partial: 'help/home_link' %>
+    </div>
+    <div class="help-embedded-content">
+      <div class="info-page reset-row">
+        <div class="md-formatted-block">
+          <%= @content.html_safe %>
+        </div>
+      </div>
+    </div>
+    <%= render partial: 'help/footer' %>
+  </div>
+</div>

--- a/app/views/reports/result_template/_edit_row.html.erb
+++ b/app/views/reports/result_template/_edit_row.html.erb
@@ -1,10 +1,14 @@
 <% if creatable? %>
 <tr class="<%= editable? ? '' : 'hidden' %>" id="report-item-new">
 
-  <% if editable? %>
+  <% if editable? 
+        nrp = new_report_path(report_id: @report.id, filter: filter_params_permitted, table_name: params[:table_name],
+                              runner_hash: @report.runner.runner_hash)
+  
+  %>
   <td class="report-el report-edit-btn-cell"><%= report_edit_btn 'new'%>
       <div class="">
-        <%= link_to "", new_report_path(report_id: @report.id), remote: true, class: "btn btn-primary report-new-item-btn glyphicon glyphicon-plus", title: 'add new report item' %>
+        <%= link_to "", nrp, remote: true, class: "btn btn-primary report-new-item-btn glyphicon glyphicon-plus", title: 'add new report item' %>
       </div>
   </td>
   <% end %>

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,5 +1,22 @@
 #!/usr/bin/env ruby
 
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+# Ensure daemons gem doesn't break IO such as Dalli
+# From https://github.com/collectiveidea/delayed_job/issues/1133#issuecomment-1710282863
+
+require 'delayed_job'
+require 'delayed_job_active_record'
 require 'delayed/command'
+
+module LoadRailsAfterRunProc
+  def self.included(base)
+    after_fork_method = base.method(:after_fork)
+    base.define_singleton_method :after_fork do |*args|
+      # after Daemons.run_proc method
+      require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+      after_fork_method.call(*args)
+    end
+  end
+end
+
+Delayed::Worker.include(LoadRailsAfterRunProc)
 Delayed::Command.new(ARGV).daemonize

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -40,7 +40,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/dynamic/external_id_implementer.rb",
-      "line": 238,
+      "line": 243,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "connection.execute((\"INSERT into #{table_name} (#{external_id_attribute}, admin_id, master_id, created_at, updated_at) VALUES \" + \"#{\"('#{generate_random_id}', #{admin.id}, NULL, '#{DateTime.now.iso8601}', '#{DateTime.now.iso8601}')\"}\"))",
       "render_path": null,
@@ -63,7 +63,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "lib/active_record/migration/app_generator.rb",
-      "line": 652,
+      "line": 653,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "ActiveRecord::Base.connection.execute(\"COMMENT ON VIEW #{schema}.#{table_name} IS '#{table_comment}';\\n\")",
       "render_path": null,
@@ -155,7 +155,7 @@
       "check_name": "MassAssignment",
       "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
       "file": "app/controllers/concerns/master_handler.rb",
-      "line": 198,
+      "line": 202,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.permit!",
       "render_path": null,
@@ -172,13 +172,47 @@
       "note": ""
     },
     {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "3761727e036f9d74ed02985b4870bda041bd3d041d9c1083b692031e1ae3e9e8",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/info_pages/_show_in_sidebar.erb",
+      "line": 9,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Admin::MessageTemplate.generate_content(:content_template_name => params[:id].gsub(/[^a-zA-Z0-9\\-_]/, \"\"), :category => :public, :allow_missing_template => true, :markdown_to_html => true)",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "InfoPagesController",
+          "method": "show",
+          "line": 42,
+          "file": "app/controllers/info_pages_controller.rb",
+          "rendered": {
+            "name": "info_pages/_show_in_sidebar",
+            "file": "app/views/info_pages/_show_in_sidebar.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "info_pages/_show_in_sidebar"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+        79
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "3c5e6a5b7b311bb51b49c35ff669a55b2ac5f277738e7d6ab4db258ed43779f8",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "lib/active_record/migration/app_generator.rb",
-      "line": 357,
+      "line": 358,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "ActiveRecord::Base.connection.execute(\"DROP FUNCTION IF EXISTS #{calc_trigger_fn_name(table_name)}() CASCADE\")",
       "render_path": null,
@@ -201,7 +235,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/admin/app_type.rb",
-      "line": 226,
+      "line": 240,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "Classification::GeneralSelection.active.where(\"item_type ~ '#{\"^(#{associated_table_names.map do\n \"#{tn.singularize}_|#{tn}_\"\n end.join(\"|\")})\"}'\")",
       "render_path": null,
@@ -224,7 +258,7 @@
       "check_name": "MassAssignment",
       "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
       "file": "app/controllers/reports_controller.rb",
-      "line": 428,
+      "line": 443,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.require(:search_attrs).permit!",
       "render_path": null,
@@ -347,7 +381,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "lib/active_record/migration/app_generator.rb",
-      "line": 1111,
+      "line": 1114,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "ActiveRecord::Base.connection.execute(\"SELECT DISTINCT v.oid::regclass AS view\\nFROM pg_depend AS d      -- objects that depend on the table\\n  JOIN pg_rewrite AS r  -- rules depending on the table\\n      ON r.oid = d.objid\\n  JOIN pg_class AS v    -- views for the rules\\n      ON v.oid = r.ev_class\\nWHERE \\n--v.relkind = 'v'    -- only interested in views\\n  --AND \\n  d.classid = 'pg_rewrite'::regclass\\n  AND d.refclassid = 'pg_class'::regclass\\n  AND d.deptype = 'n'    -- normal dependency\\n  AND d.refobjid = '#{schema}.#{table_name}'::regclass;\\n\")",
       "render_path": null,
@@ -439,7 +473,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/admin/migration_generator.rb",
-      "line": 140,
+      "line": 147,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "connection.execute(\"SELECT\\n    cols.table_schema \\\"schema_name\\\",\\n    cols.table_name,\\n    cols.column_name,\\n    pg_catalog.col_description(c.oid, cols.ordinal_position::int) AS column_comment\\nFROM\\n    information_schema.columns cols\\nINNER JOIN pg_catalog.pg_class c\\nON\\n  c.oid = ('\\\"' || cols.table_name || '\\\"')::regclass::oid\\n  AND c.relname = cols.table_name\\n\\nWHERE\\n    cols.table_catalog = '#{current_database}' AND\\n    cols.table_schema IN (#{quoted_schemas}) AND\\n    pg_catalog.col_description(c.oid, cols.ordinal_position::int) IS NOT NULL\\n;\\n\")",
       "render_path": null,
@@ -470,7 +504,7 @@
           "type": "controller",
           "class": "InfoPagesController",
           "method": "show",
-          "line": 25,
+          "line": 44,
           "file": "app/controllers/info_pages_controller.rb",
           "rendered": {
             "name": "info_pages/show",
@@ -553,7 +587,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/admin/migration_generator.rb",
-      "line": 194,
+      "line": 201,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "connection.execute(\"SELECT * FROM #{tables_and_views.find do\n (tn[\"table_name\"] == \"#{basename}_datadic\")\n end[\"table_name\"]};\\n\")",
       "render_path": null,
@@ -576,7 +610,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/dynamic/external_id_implementer.rb",
-      "line": 211,
+      "line": 216,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "connection.execute((\"INSERT into #{table_name} (#{external_id_attribute}, admin_id, master_id, created_at, updated_at) VALUES \" + \"#{\"('#{generate_random_id}', #{admin.id}, #{m}, '#{DateTime.now.iso8601}', '#{DateTime.now.iso8601}')\"}\"))",
       "render_path": null,
@@ -821,7 +855,7 @@
           "type": "controller",
           "class": "ReportsController",
           "method": "show",
-          "line": 111,
+          "line": 113,
           "file": "app/controllers/reports_controller.rb",
           "rendered": {
             "name": "reports/_form",
@@ -847,7 +881,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "lib/active_record/migration/app_generator.rb",
-      "line": 353,
+      "line": 354,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "ActiveRecord::Base.connection.execute(\"DROP FUNCTION IF EXISTS #{calc_trigger_fn_name(prev_table_name)}() CASCADE\")",
       "render_path": null,
@@ -918,6 +952,6 @@
       "note": ""
     }
   ],
-  "updated": "2024-08-06 18:49:07 +0100",
+  "updated": "2024-09-11 11:22:37 +0100",
   "brakeman_version": "6.1.2"
 }

--- a/docs/admin_reference/message_templates/0_introduction.md
+++ b/docs/admin_reference/message_templates/0_introduction.md
@@ -45,16 +45,33 @@ A *dialog* only ever has the *content* template type - *layout* types are ignore
 Formatting of the *dialog* content is typically markdown, but will be treated as HTML if one of the following HTML tags
 (including appropriate attributes) is present in the text: `p br div ul hr`
 
-### Public Info Pages
+### Public and Private Info Pages
 
-The *dialog* message type also provides a mechanism for defining content to be displayed as public information pages, to
-users whether they are logged in or not.
+The *dialog* message type also provides a mechanism for defining content to be displayed as a public or private information page.
+
+#### Public Info Pages
+
+Public information pages may be viewed by users whether they are logged in or not. Private information pages may only be viewed by
+authenticated users.
 
 A public info page is defined by selecting the message type *dialog*, template type *content* and category *public*
 
 The name should be underscored or hyphenated, and represents the page *slug* for URLs used to access the page content:
 
 `{{base_url}}/info_pages/<slug>`
+
+#### Private Info Pages
+
+A private info page is defined by selecting the message type *dialog*, template type *content* and any category, suffixed with
+the the string `- info page`.
+
+For example `study-category - info-page`.
+
+The name should be underscored or hyphenated, and represents the page *slug* for URLs used to access the page content:
+
+`{{base_url}}/info_pages/<study-category>__<slug>`
+
+For example: `/info_pages/ipa_screening__intro_call_faq`
 
 ### UI Templates
 

--- a/script/delayed_job
+++ b/script/delayed_job
@@ -1,5 +1,22 @@
 #!/usr/bin/env ruby
 
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+# Ensure daemons gem doesn't break IO such as Dalli
+# From https://github.com/collectiveidea/delayed_job/issues/1133#issuecomment-1710282863
+
+require 'delayed_job'
+require 'delayed_job_active_record'
 require 'delayed/command'
+
+module LoadRailsAfterRunProc
+  def self.included(base)
+    after_fork_method = base.method(:after_fork)
+    base.define_singleton_method :after_fork do |*args|
+      # after Daemons.run_proc method
+      require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+      after_fork_method.call(*args)
+    end
+  end
+end
+
+Delayed::Worker.include(LoadRailsAfterRunProc)
 Delayed::Command.new(ARGV).daemonize


### PR DESCRIPTION
## From FPHS - [8.8.10] - 2024-09-11

- [Fixed] message notifications sending SMS messages with HTML markup
- [Added] {{#is ...}} to substitutions - closes #222
- [Fixed] handling of report editing when creating a new row when using {{table_name}} substitution
- [Fixed] sidebar viewing of info pages
- [Fixed] delayed_job startup to avoid breaking memcached IO
- [Added] sidebar viewing and standalone page viewing of info-pages
- [Added] admin panel drop down components list
- [Added] better information about save trigger current user missing
- [Added] "# @library" within config libraries to allow import of config libraries that rely on others
- [Added] extra information to help debug iterator issues in save trigger
- [Fixed] formatting issue in dynamic model details panel
