### PR TITLE
Fixed #216 - Recreate triggers when field types change in dynamic models

### DIFF
--- a/lib/active_record/migration/app_generator.rb
+++ b/lib/active_record/migration/app_generator.rb
@@ -665,7 +665,20 @@ module ActiveRecord
           changed_history.each do |k, v|
             v = map_migration_type_to_db_type(v)
             change_type = "#{v} using #{k}::#{v}"
-            change_column "#{schema}.#{table_name}", k, change_type
+            change_column "#{schema}.#{history_table_name}", k, change_type
+          end
+        end
+
+        # Recreate the trigger if any field types changed, since the trigger function
+        # needs to reflect the correct types for the fields being copied to history
+        if changed.present? || changed_history.present?
+          case resource_type
+          when :dynamic_model
+            create_dynamic_model_trigger
+          when :activity_log
+            create_activity_log_trigger
+          when :external_identifier
+            create_external_identifier_trigger
           end
         end
 

--- a/spec/models/option_configs/dynamic_model_options_spec.rb
+++ b/spec/models/option_configs/dynamic_model_options_spec.rb
@@ -568,4 +568,168 @@ RSpec.describe 'Dynamic Model Options', type: :model do
     expect(option_type_3.show_if[:field_to_show][:any][:embedded_item][:all][:embedded_score][:condition]).to eq('>=')
     expect(option_type_3.show_if[:field_to_show][:any][:embedded_item][:all][:embedded_score][:value]).to eq(10)
   end
