### PR TITLE
Pr UI fixes

### DIFF
--- a/app/assets/javascripts/app/_fpa_form_utils.js
+++ b/app/assets/javascripts/app/_fpa_form_utils.js
@@ -1016,6 +1016,27 @@ _fpa.form_utils = {
       }).addClass('attached-hash-caret-target');
 
     block
+      .find('a[href*="add-activity-button-"]')
+      .not('.attached-add-activity-button')
+      .on('click', function () {
+        const href = $(this).attr('href');
+        const re = new RegExp('add-activity-button-([^:]+)');
+        const matches = href.match(re);
+        if (!matches) return;
+
+        let target = matches[1];
+        if (!target) return;
+
+        target = `.activity-logs-header a.add-item-button[data-extra-log-type="${target}"]`;
+
+        var $target = $(this).parents('.activity-logs-generic-block').find(target);
+
+        if ($target.is(':visible')) {
+          $target.click();
+        }
+      }).addClass('attached-add-activity-button');
+
+    block
       .find('[data-toggle~="clear"]')
       .not('.attached-datatoggle-clear')
       .on('click', function () {

--- a/app/assets/javascripts/app/_fpa_form_utils.js
+++ b/app/assets/javascripts/app/_fpa_form_utils.js
@@ -1018,7 +1018,9 @@ _fpa.form_utils = {
     block
       .find('a[href*="add-activity-button-"]')
       .not('.attached-add-activity-button')
-      .on('click', function () {
+      .each(function () {
+        var _this = this;
+        var $this = $(this);
         const href = $(this).attr('href');
         const re = new RegExp('add-activity-button-([^:]+)');
         const matches = href.match(re);
@@ -1029,11 +1031,16 @@ _fpa.form_utils = {
 
         target = `.activity-logs-header a.add-item-button[data-extra-log-type="${target}"]`;
 
-        var $target = $(this).parents('.activity-logs-generic-block').find(target);
-
-        if ($target.is(':visible')) {
-          $target.click();
-        }
+        window.setTimeout(function () {
+          var $target = $this.parents('.activity-logs-generic-block').find(target);
+          var disabled = $target.length === 0 || !$target.is(':visible');
+          $this.attr('disabled', disabled);
+          _this.add_activity_button = $target;
+        }, 1000)
+      })
+      .on('click', function () {
+        const $target = this.add_activity_button;
+        if ($target.is(':visible')) $target.click();
       }).addClass('attached-add-activity-button');
 
     block

--- a/app/assets/javascripts/app/_fpa_substitution.js
+++ b/app/assets/javascripts/app/_fpa_substitution.js
@@ -260,7 +260,7 @@ _fpa.substitution = class {
 
     if (exp) {
       const exp_length = exp.length;
-      if (exp_length > 1 && exp[0].match(/#{StartQuote}/) && exp[exp_length - 1].match(/#{EndQuote}/)) {
+      if (exp_length > 1 && exp[0].match(new RegExp(StartQuote)) && exp[exp_length - 1].match(new RegExp(EndQuote))) {
         exp = exp.slice(1, exp_length - 1);
       }
       else if (exp.toLowerCase() == 'null') {

--- a/app/assets/javascripts/app/_fpa_utils.js
+++ b/app/assets/javascripts/app/_fpa_utils.js
@@ -271,12 +271,12 @@ _fpa.utils.capitalize = function (str) {
 _fpa.utils.nl2br = function (text) {
   text = Handlebars.Utils.escapeExpression(text);
   var nl2br = (text + '').replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1' + '<br>' + '$2');
-  return new Handlebars.SafeString(nl2br);
+  return nl2br;
 };
 
 _fpa.utils.remove_tags = function (text) {
   var stre = (text + '').replace(/(\<[a-zA-Z0-9\s-=_"']+\/?\>)/g, '');
-  return new Handlebars.SafeString(stre);
+  return stre;
 };
 
 String.prototype.capitalize = function () {

--- a/app/assets/javascripts/app/handlebars-helpers.js
+++ b/app/assets/javascripts/app/handlebars-helpers.js
@@ -270,7 +270,8 @@
   });
 
   Handlebars.registerHelper('nl2br', function (text) {
-    return _fpa.utils.nl2br(text);
+    var nl2br = _fpa.utils.nl2br(text);
+    return new Handlebars.SafeString(nl2br)
   });
 
   Handlebars.registerHelper('quoteattr', function (text) {
@@ -462,7 +463,8 @@
 
   Handlebars.registerHelper('pretty_string', function (stre, options) {
     if (options && !options.hash) options.hash = {};
-    return _fpa.utils.pretty_print(stre, options.hash);
+    stre = _fpa.utils.pretty_print(stre, options.hash);
+    return new Handlebars.SafeString(stre)
   });
 
 

--- a/app/assets/stylesheets/app/forms.css.scss
+++ b/app/assets/stylesheets/app/forms.css.scss
@@ -301,6 +301,15 @@ a.add-icon {
   }
 }
 
+.attached-add-activity-button[disabled='disabled'] {
+    color: gray;
+    &:hover,
+    &:active,
+    &:link {
+      color: gray;     
+    }
+}
+
 .advanced-form-selections {
   line-height: 2.8;
 


### PR DESCRIPTION
## From FPHS - 2025-02-12

- [Added] add-activity-button-<extra log type> as a link hash option for clicking activity log buttons in the current panel header
- [Changed add-activity-button-<extra log type> link hash to show as disabled if the panel activity button is not available
- [Fixed] `{{#is tag '===' 'string literal'}}` comparison due to bad quote matching
- [Fixed] broken view_with_formats for certain strings