### PR TITLE
Added UAC summary to Dynamic Model and External Identifier admin panels - fixes #859

### DIFF
--- a/app/assets/stylesheets/admin/activity_list.scss
+++ b/app/assets/stylesheets/admin/activity_list.scss
@@ -18,8 +18,7 @@
   border-top: 1px solid silver;
 }
 
-ul.activity-list,
-ul.admin-tag-list {
+ul.activity-list {
   padding-left: 0;
   text-align: left;
 
@@ -55,6 +54,12 @@ ul.admin-tag-list {
     }
   }
 
+  ul.common-def-panel--uacs {
+    padding-left: revert;
+    &:before {
+      content: 'access';
+    }
+  }
 }
 
 ul.activity-list {
@@ -103,17 +108,6 @@ ul.activity-list {
       content: 'references';
     }
   }
-
-  ul.activity-list-activity-uacs {
-    &:before {
-      content: 'access';
-    }
-
-    span.activity-log-access-type {
-      font-style: italic;
-      padding: 0 10px 0 20px;
-    }
-  }
 }
 
 
@@ -123,10 +117,6 @@ span.activity-list-name {
   &:hover {
     cursor: pointer;
   }
-}
-
-.admin-tag-list.selectable li:hover {
-  cursor: pointer;
 }
 
 .al-details-section {

--- a/app/assets/stylesheets/admin/common_dynamic_def_panels.scss
+++ b/app/assets/stylesheets/admin/common_dynamic_def_panels.scss
@@ -1,0 +1,28 @@
+.common-def-panel--uacs {
+  span.common-def-panel--access-type {
+    font-style: italic;
+    padding: 0 10px 0 20px;
+  }
+}
+
+ul.admin-tag-list, ul.common-def-panel--uacs {
+  padding-left: 0;
+  text-align: left;
+
+  li {
+    padding: 3px 5px;
+    border: 1px solid silver;
+    border-radius: 3px;
+    line-height: 1em;
+    display: inline-block;
+    list-style: none;
+    background-color: white;
+    margin: 1px;
+    font-family: monospace;
+    font-size: 12px;
+  }
+}
+
+.admin-tag-list.selectable li:hover {
+  cursor: pointer;
+}

--- a/app/assets/stylesheets/admin_index.css
+++ b/app/assets/stylesheets/admin_index.css
@@ -18,6 +18,7 @@
  *= require codemirror/addon/scroll/simplescrollbars
  *= require admin/admin
  *= require admin/app_import
+ *= require admin/common_dynamic_def_panels
  *= require admin/diffy
  *= require admin/activity_list
  *= require admin/admin_options

--- a/app/controllers/admin/dynamic_models_controller.rb
+++ b/app/controllers/admin/dynamic_models_controller.rb
@@ -146,22 +146,13 @@ class Admin::DynamicModelsController < AdminController
   def filtered_primary_model(pm = nil)
     pm = super
 
-    # Apply the special "in_current_app_type" filter after standard filtering
-    if @in_current_app_type_filter.present?
-      app_type = current_admin.matching_user&.app_type
-      if app_type
-        in_app_ids = DynamicModel.ids_in_app_type(app_type)
-        pm = if @in_current_app_type_filter == 'yes'
-               pm.where(id: in_app_ids)
-             elsif @in_current_app_type_filter == 'no'
-               pm.where.not(id: in_app_ids)
-             else
-               pm
-             end
-      end
-    end
+    filtered_in_current_app_type(pm)
+  end
 
-    pm
+  #
+  # Show extra index column indicating if the dynamic model is in the current app type
+  def extra_index_columns
+    { in_current_app_type_result_checkbox: 'In current app type' }
   end
 
   def view_folder

--- a/app/controllers/admin/dynamic_models_controller.rb
+++ b/app/controllers/admin/dynamic_models_controller.rb
@@ -120,12 +120,48 @@ class Admin::DynamicModelsController < AdminController
   def filters
     {
       category: DynamicModel.categories,
-      table_name: DynamicModel.table_names
+      table_name: DynamicModel.table_names,
+      in_current_app_type: %w[yes no]
     }
   end
 
   def filters_on
-    %i[category table_name]
+    %i[category table_name in_current_app_type]
+  end
+
+  #
+  # Override filter_params to extract the custom in_current_app_type filter
+  # before the parent class processes it as a database column
+  # @return [Hash]
+  def filter_params
+    result = super
+    @in_current_app_type_filter = result&.delete(:in_current_app_type)
+    result
+  end
+
+  #
+  # Override to handle the special "in_current_app_type" filter
+  # This filter shows/hides items based on whether they're in the admin's current app type
+  # @return [ActiveRecord::Relation]
+  def filtered_primary_model(pm = nil)
+    pm = super
+
+    # Apply the special "in_current_app_type" filter after standard filtering
+    if @in_current_app_type_filter.present?
+      app_type = current_admin.matching_user&.app_type
+      if app_type
+        in_app_ids = DynamicModel.ids_in_app_type(app_type)
+        pm = if @in_current_app_type_filter == 'yes'
+               pm.where(id: in_app_ids)
+             elsif @in_current_app_type_filter == 'no'
+               pm.where.not(id: in_app_ids)
+             else
+               pm
+             end
+      end
+    end
+
+    pm
   end
 
   def view_folder

--- a/app/controllers/admin/external_identifiers_controller.rb
+++ b/app/controllers/admin/external_identifiers_controller.rb
@@ -71,23 +71,11 @@ class Admin::ExternalIdentifiersController < AdminController
   # @return [ActiveRecord::Relation]
   def filtered_primary_model(pm = nil)
     pm = super
+    filtered_in_current_app_type(pm)
+  end
 
-    # Apply the special "in_current_app_type" filter after standard filtering
-    if @in_current_app_type_filter.present?
-      app_type = current_admin.matching_user&.app_type
-      if app_type
-        in_app_ids = ExternalIdentifier.ids_in_app_type(app_type)
-        pm = if @in_current_app_type_filter == 'yes'
-               pm.where(id: in_app_ids)
-             elsif @in_current_app_type_filter == 'no'
-               pm.where.not(id: in_app_ids)
-             else
-               pm
-             end
-      end
-    end
-
-    pm
+  def extra_index_columns
+    { in_current_app_type_result_checkbox: 'In current app type' }
   end
 
   def admin_labels

--- a/app/controllers/admin/external_identifiers_controller.rb
+++ b/app/controllers/admin/external_identifiers_controller.rb
@@ -46,12 +46,48 @@ class Admin::ExternalIdentifiersController < AdminController
   def filters
     {
       category: ExternalIdentifier.pluck(:category).uniq.compact,
-      name: ExternalIdentifier.pluck(:name).uniq.compact
+      name: ExternalIdentifier.pluck(:name).uniq.compact,
+      in_current_app_type: %w[yes no]
     }
   end
 
   def filters_on
-    %i[category name]
+    %i[category name in_current_app_type]
+  end
+
+  #
+  # Override filter_params to extract the custom in_current_app_type filter
+  # before the parent class processes it as a database column
+  # @return [Hash]
+  def filter_params
+    result = super
+    @in_current_app_type_filter = result&.delete(:in_current_app_type)
+    result
+  end
+
+  #
+  # Override to handle the special "in_current_app_type" filter
+  # This filter shows/hides items based on whether they're in the admin's current app type
+  # @return [ActiveRecord::Relation]
+  def filtered_primary_model(pm = nil)
+    pm = super
+
+    # Apply the special "in_current_app_type" filter after standard filtering
+    if @in_current_app_type_filter.present?
+      app_type = current_admin.matching_user&.app_type
+      if app_type
+        in_app_ids = ExternalIdentifier.ids_in_app_type(app_type)
+        pm = if @in_current_app_type_filter == 'yes'
+               pm.where(id: in_app_ids)
+             elsif @in_current_app_type_filter == 'no'
+               pm.where.not(id: in_app_ids)
+             else
+               pm
+             end
+      end
+    end
+
+    pm
   end
 
   def admin_labels

--- a/app/controllers/concerns/admin_controller_handler.rb
+++ b/app/controllers/concerns/admin_controller_handler.rb
@@ -241,7 +241,7 @@ module AdminControllerHandler
   # so the param readonly=true allows the requester to control this.
   # @return [Boolean]
   def no_edit
-    false || params[:readonly] == 'true'
+    params[:readonly] == 'true'
   end
 
   def no_create
@@ -399,13 +399,13 @@ module AdminControllerHandler
     return pm unless app_type
 
     in_app_ids = primary_model.ids_in_app_type(app_type)
-    pm = if @in_current_app_type_filter == 'yes'
-           pm.where(id: in_app_ids)
-         elsif @in_current_app_type_filter == 'no'
-           pm.where.not(id: in_app_ids)
-         else
-           pm
-         end
+    if @in_current_app_type_filter == 'yes'
+      pm.where(id: in_app_ids)
+    elsif @in_current_app_type_filter == 'no'
+      pm.where.not(id: in_app_ids)
+    else
+      pm
+    end
   end
 
   #
@@ -428,7 +428,7 @@ module AdminControllerHandler
     vals = YAML.safe_load(res)
     vals.transform_values do |v|
       res = if v.is_a?(Hash)
-              v = String.yaml_dump(v)
+              String.yaml_dump(v)
             else
               v
             end

--- a/app/controllers/concerns/admin_controller_handler.rb
+++ b/app/controllers/concerns/admin_controller_handler.rb
@@ -14,7 +14,8 @@ module AdminControllerHandler
                   :objects_instance, :human_name, :no_edit, :primary_model,
                   :view_path, :extra_field_attributes, :admin_links, :view_embedded?, :hide_app_type?,
                   :help_section, :help_subsection, :title, :sub_title, :no_create, :show_head_info, :view_folder,
-                  :no_options_field, :admin_labels, :filters_prevent_disabled, :before_send_processor
+                  :no_options_field, :admin_labels, :filters_prevent_disabled, :before_send_processor, :extra_index_columns,
+                  :in_current_app_type_result_checkbox
   end
 
   def index
@@ -330,6 +331,15 @@ module AdminControllerHandler
   end
 
   #
+  # Hash of extra columns to display in admin index lists.
+  # The keys are method names in the controller, which will be called on each item in the list.
+  # The values are the humanized column names to display in the header.
+  # @return [Hash {Symbol: String} | nil]
+  def extra_index_columns
+    nil
+  end
+
+  #
   # Allow admin tables to be embedded in other pages by passing the param
   # view_as=embedded or view_as=simple-embedded
   # This returns a partial index, and hides the filter buttons
@@ -365,6 +375,37 @@ module AdminControllerHandler
   # ending with "options" or "template" as a multiline code block
   def no_options_field
     false
+  end
+
+  #
+  # Show index column checkbox if the item is in the current admin's app type
+  # @param [ActiveRecord] list_item
+  # @return [String|nil] HTML for the checkbox or nil if not applicable
+  def in_current_app_type_result_checkbox(list_item)
+    @current_app_type ||= current_admin.matching_user&.app_type
+    return unless @current_app_type
+
+    @in_current_app_ids ||= list_item.class.ids_in_app_type(@current_app_type)
+    list_val = @in_current_app_ids.include?(list_item.id)
+    helpers.index_list_item_boolean_field(list_val)
+  end
+
+  #
+  # Apply the special "in_current_app_type" filter after standard filtering
+  def filtered_in_current_app_type(pm)
+    return pm unless @in_current_app_type_filter.present?
+
+    app_type = current_admin.matching_user&.app_type
+    return pm unless app_type
+
+    in_app_ids = primary_model.ids_in_app_type(app_type)
+    pm = if @in_current_app_type_filter == 'yes'
+           pm.where(id: in_app_ids)
+         elsif @in_current_app_type_filter == 'no'
+           pm.where.not(id: in_app_ids)
+         else
+           pm
+         end
   end
 
   #

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -52,7 +52,9 @@ module AdminHelper
       like_type = title.to_s.end_with?('__%')
       title = title[0..-4] if like_type
       linkres = link_to(title, index_path(filter:),
-                        class: "btn #{val.blank? && prev_val.blank? || val.to_s == prev_val.to_s ? 'btn-primary' : 'btn-default'} btn-sm #{like_type ? 'like-type' : ''}")
+                        class: "btn #{(val.blank? && prev_val.blank?) || val.to_s == prev_val.to_s ? 'btn-primary' : 'btn-default'} btn-sm #{if like_type
+                                                                                                                                               'like-type'
+                                                                                                                                             end}")
       if like_type
         @shown_filter_break = false
         res += "<p class=\"like-type\">#{linkres}</p>".html_safe
