### PR TITLE
Hms gen enhancements

### DIFF
--- a/app/assets/javascripts/admin/user_access_controls/admin_edit_form.js
+++ b/app/assets/javascripts/admin/user_access_controls/admin_edit_form.js
@@ -30,6 +30,8 @@ _fpa_admin.user_access_controls.admin_edit_form = class {
     $(rn_fname).attr('data-big-select-subtype', val)
     $(`${a_fname} optgroup[label]`).hide()
     $(`${a_fname} optgroup[label="${val}"]`).show()
+    $(a_fname).trigger('chosen:updated');
+
   }
 
 }

--- a/app/assets/javascripts/app/_fpa_activity_logs.js
+++ b/app/assets/javascripts/app/_fpa_activity_logs.js
@@ -38,6 +38,11 @@ _fpa.activity_logs = {
 
     _fpa.activity_logs.handle_creatables(block, data);
 
+    // Shrink the activity log items if the panel view_options.default_expander option is set to "shrunk"
+    if (block.attr('data-default-expander') == "shrunk") {
+      block.find('.expander-switch.active').click()
+    }
+
     _fpa.activity_logs.show_only_one(block, data);
   },
 

--- a/app/assets/javascripts/app/_fpa_form_utils.js
+++ b/app/assets/javascripts/app/_fpa_form_utils.js
@@ -339,6 +339,30 @@ _fpa.form_utils = {
     _fpa.form_utils.sort_blocks($targets, order_alt);
   },
 
+  handle_sub_list_expander: function ($control, init) {
+    var $a = $control;
+    var sl = $a.attr('data-expander-sub-list');
+    var $targets = $('[data-sub-list="' + sl + '"]');
+
+    if (!init) {
+      var expander_alt = $a.hasClass('active');
+      if (expander_alt) {
+        $a.removeClass('active');
+        // Shrink and make expandable
+        $targets.find('.list-group').addClass('expandable expandable-target').attr('data-toggle', 'expandable');
+
+      } else {
+        // Expand and remove expandable
+        $a.addClass('active');
+        $targets.find('.list-group').removeClass('expandable expandable-target').attr('data-toggle', null);
+      }
+    }
+
+    expander_alt = $a.hasClass('active');
+    _fpa.form_utils.setup_data_toggles($targets.parent())
+    _fpa.form_utils.format_block($targets.parent());
+  },
+
   handle_sub_list_layout: function ($control, init) {
     var $a = $control;
     var sl = $a.attr('data-layout-sub-list');
@@ -358,12 +382,11 @@ _fpa.form_utils = {
     if (val == 'wide-block') {
       $targets.removeClass('card-block').addClass('wide-block');
       $targets.find('.list-group').addClass('expandable').attr('data-toggle', 'expandable');
-      _fpa.form_utils.format_block($targets.parents('[data-sub-list="' + sl + '"]').parent());
     } else {
       $targets.addClass('card-block').removeClass('wide-block');
       $targets.find('.list-group').removeClass('expandable').attr('data-toggle', null);
-      _fpa.form_utils.format_block($targets.parents('[data-sub-list="' + sl + '"]').parent());
     }
+    _fpa.form_utils.format_block($targets.parents('[data-sub-list="' + sl + '"]').parent());
   },
 
   // Setup the typeahead prediction for a specific text input element
@@ -1906,6 +1929,24 @@ _fpa.form_utils = {
         $(this).on('click', '.order-switch', function (ev) {
           ev.preventDefault();
           _fpa.form_utils.handle_sub_list_order($(this));
+          var sl = $(this).attr('data-order-sub-list');
+          var $targets = $('[data-sub-list="' + sl + '"] .common-template-item, [data-sub-list="' + sl + '"] .new-block');
+          _fpa.form_utils.resize_children($targets.parents('[data-sub-list="' + sl + '"]').parent());
+        });
+      })
+      .addClass('formatted-slfs');
+
+
+    block
+      .find('.sublist-expander-selector')
+      .not('.formatted-slfs')
+      .each(function () {
+        $(this).on('click', '.expander-switch', function (ev) {
+          ev.preventDefault();
+          _fpa.form_utils.handle_sub_list_expander($(this));
+          var sl = $(this).attr('data-order-sub-list');
+          var $targets = $('[data-sub-list="' + sl + '"] .common-template-item, [data-sub-list="' + sl + '"] .new-block');
+          _fpa.form_utils.resize_children($targets.parents('[data-sub-list="' + sl + '"]').parent());
         });
       })
       .addClass('formatted-slfs');

