### PR TITLE
Fixed failure to retrieve production.log due to Pathname

### DIFF
--- a/app/models/admin/server_info.rb
+++ b/app/models/admin/server_info.rb
@@ -101,7 +101,7 @@ class Admin::ServerInfo
     trailing_context = trailing_context.to_i
 
     cmds = [
-      ['tail', '-n', tail_length.to_s, logfilename],
+      ['tail', '-n', tail_length.to_s, logfilename.to_s],
       ['tac'],
       ['grep', '-m', max_count.to_s, "--before-context=#{trailing_context}", '-E', regex],
       ['tac']


### PR DESCRIPTION
### From FPHS - 2025-03-12

- [Fixed] failure to retrieve production.log due to Pathname
