### PR TITLE
Pr fix js substitutions

### DIFF
--- a/app/assets/javascripts/app/_fpa_substitution.js
+++ b/app/assets/javascripts/app/_fpa_substitution.js
@@ -25,6 +25,7 @@ _fpa.substitution = class {
       new_data = Object.assign({}, data);
 
       //  Set user_preference and current_user_roles in the data for possible substitution
+      _fpa.state.current_user = _fpa.state.current_user || {}
       if (!new_data.user_preference) new_data.user_preference = _fpa.state.current_user_preference;
       if (!new_data.current_user) new_data.current_user = _fpa.state.current_user;
       if (!new_data.current_user_id) new_data.current_user_id = _fpa.state.current_user.id;
@@ -151,6 +152,11 @@ _fpa.substitution = class {
           tag_value = vpair[0];
           if (tag_value && tag_value.toString().length) sub_text = if_block[6] || '';
         }
+
+        //  Handle {{else}}
+        if (sub_text == null)
+          sub_text = if_block[8] || ''
+
         text = text.replace(block_container, sub_text || '');
       });
     }

--- a/app/views/common_templates/_edit_form.html.erb
+++ b/app/views/common_templates/_edit_form.html.erb
@@ -270,6 +270,13 @@
 
         <% end # item_list.each %>
 
+        <%
+          if form_object_instance.respond_to? :user_id
+        %>
+          <%= form.hidden_field :user_id, data: { attr_name: :user_id, object_name: form_object_item_type_us } %>
+        <%
+          end
+        %>
         <% unless embedded %>
           <% unless view_options[:show_embedded_at_top]  %>
           <%= render partial: 'common_templates/edit_form_references', locals: {embedded: embedded, form_embed: form_embed} %>


### PR DESCRIPTION
### From FPHS - 2025-01-27

- [Fixed] error handling `{{else}}` in front end evaluation of substitutions (such as show_if)
- [Fixed] missing user_id in forms passing to data for show_if
