### PR TITLE
Fix batch_trigger not being removed when dynamic definition is disabled - resolves #39

### DIFF
--- a/app/models/dynamic/def_handler.rb
+++ b/app/models/dynamic/def_handler.rb
@@ -217,9 +217,9 @@ module Dynamic
             list += imp_class.attribute_names
                              .select { |a| Classification::GeneralSelection.use_with_attribute?(a) }
                              .map do |a|
-              mn = imp_class.model_name.to_s.ns_underscore
-              mn = mn.pluralize unless imp_class.respond_to?(:is_activity_log)
-              :"#{mn}_#{a}"
+                               mn = imp_class.model_name.to_s.ns_underscore
+                               mn = mn.pluralize unless imp_class.respond_to?(:is_activity_log)
+                               :"#{mn}_#{a}"
             end
           end
 
@@ -485,7 +485,13 @@ module Dynamic
     #
     # If batch_trigger specifies a schedule, set it up now. Called by after_save callback
     def handle_batch_schedule
-      def_unschedule = disabled || !persisted? || !active_model_configuration?
+      # If disabled, unschedule and return early to prevent rescheduling
+      if disabled && persisted?
+        RecurringBatchTask.unschedule_task self
+        return
+      end
+
+      def_unschedule = !persisted? || !active_model_configuration?
 
       RecurringBatchTask.unschedule_task self if def_unschedule
 


### PR DESCRIPTION
This fixes the issue where disabling a dynamic definition with batch_trigger defined does not remove the associated background job.

## Problem
When a dynamic definition (such as a dynamic model) with  configuration is disabled, the recurring background job should be removed but was not. This was because the  method would unschedule the job but then continue to check the batch_trigger configuration and reschedule it.

## Solution
Modified the  method in  to return early when the definition is disabled, preventing the job from being rescheduled.

The fix specifically:
1. Checks if the definition is disabled at the start of the method
2. If disabled and persisted, unschedules the task and returns early
3. This prevents the method from continuing to the scheduling logic that would recreate the job

## Testing
- Verified existing batch job specs still pass
- The fix ensures that when  is set on a dynamic definition, any existing recurring batch tasks are properly removed and not recreated.

Resolves #39