@@ -158,5 +160,13 @@ module AdminHelper
     END_HTML
 
     res.html_safe
+  end
+
+  def index_list_item_boolean_field(list_val)
+    if list_val
+      '<span class="glyphicon glyphicon-check val-checked"><span class="hidden">1</span></span>'.html_safe
+    else
+      '<span class="val-unchecked"><span class="hidden">0</span></span>'.html_safe
+    end
   end
 end

--- a/app/models/admin/user_access_control.rb
+++ b/app/models/admin/user_access_control.rb
@@ -21,6 +21,8 @@ class Admin::UserAccessControl < Admin::AdminBase
 
   attr_accessor :allow_bad_resource_name
 
+  scope :not_template_role, -> { where(Arel.sql("coalesce(role_name, '') <> '#{Settings::AppTemplateRole}'")) }
+
   #
   # Valid resource types
   # NOTE: external_id_assignments is deprecated and should not be used

--- a/app/models/dynamic_model.rb
+++ b/app/models/dynamic_model.rb
@@ -201,6 +201,25 @@ class DynamicModel < ActiveRecord::Base
   end
 
   #
+  # Get IDs of dynamic models that are in a specific app type
+  # @param [Admin::AppType|Integer] app_type - the app type or its ID
+  # @return [Array<Integer>] IDs of dynamic models associated with the app type
+  def self.ids_in_app_type(app_type)
+    app_type = Admin::AppType.find(app_type) if app_type.is_a?(Integer)
+    return [] unless app_type
+
+    app_type.associated_dynamic_models.pluck(:id)
+  end
+
+  #
+  # Check if this dynamic model is in a specific app type
+  # @param [Admin::AppType|Integer] app_type - the app type or its ID
+  # @return [Boolean]
+  def in_app_type?(app_type)
+    self.class.ids_in_app_type(app_type).include?(id)
+  end
+
+  #
   # Generate the protocol / sub process  / protocol event entries that will be
   # used by implementations when updating and creating records, and subsequently tracking
   # those changes in the tracker history.