--- a/app/assets/javascripts/app/_fpa_form_utils.js
+++ b/app/assets/javascripts/app/_fpa_form_utils.js
@@ -648,8 +648,9 @@ _fpa.form_utils = {
       })
       .addClass('attached-chosen');
 
-    var $dfs = sels.filter('[data-filter-selector]');
+    var $dfs = sels.filter('[data-filter-selector], [data-filters-select]');
     _fpa.form_utils.setup_chosen_groups($dfs);
+    _fpa.form_utils.setup_form_filtered_select(block);
   },
 
   setup_chosen_groups: function ($data_filter_selectors) {

--- a/app/assets/stylesheets/app/a_layout.css.scss
+++ b/app/assets/stylesheets/app/a_layout.css.scss
@@ -642,7 +642,11 @@ div.popover {
     max-height: 174px;
     // padding-bottom: 20px;
     margin-bottom: 0px;
-    border-bottom: 2px dotted gray;
+    
+    &:not(.expanded) {
+      border-bottom: 2px dotted gray;
+    }
+    
     display: block;
     overflow: hidden;
 
@@ -665,7 +669,8 @@ div.popover {
   }
   .expanded {
     max-height: none;
-    border-bottom: 0;
+    border-bottom-width: 0px;
+    border-bottom-style: solid;
 
     &.expandable-target:hover,
     .expandable-target:hover {

--- a/app/assets/stylesheets/app/search_results.scss
+++ b/app/assets/stylesheets/app/search_results.scss
@@ -887,11 +887,11 @@ li.list-group-item.is_external_id_item {
     }
   }
 
-  .sublist-order-selector {
+  .sublist-order-selector, .sublist-expander-selector {
     display: inline-block;
     float: none;
-
-    .order-switch {
+    margin-left: 2px;
+    .order-switch, .expander-switch {
       border-radius: 50%;
       background: $switch_bg_off;
       box-shadow: none;
@@ -902,7 +902,7 @@ li.list-group-item.is_external_id_item {
       font-size: normal;
     }
 
-    .order-switch.active {
+    .order-switch.active, .expander-switch.active {
       background-color: rgb(230, 213, 176);
       box-shadow: none;
       color: rgb(127, 90, 9);
@@ -914,9 +914,9 @@ li.list-group-item.is_external_id_item {
   .sublist-layout-selectors {
     display: none;
     position: relative;
-    margin-left: -66px;
+    margin-left: -96px;
     float: right;
-    right: 50px;
+    right: 80px;
 
     .layout-switch {
       box-shadow: none;
@@ -950,9 +950,9 @@ li.list-group-item.is_external_id_item {
 
 .activity-log-list {
   .sublist-controls {
-    .sublist-order-selector {
+    .sublist-order-selector, .sublist-expander-selector {
       float: right;
-      .order-switch {
+      .order-switch, .expander-switch {
         font-size: 12px;
         padding: 5px 10px;
       }
@@ -1102,16 +1102,16 @@ li.list-group-item.is_external_id_item {
   }
 
   .sublist-controls {
-    .sublist-order-selector {
+    .sublist-order-selector, .sublist-expander-selector {
       float: right;
     }
   }
 
   .activity-log-list {
     .sublist-controls {
-      .sublist-order-selector {
+      .sublist-order-selector, .sublist-expander-selector {
         float: right;
-        .order-switch {
+        .order-switch, .expander-switch {
           font-size: 12px;
           padding: 5px 10px;
         }
@@ -1132,9 +1132,9 @@ li.list-group-item.is_external_id_item {
         padding: 5px 10px;
       }
     }
-    .sublist-order-selector {
+    .sublist-order-selector, .sublist-expander-selector {
       float: right;
-      .order-switch {
+      .order-switch, .expander-switch {
         font-size: 12px;
         padding: 5px 10px;
       }

--- a/app/controllers/admin/user_access_controls_controller.rb
+++ b/app/controllers/admin/user_access_controls_controller.rb
@@ -48,6 +48,9 @@ class Admin::UserAccessControlsController < AdminController
     {
       app_type_id: {
         'data-filters-select': '#admin_user_access_control_role_name'
+      },
+      resource_type: {
+        'data-filters-select': '#admin_user_access_control_access'
       }
     }
   end

--- a/app/controllers/redcap/project_admins_controller.rb
+++ b/app/controllers/redcap/project_admins_controller.rb
@@ -112,6 +112,10 @@ class Redcap::ProjectAdminsController < AdminController
     Redcap::ProjectAdmin::Statuses.map { |_k, v| [v, v] }
   end
 
+  def server_url_list
+    Redcap::ProjectAdmin.active.pluck(:server_url).uniq
+  end
+
   def notes_editor
     :markdown
   end
@@ -151,12 +155,13 @@ class Redcap::ProjectAdminsController < AdminController
     {
       study: pas,
       status: status_options.transpose[0].uniq,
-      transfer_mode: transfer_mode_options.transpose[0].uniq
+      transfer_mode: transfer_mode_options.transpose[0].uniq,
+      server_url: server_url_list
     }
   end
 
   def filters_on
-    %i[study status transfer_mode]
+    %i[study status transfer_mode server_url]
   end
 
   #

--- a/app/jobs/handle_message_notification_job.rb
+++ b/app/jobs/handle_message_notification_job.rb
@@ -5,11 +5,13 @@ class HandleMessageNotificationJob < ApplicationJob
   # retry_on FphsException
   queue_as :default
 
-  def perform(message_notification, for_item: nil, on_complete_config: nil, alt_batch_user: nil)
+  def perform(message_notification, for_item: nil, on_complete_config: nil, alt_batch_user: nil,
+              ignore_no_recipients: nil)
     puts "Performing job on #{message_notification.inspect}" unless Rails.env.test?
     message_notification.handle_notification_now logger: Delayed::Worker.logger,
-                                                 for_item: for_item,
-                                                 on_complete_config: on_complete_config,
-                                                 alt_batch_user: alt_batch_user
+                                                 for_item:,
+                                                 on_complete_config:,
+                                                 alt_batch_user:,
+                                                 ignore_no_recipients:
   end
 end

--- a/app/models/admin/defs/config_trigger_options_defs.yaml
+++ b/app/models/admin/defs/config_trigger_options_defs.yaml
@@ -9,10 +9,17 @@
           access: create|update|read
           # Default is create
         embed:
-        # Create a default embed dynamic model. No fields need to be specified.
+        # Create a default embed dynamic model. No fields need to be specified, and leaving the configuration without
+        # a `fields` key will prevent future updates the configuration
           fields:
             - status
             - notes
+          allow_reconfiguration: nil (default) | true
+            # Allow reconfiguration with the specified fields  
+          prefix_config_libraries: string | array
+            # Either a `<category> <name>` pair for a library
+            # or a list of libraries in this format
+            # This will be added to the options, unless the embed already exists with non-blank options
         page_layout:
         # Create a master page layout for this definition resource.
       create_configs:

--- a/app/models/admin/defs/page_layout_options_defs.yaml
+++ b/app/models/admin/defs/page_layout_options_defs.yaml
@@ -33,6 +33,7 @@ view_options:
   find_with: (msid|scantron_id|...)   # the alternative id (crosswalk or external id)
                                       # to search for the master record with for standalone pages
   hide_sublist_controls:              # hide the sublist controls (filter, sort) in dynamic item panel
+  default_expander:                   # set to "shrunk" to initially shrink activity log items
   hide_activity_logs_header:          # hide the activity logs header including + buttons
   close_others:                       # when clicked to expand this tab, others will be closed
   show_for_single_master_only:        # Only show panel if a single master result is presented

--- a/app/models/admin/defs/save_triggers_notify_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_notify_options_defs.yaml
@@ -28,6 +28,8 @@
             display_name: 'display name for email address'
           
           "from_user_email(alternative)": 'string email address'
+          ignore_no_recipients: nil (default) | true - don't raise an error if no recipients are specified or found in the role
+
           layout_template: 'name of layout template'
           content_template: 'name of content template'
           content_template_text: 'alternative content template text'

--- a/app/models/admin/page_layout.rb
+++ b/app/models/admin/page_layout.rb
@@ -67,7 +67,7 @@ class Admin::PageLayout < Admin::AdminBase
   #   initial_show: initially open up a panel
   #   find_with: the alternative id (crosswalk or external id) to search for the master record with for standalone pages
   configure :view_options,
-            with: %i[initial_show orientation add_item_label limit find_with hide_sublist_controls
+            with: %i[initial_show orientation add_item_label limit find_with hide_sublist_controls default_expander
                      hide_activity_logs_header close_others
                      show_for_single_master_only show_for_multi_master_only filter_items]
 

--- a/app/models/option_configs/extra_options.rb
+++ b/app/models/option_configs/extra_options.rb
@@ -114,6 +114,23 @@ module OptionConfigs
     def clean_dialog_before_def
       self.dialog_before ||= {}
       self.dialog_before = self.dialog_before.symbolize_keys
+
+      dialog_before.each do |k, v|
+        unless v.is_a? Hash
+          failed_config :dialog_before,
+                        "dialog_before must be a Hash: #{k}",
+                        level: :error
+          next
+        end
+
+        name = v[:name]
+        mt = Admin::MessageTemplate.active.find_by(name:)
+        next if mt
+
+        failed_config :dialog_before,
+                      "dialog_before specifies a named message template that doesn't exist: #{name}",
+                      level: :warn
+      end
     end
 
     # Field labels definitions

--- a/app/models/save_triggers/create_reference.rb
+++ b/app/models/save_triggers/create_reference.rb
@@ -86,7 +86,7 @@ class SaveTriggers::CreateReference < SaveTriggers::SaveTriggersBase
 
               unless create_in.is_a?(Hash) && create_in[:specific_record]
                 raise FphsException,
-                      "Unknown 'in' value in create_reference"
+                      "Unknown 'in' value in create_reference for config #{config}"
               end
 
               # A specific instance is the target for the reference from_record

--- a/app/models/save_triggers/notify.rb
+++ b/app/models/save_triggers/notify.rb
@@ -77,6 +77,7 @@ class SaveTriggers::Notify < SaveTriggers::SaveTriggersBase
     @layout_template = config[:layout_template]
     @on_complete = config[:on_complete]
     @from_user_email = config[:from_user_email]
+    @ignore_no_recipients = config[:ignore_no_recipients]
 
     @message_type = config[:type]
     @run_if = config[:if]
@@ -282,14 +283,14 @@ class SaveTriggers::Notify < SaveTriggers::SaveTriggersBase
       user: @user,
       layout_template_name: @layout_template,
       content_template_name: content_template,
-      content_template_text: content_template_text,
+      content_template_text:,
       item_type: @item.class.name,
       item_id: @item.id,
       master_id: @item.master_id,
       message_type: @message_type,
-      subject: subject,
+      subject:,
       role_name: @role_name,
-      extra_substitutions: extra_substitutions
+      extra_substitutions:
     }
 
     setup_data[:recipient_user_ids] = @receiving_user_ids if @receiving_user_ids
@@ -298,6 +299,7 @@ class SaveTriggers::Notify < SaveTriggers::SaveTriggersBase
     setup_data[:recipient_data] = @force_recip_recs if @force_recip_recs
     setup_data[:importance] = importance if importance
     setup_data[:from_user_email] = from_user_email if from_user_email
+    setup_data[:ignore_no_recipients] = @ignore_no_recipients if @ignore_no_recipients
 
     @message_notification = Messaging::MessageNotification.create! setup_data
   end
@@ -312,7 +314,8 @@ class SaveTriggers::Notify < SaveTriggers::SaveTriggersBase
     # Also pass the on_complete configuration to follow up after the main job processing completes
     job.perform_later(@message_notification, for_item: @item,
                                              on_complete_config: @on_complete,
-                                             alt_batch_user: @alt_batch_user)
+                                             alt_batch_user: @alt_batch_user,
+                                             ignore_no_recipients: @ignore_no_recipients)
   end
 
   def calc_field_or_return(cond)

--- a/app/views/admin/app_configurations/_form.html.erb
+++ b/app/views/admin/app_configurations/_form.html.erb
@@ -4,7 +4,11 @@
   <%= render partial: 'admin_handler/form_errors' %>
   <div class="form-group">
     <%= f.label :app_type_id %>
-    <%= f.select :app_type_id, app_type_options(default_app_type_id: app_type_select_current_item), {}, extra_field_attributes[:app_type_id]||{} %>
+    <%
+            add_opts = extra_field_attributes[:app_type_id].dup || {}
+            add_opts[:class] = 'use-chosen'
+    %>
+    <%= f.select :app_type_id, app_type_options(default_app_type_id: app_type_select_current_item), {}, add_opts %>
   </div>
   <div class="form-group">
     <%= f.label :name %>

--- a/app/views/admin/common_templates/_form.html.erb
+++ b/app/views/admin/common_templates/_form.html.erb
@@ -49,11 +49,11 @@
         <%
           select_item_type = {}
           select_item_type[:selected] = filter_params_hash.first.last if filter_params_hash&.first&.first == p.to_s
-          select_item_type[:include_blank] = true
+          select_item_type[:include_blank] = true          
 
           options = send("#{p}_options")
         %>
-        <%= f.select p, options, select_item_type %>
+        <%= f.select p, options, select_item_type, {class: 'use-chosen'} %>
       <% elsif p.to_s.end_with?('options') || p.to_s.end_with?('template')
           has_options = p
       %>
@@ -65,7 +65,7 @@
         <%= form_field_label(f, p) %>
       <% elsif p == :item_type %>
         <%= f.label :item_type, 'data-add-icon' => 'info-sign', title: "#{object_instance.id ? 'item type for existing records can not be changed.' : 'Set item type'}" %>
-        <%= f.select :item_type, item_types_array, {}, disabled: !!object_instance.id  %>
+        <%= f.select :item_type, item_types_array, {}, disabled: !!object_instance.id, class: 'use-chosen'  %>
       <% elsif p == :app_type_id %>
           <%= form_field_label(f, p) %>
           <%
@@ -74,14 +74,17 @@
             if oc.respond_to?(:app_type_not_required) && oc.app_type_not_required
               ib = {include_blank: '(all)'}
             end
+
+            add_opts = extra_field_attributes[p.to_sym].dup || {}
+            add_opts[:class] = 'use-chosen'
           %>
-          <%= f.select :app_type_id, app_type_options(default_app_type_id: app_type_select_current_item), ib, extra_field_attributes[p.to_sym]||{} %>
+          <%= f.select :app_type_id, app_type_options(default_app_type_id: app_type_select_current_item), ib, add_opts %>
       <% elsif p == :user_id %>
           <%
             default_user_id = filter_params_hash.first.last if filter_params_hash&.first&.first == 'user_id'
           %>
           <%= form_field_label(f, p) %>
-          <%= f.select :user_id, active_user_options(default_user_id: default_user_id), { include_blank: true } %>
+          <%= f.select :user_id, active_user_options(default_user_id: default_user_id), { include_blank: true }, class: 'use-chosen' %>
       <% elsif p == :api_key %>
         <%= form_field_label(f, p) %>
         <% begin %>

--- a/app/views/admin/page_layouts/_form.html.erb
+++ b/app/views/admin/page_layouts/_form.html.erb
@@ -5,11 +5,15 @@
         <%= render partial: 'admin_handler/form_errors' %>
         <div class="form-group">
           <%= f.label :app_type_id %>
-          <%= f.select :app_type_id, app_type_options(default_app_type_id: app_type_select_current_item), {include_blank: '(all)'}, extra_field_attributes[:app_type_id]||{} %>
+          <%
+            add_opts = extra_field_attributes[:app_type_id].dup || {}
+            add_opts[:class] = 'use-chosen'
+          %>
+          <%= f.select :app_type_id, app_type_options(default_app_type_id: app_type_select_current_item), {include_blank: '(all)'}, add_opts %>
         </div>
         <div class="form-group">
           <%= f.label :layout_name, 'Use as' %>
-          <%= f.select :layout_name, layout_options %>
+          <%= f.select :layout_name, layout_options, {}, class: 'use-chosen' %>
         </div>
         <div class="form-group">
           <%= f.label :panel_name %>

--- a/app/views/admin/protocol_events/_form.html.erb
+++ b/app/views/admin/protocol_events/_form.html.erb
@@ -4,7 +4,7 @@
   <%= render partial: 'admin_handler/form_errors' %>
   <div class="form-group">
     <%= f.label :sub_process_id %>
-    <%= f.select :sub_process_id, sub_processes_array %>
+    <%= f.select :sub_process_id, sub_processes_array, {}, class: 'use-chosen' %>
   </div>
   <div class="form-group">
     <%= f.label :name %>

--- a/app/views/admin/protocols/_form.html.erb
+++ b/app/views/admin/protocols/_form.html.erb
@@ -4,7 +4,11 @@
   <%= render partial: 'admin_handler/form_errors' %>
   <div class="form-group">
     <%= f.label :app_type %>
-    <%= f.select :app_type_id, app_type_options(default_app_type_id: app_type_select_current_item), {include_blank: true}, extra_field_attributes[:app_type_id]||{} %>
+    <%
+      add_opts = extra_field_attributes[:app_type_id].dup || {}
+      add_opts[:class] = 'use-chosen'
+    %>
+    <%= f.select :app_type_id, app_type_options(default_app_type_id: app_type_select_current_item), {include_blank: true}, add_opts %>
   </div>
   <div class="form-group">
     <%= f.label :name %>

--- a/app/views/admin/sub_processes/_form.html.erb
+++ b/app/views/admin/sub_processes/_form.html.erb
@@ -9,7 +9,7 @@
   </div>
   <div class="form-group">
     <%= f.label :protocol_id %>
-    <%= f.select :protocol_id, protocol_array(admin_view: true) %>
+    <%= f.select :protocol_id, protocol_array(admin_view: true), {}, class: 'use-chosen' %>
   </div>
   <div class="form-group">
     <%= f.check_box :disabled %>

--- a/app/views/admin/user_access_controls/_form.html.erb
+++ b/app/views/admin/user_access_controls/_form.html.erb
@@ -4,11 +4,15 @@
   <%= render partial: 'admin_handler/form_errors' %>
   <div class="form-group">
     <%= f.label :app_type %>
-    <%= f.select :app_type_id, app_type_options(default_app_type_id: app_type_select_current_item), {include_blank: '(all)'}, extra_field_attributes[:app_type_id]||{} %>
+    <%
+            add_opts = extra_field_attributes[:app_type_id].dup || {}
+            add_opts[:class] = 'use-chosen'
+    %>
+    <%= f.select :app_type_id, app_type_options(default_app_type_id: app_type_select_current_item), {include_blank: '(all)'}, add_opts %>
   </div>
   <div class="form-group">
     <%= f.label :user_id, 'User override' %>
-    <%= f.select :user_id, active_user_options, include_blank: true %>
+    <%= f.select :user_id, active_user_options, {include_blank: true}, class: 'use-chosen' %>
   </div>
   <div class="form-group">
     <%= f.label :role_name, 'Role name override' %>
@@ -19,11 +23,15 @@
 
       options = role_name_options
     %>
-    <%= f.select :role_name, options, select_item_type %>
+    <%= f.select :role_name, options, select_item_type, class: 'use-chosen' %>
   </div>
   <div class="form-group">
     <%= f.label :resource_type %>
-    <%= f.select :resource_type, Admin::UserAccessControl.resource_types, include_blank: true %>
+    <%
+            add_opts = extra_field_attributes[:resource_type].dup || {}
+            add_opts[:class] = 'use-chosen'
+    %>    
+    <%= f.select :resource_type, Admin::UserAccessControl.resource_types, { include_blank: true }, add_opts %>
   </div>
   <div class="form-group">
     <%= f.label :resource_name %>
@@ -42,7 +50,7 @@
     <%
     accesses = Admin::UserAccessControl.access_levels
     %>
-    <%= f.select :access, accesses%>
+    <%= f.select :access, accesses, {}, class: 'use-chosen'%>
   </div>
   <div class="form-group">
     <%= f.check_box :disabled %>

--- a/app/views/common_templates/edit_fields/_name_starts_with_fixed.html.erb
+++ b/app/views/common_templates/edit_fields/_name_starts_with_fixed.html.erb
@@ -1,11 +1,9 @@
 <%
   options = field_options_for(form_object_instance, field_name_sym)
   options.merge! data: {attr_name: field_name_sym, object_name: form_object_item_type_us}
-  # options[:disabled] = 'disabled'
 %>
 <%= form.label field_name_sym, label_for(field_name_sym, labels, /^fixed_/) %>
 <span class="fixed-field">
-  <%= form.text_field field_name_sym, options %>
-  <%#= form_object_instance.attributes[field_name] %>
-  <div class="fixed-field-cover"></div>
+  <%= form.hidden_field field_name_sym, options %>
+  <%= form_object_instance.attributes[field_name_sym.to_s] %>
 </span>

--- a/app/views/masters/_search_results_parts.html.erb
+++ b/app/views/masters/_search_results_parts.html.erb
@@ -177,13 +177,17 @@
 
     {{#if layout}}
     <div class="sublist-layout-selectors">
-      <button class="btn btn-default btn-sm layout-switch glyphicon glyphicon-th active" data-layout-sub-list="{{sub_list}}" data-force-layout="card-block"></button><button class="btn btn-default btn-sm layout-switch glyphicon glyphicon-align-justify" data-layout-sub-list="{{sub_list}}" data-force-layout="wide-block"></button>
+      <button class="btn btn-default btn-sm layout-switch glyphicon glyphicon-th active" data-layout-sub-list="{{sub_list}}" data-force-layout="card-block" title="grid view"></button><button class="btn btn-default btn-sm layout-switch glyphicon glyphicon-align-justify" data-layout-sub-list="{{sub_list}}" data-force-layout="wide-block" title="list view"></button>
+    </div>
+
+    <div class="sublist-expander-selector">
+      <button class="btn btn-default btn-sm expander-switch glyphicon glyphicon-resize-vertical active" data-expander-sub-list="{{sub_list}}" title="shrink/expand items"></button>
     </div>
     {{/if}}
 
     {{#if order}}
     <div class="sublist-order-selector">
-      <button class="btn btn-default btn-sm order-switch glyphicon glyphicon-sort-by-attributes" data-order-sub-list="{{sub_list}}" data-order-val="{{order}}"></button>
+      <button class="btn btn-default btn-sm order-switch glyphicon glyphicon-sort-by-attributes" data-order-sub-list="{{sub_list}}" data-order-val="{{order}}" title="reverse sorting"></button>
     </div>
     {{/if}}
   </div>

--- a/app/views/masters/_search_results_resources_panel.html.erb
+++ b/app/views/masters/_search_results_resources_panel.html.erb
@@ -1,6 +1,7 @@
 <%
   resources = panel.contains.resources
   init_visible = panel.view_options.initial_show || nil if panel.view_options
+  default_expander = panel.view_options&.default_expander
   hide_sl_class = 'hide-sublist-controls' if panel.view_options&.hide_sublist_controls
   hide_al_header_class = 'hide-activity-logs-header' if panel.view_options&.hide_activity_logs_header
   resources.each do |resource|
@@ -22,6 +23,7 @@
          data-sub-id="{{id}}"
          data-sub-item="<%= resource %>"
          data-template="<%= resource.hyphenate %>-main-result-template"
+         data-default-expander="<%= default_expander %>"
     >
         <div id="<%= resource.hyphenate %>-inner-{{id}}" class="<%= resource_type %>-inner-block">
         </div>


### PR DESCRIPTION
### From FPHS - 2024-10-17

- [Added] use of "chosen" drop down for admin forms to aid faster configurations
- [Added] ignore_no_recipients as an option to notify sms
- [Changed] presentation of fixed_... fields to avoid them being accidentally selected
- [Added] admin filter on server url for Redcap projects
- [Added] information to help with debugging common create_reference configuration error
- [Added] config_trigger.on_define.embed options to allow_reconfiguration (default no) and prefix_config_libraries
- [Added] format check for dialog_before configurations and check message template exists
- [Added] a page layout view option for default_expander to present activity log blocks as "shrunk" by default
