### PR TITLE
Add missing documentation for use_plain_attribute_names report option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Since [version 8.4.0](#840---2024-01-10) the convention is that releases made wi
 
 ## Unreleased
 
+### From FPHS - PR #610 - 2025-07-02
+
+- [Added] missing documentation for use_plain_attribute_names report option - resolves #2
+
 ### From Viva - PR #602 - 2025-07-08
 
 - [Fixed] extra options references.filter_by to document that a Hash must return_value, and to test it works if there are no other conditions - fixes #601


### PR DESCRIPTION
Adds documentation for the use_plain_attribute_names option in report_options_defs.yaml that was missing from the configuration definitions.