+
+  # Test for GitHub issue #216: Field type changes in dynamic models
+  #
+  # This test verifies that when a field type is changed in a dynamic model configuration
+  # (e.g., from string to integer), the system properly updates:
+  # 1. The column type in the primary table
+  # 2. The column type in the corresponding history table
+  # 3. The trigger function that copies data to the history table
+  #
+  # Previously, only the primary table column was updated during field type changes.
+  # The history table column and trigger function retained the old type, causing data
+  # type mismatches when the trigger attempted to insert updated records into the history table.
+  #
+  # The fix ensures that update migrations recreate the trigger function whenever field
+  # types change, so the trigger correctly handles the new column types in both tables.
+  #
+  # Test approach:
+  # - Create a dynamic model with string fields
+  # - Change one field's type to integer
+  # - Verify both tables have integer columns
+  # - Verify trigger still works by updating a record and checking history
+  context 'field type changes' do
+    before :all do
+      # Create admin and user for this context
+      create_admin
+      create_user
+
+      # Enable migrations for this test suite
+      @original_allow_migrations = Settings::AllowDynamicMigrations
+      silence_warnings { Settings.const_set('AllowDynamicMigrations', true) }
+
+      @schema_name = 'dynamic_test'
+      @table_name = 'test_field_type_changes'
+      @history_table_name = 'test_field_type_change_history'
+
+      # Clean up any existing test tables and model
+      DynamicModel.active.where(table_name: @table_name).each { |dm| dm.disable!(@admin) }
+      DynamicModel.send(:remove_const, :TestFieldTypeChange) if defined?(DynamicModel::TestFieldTypeChange)
+
+      # Drop existing tables if they exist
+      @conn = ActiveRecord::Base.connection
+      @conn.execute("DROP TABLE IF EXISTS #{@schema_name}.#{@history_table_name} CASCADE")
+      @conn.execute("DROP TABLE IF EXISTS #{@schema_name}.#{@table_name} CASCADE")
+
+      # Create the dynamic model definition with initial db_columns configuration
+      # This will create both the primary and history tables in the dynamic_test schema
+      @dm = DynamicModel.create!(
+        current_admin: @admin,
+        name: 'Test Field Type Changes',
+        table_name: @table_name,
+        schema_name: @schema_name,
+        primary_key_name: :id,
+        foreign_key_name: :master_id,
+        category: :test,
+        field_list: 'input_a input_b input_c',
+        options: <<~YAML
+          _db_columns:
+            input_a:
+              type: string
+            input_b:
+              type: string
+            input_c:
+              type: string
+        YAML
+      )
+
+      @dm.update_tracker_events
+    end
+
+    after :all do
+      # Clean up
+      @dm&.disable!(@admin)
+      # Restore original migration setting
+      silence_warnings { Settings.const_set('AllowDynamicMigrations', @original_allow_migrations) }
+    end
+
+    it 'correctly changes field types in both primary and history tables' do
+      # Create a master record for testing
+      master = Master.create! current_user: @user
+      master.current_user = @user
+
+      # Verify initial table structure - all fields should be strings by default
+      @conn.schema_cache.clear!
+      primary_columns = @conn.columns("#{@schema_name}.#{@table_name}")
+      history_columns = @conn.columns("#{@schema_name}.#{@history_table_name}")
+
+      input_b_primary = primary_columns.find { |c| c.name == 'input_b' }
+      input_b_history = history_columns.find { |c| c.name == 'input_b' }
+
+      expect(input_b_primary).not_to be_nil
+      expect(input_b_history).not_to be_nil
+      expect(input_b_primary.type).to eq(:string)
+      expect(input_b_history.type).to eq(:string)
+
+      # Create a test record to verify data migration works
+      setup_access :dynamic_model__test_field_type_changes
+      test_record = master.dynamic_model__test_field_type_changes.create!(
+        current_user: @user,
+        input_a: 'text a',
+        input_b: '123',
+        input_c: 'text c'
+      )
+      expect(test_record.id).not_to be_nil
+
+      # Now change input_b to integer type
+      @dm.instance_variable_set(:@ran_migration, nil) # Reset flag to allow second migration
+      @dm.update!(
+        current_admin: @admin,
+        options: <<~YAML
+          _db_columns:
+            input_a:
+              type: string
+            input_b:
+              type: integer
+            input_c:
+              type: string
+        YAML
+      )
+
+      # Manually trigger migration generation and execution
+      # Force reset the migration generator to ensure it picks up the new db_configs
+      @dm.instance_variable_set(:@migration_generator, nil)
+      @dm.send(:generate_migration)
+      @dm.send(:run_migration) if @dm.instance_variable_get(:@do_migration)
+
+      @dm.update_tracker_events
+
+      # Force column cache refresh
+      @conn.schema_cache.clear!
+      DynamicModel.reset_active_model_configurations!
+
+      # Verify the type changed in both tables
+      primary_columns = @conn.columns("#{@schema_name}.#{@table_name}")
+      history_columns = @conn.columns("#{@schema_name}.#{@history_table_name}")
+
+      input_b_primary = primary_columns.find { |c| c.name == 'input_b' }
+      input_b_history = history_columns.find { |c| c.name == 'input_b' }
+
+      expect(input_b_primary).not_to be_nil, 'input_b should exist in primary table'
+      expect(input_b_history).not_to be_nil, 'input_b should exist in history table'
+      expect(input_b_primary.type).to eq(:integer), "input_b in primary table should be integer, but was #{input_b_primary.type}"
+      expect(input_b_history.type).to eq(:integer), "input_b in history table should be integer, but was #{input_b_history.type}"
+
+      # Verify that the existing data was preserved and converted
+      # The model class needs to be regenerated to pick up the new column types
+      # Clear schema cache and force model class to reload its columns
+      @conn.schema_cache.clear!
+      model_class = @dm.implementation_class
+      model_class.reset_column_information
+
+      # Re-fetch the record with the updated model class
+      test_record = master.dynamic_model__test_field_type_changes.find(test_record.id)
+      expect(test_record.input_b).to eq(123)
+
+      # Verify trigger still works by updating the record
+      test_record.update!(current_user: @user, input_b: 456)
+
+      # Check that history table received the update correctly
+      history_records = @conn.execute(
+        "SELECT input_b FROM #{@schema_name}.#{@history_table_name} WHERE #{@table_name.singularize}_id = #{test_record.id} ORDER BY id DESC LIMIT 1"
+      )
+      expect(history_records.first['input_b'].to_i).to eq(456)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
This PR addresses GitHub issue #216 by ensuring that history table triggers are recreated when field types are changed in dynamic model configurations.

## Changes Made

### Core Fix
- **lib/active_record/migration/app_generator.rb**: Added trigger recreation after field type changes
  - When  or  arrays contain field type modifications, the appropriate trigger function is now recreated
  - Supports dynamic models, activity logs, and external identifiers
  - Uses idiomatic Ruby case-when statement for resource type handling

### Test Coverage
- **spec/models/option_configs/dynamic_model_options_spec.rb**: Added comprehensive test
  - Creates dynamic model with string fields
  - Changes field type from string to integer
  - Verifies both primary and history table columns are updated
  - Verifies trigger still functions correctly after type change
  - Includes detailed documentation explaining the bug and fix

## Problem Addressed

Previously, when a field type was changed in a dynamic model:
- ✅ Primary table column type was updated
- ❌ History table column type was NOT updated
- ❌ Trigger function retained old column types

This caused PostgreSQL type mismatch errors when the trigger attempted to insert records with the new types into history tables with old types.

## Solution

The fix ensures that whenever field types change during an update migration:
1. Both primary and history table columns are changed to the new type
2. The trigger function is recreated with the correct field types
3. History tracking continues to work seamlessly

## Test Results

✅ New test passes: `correctly changes field types in both primary and history tables`
✅ All existing tests in spec/models/option_configs continue to pass
✅ Code formatted with RuboCop

## Related Issue

Closes #216