--- a/app/models/external_identifier.rb
+++ b/app/models/external_identifier.rb
@@ -75,6 +75,25 @@ class ExternalIdentifier < ActiveRecord::Base
     model_association_name
   end
 
+  #
+  # Get IDs of external identifiers that are in a specific app type
+  # @param [Admin::AppType|Integer] app_type - the app type or its ID
+  # @return [Array<Integer>] IDs of external identifiers associated with the app type
+  def self.ids_in_app_type(app_type)
+    app_type = Admin::AppType.find(app_type) if app_type.is_a?(Integer)
+    return [] unless app_type
+
+    app_type.associated_external_identifiers.pluck(:id)
+  end
+
+  #
+  # Check if this external identifier is in a specific app type
+  # @param [Admin::AppType|Integer] app_type - the app type or its ID
+  # @return [Boolean]
+  def in_app_type?(app_type)
+    self.class.ids_in_app_type(app_type).include?(id)
+  end
+
   def self.routes_load
     mn = nil
 
@@ -306,7 +325,7 @@ class ExternalIdentifier < ActiveRecord::Base
   def id_range_correct
     return if max_id.nil? || min_id.nil?
 
-    errors.add(:max_id, 'must be greater than min id') unless max_id.nil? || max_id && max_id > min_id
+    errors.add(:max_id, 'must be greater than min id') unless max_id.nil? || (max_id && max_id > min_id)
   end
 
   def name_format_correct

