### PR TITLE
Extend Rails log admin viewer with exclude field

### DIFF
--- a/app/controllers/admin/server_info_controller.rb
+++ b/app/controllers/admin/server_info_controller.rb
@@ -26,12 +26,14 @@ class Admin::ServerInfoController < AdminController
     si = Admin::ServerInfo.new(current_admin)
     @search = params[:search]
     @search = DateTime.now.iso8601[0..14].sub('T', '.') if @search.blank?
+    @exclude = params[:exclude]
     @trailing_context = params[:trailing_context]
     @trailing_context = 20 if params[:trailing_context].blank?
     # Make sure the regex is valid
     Regexp.new(@search)
+    Regexp.new(@exclude) unless @exclude.blank?
 
-    @rails_log = si.rails_log(@search, trailing_context: @trailing_context)
+    @rails_log = si.rails_log(@search, exclude: @exclude, trailing_context: @trailing_context)
     render 'admin/server_info/rails_log'
   end
 end

--- a/app/models/admin/server_info.rb
+++ b/app/models/admin/server_info.rb
@@ -127,16 +127,28 @@ class Admin::ServerInfo
     'server identifier not available'
   end
 
-  def rails_log(regex, max_count: 2000, tail_length: 10_000, trailing_context: 20)
+  def rails_log(regex, exclude: nil, max_count: 2000, tail_length: 10_000, trailing_context: 20)
     logfilename = LogFilename
     trailing_context = trailing_context.to_i
 
-    cmds = [
-      ['tail', '-n', tail_length.to_s, logfilename.to_s],
-      ['tac'],
-      ['grep', '-m', max_count.to_s, "--before-context=#{trailing_context}", '-E', regex],
-      ['tac']
-    ]
+    if exclude.present?
+      # Use awk with -v variables to safely pass patterns without injection risk
+      # Context lines can contain the exclude pattern (per requirement: "must not filter the following context lines")
+      awk_script = '{ lines[NR]=$0 } $0 ~ search && $0 !~ exclude { for(i=(NR-ctx<1?1:NR-ctx); i<NR; i++) if(lines[i]) print lines[i]; print; delete lines; count++; if(count>=max) exit }'
+      cmds = [
+        ['tail', '-n', tail_length.to_s, logfilename.to_s],
+        ['tac'],
+        ['awk', '-v', "search=#{regex}", '-v', "exclude=#{exclude}", '-v', "ctx=#{trailing_context}", '-v', "max=#{max_count}", awk_script],
+        ['tac']
+      ]
+    else
+      cmds = [
+        ['tail', '-n', tail_length.to_s, logfilename.to_s],
+        ['tac'],
+        ['grep', '-m', max_count.to_s, "--before-context=#{trailing_context}", '-E', regex],
+        ['tac']
+      ]
+    end
 
     pipe_chain = Utilities::ProcessPipes.new(cmds)
     pipe_chain.run

--- a/app/views/admin/server_info/rails_log.html.erb
+++ b/app/views/admin/server_info/rails_log.html.erb
@@ -2,28 +2,40 @@
   <div class="row well">
     <h2>Rails Log</h2>
     <%= form_with url: admin_server_info_rails_log_path, method: :get, class: 'form' do |f| %>
-    <div>
-    <%= f.label :search, 'search regex' %>
-    <%= f.text_field :search, value: @search, class: 'form-control', style: 'min-width: 500px' %>
+    <div class="form-group">
+      <%= f.label :search, 'search regex', class: 'control-label' %><br>
+      <%= f.text_field :search, value: @search, class: 'form-control', style: 'min-width: 500px' %>
     </div>
-    <div>
-    <%= f.label :trailing_context, 'trailing context lines' %>
-    <%= f.text_field :trailing_context, value: @trailing_context, class: 'form-control', style: 'min-width: 500px' %>
+    <div class="form-group">
+      <%= f.label :exclude, 'exclude regex (lines NOT containing)', class: 'control-label' %><br>
+      <%= f.text_field :exclude, value: @exclude, class: 'form-control', style: 'min-width: 500px' %>
     </div>
-    <div>
-    <%= f.button 'search' %>
+    <div class="form-group">
+      <%= f.label :trailing_context, 'trailing context lines', class: 'control-label' %><br>
+      <%= f.text_field :trailing_context, value: @trailing_context, class: 'form-control', style: 'min-width: 500px' %>
     </div>
-    
+    <div class="form-group">
+      <%= f.button 'search', class: 'btn btn-primary' %>
+    </div>
+    <div style="margin-top: 1em;">
+      <b>Common searches:</b>
+      <a href="?" class="btn btn-xs btn-info">Default</a>
+      <a href="?search=ERROR" class="btn btn-xs btn-info">ERROR</a>
+      <a href="?search=FATAL" class="btn btn-xs btn-info">FATAL</a>
+      <a href="?search=Completed.*500" class="btn btn-xs btn-info">500 errors</a>
+      <a href="?search=Started.*POST" class="btn btn-xs btn-info">POST requests</a>
+      <a href="?search=Completed.*200" class="btn btn-xs btn-info">200 responses</a>
+    </div>
     <% end %>
   </div>
 </div>
 
