### PR TITLE
Pr gen fixes

### DIFF
--- a/app-scripts/parallel_test.sh
+++ b/app-scripts/parallel_test.sh
@@ -14,7 +14,7 @@ fi
 
 # Ensure the tests run cleanly
 export DISABLE_SPRING=1
-spring stop
+bundle exec spring stop
 
 # First, run brakeman
 if [ "${NO_BRAKEMAN}" != 'true' ] && [ "${SKIP_BRAKEMAN}" != 'true' ]; then

--- a/app/assets/javascripts/admin/user_access_controls/admin_edit_form.js
+++ b/app/assets/javascripts/admin/user_access_controls/admin_edit_form.js
@@ -17,16 +17,19 @@ _fpa_admin.user_access_controls.admin_edit_form = class {
   setup_selectors() {
     var block = this.block
     var _this = this
-    this.res_type_changed($('#admin_user_access_control_resource_type'));
+    this.res_type_changed($('form #admin_user_access_control_resource_type'));
     block.on('change', '#admin_user_access_control_resource_type', function () {
       _this.res_type_changed($(this))
     })
+    window.setTimeout(function () {
+      $('form #admin_user_access_control_resource_type').change()
+    }, 1)
   }
 
   res_type_changed($el) {
     const val = $el.val()
     const rn_fname = 'input[name="admin_user_access_control[resource_name]"]'
-    const a_fname = 'select[name="admin_user_access_control[access]"]'
+    const a_fname = 'form select[name="admin_user_access_control[access]"]'
     $(rn_fname).attr('data-big-select-subtype', val)
     $(`${a_fname} optgroup[label]`).hide()
     $(`${a_fname} optgroup[label="${val}"]`).show()

--- a/app/assets/javascripts/app/_fpa_ajax_processors_reports.js
+++ b/app/assets/javascripts/app/_fpa_ajax_processors_reports.js
@@ -75,7 +75,7 @@ _fpa.postprocessors_reports = {
 
       if (_fpa.templates['search-count-template']) {
         var h = _fpa.templates['search-count-template'](data);
-        block.find('.search_count_reports').html(h);
+        $('[data-report-count]').html(h);
       }
     }
 

--- a/app/assets/javascripts/app/_fpa_form_utils.js
+++ b/app/assets/javascripts/app/_fpa_form_utils.js
@@ -852,6 +852,9 @@ _fpa.form_utils = {
         console.log(`set filtered select ${filter_sel} to val: ${new_val} == ${$(filter_sel).val()}`)
         // end of hack
 
+        window.setTimeout(function () {
+          $($el).change()
+        }, 1)
 
       })
       .addClass('filters-select-attached');

--- a/app/assets/javascripts/app/_fpa_form_utils.js
+++ b/app/assets/javascripts/app/_fpa_form_utils.js
@@ -1978,6 +1978,43 @@ _fpa.form_utils = {
       .addClass('formatted-slfs');
   },
 
+  reorder_sub_list_columns: function (block) {
+    const $outer = block.parents('.reorder-sublist-columns');
+    if ($outer.length === 0) return;
+
+    window.setTimeout(function () {
+      var heights = [];
+      var cols = $outer.find('.sublist-column');
+      if (cols.length === 0) return;
+
+      cols.each(function () {
+        var h = $(this).height();
+        if ($(this).find('[data-sub-item]').length === 0) {
+          // No items in the column
+          h = 0;
+        }
+        heights.push([$(this).prop('id'), h]);
+      });
+
+      heights.sort(function (a, b) {
+        return b[1] - a[1]
+      });
+
+      var prev = null;
+      for (var key in heights) {
+        if (!heights.hasOwnProperty(key)) continue;
+
+        var id = heights[key][0];
+        var $col = $(`#${id}`);
+        if (prev) {
+          prev.after($col);
+        }
+        prev = $col;
+      }
+    }, 200)
+
+  },
+
   setup_contact_field_mask: function (block) {
     var check_rec = function (rec_type, input) {
       if (typeof rec_type == 'string') {
@@ -2319,6 +2356,7 @@ _fpa.form_utils = {
     _fpa.form_utils.setup_error_clear(block);
     _fpa.form_utils.resize_children(block);
     _fpa.form_utils.setup_sub_lists(block);
+    _fpa.form_utils.reorder_sub_list_columns(block);
     _fpa.form_utils.apply_view_handlers(block);
     _fpa.form_utils.setup_secure_view_links(block);
 

--- a/app/assets/stylesheets/app/a_layout.css.scss
+++ b/app/assets/stylesheets/app/a_layout.css.scss
@@ -1,4 +1,4 @@
-@import "../app_vars";
+@use "../app_vars" as *;
 
 html {
   min-height: 100%;

--- a/app/assets/stylesheets/app/admin_handler.css.scss
+++ b/app/assets/stylesheets/app/admin_handler.css.scss
@@ -65,7 +65,7 @@ table.admin-list tbody {
 }
 
 #admin_user_role_role_name {
-  width: 300px;
+  width: 100%;
 }
 
 input.form-control.tt-hint {

--- a/app/assets/stylesheets/app/forms.css.scss
+++ b/app/assets/stylesheets/app/forms.css.scss
@@ -42,7 +42,7 @@ form .full-width input.form-control {
 }
 
 .form-inline .twitter-typeahead {
-  width: auto;
+  width: 100%;
 }
 
 form select {

--- a/app/assets/stylesheets/app/help.scss
+++ b/app/assets/stylesheets/app/help.scss
@@ -1,26 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Titillium+Web:wght@400");
-// @import url("/fonts/roboto/Roboto-Regular.ttf");
-
-@font-face {
-  font-family: "Roboto";
-  src: url("/fonts/roboto/Roboto-Regular.ttf");
-}
-
-@font-face {
-  font-family: "Roboto-Bold";
-  src: url("/fonts/roboto/Roboto-Bold.ttf");
-}
-
-@font-face {
-  font-family: "Roboto-Italic";
-  src: url("/fonts/roboto/Roboto-Italic.ttf");
-}
-
-@font-face {
-  font-family: "Roboto-BoldItalic";
-  src: url("/fonts/roboto/Roboto-BoldItalic.ttf");
-}
-
 div.help-view-doc,
 .common-help-item,
 .md-formatted-block,

--- a/app/assets/stylesheets/app/search_results.scss
+++ b/app/assets/stylesheets/app/search_results.scss
@@ -1,4 +1,4 @@
-@import "../app_vars";
+@use "../app_vars" as *;
 
 span.disabled,
 a.disabled {

--- a/app/assets/stylesheets/big_select/big_select.scss
+++ b/app/assets/stylesheets/big_select/big_select.scss
@@ -61,3 +61,9 @@
 .big-select-overlay[readonly] {
   background: white;
 }
+
+.big-select-description {
+  position: absolute;
+  right: 4px;
+  top: 9px;
+}

--- a/app/assets/stylesheets/bootstrap-theme.css.scss
+++ b/app/assets/stylesheets/bootstrap-theme.css.scss
@@ -1,5 +1,4 @@
-@import './app_vars';
-
+@use "app_vars" as *;
 /*!
  * Generated using the Bootstrap Customizer (https://getbootstrap.com/docs/3.4/customize/)
  */

--- a/app/controllers/admin/app_configurations_controller.rb
+++ b/app/controllers/admin/app_configurations_controller.rb
@@ -3,6 +3,10 @@ class Admin::AppConfigurationsController < AdminController
 
   protected
 
+  def view_folder
+    'admin/common_templates'
+  end
+
   def filters
     {
       name: Admin::AppConfiguration.configurations,

--- a/app/controllers/admin/reference_data_controller.rb
+++ b/app/controllers/admin/reference_data_controller.rb
@@ -22,7 +22,7 @@ class Admin::ReferenceDataController < ApplicationController
     @table_info_for_schema = Admin::MigrationGenerator.tables_and_views
                                                       .filter { |ti| ti['schema_name'] == @schema_name }
 
-    render partial: 'table_list_schema_tables.html'
+    render partial: 'table_list_schema_tables'
   end
 
   def table_list_columns

--- a/app/controllers/filestore/classification_controller.rb
+++ b/app/controllers/filestore/classification_controller.rb
@@ -51,7 +51,7 @@ module Filestore
       when 'archived_file'
         @download = @container.archived_files.find_by(id: params[:download_id])
       else
-        raise FphsException, 'Incorrect retrieval_type set'
+        raise FphsException, "Incorrect retrieval_type set: #{@retrieval_type}"
       end
 
       @container.parent_item = @activity_log

--- a/app/models/admin/defs/conditions_defs.yaml
+++ b/app/models/admin/defs/conditions_defs.yaml
@@ -117,6 +117,14 @@
             id: 123
             return: return_result
 
+        all - crosswalk:
+          # no_masters can also be used to look up against the crosswalk identifiers. For example, get the
+          # master.id for the provided msid
+          no_masters: {}          
+          masters:
+            msid: 12345
+            id: return_value
+
         all - masters:
           # if the first key is 'masters' and the value an empty hash then the query will return against all masters rather than current master record
           masters: {}

--- a/app/models/admin/server_info.rb
+++ b/app/models/admin/server_info.rb
@@ -13,6 +13,10 @@ class Admin::ServerInfo
     configuration_successful
   ].freeze
 
+  # Attempt to get the filename of the log from logger. If not, attempt to force it.
+  LogFilename = Rails.logger.instance_variable_get('@logdev')&.filename ||
+                Rails.root.join('log', "#{Rails.env}.log")
+
   attr_accessor :current_admin
 
   #
@@ -93,7 +97,7 @@ class Admin::ServerInfo
   end
 
   def rails_log(regex, max_count: 2000, tail_length: 10_000, trailing_context: 20)
-    logfilename = Rails.logger.instance_variable_get('@logdev')&.filename || 'none'
+    logfilename = LogFilename
     trailing_context = trailing_context.to_i
 
     cmds = [

--- a/app/models/concerns/handles_user_base.rb
+++ b/app/models/concerns/handles_user_base.rb
@@ -654,7 +654,7 @@ module HandlesUserBase
         raise "#{attr} set (#{ext_id_val}), but it does not match a master record #{master_id}" unless found_master
 
         self.master_id = found_master.id
-      elsif ext_id_val && master_id && found_master&.id != master_id
+      elsif ext_id_val && master_id && found_master&.id && found_master&.id != master_id
         # An external id has been provided, and so has a master_id
         # but the master record found for the external id does not match
         # the master_id

--- a/app/models/external_identifier.rb
+++ b/app/models/external_identifier.rb
@@ -113,11 +113,14 @@ class ExternalIdentifier < ActiveRecord::Base
   # @param [String] rep_type - one of the possible external ID report types
   # @param [String] item_type - optional item_type to find
   # @return [Report | nil]
-  def usage_report(rep_type, item_type = ReportItemType)
+  def usage_report(rep_type, item_type = ReportItemType, as_alt_resource_name: nil)
     rep_name = usage_report_name(rep_type)
     short_name = Report.gen_short_name(rep_name)
     arn = Report.alt_resource_name(item_type, short_name)
-    Report.active.find_by_alt_resource_name(arn, true)
+    res = Report.active.find_by_alt_resource_name(arn, true)
+    return res unless as_alt_resource_name
+
+    res&.alt_resource_name
   end
 
   def usage_report_name(rep_type)

--- a/app/models/fphs/master_search_handler.rb
+++ b/app/models/fphs/master_search_handler.rb
@@ -69,12 +69,12 @@ module Fphs
       },
       not_trackers: {
         protocol_event_id: { value: :is,
-                             condition: 'NOT EXISTS (select NULL from trackers t_inner where t_inner.protocol_event_id EQUALS_OR_IS_NULL ? AND t_inner.sub_process_id = :not_trackers_sub_process_id  AND t_inner.master_id = masters.id)', joins: NotTrackerJoin },
+                             condition: 'NOT EXISTS (select NULL from trackers t_inner where t_inner.protocol_event_id EQUALS_OR_IS_NULL AND t_inner.sub_process_id = :not_trackers_sub_process_id  AND t_inner.master_id = masters.id)', joins: NotTrackerJoin },
         sub_process_id: { value: :is, condition: 'TRUE', joins: NotTrackerJoin }
       },
       not_tracker_histories: {
         protocol_event_id: { value: :is,
-                             condition: 'NOT EXISTS (select NULL from tracker_history th_inner where th_inner.protocol_event_id EQUALS_OR_IS_NULL ? AND th_inner.sub_process_id = :not_tracker_histories_sub_process_id AND th_inner.master_id = masters.id)', joins: NotTrackerHistoryJoin },
+                             condition: 'NOT EXISTS (select NULL from tracker_history th_inner where th_inner.protocol_event_id EQUALS_OR_IS_NULL AND th_inner.sub_process_id = :not_tracker_histories_sub_process_id AND th_inner.master_id = masters.id)', joins: NotTrackerHistoryJoin },
         sub_process_id: { value: :is, condition: 'TRUE', joins: NotTrackerHistoryJoin }
       },
       general_infos: {
@@ -302,9 +302,9 @@ module Fphs
         cval = nil if cval == '(null)'
 
         eoin = if cval.nil?
-                 'IS'
+                 'IS NULL'
                else
-                 '='
+                 '= ?'
                end
         alt = alt.gsub('EQUALS_OR_IS_NULL', eoin)
 

--- a/app/models/imports/model_generator.rb
+++ b/app/models/imports/model_generator.rb
@@ -154,10 +154,12 @@ module Imports
       res = true
       field_types.each do |k, v|
         v = :integer if v == :references
-        unless dynamic_model_columns.find { |c| c.name == k.to_s }.type == v
-          res = false
-          break
-        end
+        got_type = dynamic_model_columns.find { |c| c.name == k.to_s }.type
+        next if got_type == v
+
+        res = false
+        Rails.logger.warn "Dynamic model column #{k} has type #{got_type}. Expected it to be #{v}"
+        break
       end
 
       return res unless res

--- a/app/models/master.rb
+++ b/app/models/master.rb
@@ -8,6 +8,7 @@ class Master < ActiveRecord::Base
   # within this functionality to operate, just like an association to any other table
   TemporaryMasterIds = [-1, -2].freeze
   Resources::Models.add(Master, resource_name: :temporary_master)
+  Resources::Models.add(Master, resource_name: :masters)
   has_many :temporary_master, -> { Master.temporary_master }, class_name: 'Master', foreign_key: 'id'
 
   MasterNestedAttribs = [

--- a/app/models/nfs_store/manage/container.rb
+++ b/app/models/nfs_store/manage/container.rb
@@ -16,7 +16,8 @@ module NfsStore
 
       after_create :create_in_nfs_store
 
-      attr_accessor :create_with_role, :parent_item, :previous_uploads, :previous_upload_stored_file_ids
+      attr_accessor :create_with_role, :parent_item, :previous_uploads, :previous_upload_stored_file_ids,
+                    :save_trigger_results
 
       alias_attribute :container_id, :nfs_store_container_id
 
@@ -137,6 +138,7 @@ module NfsStore
 
         return unless parent_item&.can_edit?
 
+        self.save_trigger_results ||= {}
         extra_options_config.calc_save_trigger_if self, alt_on: :upload
       end
 

--- a/app/models/option_configs/extra_options.rb
+++ b/app/models/option_configs/extra_options.rb
@@ -668,7 +668,7 @@ module OptionConfigs
       # Ensure we don't include extra_options defaults twice
       return content_to_update if force_type.nil? && new_force_type == 'extra_options'
 
-      force_type = new_force_type
+      force_type ||= new_force_type
 
       defsw = [
         'app',

--- a/app/models/option_configs/extra_options.rb
+++ b/app/models/option_configs/extra_options.rb
@@ -452,6 +452,7 @@ module OptionConfigs
       configs = []
 
       if config_text.present?
+        config_text = config_text.sub("---\n", '')
         config_text = prepend_standard_definitions(config_text)
         config_text = include_libraries(config_text)
         begin

--- a/app/views/admin/app_configurations/_form.html.erb
+++ b/app/views/admin/app_configurations/_form.html.erb
@@ -17,10 +17,6 @@
 
     <%= big_select_field(f, :name, Admin::AppConfiguration.configuation_meanings)%>
   </div>
-  <div class="form-group app-configuration-value-block">
-    <%= f.label :value %>
-    <%= f.text_area :value %>
-  </div>
   <div class="form-group">
     <%= f.label :role_name, 'Role name override' %>
     <%
@@ -36,6 +32,12 @@
     <%= f.label :user_id, 'User override' %>
     <%= f.select :user_id, active_user_options, include_blank: true %>
   </div>
+
+  <div class="form-group app-configuration-value-block">
+    <%= f.label :value %>
+    <%= f.text_area :value %>
+  </div>
+  
   <div class="form-group">
     <%= f.check_box :disabled %>
     <%= f.label :disable %>

--- a/app/views/admin/common_templates/_form.html.erb
+++ b/app/views/admin/common_templates/_form.html.erb
@@ -27,7 +27,13 @@
         test_assoc_ids = nil if test_assoc_ids == p.to_s
         test_assoc = nil if test_assoc_ids == test_assoc || test_assoc == p.to_s
 
-        next if respond_to?(:hide_edit_fields) && hide_edit_fields.include?(p.to_sym)
+        next if respond_to?(:hide_edit_fields) && hide_edit_fields.include?(p.to_sym)      
+        if false && test_assoc && test_assoc != 'app_type' && object_instance.respond_to?(test_assoc) 
+      %>
+        <%= f.hidden_field p %>
+      <% 
+          next
+        end 
       %>
       <div class="form-group" data-out-attr-name="<%= p %>" data-out-object-name="<%= object_instance.class.name.ns_underscore %>">
       <% if col_type == :boolean %>
@@ -66,9 +72,6 @@
       <% elsif respond_to?("#{p}_big_select") %>
         <%= form_field_label(f, p) %>
         <%= big_select_field(f, p, send("#{p}_big_select")) %>
-      <% elsif test_assoc && object_instance.respond_to?(test_assoc) %>
-        <%= f.hidden_field p %>
-
       <% elsif p == :disabled %>
         <%= f.check_box p %>
         <%= form_field_label(f, p) %>

--- a/app/views/admin/external_identifier_details/_index.erb
+++ b/app/views/admin/external_identifier_details/_index.erb
@@ -9,6 +9,7 @@
     <p>Unassigned IDs: <span><%=@unassigned_count%></span></p>
     <% end %>
     <h3>Reports</h3>
+    <p><%=link_to "Search for ID", report_path(id: @external_identifier.usage_report('Search', ExternalIdentifier::ReportItemSearchType, as_alt_resource_name: true)) %></p>
     <p><%=link_to "Assigned IDs", admin_external_identifier_detail_path(id: @external_identifier.id, do: :report, rep_type: 'Assigned') %>
     <% if @external_identifier.pregenerate_ids %>
       <p><%=link_to "Unassigned IDs", admin_external_identifier_detail_path(id: @external_identifier.id, do: :report, rep_type: 'Unassigned') %>
@@ -18,7 +19,7 @@
       <p><%=link_to "Generate IDs and assign them to all Master Records without an existing assignment", new_admin_external_identifier_detail_path(id: @external_identifier.id, all_master_records: true) %>
       
     <% end %>
-      
+    <h3>Configuration</h3>  
     <p><%=link_to "Configure External Identifier", admin_external_identifiers_path(filter: {name: @external_identifier.name})%></p>
   </div>
 </div>

--- a/app/views/admin/external_identifiers/_def_details.html.erb
+++ b/app/views/admin/external_identifiers/_def_details.html.erb
@@ -16,8 +16,12 @@
   </p>
 
   <label>identifier records</label>
-  <p><%=link_to link_label_open_in_new('create identifiers and view counts'), "/admin/external_identifier_details/#{object_instance.id}", target: '_blank' %></p>
-  <p><%= link_to link_label_open_in_new('search data'), "/reports/reference_data__table_data?schema_name=#{object_instance.schema_name}&search_attrs%5B_blank%5D=true&search_attrs%5Bno_run%5D=true&table_name=#{object_instance.table_name}", 
+  <p><%= link_to link_label_open_in_new('create identifiers and view counts'), "/admin/external_identifier_details/#{object_instance.id}", target: '_blank' %></p>
+  <p><%= link_to link_label_open_in_new('list data'), 
+                "/reports/reference_data__table_data?schema_name=#{object_instance.schema_name}&search_attrs%5B_blank%5D=true&search_attrs%5Bno_run%5D=true&table_name=#{object_instance.table_name}", 
+                target: '_blank' %></p>
+  <p><%= link_to link_label_open_in_new('search identifier'), 
+                report_path(id: @external_identifier.usage_report('Search', ExternalIdentifier::ReportItemSearchType, as_alt_resource_name: true)),
                 target: '_blank' %></p>
   <%= render partial: 'admin/dynamic_models/est_record_count' %>
   <%= render partial: 'admin/dynamic_models/check_tracker_updates' %>

--- a/app/views/admin/external_identifiers/_def_details.html.erb
+++ b/app/views/admin/external_identifiers/_def_details.html.erb
@@ -9,11 +9,31 @@
   <p class="dynamic-item-type">
   <%= object_instance.full_item_type_name %>
   </p>
-
-  <label>fields</label>
-  <p class="dynamic-field-list">
-  <code><%= object_instance.all_implementation_fields.join("</code> <code>").html_safe %></code>
+  <label>resource name</label>
+  <p class="dynamic-resource-name">
+  <%= object_instance.resource_name %>
   </p>
+
+<label>database <%= object_instance.table_or_view || '<span class="info-danger">not defined</span>'.html_safe %></label>
+  <%
+    schema_name = object_instance.schema_name.presence || object_instance.schema_name_in_db
+  %>
+  <p>
+    <code><%= [schema_name, object_instance.table_name].compact.join('.') %></code>
+  </p>
+  
+  <% if object_instance.schema_name.blank? %>
+    <p>The schema name is not specified in the definition.</p>
+    <p>The assumed schema name from the database is: <code><%= object_instance.schema_name_in_db %></code>
+  <% elsif object_instance.schema_name != object_instance.schema_name_in_db %>
+  <div class="config-error-block">
+    <p>The schema name in the definition <code><%=object_instance.schema_name%></code> does not match the schema the database is using for the table <code><%= object_instance.schema_name_in_db %></code></p>
+  </div>
+  <div class="help-block">
+    <p>You should consider correcting the schema name in the definition, or checking and moving the table in the database.</p>
+  </div>
+  <% end %>
+
 
   <label>identifier records</label>
   <p><%= link_to link_label_open_in_new('create identifiers and view counts'), "/admin/external_identifier_details/#{object_instance.id}", target: '_blank' %></p>
@@ -25,6 +45,12 @@
                 target: '_blank' %></p>
   <%= render partial: 'admin/dynamic_models/est_record_count' %>
   <%= render partial: 'admin/dynamic_models/check_tracker_updates' %>
+
+
+  <label>fields</label>
+  <ul class="activity-list">
+    <%= sortable_block "#external_identifier_extra_fields", "li" %>
+  </ul>
 
 
   <% unless object_instance.table_or_view_ready?%>

--- a/app/views/admin/external_identifiers/_form_info.html.erb
+++ b/app/views/admin/external_identifiers/_form_info.html.erb
@@ -3,6 +3,7 @@
   <!-- Nav tabs -->
   <ul class="nav nav-tabs" role="tablist">
     <li role="presentation" class="active"><a href="#def-details-block" aria-controls="def-details-block" role="tab" data-toggle="tab">Details</a></li>
+    <li role="presentation"><a href="#sample-form" aria-controls="sample-form" role="tab" data-toggle="tab">Sample Form</a></li>
     <li role="presentation"><a href="#user-access-controls" aria-controls="user-access-controls" role="tab" data-toggle="tab">User Access Controls</a></li>
   </ul>
 
@@ -12,6 +13,11 @@
     <div role="tabpanel" class="tab-pane active" id="def-details-block">
       <h4>Details</h4>
       <%= render partial: 'admin/external_identifiers/def_details', locals: {object_instance: object_instance} %>
+    </div>
+
+    <div role="tabpanel" class="tab-pane" id="sample-form">
+      <h4>Sample Form</h4>
+      <%= render partial: 'admin/dynamic_models/sample_form', locals: {object_instance: object_instance} %>
     </div>
 
     <div role="tabpanel" class="tab-pane  on-open-click" id="user-access-controls">

--- a/app/views/common_templates/_search_results_template.html.erb
+++ b/app/views/common_templates/_search_results_template.html.erb
@@ -112,6 +112,8 @@
     edit_button_href = "{{#if master_id}}/masters/{{master_id}}{{/if}}/#{name.pluralize}/{{this.id}}/edit"
   end
 
+  edit_button_href = edit_button_href&.html_safe
+
   # with_data provides an alternatively named set of data for a template to use, rather than just the name
   # this is useful when providing multiple templates that should use the same set of data on a single page
   unless defined? with_data

--- a/app/views/masters/_master_panels.html.erb
+++ b/app/views/masters/_master_panels.html.erb
@@ -5,7 +5,7 @@
 </script>
 
 <script id="master_external_ids_panel" type="text/x-handlebars-template" class="hidden handlebars-partial">
-    <div class="row panel-body panel-with-sublists external-ids-panel">
+    <div class="row panel-body panel-with-sublists external-ids-panel reorder-sublist-columns">
       <div class="on-open-click hidden">
       <%  external_id_types.each do |e|%>
         <% if master_viewables[e.plural_name.to_sym] %>

--- a/app/views/masters/search.html.erb
+++ b/app/views/masters/search.html.erb
@@ -12,8 +12,8 @@
       <%= hidden_field_tag :mode, "MSID" %>
       <div class="form-group col-sm-3">
         <%= f.text_field :id, id: 'simple_m_id', class: 'form-control', min: 0, value: @master_id %>
-        <%= f.text_field 'external_id[id]', id: 'simple_external_id_id', class: 'form-control', min: 0, value: @ext_id %>
-        <%= f.text_field 'external_id[field]', id: 'simple_external_id_field', class: 'form-control', min: 0, value: @ext_field %>
+        <%= text_field_tag 'master[external_id][id]', @ext_id, id: 'simple_external_id_id', class: 'form-control', min: 0 %>
+        <%= text_field_tag 'master[external_id][field]', @ext_field, id: 'simple_external_id_field', class: 'form-control', min: 0 %>
       </div>
     <%= f.submit :search, id: 'msid_search_reg', class: "btn btn-default btn-sm pull-right auto-submitter #{@master_req_format == 'reg' ? 'run-master-search' : ''}" %>
     <%= f.submit "csv", id: 'msid_search_csv', name: :format, value: "csv", class: "btn btn-default pull-right btn-sm #{@master_req_format == 'csv' ? 'run-master-search' : ''}" %>

--- a/app/views/reports/criteria/_count_block.html.erb
+++ b/app/views/reports/criteria/_count_block.html.erb
@@ -1,3 +1,3 @@
-<% if @report.report_type != 'count' && !@view_options&.hide_result_count%>
-  <span class="search_count_reports search-results-count pull-right" data-sub-item="count" data-template="search-count-template" ></span>
+<% if !@view_options&.hide_result_count%>
+  <span class="search_count_reports search-results-count pull-right" data-report-count="<%= @report.report_type %>" data-sub-item="count" data-template="search-count-template" ></span>
 <%end%>

--- a/app/views/trackers/_search_results_template.html.erb
+++ b/app/views/trackers/_search_results_template.html.erb
@@ -9,7 +9,7 @@
       </td>
       {{#filter this "protocol_name,sub_process_name,event_name,event_date,notes" }}
       <td class="tracker-{{@key}}" {{#is @key 'event_name'}}data-event-id="{{../protocol_event_id}}"{{/is}}>
-      <div class="cell-holder">{{#if this}}{{#is @key 'notes'}}{{this}}{{else}}{{pretty_string this  return_string="true" capitalize="true"}}{{/is}}{{/if}}
+      <div class="cell-holder">{{#if this}}{{#is @key 'in' 'notes,protocol_name'}}{{this}}{{else}}{{pretty_string this  return_string="true" capitalize="true"}}{{/is}}{{/if}}
       {{#is @key 'event_name'}}
       {{#if ../record_id}} <a href="#{{hyphenate ../record_type_us}}-{{../master_id}}-{{../record_id}}" data-record-type="{{../record_type_us}}" class="glyphicon glyphicon-paperclip tracker-link-to-item" title="jump to this {{humanize (replace ../record_type_us 'dynamic_model_' '')}}" data-master-id="{{../master_id}}" data-record-id="{{../record_id}}" data-call-if-needed="postprocessors_activity_logs.open_{{../record_type_us}}"></a>{{/if}}
       {{/is}}

--- a/docs/admin_reference/protocols/0_introduction.md
+++ b/docs/admin_reference/protocols/0_introduction.md
@@ -46,7 +46,7 @@ changed. This allows the protocols to appear as:
 
 - protocol position value
 - protocol name
-- latest entry
+- latest entry date
 
 ## Adding Sub Processes to a Protocol
 

--- a/spec/models/calc_actions/calculate_spec.rb
+++ b/spec/models/calc_actions/calculate_spec.rb
@@ -2920,6 +2920,23 @@ RSpec.describe 'Calculate conditional actions', type: :model do
       expect(res).to eq @alref
     end
 
+    it 'returns a master.id when looking up MSID in the crosswalk' do
+      msid = (Master.all.order(msid: :desc).first&.msid || 10) + 1
+      new_master = Master.create!(msid: msid, current_user: @alref2.user)
+      conf = {
+        masters: {
+          msid: msid,
+          id: 'return_value'
+        },
+        no_masters: {}
+      }
+
+      ca = ConditionalActions.new conf, @alref2
+
+      res = ca.get_this_val
+      expect(res).to eq new_master.id
+    end
+
     it 'returns the first record referring to this one' do
       conf = {
         referring_record: {

--- a/spec/support/nfs_store_support.rb
+++ b/spec/support/nfs_store_support.rb
@@ -83,7 +83,7 @@ module NfsStoreSupport
     t = '<html><head><style>body {font-family: sans-serif;}</style></head><body><h1>Test Email</h1><div>{{main_content}}</div></body></html>'
     @layout = Admin::MessageTemplate.create! name: 'test email layout upload', message_type: :email, template_type: :layout, template: t, current_admin: @admin
 
-    t = '<p>This is some content.</p><p>Related to master_id {{master_id}}. This is a name: {{select_who}}.</p>'
+    t = '<p>This is some content.</p><p>Related to master_id {{master_id}}. This is a name: {{user.first_name}}.</p>'
     @content = Admin::MessageTemplate.create! name: 'test email content upload', message_type: :email, template_type: :content, template: t, current_admin: @admin
 
     @aldef.extra_log_types = <<~ENDDEF
@@ -377,9 +377,9 @@ module NfsStoreSupport
     create_filter('.*', resource_name: "activity_log__player_contact_phone__#{activity}", role_name: nil)
   end
 
-  def upload_file(filename = 'test-name.txt', content = nil)
+  def upload_file(filename = 'test-name.txt', content = nil, upload_set: nil)
     content ||= SecureRandom.hex
-    upload_set = SecureRandom.hex
+    upload_set ||= SecureRandom.hex
     md5tot = Digest::MD5.hexdigest(content)
     ioupload = StringIO.new(content)
 


### PR DESCRIPTION
## From FPHS - 2025-01-20

- [Fixed] issue with standard definitions for extra options
- [Fixed] the use of masters resource name when using no_masters to lookup a crosswalk identifier
- [Fixed] broken log filename in some environments
- [Fixed] Zeus Advanced Search protocol not having a sub process query fails with SQL syntax error - fixes #438
- [Added] sample form to external identifiers admin panel
- [Added] fields sorter to external identifiers admin panel
- [Added] resource name value to external identifiers admin panel
- [Fixed] report  count button not working - fixes #439
- [Added] link from external identifier details panel to pregenerated search report - fixes #377
- [Changed] ordering of external identifier master panel based on size - fixes #390
- [Fixed] incorrect URL for editing file classification record
- [Fixed] error running notify after uploading files
- [Added] save_trigger_results to notify
- [Fixed] spring stop in parallel test
- [Fixed] admin forms with dependent fields not setting up on load
- [Fixed] admin forms display
- [Fixed] tracker, protocol column shows with titelized case, rather than original entry - fixes #433
- [Changed] use of `@import` in SCSS files to use `@use` without a namespace - fixes #436
- [Fixed] Zeus toolbar search broken after upgrade to Rails 7 - fixes #437
- [Fixed] a crosswalk error when requested master records don't match
- [Fixed] incorrect documentation for tracker sorter options
- [Fixed] failure of table lists to be rendered
- [Fixed] dynamic options standard definitions not being preprended correctly
- [Fixed] handling of legacy otp for 2FA
