### PR TITLE
Hms preset fixes

### DIFF
--- a/app/controllers/concerns/embedded_item_handler.rb
+++ b/app/controllers/concerns/embedded_item_handler.rb
@@ -32,7 +32,7 @@ module EmbeddedItemHandler
 
     return unless @embedded_item
 
-    @embedded_item.force_preset_values
+    @embedded_item.force_preset_values if @embedded_item.respond_to?(:force_preset_values)
     case action_name
     when 'new'
       set_embedded_item_optional_params

--- a/app/controllers/concerns/master_handler.rb
+++ b/app/controllers/concerns/master_handler.rb
@@ -453,7 +453,9 @@ module MasterHandler
       build_with = secure_params
     rescue StandardError => e
       logger.warn("set_instance_from_build: #{e}")
+      build_with = {}
     end
+    build_with[:skip_presets] = 'preset_fields' if action_name != 'new'
     set_object_instance @master_objects.build(build_with)
 
     if set_master_on_build

--- a/app/models/admin/defs/extra_options_defs.yaml
+++ b/app/models/admin/defs/extra_options_defs.yaml
@@ -171,6 +171,45 @@
       use_app_type: |
         use the specified app type id or name instead of the user's current app type
         to filter protocol (and in the future other) selections
+  
+  # Add preset values to a mass of fields on initialization of new items, or before
+  # creating a reference.
+  # `field_options.<field_name>.preset_value` and `field_options.<field_name>.blank_preset_value` are
+  # evalutated after this, and may override any settings here.
+  preset_fields:
+    with_result: 
+    # Map attributes from a related item to the target item.
+    # NOTE: with: fields override any specified here
+      from:
+        embedded_item:
+          return: return_result
+      attributes:
+        receipt_date: event_date
+        receipt_time: event_time
+        received_by: received_by
+        select_facility: 'Lab: {{select_lab}}'
+        # Substitutions use data only from the "from:" item                
+        embedded_item:
+          rank: rank
+          rec_type: rec_type
+          data: '{{select_lab}}'
+    with: 
+      field_name: 'now()'
+      field_name_2: 'literal value'
+      field_name_3: 
+        this: 
+          field_name: return_value
+      field_name_4: 
+        reference_name:
+          field_name: return_value
+      field_name_5: '\{\{curly_tag\}\} - \{\{curly_tag2\}\}'
+      field_name_6: '\{\{\{data.data_structure\}\}\}' # Get a data structure as original object, for JSON fields etc                  
+      embedded_item:
+        field_name: 'literal value'
+        field_name_2: 
+          reference_name:
+            field_name: return_value
+  
   dialog_before:
     field_name:
       name: message template name

--- a/app/models/classification/selection_options_handler.rb
+++ b/app/models/classification/selection_options_handler.rb
@@ -294,7 +294,7 @@ class Classification::SelectionOptionsHandler
     impl_classes.select! { |ic| !ic.respond_to?(:definition) || ic.definition.ready_to_generate? }
 
     impl_classes.each do |impl_class|
-      dyn_object = impl_class.new
+      dyn_object = impl_class.new(skip_presets: true)
 
       # If an extra log type was specified, use it, since the alt_options are specified at that level
       dyn_object.extra_log_type = extra_log_type if extra_log_type && dyn_object.respond_to?(:extra_log_type)

--- a/app/models/concerns/handles_user_base.rb
+++ b/app/models/concerns/handles_user_base.rb
@@ -48,6 +48,9 @@ module HandlesUserBase
     # Used primarily by #model_references to calculate ConditionalAction#calc_reference_if
     attr_accessor :reference, :embedded_item
 
+    # Prevent preset_value handling from running if true
+    attr_accessor :skip_presets
+
     NotPermittedParams = %i[user_id created_at updated_at tracker_id tracker_history_id admin_id disabled].freeze
 
     # Setup alternative id field methods

