### PR TITLE
Fixed log filename breaking Rails server log search

### DIFF
--- a/app/models/admin/server_info.rb
+++ b/app/models/admin/server_info.rb
@@ -14,8 +14,8 @@ class Admin::ServerInfo
   ].freeze
 
   # Attempt to get the filename of the log from logger. If not, attempt to force it.
-  LogFilename = Rails.logger.instance_variable_get('@logdev')&.filename ||
-                Rails.root.join('log', "#{Rails.env}.log")
+  LogFilename = Rails.logger.instance_variable_get('@logdev')&.filename&.to_s ||
+                Rails.root.join('log', "#{Rails.env}.log").to_s
 
   attr_accessor :current_admin
 


### PR DESCRIPTION
### From Viva - 2025-01-30

- [Fixed] log filename breaking Rails server log search