--- a/app/views/admin/activity_logs/_def_activity_uac_info.html.erb
+++ b/app/views/admin/activity_logs/_def_activity_uac_info.html.erb
@@ -5,7 +5,7 @@
     access_changed = prev_access != uac.access
     prev_access = uac.access
 %>
-<% if access_changed %><span class="activity-log-access-type"><%= uac.access.presence || 'no access' %></span><% end %>
+<% if access_changed %><span class="common-def-panel--access-type"><%= uac.access.presence || 'no access' %></span><% end %>
 <li>
   <%= uac.user&.email.presence || '' %> 
   <%= uac.role_name.nil? ? '' :  link_to(uac.role_name, admin_user_roles_url(filter: {role_name: uac.role_name} ), target: '_blank') %>

--- a/app/views/admin/activity_logs/_def_details.html.erb
+++ b/app/views/admin/activity_logs/_def_details.html.erb
@@ -86,7 +86,7 @@
               <% end %>
           </ul>
       <% end %>
-      <ul class="activity-list-activity-uacs">
+      <ul class="common-def-panel--uacs">
         <%= render partial: 'admin/activity_logs/def_activity_uac_info', locals: {app_type_id: current_admin.matching_user&.app_type_id, resource_name: conf.resource_name} %>
       </ul>
     </div>

--- a/app/views/admin/common_templates/_def_uac_summary.html.erb
+++ b/app/views/admin/common_templates/_def_uac_summary.html.erb
@@ -15,9 +15,7 @@
   resource_name = object_instance.resource_name&.pluralize
   return unless resource_name.present?
 
-  app_template_role = Settings::AppTemplateRole
-  uacs = Admin::UserAccessControl.active_for(resource_name:).where.not(role_name: app_template_role )
-  
+  uacs = Admin::UserAccessControl.active_for(resource_name:).not_template_role
   no_non_template_uacs = uacs.empty? 
   
   # Check if current user has access to this resource