--- a/app/models/dynamic/model_reference_handler.rb
+++ b/app/models/dynamic/model_reference_handler.rb
@@ -471,7 +471,18 @@ module Dynamic
 
       optional_params.merge!(tot)
 
-      cmrdef[:ref_type].ns_camelize.constantize.new optional_params
+      new_c = cmrdef[:ref_type].ns_camelize.constantize
+
+      # If there is a master for the current item, and the new ref item will accept a master
+      # and no master is already set through the filters, then add it.
+      # This ensures that preset values and anything else that relies on associations with the master
+      # can operate correctly.
+      if respond_to?(:master) && new_c.instance_methods.include?(:master)
+        m_set = optional_params[:master] || optional_params[:master_id]
+        optional_params[:master] = master unless m_set
+      end
+
+      new_c.new optional_params
     end
 
     #

--- a/app/models/save_triggers/preset_fields.rb
+++ b/app/models/save_triggers/preset_fields.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class SaveTriggers::PresetFields < SaveTriggers::SaveTriggersBase
+  # def self.config_def(if_extras: {})
+  # end
+
+  def perform
+    vals = {}
+
+    nil unless config&.present?
+
+    preset_if = config[:if]
+    preset_with = config[:with]
+    with_result = config[:with_result]
+
+    if preset_if
+      ca = ConditionalActions.new preset_if, @item
+      return unless ca.calc_action_if
+    end
+
+    handle_with_result with_result, vals
+    handle_with_attributes preset_with, vals
+
+    ei = vals[:embedded_item]
+    if ei
+      @item.prep_embedded_item(ei,
+                               force_create: @item.force_save?,
+                               force_not_valid: @item.ignore_configurable_valid_if)
+
+      @item.embedded_item&.assign_attributes(ei)
+    end
+
+    @item.assign_attributes(vals)
+  end
+end

--- a/spec/models/dynamic/implementation_handler_spec.rb
+++ b/spec/models/dynamic/implementation_handler_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Use the activity log player contact phone activity log implementation,
+# since it includes the works_with concern
+
+RSpec.describe 'Implementation handler', type: :model do
+  include ModelSupport
+  include PlayerContactSupport
+
+  before :example do
+    # SetupHelper.setup_al_player_contact_phones
+    # ::ActivityLog.define_models
+    create_user
+    setup_access :player_contacts
+    let_user_create_player_contacts
+    setup_access :activity_log__player_contact_phones, user: @user
+    setup_access :activity_log__player_contact_phone__primary, resource_type: :activity_log_type, user: @user
+    create_item(data: rand(10_000_000_000_000_000), rank: 10)
+  end
+
+  it 'presets fields in a new item' do
+    resource_name = :activity_log__player_contact_phone__primary
+    @player_contact.master.current_user = @user
+    master = @player_contact.master
+    expect(master.current_user).to eq @user
+
+    ActivityLog::PlayerContactPhone.definition.option_type_config_for(:primary).preset_fields = {
+      with_result: {
+        from: {
+          player_contacts: {
+            return: 'return_result'
+          }
+        },
+        attributes: {
+          select_who: 'rec_type'
+        }
+      },
+      with: {
+        select_call_direction: 'from staff'
+      }
+    }
+
+    al = @player_contact.activity_log__player_contact_phones.create!({})
+    expect(al.master_user).to eq @user
+    expect(master.activity_log__player_contact_phones).not_to be nil
+    expect(al.select_who).to eq @player_contact.rec_type
+    expect(al.select_call_direction).to eq 'from staff'
+  end
+
+  after :example do
+    ActivityLog::PlayerContactPhone.definition.option_type_config_for(:primary).preset_fields = {}
+  end
+end


### PR DESCRIPTION
### From FPHS - 2024-10-17

- [Fixed] occasional error due to presets being loaded unnecessarily
- [Added] ability for create/update reference and preset_fields to use with_results multiple times (array) to pull from different sources
- [Added] preset_fields option to preset values to a mass of fields on initialization of new items, or before creating a reference.
- [Fixed] issue with preset_value being set within a referenced item
