### PR TITLE
Fixed using field default 'current_user_email' fails in a report criteria default when viewed within the admin panel - fixes #620

### DIFF
--- a/app/views/admin/reports/form/_admin_criteria_view.html.erb
+++ b/app/views/admin/reports/form/_admin_criteria_view.html.erb
@@ -1,4 +1,5 @@
 <% if object_instance.persisted? 
+    object_instance.current_user = current_user if current_user
     @runner = object_instance.runner
     @report = object_instance
     @view_options = @report.report_options(fail_without_exception: true)&.view_options


### PR DESCRIPTION
Fixed #620