### PR TITLE
Fixed rubocop line length cop for new naming

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: true
   Max: 120
   Include:


### PR DESCRIPTION
### From FPHS - 2025-01-30

- [Fixed] rubocop line length cop for new naming