--- a/app/views/admin/common_templates/_def_uac_summary.html.erb
+++ b/app/views/admin/common_templates/_def_uac_summary.html.erb
@@ -1,0 +1,81 @@
+<%#
+  Partial to display User Access Control summary for a dynamic definition (dynamic model, external identifier, etc.)
+  
+  Required local variables:
+  - object_instance: The dynamic definition instance (DynamicModel, ExternalIdentifier, etc.)
+  - current_app_type_id: The current admin user's app type ID (via current_admin.matching_user.app_type_id)
+  - current_user: The current admin user's matching user (for access check)
+  
+  This partial:
+  1. Shows a summary of UAC roles and access levels for this resource
+  2. Warns if no user access controls are set (ignoring _app_ template roles)
+  3. Warns if the current user/admin has no access to this resource
+%>
+<%
+  resource_name = object_instance.resource_name&.pluralize
+  return unless resource_name.present?
+
+  app_template_role = Settings::AppTemplateRole
+  uacs = Admin::UserAccessControl.active_for(resource_name:).where.not(role_name: app_template_role )
+  
+  no_non_template_uacs = uacs.empty? 
+  
+  # Check if current user has access to this resource
+  current_user_has_access = false
+  if current_user && current_app_type_id
+    current_user_has_access = Admin::UserAccessControl.access_for?(
+      current_user,
+      :access,
+      :table,
+      resource_name,
+      alt_app_type_id: current_app_type_id
+    ).present?
+  end
+  
+  # Check if there are any UACs for the current app type
+  current_app_uacs = uacs.select { |uac| uac.app_type_id == current_app_type_id }
+  
+  prev_access = :not_set
+%>
+
+<label>user access controls</label>
+<%= link_to link_label_open_in_new("view all"), 
+            admin_user_access_controls_path(filter: { resource_name:, resource_type: "table", app_type_id: '' }), 
+            target: '_blank' %>
+
+<% if no_non_template_uacs %>
+  <p class="text-warning">
+    <span class="glyphicon glyphicon-warning-sign"></span>
+    No user access controls defined for this resource.
+  </p>
+<% end %>
+
+<% if current_app_type_id && !current_user_has_access %>
+  <p class="text-warning">
+    <span class="glyphicon glyphicon-warning-sign"></span>
+    Current admin user does not have access to this resource in the current app type.
+  </p>
+<% end %>
+
+<% if current_app_type_id && current_app_uacs.empty? %>
+  <p class="text-info">
+    <span class="glyphicon glyphicon-info-sign"></span>
+    No user access controls defined for the current app type.
+  </p>
+<% end %>
+
+<ul class="common-def-panel--uacs">
+<% uacs.each do |uac|
+     access_changed = prev_access != uac.access
+     prev_access = uac.access
+%>
+<% if access_changed %><span class="common-def-panel--access-type"><%= uac.access.presence || 'no access' %></span><% end %>
+<li>
+  <%= uac.user&.email.presence || '' %> 
+  <%= uac.role_name.nil? ? '' : link_to(uac.role_name, admin_user_roles_url(filter: { role_name: uac.role_name }), target: '_blank') %>
+  <% if uac.app_type_id %>
+    <small class="text-muted">(<%= uac.app_type&.name || "app #{uac.app_type_id}" %>)</small>
+  <% end %>
+</li>
+<% end %>
+</ul>

--- a/app/views/admin/common_templates/_index.html.erb
+++ b/app/views/admin/common_templates/_index.html.erb
@@ -29,6 +29,11 @@
             <th><%= p.to_s.humanize %></th>
           <% end %>
         <% end %>
+        <% if extra_index_columns.present? 
+          extra_index_columns.each do |method_name, col_header| %>
+            <th><%= col_header %></th>
+          <% end %>
+        <% end %>
         <% if admin_links.present? %>
           <th>Admin Links</th>
         <% end %>

--- a/app/views/admin/common_templates/_item.html.erb
+++ b/app/views/admin/common_templates/_item.html.erb
@@ -47,16 +47,16 @@
       <td class="admin-field-<%=p%>"><%= list_val.present? ? '********' : ''  %></td>
     <% elsif p_type == :boolean %>
       <td class="admin-field-<%=p%>">
-        <%= if list_val
-          "<span class=\"glyphicon glyphicon-check val-checked\"><span class=\"hidden\">1</span></span>".html_safe  
-        else
-          "<span class=\"val-unchecked\"><span class=\"hidden\">0</span></span>".html_safe  
-        end
-        %>
+        <%= index_list_item_boolean_field(list_val) %>
       </td>
     <% else %>
       <td class="admin-field-<%=p%>"><%= list_val %></td>
     <% end %>
+    <% end %>
+    <% if extra_index_columns.present? 
+      extra_index_columns.each do |method_name, col_header| %>
+        <td class="admin-item-extra-index-column" data-extra-index-col="<%= col_header %>"><%= send(method_name, list_item) %></td>
+      <% end %>
     <% end %>
 
     <% if admin_links.present? %>

