### PR TITLE
Fixed "created_by_user_id" field showing unnecessarily in edit forms

### DIFF
--- a/app/assets/stylesheets/app/forms.css.scss
+++ b/app/assets/stylesheets/app/forms.css.scss
@@ -113,6 +113,10 @@ li.list-group-item.placeholder-field-item {
   display: none !important;
 }
 
+li.edit-field-container[data-edit-field-name="created_by_user_id"] {
+  display: none !important;
+}
+
 .fixed-field {
   position: relative;
   input.form-control.has-value,

--- a/app/views/common_templates/_edit_form.html.erb
+++ b/app/views/common_templates/_edit_form.html.erb
@@ -257,7 +257,8 @@
           <% end %>
 
 
-          <li class="list-group-item edit-field-container column_type_<%= column_type %> <%= showed_caption_before ? 'showed-caption-before' : ''%> <%=form_object_item_type_us.hyphenate%>-<%=field_name_sym%> <%=field_name.start_with?('placeholder_') ? 'placeholder-field-item' : ''%>">
+          <li class="list-group-item edit-field-container column_type_<%= column_type %> <%= showed_caption_before ? 'showed-caption-before' : ''%> <%=form_object_item_type_us.hyphenate%>-<%=field_name_sym%> <%=field_name.start_with?('placeholder_') ? 'placeholder-field-item' : ''%>"
+              data-edit-field-name="<%= field_name_sym %>">
             <%= edit_form_field(**local_vars) %>
           </li>
 


### PR DESCRIPTION
### From Viva - 2024-12-03

- [Fixed] "created_by_user_id" field showing unnecessarily in edit forms