### PR TITLE
Pr extend config trigger

### DIFF
--- a/app/models/admin/defs/config_trigger_options_defs.yaml
+++ b/app/models/admin/defs/config_trigger_options_defs.yaml
@@ -1,41 +1,41 @@
 # Config Trigger options      
-      create_defaults:
-      # Specify one or more of the following options to automatically set them up during definition
-        user_access_control:
-        # Create default user controls (and role for this admin user) to allow this resource
-        # and any embed to be created
-          role_name: optional role name
-          # If excluded the default role name will be `user - <category>`
-          access: create|update|read
-          # Default is create
-        embed:
-        # Create a default embed dynamic model. No fields need to be specified, and leaving the configuration without
-        # a `fields` key will prevent future updates the configuration
-          fields:
-            - status
-            - notes
-          allow_reconfiguration: nil (default) | true
-            # Allow reconfiguration with the specified fields  
-          prefix_config_libraries: string | array
-            # Either a `<category> <name>` pair for a library
-            # or a list of libraries in this format
-            # This will be added to the options, unless the embed already exists with non-blank options
-        page_layout:
-        # Create a master page layout for this definition resource.
-      create_configs:
-      # Create configs for any type of additional definition. This follows the format of an app type export.
-        associated_general_selections:
-          - name: Not Started
-            value: not started
-            item_type: '{{default_embed_resource_name}}_status'
-            position: 1600
-          - name: Pending
-            value: pending
-            item_type: #{rn}_status
-            position: 1601
-          - name: In Progress
-            value: in progress
-            item_type: #{rn}_status
-            position: 1602
+      - create_defaults:
+        # Specify one or more of the following options to automatically set them up during definition
+          user_access_control:
+          # Create default user controls (and role for this admin user) to allow this resource
+          # and any embed to be created
+            role_name: optional role name
+            # If excluded the default role name will be `user - <category>`
+            access: create|update|read
+            # Default is create
+          embed:
+          # Create a default embed dynamic model. No fields need to be specified, and leaving the configuration without
+          # a `fields` key will prevent future updates the configuration
+            fields:
+              - status
+              - notes
+            allow_reconfiguration: nil (default) | true
+              # Allow reconfiguration with the specified fields  
+            prefix_config_libraries: string | array
+              # Either a `<category> <name>` pair for a library
+              # or a list of libraries in this format
+              # This will be added to the options, unless the embed already exists with non-blank options
+          page_layout:
+          # Create a master page layout for this definition resource.
+      - create_configs:
+        # Create configs for any type of additional definition. This follows the format of an app type export.
+          associated_general_selections:
+            - name: Not Started
+              value: not started
+              item_type: '{{default_embed_resource_name}}_status'
+              position: 1600
+            - name: Pending
+              value: pending
+              item_type: #{rn}_status
+              position: 1601
+            - name: In Progress
+              value: in progress
+              item_type: #{rn}_status
+              position: 1602
 
         

--- a/app/models/dynamic/def_config_triggers.rb
+++ b/app/models/dynamic/def_config_triggers.rb
@@ -37,9 +37,9 @@ module Dynamic
     end
 
     def handle_all_option_configs
-      option_configs.each do |option_config|
-        create_defaults(option_config)
-        create_configs(option_config)
+      option_configs.each do |option_config|        
+        create_defaults( option_config)
+        create_configs( option_config)
       end
     rescue StandardError => e
       Rails.logger.warn e
@@ -50,19 +50,35 @@ module Dynamic
 
     private
 
-    def create_defaults(option_config)
+    def on_defines(option_config)
       config_trigger = option_config&.config_trigger
-      return unless config_trigger
+        return [] unless config_trigger
 
-      config = config_trigger.dig(:on_define, :create_defaults)
-      return unless config
-
-      setup config
-      create_role_for_admin_matching_user(config, option_config)
-      create_default_user_access_controls(config, option_config)
-      create_default_embed(config, option_config)
-      create_activity_log_page_layout(config, option_config)
+        config_trigger[:on_define]
     end
+
+    def create_defaults(option_config)
+      on_defines(option_config).each do |on_define|
+        config = on_define[:create_defaults]
+        next unless config
+
+        setup config
+        create_role_for_admin_matching_user(config, option_config)
+        create_default_user_access_controls(config, option_config)
+        create_default_embed(config, option_config)
+        create_activity_log_page_layout(config, option_config)
+      end
+    end
+
+    def create_configs(option_config)      
+      on_defines(option_config).each do |on_define|
+        config = on_define[:create_configs]
+        next unless config
+
+        create_config(config)
+      end      
+    end
+
 
     def setup(config)
       uac = config[:user_access_control] || {}
@@ -203,11 +219,7 @@ module Dynamic
       Admin::PageLayout.create! cond
     end
 
-    def create_configs(option_config)
-      config_trigger = option_config&.config_trigger
-      return unless config_trigger
-
-      config = config_trigger.dig(:on_define, :create_configs)
+    def create_config(config)
       return nil unless config
 
       subdata = if dynamic_def_type == :activity_log

--- a/app/models/dynamic/def_config_triggers.rb
+++ b/app/models/dynamic/def_config_triggers.rb
@@ -38,8 +38,8 @@ module Dynamic
 
     def handle_all_option_configs
       option_configs.each do |option_config|        
-        create_defaults( option_config)
-        create_configs( option_config)
+        create_defaults(option_config)
+        create_configs(option_config)
       end
     rescue StandardError => e
       Rails.logger.warn e
@@ -75,7 +75,7 @@ module Dynamic
         config = on_define[:create_configs]
         next unless config
 
-        create_config(config)
+        create_config(config, option_config)
       end      
     end
 
@@ -219,7 +219,7 @@ module Dynamic
       Admin::PageLayout.create! cond
     end
 
-    def create_config(config)
+    def create_config(config, option_config)
       return nil unless config
 
       subdata = if dynamic_def_type == :activity_log

--- a/app/models/option_configs/extra_options.rb
+++ b/app/models/option_configs/extra_options.rb
@@ -420,9 +420,10 @@ module OptionConfigs
 
     def clean_config_triggers
       self.config_trigger ||= {}
-      self.config_trigger = self.config_trigger.symbolize_keys
-      self.config_trigger = self.config_trigger.symbolize_keys
-      self.config_trigger[:on_define] ||= {}
+      self.config_trigger = self.config_trigger.symbolize_keys      
+      od = self.config_trigger[:on_define] ||= []
+
+      self.config_trigger[:on_define] = [od] unless od.is_a?(Array)
     end
 
     def clean_preset_fields


### PR DESCRIPTION
### From FPHS - 2025-01-29

- [Added] ability to define config_trigger.on_define as an array, allowing multiple similar configurations
   to be added (for example user access controls) for each activity