--- a/app/views/admin/dynamic_models/_def_details.html.erb
+++ b/app/views/admin/dynamic_models/_def_details.html.erb
@@ -116,6 +116,13 @@
   <% end %>
 
   <%= render partial: 'admin/dynamic_models/config_errors', locals: { object_instance: } %>
+
+  <%= render partial: 'admin/common_templates/def_uac_summary', 
+             locals: { 
+               object_instance:, 
+               current_app_type_id: current_admin.matching_user&.app_type_id,
+               current_user: current_admin.matching_user
+             } %>
 <% else %>
   <p>
   <label>not yet saved</label>

--- a/app/views/admin/external_identifiers/_def_details.html.erb
+++ b/app/views/admin/external_identifiers/_def_details.html.erb
@@ -75,6 +75,13 @@
 
 <%= render partial: 'admin/dynamic_models/config_errors', locals: { object_instance: } %>
 
+<%= render partial: 'admin/common_templates/def_uac_summary', 
+           locals: { 
+             object_instance:, 
+             current_app_type_id: current_admin.matching_user&.app_type_id,
+             current_user: current_admin.matching_user
+           } %>
+
 </div>
 <div class="dynamic-list-section">
   <label>activities</label>

--- a/spec/controllers/admin/dynamic_models_filter_spec.rb
+++ b/spec/controllers/admin/dynamic_models_filter_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Tests for the DynamicModelsController admin panel enhancements:
+# - in_current_app_type filter
+RSpec.describe Admin::DynamicModelsController, type: :controller do
+  include ModelSupport
+  include DynamicModelSupport
+
+  describe 'filtering by in_current_app_type' do
+    before :all do
+      create_admin
+      create_user
+      @app_type = create_app_type(name: "filter_test_#{rand(100_000)}", label: 'Filter Test')
+
+      # Create a test user
+      @test_user = User.create!(
+        email: "filter_test_#{rand(100_000)}@test.com",
+        first_name: 'Filter',
+        last_name: 'Test',
+        current_admin: @admin
+      )
+
+      # Grant user access to the app type (required before app_type can be set)
+      Admin::UserAccessControl.create!(
+        app_type: @app_type,
+        user: @test_user,
+        resource_type: :general,
+        resource_name: :app_type,
+        access: :read,
+        current_admin: @admin
+      )
+
+      # Now set app_type on user
+      @test_user.app_type = @app_type
+      @test_user.save!
+      @test_user.reload
+      raise "Test user app_type_id not set: #{@test_user.app_type_id}" unless @test_user.app_type_id == @app_type.id
+
+      # Find or create a dynamic model for testing
+      # First try to find an active one, if not try any that exists (may have been disabled by other tests)
+      @dm_in_app = DynamicModel.active.where(table_name: 'test_created_by_recs').first
+      unless @dm_in_app
+        # Try to re-enable an existing disabled one
+        disabled_dm = DynamicModel.where(table_name: 'test_created_by_recs', disabled: true).first
+        if disabled_dm
+          disabled_dm.current_admin = @admin
+          disabled_dm.update!(disabled: false)
+          @dm_in_app = disabled_dm
+        else
+          # Create a new one
+          generate_test_dynamic_model
+          @dm_in_app = DynamicModel.active.where(table_name: 'test_created_by_recs').first
+        end
+      end
+      raise 'Test dynamic model not created' unless @dm_in_app
+
+      # Add UAC for the dynamic model to associate it with the app type
+      Admin::UserAccessControl.create!(
+        app_type: @app_type,
+        resource_type: :table,
+        resource_name: @dm_in_app.resource_name.pluralize,
+        access: :read,
+        current_admin: @admin
+      )
+    end
+
+    after :all do
+      @app_type&.update!(disabled: true, current_admin: @admin)
+    end
+
+    before :each do
+      sign_in @admin
+      # Set up the matching user for the admin
+      allow(@admin).to receive(:matching_user).and_return(@test_user)
+    end
+
+    it 'filters dynamic models that are in the current app type when filter is yes' do
+      controller.instance_variable_set(:@current_admin, @admin)
+      allow(controller).to receive(:current_admin).and_return(@admin)
+      # Set the instance variable that filter_params populates
+      controller.instance_variable_set(:@in_current_app_type_filter, 'yes')
+      # Return empty hash so parent doesn't try to filter on non-existent column
+      allow(controller).to receive(:filter_params).and_return({})
+
+      pm = controller.send(:filtered_primary_model)
+      expect(pm.pluck(:id)).to include(@dm_in_app.id)
+    end
+
+    it 'filters dynamic models that are NOT in the current app type when filter is no' do
+      allow(@admin).to receive(:matching_user).and_return(@test_user)
+      controller.instance_variable_set(:@current_admin, @admin)
+      allow(controller).to receive(:current_admin).and_return(@admin)
+      # Set the instance variable that filter_params populates
+      controller.instance_variable_set(:@in_current_app_type_filter, 'no')
+      # Return empty hash so parent doesn't try to filter on non-existent column
+      allow(controller).to receive(:filter_params).and_return({})
+
+      pm = controller.send(:filtered_primary_model)
+      expect(pm.pluck(:id)).not_to include(@dm_in_app.id)
+    end
+  end
+
+  describe 'filters configuration' do
+    before do
+      create_admin
+      sign_in @admin
+    end
+
+    it 'includes in_current_app_type in the filters' do
+      filters = controller.send(:filters)
+      expect(filters).to have_key(:in_current_app_type)
+      expect(filters[:in_current_app_type]).to eq(%w[yes no])
+    end
+
+    it 'includes in_current_app_type in filters_on' do
+      filters_on = controller.send(:filters_on)
+      expect(filters_on).to include(:in_current_app_type)
+    end
+  end
+end

