### PR TITLE
Fixed e-signature form captions don't handle substitutions - fixes #425

### DIFF
--- a/app/views/e_signature/_document.html.erb
+++ b/app/views/e_signature/_document.html.erb
@@ -36,11 +36,12 @@
   attributes.each do |key, field_val|
        key_sym = key.to_sym
        got_caption_before = false
+       @form_object_instance = @e_sign_document
 
      if caption_before.has_key? key_sym
 
 %>      <li class="e-sign-group-item caption-before results-caption-before"
-        ><%= caption_before[key_sym] && (caption_before[key_sym][:caption] || '') %></li>
+        ><%= show_caption_before key_sym, caption_before %></li>
 <%
      end
 


### PR DESCRIPTION
## From FPHS - 2024-12-18

- [Fixed] e-signature form captions don't handle substitutions - fixes #425