### PR TITLE
Added substitutions within save trigger pull_external_data headers, to support `Authorization: Bearer {{access_token}}` requirements - references #840

### DIFF
--- a/app/models/admin/defs/save_triggers_pull_external_data_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_pull_external_data_options_defs.yaml
@@ -58,6 +58,9 @@
               format: xml|json|text
               allow_empty_result: true | false (default)
               allow_response_codes: [array of allowable integer codes that are not 200]
+              headers:
+                'Authorization': 'Bearer {{save_trigger_results.identity.access_token}}'
+                'Content-Type': 'application/json'
 
             post_data: |
               For 'post' requests, the string or hash of data to post

--- a/app/models/save_triggers/pull_external_data.rb
+++ b/app/models/save_triggers/pull_external_data.rb
@@ -186,6 +186,10 @@ class SaveTriggers::PullExternalData < SaveTriggers::SaveTriggersBase
 
   def header_config
     sub_config = from_config || to_config
-    sub_config[:headers]&.stringify_keys
+    headers = sub_config[:headers]
+    return unless headers
+
+    substitute_values_in_config(headers)
+    headers.stringify_keys
   end
 end

--- a/app/models/save_triggers/save_triggers_base.rb
+++ b/app/models/save_triggers/save_triggers_base.rb
@@ -114,5 +114,16 @@ class SaveTriggers::SaveTriggersBase
     end
   end
 
+  #
+  # Perform substitutions for all the values in a sub_config hash
+  # The substitutions are performed in place, and returned by value.
+  # @param [Hash] sub_config The configuration hash to perform substitutions on
+  # @return [Hash] The configuration hash with substituted values
+  def substitute_values_in_config(sub_config)
+    sub_config.deep_transform_values! do |v|
+      FieldDefaults.calculate_default @item, v
+    end
+  end
+
   def self.config_def(if_extras: nil); end
 end

--- a/spec/models/save_triggers/pull_external_data_spec.rb
+++ b/spec/models/save_triggers/pull_external_data_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe SaveTriggers::PullExternalData, type: :model do
       )
       .to_return(status: 200, body: '{"requestId":"6346#87d796ac7","result":[{"id":1081,"name":"Annual Revenue","description":"Run this Campaign at least once as a Batch Campaign, so it can score all the existing leads in your database. Then you can either schedule it to run every night, or you can add the following two triggers: \"Lead is Created\" AND \"Data Value Changes\" in the \"Annual Revenue\" Field.","type":"batch","programName":"OP-Scoring-Demographic","programId":1014,"workspaceName":"Default","createdAt":"2014-06-27T02:58:28Z","updatedAt":"2016-03-24T08:27:50Z","active":false}],"success":true}', headers: {})
 
-    stub_request(:post, "#{api_uri}/rest/v1/leads/push.json?access_token=123123123-ad12-1234-99ce-893645:ab")
+    stub_request(:post, "#{api_uri}/rest/v1/leads/push.json")
       .with(
         body: /\{"programName":"HCI Participant Import","lookupField":"email","source":"HCIQ Zeus","reason":"Changed status","input":\[\{"email":"phil-test12@consected.com","firstName":"Test FN","lastName":"Test LN","hCIStage":"Invitation Email","hCIStageUpdatedAt":".*","hCIQLink":".*"\}\]\}/,
         headers: {
@@ -170,7 +170,8 @@ RSpec.describe SaveTriggers::PullExternalData, type: :model do
           'Accept-Encoding' => /.*/,
           'Host' => /.*/,
           'User-Agent' => /.*/,
-          'Content-Type' => 'application/json'
+          'Content-Type' => 'application/json',
+          'Authorization' => 'Bearer 123123123-ad12-1234-99ce-893645:ab'
         }
       )
       .to_return(
@@ -331,10 +332,11 @@ RSpec.describe SaveTriggers::PullExternalData, type: :model do
           }
         },
         to: {
-          url: "#{api_uri}/rest/v1/leads/push.json?access_token={{save_trigger_results.identity.access_token}}",
+          url: "#{api_uri}/rest/v1/leads/push.json",
           format: 'json',
           headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer {{save_trigger_results.identity.access_token}}'
           }
         },
         post_data: {


### PR DESCRIPTION
#840