--- a/spec/models/dynamic_definition_uac_spec.rb
+++ b/spec/models/dynamic_definition_uac_spec.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Tests for the DynamicModel and ExternalIdentifier admin panel enhancements:
+# - UAC summary display in details panel
+# - in_current_app_type filtering
+# - in_app_type? instance method
+# - ids_in_app_type class method
+RSpec.describe 'Dynamic Definition Admin UAC Features', type: :model do
+  include ModelSupport
+  include DynamicModelSupport
+
+  describe 'DynamicModel.ids_in_app_type' do
+    before :all do
+      create_admin
+      create_user
+      @app_type = create_app_type(name: "uac_test_app_#{rand(100_000)}", label: 'UAC Test App')
+
+      # Find or create a dynamic model for testing
+      @dm = DynamicModel.active.where(table_name: 'test_created_by_recs').first
+      unless @dm
+        disabled_dm = DynamicModel.where(table_name: 'test_created_by_recs', disabled: true).first
+        if disabled_dm
+          disabled_dm.current_admin = @admin
+          disabled_dm.update!(disabled: false)
+          @dm = disabled_dm
+        else
+          generate_test_dynamic_model
+          @dm = DynamicModel.active.where(table_name: 'test_created_by_recs').first
+        end
+      end
+      raise 'Test dynamic model not created' unless @dm
+
+      # Add UAC for the dynamic model to associate it with the app type
+      Admin::UserAccessControl.create!(
+        app_type: @app_type,
+        resource_type: :table,
+        resource_name: @dm.resource_name.pluralize,
+        access: :read,
+        current_admin: @admin
+      )
+    end
+
+    after :all do
+      @app_type&.update!(disabled: true, current_admin: @admin)
+    end
+
+    it 'returns IDs of dynamic models associated with an app type' do
+      ids = DynamicModel.ids_in_app_type(@app_type)
+      expect(ids).to include(@dm.id)
+    end
+
+    it 'returns empty array for app type with no dynamic models' do
+      empty_app_type = create_app_type(name: "empty_app_#{rand(100_000)}", label: 'Empty App')
+      ids = DynamicModel.ids_in_app_type(empty_app_type)
+      expect(ids).to be_empty
+      empty_app_type.update!(disabled: true, current_admin: @admin)
+    end
+
+    it 'accepts app type ID as integer' do
+      ids = DynamicModel.ids_in_app_type(@app_type.id)
+      expect(ids).to include(@dm.id)
+    end
+  end
+
+  describe 'DynamicModel#in_app_type?' do
+    before :all do
+      create_admin
+      create_user
+      @app_type = create_app_type(name: "in_app_test_#{rand(100_000)}", label: 'In App Test')
+
+      # Reuse existing dynamic model or re-enable a disabled one
+      @dm = DynamicModel.active.where(table_name: 'test_created_by_recs').first
+      unless @dm
+        disabled_dm = DynamicModel.where(table_name: 'test_created_by_recs', disabled: true).first
+        if disabled_dm
+          disabled_dm.current_admin = @admin
+          disabled_dm.update!(disabled: false)
+          @dm = disabled_dm
+        else
+          generate_test_dynamic_model
+          @dm = DynamicModel.active.where(table_name: 'test_created_by_recs').first
+        end
+      end
+      raise 'Test dynamic model not found' unless @dm
+
+      # Add UAC for the dynamic model
+      Admin::UserAccessControl.create!(
+        app_type: @app_type,
+        resource_type: :table,
+        resource_name: @dm.resource_name.pluralize,
+        access: :read,
+        current_admin: @admin
+      )
+    end
+
+    after :all do
+      @app_type&.update!(disabled: true, current_admin: @admin)
+    end
+
+    it 'returns true when dynamic model is in the app type' do
+      expect(@dm.in_app_type?(@app_type)).to be true
+    end
+
+    it 'returns false when dynamic model is not in the app type' do
+      other_app_type = create_app_type(name: "other_app_#{rand(100_000)}", label: 'Other App')
+      expect(@dm.in_app_type?(other_app_type)).to be false
+      other_app_type.update!(disabled: true, current_admin: @admin)
+    end
+  end
+
+  describe 'ExternalIdentifier.ids_in_app_type' do
+    before :all do
+      create_admin
+
+      @app_type = create_app_type(name: "ext_id_test_#{rand(100_000)}", label: 'Ext ID Test')
+
+      # Find an existing external identifier to test with
+      @ext_id = ExternalIdentifier.active.first
+      next unless @ext_id
+
+      # Add UAC for the external identifier to associate it with the app type
+      Admin::UserAccessControl.create!(
+        app_type: @app_type,
+        resource_type: :table,
+        resource_name: @ext_id.name,
+        access: :read,
+        current_admin: @admin
+      )
+    end
+
+    after :all do
+      @app_type&.update!(disabled: true, current_admin: @admin)
+    end
+
+    it 'returns IDs of external identifiers associated with an app type', if: -> { ExternalIdentifier.active.any? } do
+      next unless @ext_id
+
+      ids = ExternalIdentifier.ids_in_app_type(@app_type)
+      expect(ids).to include(@ext_id.id)
+    end
+
+    it 'returns empty array for app type with no external identifiers' do
+      empty_app_type = create_app_type(name: "empty_ext_#{rand(100_000)}", label: 'Empty Ext')
+      ids = ExternalIdentifier.ids_in_app_type(empty_app_type)
+      expect(ids).to be_empty
+      empty_app_type.update!(disabled: true, current_admin: @admin)
+    end
+  end
+
+  describe 'ExternalIdentifier#in_app_type?' do
+    before :all do
+      create_admin
+
+      @app_type = create_app_type(name: "ext_in_app_#{rand(100_000)}", label: 'Ext In App')
+
+      @ext_id = ExternalIdentifier.active.first
+      next unless @ext_id
+
+      Admin::UserAccessControl.create!(
+        app_type: @app_type,
+        resource_type: :table,
+        resource_name: @ext_id.name,
+        access: :read,
+        current_admin: @admin
+      )
+    end
+
+    after :all do
+      @app_type&.update!(disabled: true, current_admin: @admin)
+    end
+
+    it 'returns true when external identifier is in the app type', if: -> { ExternalIdentifier.active.any? } do
+      next unless @ext_id
+
+      expect(@ext_id.in_app_type?(@app_type)).to be true
+    end
+
+    it 'returns false when external identifier is not in the app type', if: -> { ExternalIdentifier.active.any? } do
+      next unless @ext_id
+
+      other_app_type = create_app_type(name: "other_ext_#{rand(100_000)}", label: 'Other Ext')
+      expect(@ext_id.in_app_type?(other_app_type)).to be false
+      other_app_type.update!(disabled: true, current_admin: @admin)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR adds User Access Control (UAC) summaries to the Dynamic Model and External Identifier admin panels, addressing issue #859.

