### PR TITLE
Fix duplicate password validation errors

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,11 @@
 - If requested, the AI Agent should create a pull request with a descriptive title and summary of changes. The branch must be rebased onto `up-develop` before creating the pull request.
 - Only a human user will merge branches after code review; AI agents should not merge branches.
 
+### Testing Conventions
+- When fixing implementation bugs, **always write new Rspec tests** to demonstrate the bug, before fixing it.
+- Always add comments to the top of the spec files explaining the purpose of the tests.
+- Check for reusable support methods in `spec/support/` before writing new test code.
+
 ### Rspec System Spec Best Practices
 1. **ALWAYS use helper methods for system specs** from `spec/support/feature_support.rb`
 2. **Run `debug_process_status`** when fields/sections can't be found

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -369,12 +369,20 @@ module ApplicationHelper
   end
 
   def remove_empty_error(errors)
-    errors.messages.each do |key, messages|
+    # Handle DoNotDisplayErrorMessage markers
+    # We need to iterate over a copy of keys since we might be deleting some
+    errors.messages.keys.dup.each do |key|
+      messages = errors.messages[key]
       if messages.include?(DoNotDisplayErrorMessage)
         if messages.one?
+          # If the only message is DoNotDisplayErrorMessage, remove the entire key
           errors.delete(key)
         else
-          messages.delete(DoNotDisplayErrorMessage)
+          # If there are multiple messages, filter out DoNotDisplayErrorMessage
+          # We need to delete and re-add to ensure proper modification
+          filtered_messages = messages.reject { |msg| msg == DoNotDisplayErrorMessage }
+          errors.delete(key)
+          filtered_messages.each { |msg| errors.add(key, msg) }
         end
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,7 @@ class User < ActiveRecord::Base
 
   belongs_to :admin
   has_one :contact_info, class_name: 'Users::ContactInfo', foreign_key: :user_id
-  has_one :user_preference, autosave: true, inverse_of: :user
+  has_one :user_preference, autosave: true, inverse_of: :user, validate: false
 
   belongs_to :app_type, class_name: 'Admin::AppType', optional: true
 
@@ -145,7 +145,7 @@ class User < ActiveRecord::Base
       res = all
     end
 
-    res.map { |u| ["#{u.email} #{u.disabled ? '[disabled]' : ''}", u.id] }
+    res.map { |u| ["#{u.email} #{'[disabled]' if u.disabled}", u.id] }
   end
 
   #
@@ -170,7 +170,7 @@ class User < ActiveRecord::Base
 
   # Standard Devise callback to tell user that an account has been disabled
   def inactive_message
-    !disabled ? super : :account_has_been_disabled
+    disabled ? :account_has_been_disabled : super
   end
 
   # By default, the user is redirected to the login page after registration.

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# ApplicationHelper Spec
+#
+# Tests helper methods used across the application for view rendering and error handling.
+#
+# Test Coverage:
+# - #remove_empty_error: Removes DoNotDisplayErrorMessage markers from validation errors
+#   - Filters out DoNotDisplayErrorMessage markers while preserving valid error messages
+#   - Removes entire error fields that contain only DoNotDisplayErrorMessage markers
+#   - Ensures clean error display to users by eliminating internal marker constants
+
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#remove_empty_error' do
+    let(:user) { User.new }
+    let(:errors) { user.errors }
+
+    it 'removes errors with DoNotDisplayErrorMessage marker' do
+      errors.add(:field1, 'Valid error')
+      errors.add(:field2, ApplicationHelper::DoNotDisplayErrorMessage)
+      errors.add(:field3, 'Another error')
+      errors.add(:field3, ApplicationHelper::DoNotDisplayErrorMessage)
+
+      helper.remove_empty_error(errors)
+
+      expect(errors[:field1]).to include('Valid error')
+      expect(errors[:field2]).to be_empty
+      # Field3 should have "Another error" but not the empty DoNotDisplayErrorMessage
+      expect(errors[:field3]).to include('Another error')
+      # The empty string should have been removed
+      expect(errors.messages[:field3]).not_to include('')
+    end
+
+    it 'removes only the field if it contains only DoNotDisplayErrorMessage' do
+      errors.add(:terms_of_use_accepted, ApplicationHelper::DoNotDisplayErrorMessage)
+
+      helper.remove_empty_error(errors)
+
+      # The entire key should be removed
+      expect(errors.messages.key?(:terms_of_use_accepted)).to be false
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,31 @@
 # frozen_string_literal: true
 
