### PR TITLE
Fixed switch_id_on_click for multiple external IDs - fixed #312

### DIFF
--- a/app/assets/javascripts/app/masters.js
+++ b/app/assets/javascripts/app/masters.js
@@ -9,20 +9,35 @@ _fpa.masters = {
     max_results: 100,
 
     switch_id_on_click: function (block) {
-        block.find('.switch_id').not('attached-switch-click').click(function (ev) {
+        block.find('.switch_id').not('.attached-switch-click').click(function (ev) {
             ev.preventDefault();
             var p = $(this).parent();
-            var alt_id = p.find('span.alt_id');
-            var master_id = p.find('span.master_id');
-            if (alt_id.is(':visible')) {
-                alt_id.hide();
-                master_id.show();
-                $(this).attr('title', 'switch to Master ID');
-            } else {
-                master_id.hide();
-                alt_id.show();
-                $(this).attr('title', 'switch to alternative ID');
-            }
+            var id_items = p.find('span.alt-id-item');
+
+            if (id_items.length <= 1) return;
+
+            // Find the currently visible item
+            var visible_index = -1;
+            id_items.each(function (i) {
+                if ($(this).is(':visible')) {
+                    visible_index = i;
+                    return false;
+                }
+            });
+
+            // Hide all items
+            id_items.hide();
+
+            // Show the next item (cycling back to first)
+            var next_index = (visible_index + 1) % id_items.length;
+            var next_item = id_items.eq(next_index);
+            next_item.show();
+
+            // Update the switch icon title to indicate the next ID to switch to
+            var after_next_index = (next_index + 1) % id_items.length;
+            var after_next_item = id_items.eq(after_next_index);
+            var next_title = after_next_item.data('idLabel') || 'alternative ID';
+            $(this).attr('title', 'switch to ' + next_title);
         }).addClass('attached-switch-click');
     },
 

--- a/app/assets/stylesheets/app/search_results.scss
+++ b/app/assets/stylesheets/app/search_results.scss
@@ -754,7 +754,7 @@ div[data-sub-list="sage_assignments"] .sage-assignment-item:nth-of-type(1) {
   opacity: 1;
 }
 
-.master-result span.alt_id,
+.master-result span.alt-id-item,
 .master-result span.master_id {
   color: gray;
 }
@@ -787,7 +787,7 @@ div[data-sub-list="sage_assignments"] .sage-assignment-item:nth-of-type(1) {
   background: #f6e9cc;
 }
 
-span.alt_id {
+span.alt-id-item {
   font-size: 87%;
   cursor: help;
 }

--- a/app/models/admin/app_configuration.rb
+++ b/app/models/admin/app_configuration.rb
@@ -63,6 +63,14 @@ class Admin::AppConfiguration < Admin::AdminBase
     res.split(',').map { |i| i.strip.send(to) }
   end
 
+  def self.hash_for(name, user = nil, keys_to: :to_sym)
+    res = value_for(name, user)
+    return {} if res.blank?
+
+    res = YAML.safe_load(res, permitted_classes: [Symbol]) || {}
+    res.transform_keys(&keys_to)
+  end
+
   #
   # Get all the active config values for the specified user.
   # The user's current app type is considered in the evaluation
@@ -181,6 +189,7 @@ class Admin::AppConfiguration < Admin::AdminBase
   # Clear the value_for memo. Called as an after_save callback
   def self.clear_memo!
     @value_for = {}
+    Master.reset_crosswalk_field_labels!
   end
 
   private

--- a/app/models/admin/defs/app_configuration_defs.yaml
+++ b/app/models/admin/defs/app_configuration_defs.yaml
@@ -121,6 +121,14 @@ report library button label: |
 show ids in master result: |
   Master record results headers show one or more IDs. Provide a comma separated list of IDs to show using 
   alternative ID names, "master_id", or "none" to hide all IDs
+crosswalk field labels: |
+  Labels for crosswalk ID fields on the masters table (e.g. msid, pro_id). Provide a YAML formatted 
+  hash mapping field names to their display labels. For example:
+  
+      msid: MSID
+      pro_id: Pro Football ID
+  
+  If not set, field names will be humanized (e.g., "msid" becomes "Msid")
 tracker order: |
   Tracker records are ordered by "protocol position", "protocol name", or "latest entry date"
 user session timeout: |

--- a/app/models/concerns/alternative_ids.rb
+++ b/app/models/concerns/alternative_ids.rb
@@ -107,6 +107,42 @@ module AlternativeIds
     def reset_external_id_matching_fields!
       @external_id_definitions_access_by = nil
       @external_id_definitions = nil
+      @alternative_id_labels = nil
+      @alternative_id_labels_access_by = nil
+      reset_crosswalk_field_labels!
+    end
+
+    #
+    # Get a hash of all alternative ID field names to their human-readable labels
+    # This includes both crosswalk fields (from Master.crosswalk_field_labels) and
+    # external identifier fields (from their label attribute)
+    # @param [User | nil] access_by - current user making the request for access control
+    # @return [Hash{Symbol => String}] hash of field names to labels
+    def alternative_id_labels(access_by: nil)
+      if access_by
+        key = access_by_key(access_by)
+        @alternative_id_labels_access_by ||= {}
+        return @alternative_id_labels_access_by[key] if @alternative_id_labels_access_by.key?(key)
+      elsif @alternative_id_labels
+        return @alternative_id_labels
+      end
+
+      labels = {}
+
+      # Add crosswalk field labels from Master.crosswalk_field_labels
+      labels.merge!(crosswalk_field_labels(access_by:))
+
+      # Add external identifier labels
+      ext_defs = access_by ? external_id_definitions_access_by(access_by) : external_id_definitions
+      labels.merge!(ext_defs.transform_values(&:label))
+
+      if access_by
+        @alternative_id_labels_access_by[key] = labels
+      else
+        @alternative_id_labels = labels
+      end
+
+      labels
     end
 
     # Generate an instance method that allow easy access to alternative_id values
@@ -166,7 +202,7 @@ module AlternativeIds
 
       unless alternative_id?(field_name, access_by: current_user)
         raise FphsException, "Can not match on this field (#{field_name}). " \
-          'It is not an accepted alterative ID field for this user.'
+                             'It is not an accepted alterative ID field for this user.'
       end
 
       # Start by attempting to match on a field in the master record

--- a/app/models/master.rb
+++ b/app/models/master.rb
@@ -3,6 +3,41 @@
 class Master < ActiveRecord::Base
   FilteredAssocPrefix = 'filtered__'
 
+  #
+  # Get the labels for crosswalk ID fields on the masters table from AppConfiguration.
+  # The configuration value should be a YAML hash format, e.g.:
+  #   msid: MSID
+  #   pro_id: Pro Football ID
+  # Falls back to humanizing the field name if no configuration is set.
+  # @param [User | nil] access_by - current user for app-type specific configuration
+  # @return [Hash{Symbol => String}] hash of field names to labels
+  def self.crosswalk_field_labels(access_by: nil)
+    if access_by
+      key = "#{access_by.id}-#{access_by.app_type_id}"
+      @crosswalk_field_labels_by_user ||= {}
+      return @crosswalk_field_labels_by_user[key] if @crosswalk_field_labels_by_user.key?(key)
+    elsif @crosswalk_field_labels
+      return @crosswalk_field_labels
+    end
+
+    config_value = Admin::AppConfiguration.hash_for(:crosswalk_field_labels, access_by)
+    labels = config_value.presence || crosswalk_attrs.to_h { |attr| [attr, attr.to_s.humanize] }
+
+    if access_by
+      @crosswalk_field_labels_by_user[key] = labels
+    else
+      @crosswalk_field_labels = labels
+    end
+
+    labels
+  end
+
+  # Clear memoized crosswalk field labels (called when app configuration changes)
+  def self.reset_crosswalk_field_labels!
+    @crosswalk_field_labels = nil
+    @crosswalk_field_labels_by_user = nil
+  end
+
   # Temporary master records can be used with limited(_if_one) user access controls
   # Providing an association onto these records allows inner join or left joins to
   # within this functionality to operate, just like an association to any other table

--- a/app/views/admin/external_identifiers/_def_details.html.erb
+++ b/app/views/admin/external_identifiers/_def_details.html.erb
@@ -45,9 +45,15 @@
                 target: '_blank' %>
   </p>
                 
-  <p><%= link_to link_label_open_in_new('search identifier'), 
+  <p>
+    <% begin %>
+    <%= link_to link_label_open_in_new('search identifier'), 
                 report_path(id: @external_identifier.usage_report('Search', ExternalIdentifier::ReportItemSearchType, as_alt_resource_name: true)),
-                target: '_blank' %></p>
+                target: '_blank' %>
+    <% rescue StandardError => e %>
+    (no report defined)
+    <% end %>
+  </p>
   <%= render partial: 'admin/dynamic_models/est_record_count' %>
   <%= render partial: 'admin/dynamic_models/check_tracker_updates' %>
 

--- a/app/views/layouts/_setup_app.html.erb
+++ b/app/views/layouts/_setup_app.html.erb
@@ -15,6 +15,7 @@
   _fpa.state.current_user_preference = <%= current_user.user_preference.to_json.html_safe %>
   _fpa.state.crosswalk_attrs = <%= Master.crosswalk_attrs.to_json.html_safe %>;
   _fpa.state.alternative_id_fields = <%= Master.alternative_id_fields.to_json.html_safe %>;
+  _fpa.state.alternative_id_labels = <%= Master.alternative_id_labels(access_by: current_user).to_json.html_safe %>;
   _fpa.state.user_can = {
     download_files: <%=!!current_user.can?(:download_files)%>,
     view_files_as_image: <%=!!current_user.can?(:view_files_as_image)%>,

--- a/app/views/masters/_search_results_parts.html.erb
+++ b/app/views/masters/_search_results_parts.html.erb
@@ -96,18 +96,22 @@
 
 <script id="master_id_summary_result-partial" type="text/x-handlebars-template" class="hidden handlebars-partial">
 <% id_list = app_config_items(:show_ids_in_master_result, ['master_id']) %>
+<%
+  # Get the alternative ID labels for display
+  id_labels = Master.alternative_id_labels(access_by: current_user)
+%>
 <% unless id_list.first == 'none' %>
 <div class="col-md-2 col-lg-2 result-refs">
-  <% if id_list.length > 1 %>
-  <% end %>
   <%
   first = true
   id_list.each do |i|
+    id_label = id_labels[i.to_sym] || i.to_s.humanize
   %>
     <% if first && id_list.length > 1 %>
-    <a href="#" class="switch_id glyphicon glyphicon-random" title="switch to alternative ID"></a>
+    <% next_label = id_labels[id_list[1].to_sym] || id_list[1].to_s.humanize %>
+    <a href="#" class="switch_id glyphicon glyphicon-random" title="switch to <%= next_label %>"></a>
     <% end %>
-    <span class="alt-id-item <%= first && id_list.length > 1 ? '' : 'alt_id' %> <%=i%>" <% unless first %> style="display: none"<% end %> title="<%= i.humanize %>">{{#if <%= i %>}}{{<%= i %>}}{{else}}no&nbsp;<%= i.humanize %>{{/if}}</span>
+    <span class="alt-id-item<%= first && id_list.length > 1 ? '' : ' alt_id' %> <%=i%>" data-id-label="<%= id_label %>"<% unless first %> style="display: none"<% end %>>{{#if <%= i %>}}<span title="<%= id_label %>">{{<%= i %>}}</span>{{else}}<span title="No <%= id_label %>">(none)</span>{{/if}}</span>
   <%
     first = false
   end

--- a/spec/system/switch_id_display_spec.rb
+++ b/spec/system/switch_id_display_spec.rb
@@ -1,0 +1,370 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Tests for GitHub issue #312 - switch_id_on_click does not work correctly
+# for multiple external ids or when not showing the master_id
+#
+# Test Coverage:
+# - Single ID display (master_id only, scantron_id only): no switch button shown
+# - Two IDs (master_id + msid): switch button toggles between them
+# - Multiple IDs (master_id, msid, scantron_id, sage_id): rotates through all IDs
+# - External IDs only (no master_id): rotates correctly without master_id
+# - Mixed ID availability: shows actual values or "(none)" with appropriate titles
+# - Crosswalk field labels: configured via AppConfiguration for proper display names
+#   (e.g., "MSID" instead of "Msid", "Scantron ID" instead of "Scantron")
+#
+# Key functionality tested:
+# - Switch button title updates to show next ID label
+# - ID spans have correct visibility (only current ID visible)
+# - data-id-label attributes set correctly for JavaScript switch logic
+# - Title attributes show proper labels (e.g., "No MSID" for missing values)
+describe 'switch ID display in search results', js: true, driver: $browser_driver do
+  include ModelSupport
+  include MasterDataSupport
+  include FeatureSupport
+
+  before(:all) do
+    change_setting('TwoFactorAuthDisabledForUser', true)
+    SetupHelper.feature_setup
+
+    seed_database
+    create_data_set_outside_tx
+
+    @admin, = create_admin
+    @user, @good_password = create_user
+    @good_email = @user.email
+
+    # Ensure external identifiers are active
+    setup_external_identifiers
+
+    # Create masters with different ID combinations
+    create_masters_with_varying_ids
+  end
+
+  def setup_external_identifiers
+    # Ensure scantrons and sage_assignments are active
+    ExternalIdentifier.where(name: 'scantrons').update_all(disabled: false)
+    ExternalIdentifier.where(name: 'sage_assignments').update_all(disabled: false)
+
+    # Ensure user has access to external identifiers (read and create)
+    setup_access :scantrons, resource_type: :table, access: :create
+    setup_access :sage_assignments, resource_type: :table, access: :create
+
+    # Configure crosswalk field labels
+    crosswalk_labels = "msid: MSID\npro_id: Pro Football ID"
+    add_app_config(@user.app_type, 'crosswalk field labels', crosswalk_labels)
+    Admin::AppConfiguration.clear_memo!
+    Master.reset_crosswalk_field_labels!
+    Master.reset_external_id_matching_fields!
+  end
+
+  def create_masters_with_varying_ids
+    # Generate unique IDs for this test run (within valid ranges)
+    # Scantron: 1-999999, Sage: 1000000000-9999999999
+    @msid_base = rand(1_000_000..9_000_000)
+    @scantron_base = rand(100_000..900_000)
+    @sage_base = rand(1_000_000_000..9_000_000_000)
+
+    # Master with all IDs: msid, scantron_id, sage_id
+    @master_all_ids = create_master(@user, { msid: @msid_base, pro_id: rand(1_000_000_000) })
+    scantron = Scantron.new(scantron_id: @scantron_base)
+    scantron.master = @master_all_ids
+    scantron.save!
+    sage = SageAssignment.new(sage_id: @sage_base)
+    sage.master = @master_all_ids
+    sage.save!
+
+    # Master with only msid
+    @master_msid_only = create_master(@user, { msid: @msid_base + 1, pro_id: rand(1_000_000_000) })
+
+    # Master with only scantron_id (no msid)
+    @master_scantron_only = create_master(@user, { msid: nil, pro_id: rand(1_000_000_000) })
+    scantron2 = Scantron.new(scantron_id: @scantron_base + 2)
+    scantron2.master = @master_scantron_only
+    scantron2.save!
+
+    # Master with only sage_id (no msid)
+    @master_sage_only = create_master(@user, { msid: nil, pro_id: rand(1_000_000_000) })
+    sage2 = SageAssignment.new(sage_id: @sage_base + 3)
+    sage2.master = @master_sage_only
+    sage2.save!
+
+    # Master with no IDs (only master_id)
+    @master_no_ext_ids = create_master(@user, { msid: nil, pro_id: rand(1_000_000_000) })
+  end
+
+  before(:each) do
+    validate_setup
+    login
+  end
+
+  after(:each) do
+    # Reset the app configuration to default
+    reset_id_display_config
+  end
+
+  def set_id_display_config(id_list)
+    add_app_config(@user.app_type, 'show ids in master result', id_list)
+  end
+
+  def reset_id_display_config
+    # Reset to default master_id only
+    add_app_config(@user.app_type, 'show ids in master result', 'master_id')
+  end
+
+  def search_for_master(master)
+    visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{master.id}"
+    finish_page_loading
+
+    # Wait for search results to load
+    expect(page).to have_css('#master_results_block .master-result', wait: 10)
+  end
+
+  describe 'with single ID (master_id only)' do
+    before(:each) do
+      set_id_display_config('master_id')
+    end
+
+    it 'displays master_id without switch button' do
+      search_for_master(@master_all_ids)
+
+      # Should show master_id
+      within '#master_results_block .master-result' do
+        expect(page).to have_css('.alt-id-item.master_id', text: @master_all_ids.id.to_s)
+        # Should not show switch button when only one ID
+        expect(page).not_to have_css('a.switch_id')
+      end
+    end
+  end
+
+  describe 'with single ID (scantron_id only)' do
+    before(:each) do
+      set_id_display_config('scantron_id')
+    end
+
+    it 'displays scantron_id without switch button' do
+      search_for_master(@master_all_ids)
+
+      # Should show scantron_id
+      within '#master_results_block .master-result' do
+        expect(page).to have_css('.alt-id-item.scantron_id', text: @master_all_ids.scantron_id.to_s)
+        # Should not show switch button when only one ID
+        expect(page).not_to have_css('a.switch_id')
+      end
+    end
+  end
+
+  describe 'with master_id and msid' do
+    before(:each) do
+      set_id_display_config('master_id,msid')
+    end
+
+    it 'displays master_id first and can switch to msid' do
+      search_for_master(@master_all_ids)
+
+      within '#master_results_block .master-result' do
+        # First ID (master_id) should be visible
+        master_id_span = find('.alt-id-item.master_id', visible: true)
+        expect(master_id_span).to have_content(@master_all_ids.id.to_s)
+        expect(master_id_span).to have_css('[title="Master"]')
+
+        # Second ID (msid) should be hidden initially
+        msid_span = find('.alt-id-item.msid', visible: :all)
+        expect(msid_span).not_to be_visible
+
+        # Click switch button
+        switch_button = find('a.switch_id')
+        expect(switch_button['title']).to eq('switch to MSID')
+        switch_button.click
+
+        # Now msid should be visible and master_id hidden
+        expect(master_id_span).not_to be_visible
+        expect(msid_span).to be_visible
+        expect(msid_span).to have_content(@master_all_ids.msid.to_s)
+        expect(msid_span).to have_css('[title="MSID"]')
+
+        # Switch button title should now point to next ID (master_id)
+        expect(switch_button['title']).to eq('switch to Master')
+      end
+    end
+
+    it 'shows (none) for missing msid with correct title' do
+      search_for_master(@master_no_ext_ids)
+
+      within '#master_results_block .master-result' do
+        # Click switch to show msid
+        find('a.switch_id').click
+
+        # Should show (none) with "No MSID" title
+        msid_span = find('.alt-id-item.msid', visible: true)
+        none_indicator = msid_span.find('[title="No MSID"]')
+        expect(none_indicator).to have_content('(none)')
+      end
+    end
+  end
+
+  describe 'with multiple external IDs (msid, scantron_id, sage_id)' do
+    before(:each) do
+      set_id_display_config('master_id,msid,scantron_id,sage_id')
+    end
+
+    it 'rotates through all four IDs when switch button is clicked' do
+      search_for_master(@master_all_ids)
+
+      within '#master_results_block .master-result' do
+        switch_button = find('a.switch_id')
+
+        # Initially master_id should be visible
+        expect(find('.alt-id-item.master_id', visible: :all)).to be_visible
+
+        # First click: switch to msid
+        switch_button.click
+        expect(find('.alt-id-item.master_id', visible: :all)).not_to be_visible
+        expect(find('.alt-id-item.msid', visible: :all)).to be_visible
+        expect(switch_button['title']).to eq('switch to Scantron ID')
+
+        # Second click: switch to scantron_id
+        switch_button.click
+        expect(find('.alt-id-item.msid', visible: :all)).not_to be_visible
+        expect(find('.alt-id-item.scantron_id', visible: :all)).to be_visible
+        expect(switch_button['title']).to eq('switch to Sage ID')
+
+        # Third click: switch to sage_id
+        switch_button.click
+        expect(find('.alt-id-item.scantron_id', visible: :all)).not_to be_visible
+        expect(find('.alt-id-item.sage_id', visible: :all)).to be_visible
+        expect(switch_button['title']).to eq('switch to Master')
+
+        # Fourth click: back to master_id
+        switch_button.click
+        expect(find('.alt-id-item.sage_id', visible: :all)).not_to be_visible
+        expect(find('.alt-id-item.master_id', visible: :all)).to be_visible
+        expect(switch_button['title']).to eq('switch to MSID')
+      end
+    end
+
+    it 'displays actual values and (none) appropriately for mixed IDs' do
+      # Master with only some IDs set
+      search_for_master(@master_msid_only)
+
+      within '#master_results_block .master-result' do
+        switch_button = find('a.switch_id')
+
+        # master_id should show actual value
+        expect(find('.alt-id-item.master_id', visible: true)).to have_content(@master_msid_only.id.to_s)
+
+        # Switch to msid - should show actual value
+        switch_button.click
+        msid_span = find('.alt-id-item.msid', visible: true)
+        expect(msid_span).to have_css('[title="MSID"]')
+        expect(msid_span).to have_content(@master_msid_only.msid.to_s)
+
+        # Switch to scantron_id - should show (none)
+        switch_button.click
+        scantron_span = find('.alt-id-item.scantron_id', visible: true)
+        expect(scantron_span).to have_css('[title="No Scantron ID"]')
+        expect(scantron_span).to have_content('(none)')
+
+        # Switch to sage_id - should show (none)
+        switch_button.click
+        sage_span = find('.alt-id-item.sage_id', visible: true)
+        expect(sage_span).to have_css('[title="No Sage ID"]')
+        expect(sage_span).to have_content('(none)')
+      end
+    end
+  end
+
+  describe 'without master_id (external IDs only)' do
+    before(:each) do
+      set_id_display_config('msid,scantron_id')
+    end
+
+    it 'rotates through external IDs without master_id' do
+      search_for_master(@master_all_ids)
+
+      within '#master_results_block .master-result' do
+        switch_button = find('a.switch_id')
+
+        # First should be msid
+        expect(find('.alt-id-item.msid', visible: :all)).to be_visible
+        expect(switch_button['title']).to eq('switch to Scantron ID')
+
+        # Click to switch to scantron_id
+        switch_button.click
+        expect(find('.alt-id-item.msid', visible: :all)).not_to be_visible
+        expect(find('.alt-id-item.scantron_id', visible: :all)).to be_visible
+        expect(switch_button['title']).to eq('switch to MSID')
+
+        # Click again to return to msid
+        switch_button.click
+        expect(find('.alt-id-item.scantron_id', visible: :all)).not_to be_visible
+        expect(find('.alt-id-item.msid', visible: :all)).to be_visible
+      end
+    end
+
+    it 'shows (none) for both when no external IDs assigned' do
+      search_for_master(@master_no_ext_ids)
+
+      within '#master_results_block .master-result' do
+        switch_button = find('a.switch_id')
+
+        # First (msid) should show (none)
+        msid_span = find('.alt-id-item.msid', visible: true)
+        expect(msid_span).to have_css('[title="No MSID"]')
+        expect(msid_span).to have_content('(none)')
+
+        # Switch to scantron_id - should also show (none)
+        switch_button.click
+        scantron_span = find('.alt-id-item.scantron_id', visible: true)
+        expect(scantron_span).to have_css('[title="No Scantron ID"]')
+        expect(scantron_span).to have_content('(none)')
+      end
+    end
+  end
+
+  describe 'with sage_id and scantron_id (no master_id or msid)' do
+    before(:each) do
+      set_id_display_config('sage_id,scantron_id')
+    end
+
+    it 'displays sage_id first and switches correctly' do
+      search_for_master(@master_all_ids)
+
+      within '#master_results_block .master-result' do
+        switch_button = find('a.switch_id')
+
+        # First should be sage_id
+        sage_span = find('.alt-id-item.sage_id', visible: :all)
+        expect(sage_span).to be_visible
+        expect(sage_span).to have_content(@sage_base.to_s)
+
+        # Switch to scantron_id
+        switch_button.click
+        expect(sage_span).not_to be_visible
+        scantron_span = find('.alt-id-item.scantron_id', visible: :all)
+        expect(scantron_span).to be_visible
+        expect(scantron_span).to have_content(@scantron_base.to_s)
+      end
+    end
+
+    it 'handles master with only one of the two IDs' do
+      # Master with only sage_id
+      search_for_master(@master_sage_only)
+
+      within '#master_results_block .master-result' do
+        switch_button = find('a.switch_id')
+
+        # First should be sage_id with value
+        sage_span = find('.alt-id-item.sage_id', visible: true)
+        expect(sage_span).to have_content((@sage_base + 3).to_s)
+
+        # Switch to scantron_id - should show (none)
+        switch_button.click
+        scantron_span = find('.alt-id-item.scantron_id', visible: true)
+        expect(scantron_span).to have_css('[title="No Scantron ID"]')
+        expect(scantron_span).to have_content('(none)')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Fixes GitHub issue #312 - switch_id_on_click does not work correctly for multiple external IDs or when not showing the master_id.

## Changes

### JavaScript (masters.js)
- Rewrote `switch_id_on_click` to rotate through all configured ID spans (not just toggle between two)
- Uses `data-id-label` attribute on spans to get proper display labels for switch button title
- Fixed selector typo (`.attached-switch-click` was missing the dot)

### CSS (search_results.scss)
- Updated class name from `.alt_id` to `.alt-id-item` for consistency

### Templates (_search_results_parts.html.erb)
- Added `data-id-label` attribute to ID spans with proper labels
- Switch button title now shows the correct next ID label (e.g., "switch to MSID")
- ID values show with proper titles (e.g., "MSID", "No Scantron ID")

### Configurable Crosswalk Field Labels
- Added `Master.crosswalk_field_labels(access_by:)` method to read labels from AppConfiguration
- Added `Master.alternative_id_labels(access_by:)` method combining crosswalk and external ID labels
- Added `crosswalk field labels` AppConfiguration definition (YAML format)
- Labels are app-type specific via the `access_by` user parameter
- Added `Admin::AppConfiguration.hash_for` method for YAML-formatted config values

### Frontend State
- Added `_fpa.state.alternative_id_labels` for JavaScript access to ID labels

## Test Coverage
Added 10 system specs covering:
- Single ID display (master_id only, scantron_id only): no switch button
- Two IDs (master_id + msid): switch button toggles between them
- Multiple IDs (master_id, msid, scantron_id, sage_id): rotates through all
- External IDs only (no master_id): rotates correctly
- Mixed ID availability: shows values or "(none)" with appropriate titles
- Proper label display from configuration