## Changes

### New Features
- **UAC Summary Panel**: Shows all user access controls for the resource in admin detail views
- **Warning: No UAC**: Displays warning when no user access controls are defined (excluding `_app_` template roles)
- **Warning: No Current User Access**: Displays warning if the current admin has no access to the resource
- **Info: No Current App Type UAC**: Informs if no UACs exist for the current app type
- **`in_current_app_type` Filter**: Allows filtering Dynamic Models and External Identifiers by whether they are in the current app type
- **Index Column**: Shows checkbox indicator for items in the current app type

### Files Changed
- **New**: `app/views/admin/common_templates/_def_uac_summary.html.erb` - Shared partial for UAC summary
- **New**: `app/assets/stylesheets/admin/common_dynamic_def_panels.scss` - Shared styling for UAC panels
- **New**: `spec/controllers/admin/dynamic_models_filter_spec.rb` - Controller filter tests
- **New**: `spec/models/dynamic_definition_uac_spec.rb` - Model method tests
- **Modified**: Controllers to add filter and extra index column support
- **Modified**: Models to add `ids_in_app_type` and `in_app_type?` methods
- **Modified**: `AdminControllerHandler` concern with shared filtering and column logic

## Testing
- 13 RSpec tests covering model methods and controller filtering
- All tests pass

## Checklist
- [x] Code follows project conventions
- [x] RuboCop checks pass (autocorrected)
- [x] Tests written and passing
- [x] Documentation in code (YARD comments)