-<div class="container rails-log">
-  <div class="row">
-<code>
-<pre id="rails-log-listing">
-<%= @rails_log %>
-</pre>
-</code>
+<div class="container-fluid rails-log" style="width: 100vw; max-width: 100vw; padding: 0;">
+  <div class="row" style="margin: 0;">
+    <code style="width: 100vw; display: block; overflow-x: auto;">
+      <pre id="rails-log-listing" style="width: 100vw; overflow-x: auto; white-space: pre; margin-bottom: 0;">
+<%= @rails_log.to_s.sub(/^\s*\n/, '') %>
+      </pre>
+    </code>
   </div>
 </div>

--- a/spec/system/admin/server_info_rails_log_spec.rb
+++ b/spec/system/admin/server_info_rails_log_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Rails Log Viewer', js: true, type: :system do
+  include MasterSupport
+  include FeatureSupport
+
+  before(:all) do
+    change_setting('TwoFactorAuthDisabledForAdmin', true)
+    create_admin
+  end
+
+  before(:each) do
+    login_as(@admin, scope: :admin)
+  end
+
+  it 'shows the search, exclude, and context fields and common search links' do
+    visit '/admin/server_info/rails_log'
+    finish_page_loading
+
+    expect(page).to have_field('search regex')
+    expect(page).to have_field('exclude regex (lines NOT containing)')
+    expect(page).to have_field('trailing context lines')
+    expect(page).to have_button('search')
+    expect(page).to have_link('ERROR')
+    expect(page).to have_link('FATAL')
+    expect(page).to have_link('500 errors')
+    expect(page).to have_link('POST requests')
+    expect(page).to have_link('200 responses')
+  end
+
+  it 'returns log lines matching search and not matching exclude' do
+    # Ensure the test log file contains the expected lines
+    log_path = Rails.root.join('log', 'test.log')
+    log_lines = [
+      'Started GET "/test1" for 127.0.0.1 at 2026-01-19 12:00:00 +0000',
+      'Processing by TestController#index as HTML',
+      'Completed 200 OK in 10ms',
+      '',
+      'Started POST "/test2" for 127.0.0.1 at 2026-01-19 12:01:00 +0000',
+      'Processing by TestController#create as HTML',
+      'Completed 500 ERROR',
+      '',
+      'Started GET "/test3" for 127.0.0.1 at 2026-01-19 12:02:00 +0000',
+      'Processing by TestController#show as HTML',
+    ]
+    File.open(log_path, 'a') { |f| log_lines.each { |l| f.puts l } }
+
+    visit '/admin/server_info/rails_log?search=Started&exclude=POST&trailing_context=2'
+    finish_page_loading
+    log_text = find('#rails-log-listing', visible: true).text
+    if log_text.include?('log not available:')
+      raise "Log command failed: #{log_text}"
+    end
+    # Should include GET lines that match "Started" and don't contain POST
+    expect(log_text).to include('Started GET "/test1"')
+    expect(log_text).to include('Started GET "/test3"')
+    # Context lines for the GET matches should be included
+    expect(log_text).to include('Processing by TestController#index')
+    # The "Started POST" line should NOT appear as a primary match
+    # (it matches "Started" but is excluded because it contains POST)
+    # However, since there's a blank line separating it from GET requests,
+    # and trailing_context=2, it should NOT appear
+    expect(log_text).not_to include('Started POST')
+  end
+
+  it 'shows full width log output with horizontal scroll' do
+    visit '/admin/server_info/rails_log?search=ERROR'
+    finish_page_loading
+    log_pre = find('#rails-log-listing', visible: true)
+    expect(log_pre[:style]).to include('width: 100vw')
+  end
+
+  it 'safely handles regex patterns that could contain injection attempts' do
+    # Ensure malicious patterns are treated as literal regex, not executed
+    log_path = Rails.root.join('log', 'test.log')
+    log_lines = [
+      'Normal log line with GET',
+      'Another line',
+    ]
+    File.open(log_path, 'a') { |f| log_lines.each { |l| f.puts l } }
+
+    # Try to inject a command through the search or exclude pattern
+    malicious_search = 'GET/ { system("echo HACKED") } /fake'
+    visit "/admin/server_info/rails_log?search=#{CGI.escape(malicious_search)}&exclude=POST"
+    finish_page_loading
+    log_text = find('#rails-log-listing', visible: true).text
+    
+    # Should not contain any output from injected command
+    expect(log_text).not_to include('HACKED')
+    # Should treat the pattern as a literal regex (which won't match anything)
+    expect(log_text).not_to include('Normal log line with GET')
+  end
+end


### PR DESCRIPTION
Closes #751

## Summary
Added an exclude regex field to the Rails log admin viewer that filters primary matching lines while preserving context lines, along with UI improvements.

## Changes
- **Exclude field**: Added new field that excludes lines matching a regex pattern from primary search results, while preserving all context lines (even those containing the exclude pattern)
- **Security**: Implemented secure awk-based filtering using `-v` variables to prevent command injection
- **UI improvements**: 
  - Made results block full page width for horizontal scrolling
  - Added common search links (ERROR, FATAL, 500 errors, POST requests, 200 responses)
  - Improved form layout with proper labels and spacing
- **Test coverage**: Added comprehensive system specs including injection protection test

## Implementation Details
- Uses `awk` with `-v` variables to safely pass regex patterns without injection risk
- Context lines can contain the exclude pattern (per requirement: "must not filter the following context lines")
- Preserves existing grep-based behavior when no exclude pattern is provided

## Testing
- ✅ All 4 system specs pass
- ✅ All 7 model specs pass
- ✅ Injection protection verified
- ✅ UI and functionality tested