### PR TITLE
Added simplified `with: <String>` option to define item to use in a trigger

### DIFF
--- a/app/models/admin/defs/extra_options_defs.yaml
+++ b/app/models/admin/defs/extra_options_defs.yaml
@@ -180,6 +180,8 @@
     with_result: 
     # Map attributes from a related item to the target item.
     # NOTE: with: fields override any specified here
+    # from: may also just take a simple String such as `from: embedded_item` to
+    # as shorthand for the following full calculation
       from:
         embedded_item:
           return: return_result

--- a/app/models/admin/defs/save_triggers_create_reference_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_create_reference_options_defs.yaml
@@ -16,6 +16,8 @@
             with_result: 
             # Map attributes from a related item to the target item.
             # NOTE: with: fields override any specified here
+            # from: may also just take a simple String such as `from: embedded_item` to
+            # as shorthand for the following full calculation            
               from:
                 embedded_item:
                   return: return_result

--- a/app/models/admin/defs/save_triggers_update_reference_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_update_reference_options_defs.yaml
@@ -30,6 +30,8 @@
             with_result: 
             # Map attributes from a related item to the target item.
             # NOTE: with: fields override any specified here
+            # from: may also just take a simple String such as `from: embedded_item` to
+            # as shorthand for the following full calculation            
               from:
                 embedded_item:
                   return: return_result

--- a/app/models/admin/defs/save_triggers_update_this_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_update_this_options_defs.yaml
@@ -8,6 +8,8 @@
             with_result: 
             # Map attributes from a related item to the target item.
             # NOTE: with: fields override any specified here
+            # from: may also just take a simple String such as `from: embedded_item` to
+            # as shorthand for the following full calculation            
               from:
                 embedded_item:
                   return: return_result

--- a/app/models/save_triggers/save_triggers_base.rb
+++ b/app/models/save_triggers/save_triggers_base.rb
@@ -48,7 +48,16 @@ class SaveTriggers::SaveTriggersBase
     with_results = [with_results] unless with_results.is_a? Array
 
     with_results.each do |with_result|
-      ca = ConditionalActions.new with_result[:from], @item
+      wr_from = with_result[:from]
+
+      # Allow simple use of 'embedded_item' or 'dynamic_model__some_recs'
+      if wr_from.is_a? String
+        wr_from = {
+          wr_from.to_sym => { return: return_result }
+        }
+      end
+
+      ca = ConditionalActions.new wr_from, @item
       source = ca.get_this_val
 
       unless source


### PR DESCRIPTION
### From FPHS - 2025-01-30

- [Added] simplified `with: <String>` option to define item to use in a trigger