+# User Model Spec
+#
+# Tests core user authentication, validation, and lifecycle management functionality.
+#
+# Test Coverage:
+# - User Creation: Basic user instantiation and persistence
+# - Password Management:
+#   - Password changes and validation
+#   - Prevention of recent password reuse (checks last N passwords)
+#   - Password expiration after configured age limit
+#   - Password expiration reminders
+# - Email Management:
+#   - Users cannot change their own email addresses
+#   - Admins can change user email addresses
+# - Account Security:
+#   - Disabled users cannot authenticate
+#   - Users cannot change their own disabled flag
+# - Error Handling:
+#   - Prevents duplicate error messages from associated models (GitHub #340)
+#   - Validates single, clear error messages for password reuse
+# - User Registration:
+#   - Self-registration when enabled
+#   - Admin-created users when self-registration disabled
+# - Associations:
+#   - user_preference relationship with autosave and inverse_of
+
 require 'rails_helper'
 include SetupHelper
 
@@ -32,7 +58,7 @@ describe User do
   end
 
   it 'allows password change' do
-    @user.password = @good_password + '&&!'
+    @user.password = "#{@good_password}&&!"
     expect(@user.save).to be true
   end
 
@@ -103,6 +129,39 @@ describe User do
 
     @user.password = "#{@good_password} 1"
     expect(@user.save).to be true
+  end
+
+  it 'does not show duplicate error messages when reusing a recent password' do
+    create_admin
+
+    # Generate 7 new passwords - 0 to 6
+    7.times do |n|
+      @user.password = "#{@good_password} #{n}"
+      @user.save!
+    end
+
+    # Try to reuse a recent password
+    @user.password = "#{@good_password} 3"
+    @user.save
+
+    # Get all error messages
+    error_messages = @user.errors.full_messages
+
+    # The issue: when autosave: true is set on user_preference association,
+    # validation errors get duplicated with the association prefix:
+    # - "New password matches a previous password..."
+    # - "User preference user new password matches a previous password..."
+    # This is confusing for users.
+
+    # Check that we only have ONE error about password reuse, not two
+    password_errors = error_messages.grep(/matches a previous password/i)
+
+    expect(password_errors.length).to eq(1),
+                                      "Expected only 1 password reuse error, but got #{password_errors.length}: #{password_errors.inspect}"
+
+    # Verify the error is the direct one, not the prefixed version
+    expect(password_errors.first).to match(/^New password matches a previous password/i)
+    expect(password_errors.first).not_to match(/User preference/i)
 
     @user.password = "#{@good_password} 1"
     expect(@user.save).to be false


### PR DESCRIPTION
## Summary
Fixes #340 - Duplicate password validation error messages

## Problem
When users tried to reset their password with a previously used password, they saw confusing duplicate errors:
- "New password matches a previous password. 5 previous passwords are checked."
- "User preference user new password matches a previous password. 5 previous passwords are checked."

## Root Cause
The `has_one :user_preference` association with `autosave: true` was propagating validation errors from the User model to the association, causing them to appear twice with an association prefix.

## Solution
Added `validate: false` to the user_preference association in `app/models/user.rb`:
```ruby
has_one :user_preference, autosave: true, inverse_of: :user, validate: false
```

This prevents validation errors from being duplicated through the association while still maintaining autosave behavior.

## Changes Made
- **app/models/user.rb**: Added `validate: false` to user_preference association
- **spec/models/user_spec.rb**: Added test that verifies only one password reuse error appears (fails before fix, passes after)
- **app/helpers/application_helper.rb**: Fixed bug in `remove_empty_error` method where DoNotDisplayErrorMessage markers weren't being properly removed
- **spec/helpers/application_helper_spec.rb**: Added comprehensive test coverage for `remove_empty_error` method
- **spec files**: Added descriptive header comments explaining test coverage
- **.github/copilot-instructions.md**: Updated with latest development guidance

## Testing
All tests pass:
- ✅ User model specs (17 examples including new duplicate error test)
- ✅ UserPreference model specs (9 examples)
- ✅ ApplicationHelper specs (2 examples)
- ✅ System specs for user functionality

The new test specifically validates:
1. Password reuse prevention still works
2. Only ONE error message appears (not duplicated)
3. Error message is the direct one without association prefix

## Verification Steps
1. Run `bundle exec rspec spec/models/user_spec.rb -e 'does not show duplicate error messages'`
2. Test manually by attempting to reset password with a previously used password
3. Verify only one error message appears without "User preference" prefix