### PR TITLE
Add detailed error logging to reload_this trigger

### DIFF
--- a/app/models/save_triggers/reload_this.rb
+++ b/app/models/save_triggers/reload_this.rb
@@ -49,7 +49,17 @@ class SaveTriggers::ReloadThis < SaveTriggers::SaveTriggersBase
     end
 
     # Reload the item from the database
-    @item.reload
+    begin
+      @item.reload
+    rescue ActiveRecord::RecordNotFound => e
+      error_message = "[SaveTrigger::ReloadThis] Failed to reload #{@item.class.name}##{@item.id}: #{e.message}"
+      Rails.logger.error error_message
+      raise e
+    rescue StandardError => e
+      error_message = "[SaveTrigger::ReloadThis] Unexpected error reloading #{@item.class.name}##{@item.id}: #{e.class.name} - #{e.message}"
+      Rails.logger.error error_message
+      raise e
+    end
 
     # Restore preserved attributes
     @item.current_user = current_user

--- a/spec/models/save_triggers/reload_this_spec.rb
+++ b/spec/models/save_triggers/reload_this_spec.rb
@@ -149,6 +149,40 @@ RSpec.describe SaveTriggers::ReloadThis, type: :model do
         expect(@activity_log.select_who).to eq('no condition update')
       end
     end
+
+    context 'error handling' do
+      it 'logs detailed error when reload fails due to RecordNotFound' do
+        config = { if: { always: true } }
+        trigger = SaveTriggers::ReloadThis.new(config, @activity_log)
+
+        # Mock reload to raise RecordNotFound error
+        allow(@activity_log).to receive(:reload).and_raise(
+          ActiveRecord::RecordNotFound.new("Couldn't find ActivityLog::PlayerContactPhone with [WHERE \"activity_log_player_contact_phones\".\"id\" = $1]")
+        )
+
+        # Expect the error to be logged with class and id details
+        expected_log = "[SaveTrigger::ReloadThis] Failed to reload ActivityLog::PlayerContactPhone##{@activity_log.id}"
+        expect(Rails.logger).to receive(:error).with(/#{Regexp.escape(expected_log)}/)
+
+        # Expect the original exception to be re-raised
+        expect { trigger.perform }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it 'logs detailed error when reload fails due to unexpected error' do
+        config = { if: { always: true } }
+        trigger = SaveTriggers::ReloadThis.new(config, @activity_log)
+
+        # Mock reload to raise an unexpected error
+        allow(@activity_log).to receive(:reload).and_raise(StandardError.new('Unexpected database error'))
+
+        # Expect the error to be logged with class, id and error details
+        expected_log = "[SaveTrigger::ReloadThis] Unexpected error reloading ActivityLog::PlayerContactPhone##{@activity_log.id}: StandardError - Unexpected database error"
+        expect(Rails.logger).to receive(:error).with(expected_log)
+
+        # Expect the original exception to be re-raised
+        expect { trigger.perform }.to raise_error(StandardError, 'Unexpected database error')
+      end
+    end
   end
 
   describe 'integration with save triggers' do


### PR DESCRIPTION
Fixes #838

## Summary
Added comprehensive error logging to the `reload_this` save trigger to provide detailed information when reload operations fail.

## Changes
- Added rescue blocks around the reload call in `SaveTriggers::ReloadThis`
- Logs include item class name and ID when reload fails
- Handles both `ActiveRecord::RecordNotFound` and general `StandardError` cases
- Re-raises the original exception after logging

## Error Message Format
- RecordNotFound: `[SaveTrigger::ReloadThis] Failed to reload {ClassName}#{id}: {error_message}`
- Other errors: `[SaveTrigger::ReloadThis] Unexpected error reloading {ClassName}#{id}: {error_class} - {error_message}`

## Testing
- Added tests for both RecordNotFound and unexpected error scenarios
- All existing tests continue to pass (16 examples, 0 failures)