### PR TITLE
Add active_sublist_values and sort_sublists config options - fixes #584

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,6 +50,13 @@ For general Rspec standards refer to: [Rspec project coding standards](instructi
 
 For Rspec System Specs Refer to: [Rspec System Specs project coding standards](instructions/rspec-system-spec.instructions.md)
 
+### Command Line Usage
+- Create a directory `./tmp/agent-tmp` in the workspace root
+- Use `./tmp/agent-tmp` for all temporary files and logs
+- DO NOT set environment variables or prefix commands with `VAR=VALUE`
+- DO NOT run commands that redirect output to `/dev/null` or `/tmp/`
+- DO NOT run commands in the background using `&` or `nohup`
+- DO NOT run commands with `timeout` unless absolutely necessary
 
 ## Project-Specific Conventions
 
@@ -160,14 +167,17 @@ Resource names are used extensively in access control definitions and naming of 
 ## Development Setup
 ```bash
 # Run once after reboot to setup filestore simulation
+# The user will be prompted for sudo access, so avoid running unless necessary
 app-scripts/setup-dev-filestore.sh 
 
-# Database setup
+# Create an admin user
 app-scripts/add_admin.sh <email>
-FPHS_2FA_AUTH_DISABLED=true bundle exec rails s
+
+# Run the development server
+bundle exec rails s
 
 # Set up test database
-app-scripts/create-test-db.sh 1
+app-scripts/clean-test-db.sh
 
 # Run parallel test suite to validate configuration
 app-scripts/parallel_test.sh

--- a/.github/instructions/rspec-system-spec.instructions.md
+++ b/.github/instructions/rspec-system-spec.instructions.md
@@ -4,6 +4,11 @@ applyTo: 'spec/system/**'
 
 # Rspec System Specs project coding standards
 
+
+## System Specs
+
+System specs are located in `spec/system/`. Follow Best Practices and Development Patterns below when implementing system specs. We write system specs to simulate real user/admin interactions through the UI as much as possible. Interacting with underlying Javascript is discouraged; use Jasmine tests for Javascript-specific behavior. 
+
 ## Rspec System Spec Best Practices
 1. **ALWAYS use helper methods for system specs** - read `spec/support/feature_support.rb` before starting to implement system spec tests
 2. **Run `debug_process_status`** when fields/sections can't be found
@@ -72,10 +77,6 @@ page.execute_script('window.browserLogs = []; console.log = function(msg) { wind
 logs = page.evaluate_script('window.browserLogs')
 puts "Browser console logs:\n#{logs.join("\n")}"
 ```
-
-## System Specs
-
-System specs are located in `spec/system/`. Follow Best Practices and Development Patterns below when implementing system specs. We write system specs to simulate real user/admin interactions through the UI as much as possible. Interacting with underlying Javascript is discouraged; use Jasmine tests for Javascript-specific behavior. 
 
 ### Things to Remember
 - Standard string / varchar fields downcase data on storage and titleize on display. Keep this in mind when writing system specs that interact with user data fields.

--- a/.github/instructions/rspec.instructions.md
+++ b/.github/instructions/rspec.instructions.md
@@ -49,7 +49,7 @@ grep -E --after-context=100 "other pattern" /tmp/rspec_output.log | tail -200
 app-scripts/rails_runner_test.sh "puts User.count"
 app-scripts/headless_rspec.sh spec/system/my_spec.rb -e 'the example to test'
 app-scripts/not_headless_rspec.sh spec/system/my_spec.rb -e 'the example to test'
-app-scripts/clean-test-db.sh 
+app-scripts/clean-test-db.sh # Clean the test database (creates a fresh one)
 app-scripts/clean-test-assets-and-cache.sh # Clean test assets and cache
 ```
 

--- a/.github/instructions/rspec.instructions.md
+++ b/.github/instructions/rspec.instructions.md
@@ -31,6 +31,9 @@ bundle exec rspec spec/system/ > /tmp/output.log 2>&1 &
 # ❌ Redirecting output to /dev/null (lose debugging information)
 bundle exec rspec spec/system/ >/dev/null 2>&1
 bundle exec rspec spec/system/ 2>/dev/null
+
+# ❌ Clearing the assets and cache manually
+rm -rf tmp/cache/assets && rm -rf public/assets
 ```
 
 #### ✅ ALWAYS Do This Instead
@@ -46,6 +49,8 @@ grep -E --after-context=100 "other pattern" /tmp/rspec_output.log | tail -200
 app-scripts/rails_runner_test.sh "puts User.count"
 app-scripts/headless_rspec.sh spec/system/my_spec.rb -e 'the example to test'
 app-scripts/not_headless_rspec.sh spec/system/my_spec.rb -e 'the example to test'
+app-scripts/clean-test-db.sh 
+app-scripts/clean-test-assets-and-cache.sh # Clean test assets and cache
 ```
 
 #### Why These Rules Exist

--- a/app/assets/javascripts/app/handlebars-helpers.js
+++ b/app/assets/javascripts/app/handlebars-helpers.js
@@ -71,13 +71,15 @@
       if (!right) right = '';
       right = right.split(',');
     }
-    return right.indexOf(left) !== -1;
+    // Convert left to string for comparison to handle number/string mismatches
+    return right.indexOf(String(left)) !== -1;
   });
   eR.add('!in', function (left, right) {
     if (!isArray(right)) {
       right = right.split(',');
     }
-    return right.indexOf(left) === -1;
+    // Convert left to string for comparison to handle number/string mismatches
+    return right.indexOf(String(left)) === -1;
   });
   eR.add('includes', function (left, right) {
     return includes(left, right);

--- a/app/helpers/page_layouts_helper.rb
+++ b/app/helpers/page_layouts_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Support the display of page layouts and panels
 module PageLayoutsHelper
   #
@@ -36,5 +38,19 @@ module PageLayoutsHelper
        .reduce([], :concat)
        .uniq
        .compact
+  end
+
+  #
+  # Format active sublist values for Handlebars template rendering.
+  # Converts arrays to comma-separated strings for use with the 'in' operator.
+  # @param [Array|String|nil] values - array of values, 'all' string, or nil
+  # @return [String] formatted value: 'all', 'none', comma-separated string, or empty string
+  def format_active_values(values)
+    return '' if values.nil?
+    return 'all' if values == 'all'
+    return 'none' if values.is_a?(Array) && values.empty?
+    return values.map(&:to_s).join(',') if values.is_a?(Array)
+
+    values.to_s
   end
 end

--- a/app/models/admin/defs/page_layout_options_defs.yaml
+++ b/app/models/admin/defs/page_layout_options_defs.yaml
@@ -43,6 +43,16 @@ view_options:
                                       # or set a series of hashes (keyed by resource name) representing params
                                       # For example:
                                       # { <resource_name>: { <param_name>: <param_value>, ...}, ... }
+  active_sublist_values:              # hash of resource names to filter values that should be active by default
+                                      # For each resource, specify an array of values or 'all' to activate all buttons
+                                      # Example:
+                                      #   player_contacts: [10, 5]    # activate ranks 10 and 5
+                                      #   addresses: all              # activate all filter buttons
+                                      #   dynamic_model__contacts: [] # no buttons active by default
+  sort_sublists:                      # hash of resource names to default sort order ('asc' or 'desc')
+                                      # Example:
+                                      #   player_contacts: desc
+                                      #   addresses: asc
 
 list_options:
   hide_in_list: false (default) | true

--- a/app/models/admin/page_layout.rb
+++ b/app/models/admin/page_layout.rb
@@ -67,10 +67,15 @@ class Admin::PageLayout < Admin::AdminBase
   #   limit: max number of items to show in panel
   #   initial_show: initially open up a panel
   #   find_with: the alternative id (crosswalk or external id) to search for the master record with for standalone pages
+  #   active_sublist_values: hash of resource names to array of filter values that should be active by default
+  #                         e.g. { player_contacts: [10, 5], addresses: 'all' }
+  #   sort_sublists: hash of resource names to default sort order ('asc' or 'desc')
+  #                  e.g. { player_contacts: 'desc', addresses: 'asc' }
   configure :view_options,
             with: %i[initial_show orientation add_item_label limit find_with hide_sublist_controls default_expander
                      hide_activity_logs_header close_others
-                     show_for_single_master_only show_for_multi_master_only filter_items]
+                     show_for_single_master_only show_for_multi_master_only filter_items
+                     active_sublist_values sort_sublists]
 
   # List options for dashboards list
   configure :list_options, with: %i[hide_in_list]

--- a/app/views/masters/_dynamic_model_blocks.html.erb
+++ b/app/views/masters/_dynamic_model_blocks.html.erb
@@ -51,12 +51,20 @@ unless defined? orientation
   orientation = nil
 end
 
+# Get active_sublist_values and sort_sublists from panel view_options
+active_sublist_values = (panel&.view_options&.active_sublist_values || {}).with_indifferent_access
+sort_sublists = (panel&.view_options&.sort_sublists || {}).with_indifferent_access
+
 category_models.each do |m|
 
   if viewable  [m.resource_name.to_sym]
     po = panel&.view_options&.orientation
     awc = m.default_options&.view_options&.dig(:alt_width_classes)
     hide_sl = panel&.view_options&.hide_sublist_controls
+    
+    # Get resource-specific active values and sort order
+    resource_active_values = format_active_values(active_sublist_values[m.full_item_types_name])
+    resource_sort_order = sort_sublists[m.full_item_types_name] || 'asc'
 
     orientation ||= po == 'horizontal' || (DynamicModel.orientation(category) == :horizontal) ? 'horizontal' : po
 
@@ -82,7 +90,7 @@ category_models.each do |m|
 %>  
     <div class="masters--dynamic-model-blocks-outer-alt-orientation <%= width_classes %> category-<%=category%> orientation-<%=orientation%> sublist-column details-item-type-<%=m.full_item_types_name.id_hyphenate%>">
       <% unless hide_sl %>
-      {{>sublist_controls sub_list="<%=m.full_item_types_name%>" order='asc'}}
+      {{>sublist_controls sub_list="<%=m.full_item_types_name%>" order='<%= resource_sort_order %>' active_values='<%= resource_active_values %>' }}
       <% end %>
       <div class="masters--dynamic-model-blocks dynamic-container do-not-resize-children category-<%=category%> orientation-<%=orientation%>" id="<%=m.full_item_types_name%>-{{id}}-" data-sub-list="<%=m.full_item_types_name%>"></div>
     </div>

--- a/app/views/masters/_master_panels.html.erb
+++ b/app/views/masters/_master_panels.html.erb
@@ -12,16 +12,6 @@
   # Use with_indifferent_access to allow both symbol and string key access
   active_sublist_values = (details_view_options&.active_sublist_values || {}).with_indifferent_access
   sort_sublists = (details_view_options&.sort_sublists || {}).with_indifferent_access
-
-  # Helper to format active values for Handlebars - converts array to comma-separated string
-  # or returns 'all' for all-active mode, or 'none' for no buttons active
-  def format_active_values(values)
-    return '' if values.nil?
-    return 'all' if values == 'all'
-    return 'none' if values.is_a?(Array) && values.empty?
-    return values.map(&:to_s).join(',') if values.is_a?(Array)
-    values.to_s
-  end
 %>
 
 <script id="master_external_links_panel" type="text/x-handlebars-template" class="hidden handlebars-partial">

--- a/app/views/masters/_master_panels.html.erb
+++ b/app/views/masters/_master_panels.html.erb
@@ -14,10 +14,11 @@
   sort_sublists = (details_view_options&.sort_sublists || {}).with_indifferent_access
 
   # Helper to format active values for Handlebars - converts array to comma-separated string
-  # or returns 'all' for all-active mode
+  # or returns 'all' for all-active mode, or 'none' for no buttons active
   def format_active_values(values)
     return '' if values.nil?
     return 'all' if values == 'all'
+    return 'none' if values.is_a?(Array) && values.empty?
     return values.map(&:to_s).join(',') if values.is_a?(Array)
     values.to_s
   end

--- a/app/views/masters/_master_panels.html.erb
+++ b/app/views/masters/_master_panels.html.erb
@@ -5,6 +5,22 @@
   #
   # The view `views/masters/_search_results_template.html.erb` is responsible for
   # rendering the overall master record view and deciding which panels to show.
+
+  # Get page layout configuration for the details panel to access view_options
+  details_panel = page_layout_panel(panel_name: 'details')
+  details_view_options = details_panel&.view_options
+  # Use with_indifferent_access to allow both symbol and string key access
+  active_sublist_values = (details_view_options&.active_sublist_values || {}).with_indifferent_access
+  sort_sublists = (details_view_options&.sort_sublists || {}).with_indifferent_access
+
+  # Helper to format active values for Handlebars - converts array to comma-separated string
+  # or returns 'all' for all-active mode
+  def format_active_values(values)
+    return '' if values.nil?
+    return 'all' if values == 'all'
+    return values.map(&:to_s).join(',') if values.is_a?(Array)
+    values.to_s
+  end
 %>
 
 <script id="master_external_links_panel" type="text/x-handlebars-template" class="hidden handlebars-partial">
@@ -98,8 +114,12 @@
       <% end %>
 
       <% if master_viewables[:addresses] %>
+      <%
+        addresses_active_values = format_active_values(active_sublist_values[:addresses])
+        addresses_sort_order = sort_sublists[:addresses] || 'asc'
+      %>
       <div class="<%= layout_item_block_sizes[:regular] %> sublist-column" id="addresses-{{id}}-" data-sub-list="addresses">
-        {{>sublist_controls sub_list="addresses" filter_attr='rank' filter_name="rank_name" order='asc' }}
+        {{>sublist_controls sub_list="addresses" filter_attr='rank' filter_name="rank_name" order='<%= addresses_sort_order %>' active_values='<%= addresses_active_values %>' }}
 
         {{#each addresses}}
 
@@ -116,8 +136,12 @@
       <% end %>
 
       <% if master_viewables[:player_contacts] %>
+      <%
+        player_contacts_active_values = format_active_values(active_sublist_values[:player_contacts])
+        player_contacts_sort_order = sort_sublists[:player_contacts] || 'asc'
+      %>
       <div class="<%= layout_item_block_sizes[:regular] %> sublist-column" id="player_contacts-{{id}}-" data-sub-list="player_contacts">
-        {{>sublist_controls sub_list="player_contacts" filter_attr='rank' filter_name="rank_name" order='asc' }}
+        {{>sublist_controls sub_list="player_contacts" filter_attr='rank' filter_name="rank_name" order='<%= player_contacts_sort_order %>' active_values='<%= player_contacts_active_values %>' }}
 
         {{#each player_contacts}}
 

--- a/app/views/masters/_search_results_parts.html.erb
+++ b/app/views/masters/_search_results_parts.html.erb
@@ -173,7 +173,7 @@
       {{#each (sort (unique (pluck (lookup this (or sub_list_data_name sub_list)) filter_attr filter_name)) 'desc')}}
       {{#is this.[1] 'includes' '{{' }}
       {{else}}
-      <button class="btn btn-default btn-sm filter-switch {{#if ../all_active}}active{{else}}{{#is ../active_values 'all'}}active{{else}}{{#if ../active_values}}{{#is this.[0] 'in' ../active_values}}active{{/is}}{{else}}{{#is @key 0}}active{{/is}}{{/if}}{{/is}}{{/if}}" data-filter-sub-list="{{../sub_list}}" data-filter-sub-list-attr="{{hyphenate ../filter_attr}}" data-filter-val="{{this.[0]}}">{{#is this.[1]}}{{this.[1]}}{{else}}(none){{/is}}</button>
+      <button class="btn btn-default btn-sm filter-switch {{#if ../all_active}}active{{else}}{{#is ../active_values 'all'}}active{{else}}{{#is ../active_values 'none'}}{{else}}{{#if ../active_values}}{{#is this.[0] 'in' ../active_values}}active{{/is}}{{else}}{{#is @key 0}}active{{/is}}{{/if}}{{/is}}{{/is}}{{/if}}" data-filter-sub-list="{{../sub_list}}" data-filter-sub-list-attr="{{hyphenate ../filter_attr}}" data-filter-val="{{this.[0]}}">{{#is this.[1]}}{{this.[1]}}{{else}}(none){{/is}}</button>
       {{/is}}
       {{/each}}
     </div>

--- a/app/views/masters/_search_results_parts.html.erb
+++ b/app/views/masters/_search_results_parts.html.erb
@@ -173,7 +173,7 @@
       {{#each (sort (unique (pluck (lookup this (or sub_list_data_name sub_list)) filter_attr filter_name)) 'desc')}}
       {{#is this.[1] 'includes' '{{' }}
       {{else}}
-      <button class="btn btn-default btn-sm filter-switch {{#if ../all_active}}active{{else}}{{#is @key 0}}active{{/is}}{{/if}}" data-filter-sub-list="{{../sub_list}}" data-filter-sub-list-attr="{{hyphenate ../filter_attr}}" data-filter-val="{{this.[0]}}">{{#is this.[1]}}{{this.[1]}}{{else}}(none){{/is}}</button>
+      <button class="btn btn-default btn-sm filter-switch {{#if ../all_active}}active{{else}}{{#is ../active_values 'all'}}active{{else}}{{#if ../active_values}}{{#is this.[0] 'in' ../active_values}}active{{/is}}{{else}}{{#is @key 0}}active{{/is}}{{/if}}{{/is}}{{/if}}" data-filter-sub-list="{{../sub_list}}" data-filter-sub-list-attr="{{hyphenate ../filter_attr}}" data-filter-val="{{this.[0]}}">{{#is this.[1]}}{{this.[1]}}{{else}}(none){{/is}}</button>
       {{/is}}
       {{/each}}
     </div>

--- a/spec/helpers/page_layouts_helper_spec.rb
+++ b/spec/helpers/page_layouts_helper_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Unit tests for PageLayoutsHelper methods, specifically the format_active_values
+# helper used for configuring sublist filter button defaults.
+# Related to GitHub Issue #584.
+
+RSpec.describe PageLayoutsHelper, type: :helper do
+  describe '#format_active_values' do
+    it 'returns empty string for nil values' do
+      expect(helper.format_active_values(nil)).to eq('')
+    end
+
+    it "returns 'all' when value is 'all' string" do
+      expect(helper.format_active_values('all')).to eq('all')
+    end
+
+    it "returns 'none' for empty array" do
+      expect(helper.format_active_values([])).to eq('none')
+    end
+
+    it 'returns comma-separated string for array of integers' do
+      expect(helper.format_active_values([10, 5, -1])).to eq('10,5,-1')
+    end
+
+    it 'returns comma-separated string for array of strings' do
+      expect(helper.format_active_values(%w[primary secondary])).to eq('primary,secondary')
+    end
+
+    it 'returns comma-separated string for mixed array' do
+      expect(helper.format_active_values([10, 'active', 5])).to eq('10,active,5')
+    end
+
+    it 'returns string representation for single value' do
+      expect(helper.format_active_values(10)).to eq('10')
+    end
+
+    it 'converts symbols to strings' do
+      expect(helper.format_active_values(:active)).to eq('active')
+    end
+  end
+end

--- a/spec/support/feature_support.rb
+++ b/spec/support/feature_support.rb
@@ -531,7 +531,7 @@ module FeatureSupport
   end
 
   #
-  # Expand a master record, optionally with matching text
+  # Expand a master record, by id or matching link text
   # @param [String, nil] text The text to match for the master-expander link
   def expand_master_record(text: nil, master_id: nil)
     finish_form_formatting

--- a/spec/system/page_layout/sublist_default_filters_spec.rb
+++ b/spec/system/page_layout/sublist_default_filters_spec.rb
@@ -199,4 +199,154 @@ describe 'sublist default filter configuration', js: true, driver: $browser_driv
                                           'Expected filter button for rank -1 to NOT be active (not in active_sublist_values config)'
     end
   end
+
+  it 'activates all filter buttons when configured with "all" value' do
+    # Update config to use 'all'
+    @panel_layout.update!(
+      current_admin: @admin,
+      options: <<~YAML
+        contains:
+          categories:
+            - details
+        view_options:
+          initial_show: true
+          active_sublist_values:
+            player_contacts: all
+      YAML
+    )
+
+    visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@master.id}"
+    finish_page_loading
+    expect(page).to have_css("#master-#{@master.id}", wait: 10)
+    dismiss_modal
+
+    unless page.has_css?("[id^='player_contacts-#{@master.id}']", wait: 15)
+      master_link = find("#master-#{@master.id} a.master-expander", wait: 5)
+      scroll_into_view(master_link)
+      master_link.click
+      finish_page_loading
+      sleep 3
+    end
+
+    within '[data-sub-list="player_contacts"] .sublist-filter-selectors' do
+      # All buttons should be active when 'all' is configured
+      all('button.filter-switch').each do |button|
+        expect(button[:class]).to include('active'),
+                                  "Expected all filter buttons to be active when active_sublist_values is 'all'"
+      end
+    end
+  end
+
+  it 'activates no filter buttons when configured with empty array' do
+    # Update config to use empty array
+    @panel_layout.update!(
+      current_admin: @admin,
+      options: <<~YAML
+        contains:
+          categories:
+            - details
+        view_options:
+          initial_show: true
+          active_sublist_values:
+            player_contacts: []
+      YAML
+    )
+
+    visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@master.id}"
+    finish_page_loading
+    expect(page).to have_css("#master-#{@master.id}", wait: 10)
+    dismiss_modal
+
+    unless page.has_css?("[id^='player_contacts-#{@master.id}']", wait: 15)
+      master_link = find("#master-#{@master.id} a.master-expander", wait: 5)
+      scroll_into_view(master_link)
+      master_link.click
+      finish_page_loading
+      sleep 3
+    end
+
+    within '[data-sub-list="player_contacts"] .sublist-filter-selectors' do
+      # No buttons should be active when empty array is configured
+      all('button.filter-switch').each do |button|
+        expect(button[:class]).not_to include('active'),
+                                       'Expected no filter buttons to be active when active_sublist_values is empty array'
+      end
+    end
+  end
+
+  it 'falls back to first button active when key is missing from config' do
+    # Update config without player_contacts key
+    @panel_layout.update!(
+      current_admin: @admin,
+      options: <<~YAML
+        contains:
+          categories:
+            - details
+        view_options:
+          initial_show: true
+          active_sublist_values:
+            addresses: all
+      YAML
+    )
+
+    visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@master.id}"
+    finish_page_loading
+    expect(page).to have_css("#master-#{@master.id}", wait: 10)
+    dismiss_modal
+
+    unless page.has_css?("[id^='player_contacts-#{@master.id}']", wait: 15)
+      master_link = find("#master-#{@master.id} a.master-expander", wait: 5)
+      scroll_into_view(master_link)
+      master_link.click
+      finish_page_loading
+      sleep 3
+    end
+
+    within '[data-sub-list="player_contacts"] .sublist-filter-selectors' do
+      buttons = all('button.filter-switch')
+      # First button should be active (default behavior when no config)
+      expect(buttons.first[:class]).to include('active'),
+                                        'Expected first filter button to be active as fallback when key missing'
+      # Other buttons should not be active
+      buttons[1..].each do |button|
+        expect(button[:class]).not_to include('active'),
+                                       'Expected non-first buttons to be inactive as fallback when key missing'
+      end
+    end
+  end
+
+  it 'sets sort order based on sort_sublists configuration' do
+    # Update config to include sort order
+    @panel_layout.update!(
+      current_admin: @admin,
+      options: <<~YAML
+        contains:
+          categories:
+            - details
+        view_options:
+          initial_show: true
+          sort_sublists:
+            player_contacts: desc
+      YAML
+    )
+
+    visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@master.id}"
+    finish_page_loading
+    expect(page).to have_css("#master-#{@master.id}", wait: 10)
+    dismiss_modal
+
+    unless page.has_css?("[id^='player_contacts-#{@master.id}']", wait: 15)
+      master_link = find("#master-#{@master.id} a.master-expander", wait: 5)
+      scroll_into_view(master_link)
+      master_link.click
+      finish_page_loading
+      sleep 3
+    end
+
+    within '[data-sub-list="player_contacts"] .sublist-order-selector' do
+      order_button = find('button.order-switch')
+      expect(order_button['data-order-val']).to eq('desc'),
+                                                 'Expected order button to have data-order-val="desc" based on sort_sublists config'
+    end
+  end
 end

--- a/spec/system/page_layout/sublist_default_filters_spec.rb
+++ b/spec/system/page_layout/sublist_default_filters_spec.rb
@@ -33,6 +33,43 @@ describe 'sublist default filter configuration', js: true, driver: $browser_driv
   include MasterDataSupport
   include FeatureSupport
 
+  # Helper to navigate to master record and wait for player_contacts to render
+  def navigate_to_master_and_wait_for_contacts
+    visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@master.id}"
+    finish_page_loading
+    expect(page).to have_css("#master-#{@master.id}", wait: 10)
+    dismiss_modal
+
+    # Wait for master content to be fully rendered
+    unless page.has_css?("[id^='player_contacts-#{@master.id}']", wait: 15)
+      master_link = find("#master-#{@master.id} a.master-expander", wait: 5)
+      scroll_into_view(master_link)
+      master_link.click
+      finish_page_loading
+      sleep 3
+    end
+
+    # Debug if player_contacts still not found
+    return if page.has_css?("[id^='player_contacts-#{@master.id}']", wait: 10)
+
+    puts '=== Checking for JS errors ==='
+    begin
+      logs = page.driver.browser.logs.get(:browser)
+      logs.each { |log| puts "Browser log: #{log.level} - #{log.message}" }
+    rescue StandardError => e
+      puts "Could not get browser logs: #{e.message}"
+    end
+
+    debug_process_status
+    save_html_snapshot('/tmp/sublist_expanded.html')
+    raise 'Could not find player_contacts. Check /tmp/sublist_expanded.html'
+  end
+
+  # Helper to update page layout configuration
+  def update_layout_config(options_yaml)
+    @panel_layout.update!(current_admin: @admin, options: options_yaml)
+  end
+
   before(:all) do
     change_setting('TwoFactorAuthDisabledForUser', true)
     change_setting('TwoFactorAuthDisabledForAdmin', true)
@@ -146,90 +183,37 @@ describe 'sublist default filter configuration', js: true, driver: $browser_driv
   end
 
   it 'activates only filter buttons matching the configured array values - fixes #584' do
-    # Navigate to the master record
-    visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@master.id}"
-    finish_page_loading
-
-    # Wait for search results to load (the master-result heading)
-    expect(page).to have_css("#master-#{@master.id}", wait: 10)
-    dismiss_modal
-
-    # Wait for master content to be fully rendered - look for player_contacts with an ID
-    # The ID indicates Handlebars has rendered the template with actual data
-    unless page.has_css?("[id^='player_contacts-#{@master.id}']", wait: 15)
-      # The Handlebars templates haven't been rendered yet
-      # Try clicking the master expander to trigger content load
-      master_link = find("#master-#{@master.id} a.master-expander", wait: 5)
-      scroll_into_view(master_link)
-      master_link.click
-      finish_page_loading
-      sleep 3 # Allow time for AJAX and Handlebars rendering
-    end
-
-    # Debug if player_contacts still not found
-    unless page.has_css?("[id^='player_contacts-#{@master.id}']", wait: 10)
-      # Check for JavaScript errors
-      puts '=== Checking for JS errors ==='
-      begin
-        logs = page.driver.browser.logs.get(:browser)
-        logs.each { |log| puts "Browser log: #{log.level} - #{log.message}" }
-      rescue StandardError => e
-        puts "Could not get browser logs: #{e.message}"
-      end
-
-      debug_process_status
-      save_html_snapshot('/tmp/sublist_expanded.html')
-      raise 'Could not find player_contacts. Check /tmp/sublist_expanded.html'
-    end
-
+    navigate_to_master_and_wait_for_contacts
     expect(page).not_to have_css('.alert-danger')
 
-    # Find the player_contacts sublist filter buttons
     within '[data-sub-list="player_contacts"] .sublist-filter-selectors' do
-      # Buttons for rank 10 and 5 should be active (in our configuration)
       filter_10 = find('button.filter-switch[data-filter-val="10"]')
       filter_5 = find('button.filter-switch[data-filter-val="5"]')
       filter_other = find('button.filter-switch[data-filter-val="-1"]')
 
       expect(filter_10[:class]).to include('active'),
-                                   'Expected filter button for rank 10 to be active based on active_sublist_values config'
+                                   'Expected filter button for rank 10 to be active'
       expect(filter_5[:class]).to include('active'),
-                                  'Expected filter button for rank 5 to be active based on active_sublist_values config'
+                                  'Expected filter button for rank 5 to be active'
       expect(filter_other[:class]).not_to include('active'),
-                                          'Expected filter button for rank -1 to NOT be active (not in active_sublist_values config)'
+                                          'Expected filter button for rank -1 to NOT be active'
     end
   end
 
   it 'activates all filter buttons when configured with "all" value' do
-    # Update config to use 'all'
-    @panel_layout.update!(
-      current_admin: @admin,
-      options: <<~YAML
-        contains:
-          categories:
-            - details
-        view_options:
-          initial_show: true
-          active_sublist_values:
-            player_contacts: all
-      YAML
-    )
+    update_layout_config(<<~YAML)
+      contains:
+        categories:
+          - details
+      view_options:
+        initial_show: true
+        active_sublist_values:
+          player_contacts: all
+    YAML
 
-    visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@master.id}"
-    finish_page_loading
-    expect(page).to have_css("#master-#{@master.id}", wait: 10)
-    dismiss_modal
-
-    unless page.has_css?("[id^='player_contacts-#{@master.id}']", wait: 15)
-      master_link = find("#master-#{@master.id} a.master-expander", wait: 5)
-      scroll_into_view(master_link)
-      master_link.click
-      finish_page_loading
-      sleep 3
-    end
+    navigate_to_master_and_wait_for_contacts
 
     within '[data-sub-list="player_contacts"] .sublist-filter-selectors' do
-      # All buttons should be active when 'all' is configured
       all('button.filter-switch').each do |button|
         expect(button[:class]).to include('active'),
                                   "Expected all filter buttons to be active when active_sublist_values is 'all'"
@@ -238,35 +222,19 @@ describe 'sublist default filter configuration', js: true, driver: $browser_driv
   end
 
   it 'activates no filter buttons when configured with empty array' do
-    # Update config to use empty array
-    @panel_layout.update!(
-      current_admin: @admin,
-      options: <<~YAML
-        contains:
-          categories:
-            - details
-        view_options:
-          initial_show: true
-          active_sublist_values:
-            player_contacts: []
-      YAML
-    )
+    update_layout_config(<<~YAML)
+      contains:
+        categories:
+          - details
+      view_options:
+        initial_show: true
+        active_sublist_values:
+          player_contacts: []
+    YAML
 
-    visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@master.id}"
-    finish_page_loading
-    expect(page).to have_css("#master-#{@master.id}", wait: 10)
-    dismiss_modal
-
-    unless page.has_css?("[id^='player_contacts-#{@master.id}']", wait: 15)
-      master_link = find("#master-#{@master.id} a.master-expander", wait: 5)
-      scroll_into_view(master_link)
-      master_link.click
-      finish_page_loading
-      sleep 3
-    end
+    navigate_to_master_and_wait_for_contacts
 
     within '[data-sub-list="player_contacts"] .sublist-filter-selectors' do
-      # No buttons should be active when empty array is configured
       all('button.filter-switch').each do |button|
         expect(button[:class]).not_to include('active'),
                                       'Expected no filter buttons to be active when active_sublist_values is empty array'
@@ -275,78 +243,83 @@ describe 'sublist default filter configuration', js: true, driver: $browser_driv
   end
 
   it 'falls back to first button active when key is missing from config' do
-    # Update config without player_contacts key
-    @panel_layout.update!(
-      current_admin: @admin,
-      options: <<~YAML
-        contains:
-          categories:
-            - details
-        view_options:
-          initial_show: true
-          active_sublist_values:
-            addresses: all
-      YAML
-    )
+    update_layout_config(<<~YAML)
+      contains:
+        categories:
+          - details
+      view_options:
+        initial_show: true
+        active_sublist_values:
+          addresses: all
+    YAML
 
-    visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@master.id}"
-    finish_page_loading
-    expect(page).to have_css("#master-#{@master.id}", wait: 10)
-    dismiss_modal
-
-    unless page.has_css?("[id^='player_contacts-#{@master.id}']", wait: 15)
-      master_link = find("#master-#{@master.id} a.master-expander", wait: 5)
-      scroll_into_view(master_link)
-      master_link.click
-      finish_page_loading
-      sleep 3
-    end
+    navigate_to_master_and_wait_for_contacts
 
     within '[data-sub-list="player_contacts"] .sublist-filter-selectors' do
       buttons = all('button.filter-switch')
-      # First button should be active (default behavior when no config)
       expect(buttons.first[:class]).to include('active'),
-                                       'Expected first filter button to be active as fallback when key missing'
-      # Other buttons should not be active
+                                       'Expected first filter button to be active as fallback'
       buttons[1..].each do |button|
         expect(button[:class]).not_to include('active'),
-                                      'Expected non-first buttons to be inactive as fallback when key missing'
+                                      'Expected non-first buttons to be inactive as fallback'
       end
     end
   end
 
   it 'sets sort order based on sort_sublists configuration' do
-    # Update config to include sort order
-    @panel_layout.update!(
-      current_admin: @admin,
-      options: <<~YAML
-        contains:
-          categories:
-            - details
-        view_options:
-          initial_show: true
-          sort_sublists:
-            player_contacts: desc
-      YAML
-    )
+    update_layout_config(<<~YAML)
+      contains:
+        categories:
+          - details
+      view_options:
+        initial_show: true
+        sort_sublists:
+          player_contacts: desc
+    YAML
 
-    visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@master.id}"
-    finish_page_loading
-    expect(page).to have_css("#master-#{@master.id}", wait: 10)
-    dismiss_modal
-
-    unless page.has_css?("[id^='player_contacts-#{@master.id}']", wait: 15)
-      master_link = find("#master-#{@master.id} a.master-expander", wait: 5)
-      scroll_into_view(master_link)
-      master_link.click
-      finish_page_loading
-      sleep 3
-    end
+    navigate_to_master_and_wait_for_contacts
 
     within '[data-sub-list="player_contacts"] .sublist-order-selector' do
       order_button = find('button.order-switch')
       expect(order_button['data-order-val']).to eq('desc'),
-                                                'Expected order button to have data-order-val="desc" based on sort_sublists config'
+                                                'Expected order button to have data-order-val="desc"'
+    end
+  end
+
+  it 'applies both active_sublist_values and sort_sublists together' do
+    update_layout_config(<<~YAML)
+      contains:
+        categories:
+          - details
+      view_options:
+        initial_show: true
+        active_sublist_values:
+          player_contacts: [5]
+        sort_sublists:
+          player_contacts: desc
+    YAML
+
+    navigate_to_master_and_wait_for_contacts
+
+    # Verify active filter buttons
+    within '[data-sub-list="player_contacts"] .sublist-filter-selectors' do
+      filter_5 = find('button.filter-switch[data-filter-val="5"]')
+      filter_10 = find('button.filter-switch[data-filter-val="10"]')
+      filter_other = find('button.filter-switch[data-filter-val="-1"]')
+
+      expect(filter_5[:class]).to include('active'),
+                                  'Expected only rank 5 button to be active'
+      expect(filter_10[:class]).not_to include('active'),
+                                       'Expected rank 10 button to NOT be active'
+      expect(filter_other[:class]).not_to include('active'),
+                                          'Expected rank -1 button to NOT be active'
+    end
+
+    # Verify sort order
+    within '[data-sub-list="player_contacts"] .sublist-order-selector' do
+      order_button = find('button.order-switch')
+      expect(order_button['data-order-val']).to eq('desc'),
+                                                'Expected order button to have data-order-val="desc"'
     end
   end
 end

--- a/spec/system/page_layout/sublist_default_filters_spec.rb
+++ b/spec/system/page_layout/sublist_default_filters_spec.rb
@@ -42,9 +42,7 @@ describe 'sublist default filter configuration', js: true, driver: $browser_driv
 
     # Wait for master content to be fully rendered
     unless page.has_css?("[id^='player_contacts-#{@master.id}']", wait: 15)
-      master_link = find("#master-#{@master.id} a.master-expander", wait: 5)
-      scroll_into_view(master_link)
-      master_link.click
+      expand_master_record(master_id: @master.id)
       finish_page_loading
       sleep 3
     end

--- a/spec/system/page_layout/sublist_default_filters_spec.rb
+++ b/spec/system/page_layout/sublist_default_filters_spec.rb
@@ -125,7 +125,7 @@ describe 'sublist default filter configuration', js: true, driver: $browser_driv
       )
     end
 
-    ac = add_app_config(@app_type, 'open panels', 'details', user: @user)
+    add_app_config(@app_type, 'open panels', 'details', user: @user)
   end
 
   after(:all) do
@@ -269,7 +269,7 @@ describe 'sublist default filter configuration', js: true, driver: $browser_driv
       # No buttons should be active when empty array is configured
       all('button.filter-switch').each do |button|
         expect(button[:class]).not_to include('active'),
-                                       'Expected no filter buttons to be active when active_sublist_values is empty array'
+                                      'Expected no filter buttons to be active when active_sublist_values is empty array'
       end
     end
   end
@@ -306,11 +306,11 @@ describe 'sublist default filter configuration', js: true, driver: $browser_driv
       buttons = all('button.filter-switch')
       # First button should be active (default behavior when no config)
       expect(buttons.first[:class]).to include('active'),
-                                        'Expected first filter button to be active as fallback when key missing'
+                                       'Expected first filter button to be active as fallback when key missing'
       # Other buttons should not be active
       buttons[1..].each do |button|
         expect(button[:class]).not_to include('active'),
-                                       'Expected non-first buttons to be inactive as fallback when key missing'
+                                      'Expected non-first buttons to be inactive as fallback when key missing'
       end
     end
   end
@@ -346,7 +346,7 @@ describe 'sublist default filter configuration', js: true, driver: $browser_driv
     within '[data-sub-list="player_contacts"] .sublist-order-selector' do
       order_button = find('button.order-switch')
       expect(order_button['data-order-val']).to eq('desc'),
-                                                 'Expected order button to have data-order-val="desc" based on sort_sublists config'
+                                                'Expected order button to have data-order-val="desc" based on sort_sublists config'
     end
   end
 end

--- a/spec/system/page_layout/sublist_default_filters_spec.rb
+++ b/spec/system/page_layout/sublist_default_filters_spec.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+# Spec for GitHub Issue #584: Phone contacts rank filter buttons - need an app config for which to show as active
+#
+# This spec tests the page layout view_options configuration for:
+#
+# Requirement 1: active_sublist_values
+#   - Array config [10,5] → only buttons matching those values have 'active' class
+#   - String 'all' → all filter buttons have 'active' class
+#   - Empty array [] → no filter buttons have 'active' class
+#   - Missing key → falls back to current default (first button active)
+#
+# Requirement 2: sort_sublists
+#   - 'desc' config → order button has data-order-val="desc"
+#   - 'asc' config → order button has data-order-val="asc"
+#   - Missing key → falls back to current default
+#
+# The view_options settings are configured in Admin::PageLayout for master panel layouts.
+# Example configuration:
+#   view_options:
+#     active_sublist_values:
+#       player_contacts: [10,5]
+#       addresses: all
+#       dynamic_model__other_contacts: []
+#     sort_sublists:
+#       player_contacts: desc
+#       addresses: asc
+
+require 'rails_helper'
+
+describe 'sublist default filter configuration', js: true, driver: $browser_driver do
+  include ModelSupport
+  include MasterDataSupport
+  include FeatureSupport
+
+  before(:all) do
+    change_setting('TwoFactorAuthDisabledForUser', true)
+    change_setting('TwoFactorAuthDisabledForAdmin', true)
+    SetupHelper.feature_setup
+
+    @admin, @admin_password = create_admin
+
+    # Use create_data_set_outside_tx to properly create test data visible to browser
+    create_data_set_outside_tx
+
+    # Create test user with access to master
+    @user, @good_password = create_user
+    @good_email = @user.email
+    @app_type = @user.app_type
+    expect(@user.two_factor_setup_required?).to be_falsey
+    setup_access :player_infos, user: @user
+    setup_access :addresses, user: @user
+    setup_access :player_contacts, user: @user
+
+    # Use the master created by create_data_set_outside_tx
+    @master = create_master(@user)
+    @master_id = @master.id
+
+    @master.player_infos.create!(
+      first_name: 'Sublist',
+      last_name: 'FilterTest',
+      birth_date: '1990-01-01',
+      rank: 10,
+      source: 'nflpa'
+    )
+
+    # Create test contacts with specific ranks
+    @master.player_contacts.create!(
+      data: '(555)111-1111',
+      rec_type: 'phone',
+      rank: 10 # Primary
+    )
+
+    @master.player_contacts.create!(
+      data: '(555)222-2222',
+      rec_type: 'phone',
+      rank: 5 # Secondary
+    )
+    @master.player_contacts.create!(
+      data: '(555)333-3333',
+      rec_type: 'phone',
+      rank: -1 # Bad contact
+    )
+
+    # Create or update the page layout with active_sublist_values configuration
+    # First check for an existing panel (including disabled ones), then create if needed
+    @panel_layout = Admin::PageLayout.where(
+      layout_name: 'master',
+      panel_name: 'details'
+    ).where('app_type_id = ? OR app_type_id IS NULL', @app_type.id).first
+
+    if @panel_layout
+      @original_options = @panel_layout.options
+      @original_disabled = @panel_layout.disabled
+      @panel_layout.update!(
+        disabled: false,
+        current_admin: @admin,
+        options: <<~YAML
+          contains:
+            categories:
+              - details
+          view_options:
+            initial_show: true
+            active_sublist_values:
+              player_contacts: [10, 5]
+        YAML
+      )
+    else
+      @panel_layout = Admin::PageLayout.create!(
+        layout_name: 'master',
+        panel_name: 'details',
+        panel_label: 'Details',
+        panel_position: 0,
+        app_type: @app_type,
+        current_admin: @admin,
+        options: <<~YAML
+          contains:
+            categories:
+              - details
+          view_options:
+            initial_show: true
+            active_sublist_values:
+              player_contacts: [10, 5]
+        YAML
+      )
+    end
+
+    ac = add_app_config(@app_type, 'open panels', 'details', user: @user)
+  end
+
+  after(:all) do
+    # Restore original options if we modified an existing layout
+    if @panel_layout && @original_options
+      @panel_layout.update!(
+        current_admin: @admin,
+        options: @original_options,
+        disabled: @original_disabled
+      )
+    elsif @panel_layout && !@original_options
+      @panel_layout.update!(current_admin: @admin, disabled: true)
+    end
+  end
+
+  before :each do
+    login
+  end
+
+  it 'activates only filter buttons matching the configured array values - fixes #584' do
+    # Navigate to the master record
+    visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@master.id}"
+    finish_page_loading
+
+    # Wait for search results to load (the master-result heading)
+    expect(page).to have_css("#master-#{@master.id}", wait: 10)
+    dismiss_modal
+
+    # Wait for master content to be fully rendered - look for player_contacts with an ID
+    # The ID indicates Handlebars has rendered the template with actual data
+    unless page.has_css?("[id^='player_contacts-#{@master.id}']", wait: 15)
+      # The Handlebars templates haven't been rendered yet
+      # Try clicking the master expander to trigger content load
+      master_link = find("#master-#{@master.id} a.master-expander", wait: 5)
+      scroll_into_view(master_link)
+      master_link.click
+      finish_page_loading
+      sleep 3 # Allow time for AJAX and Handlebars rendering
+    end
+
+    # Debug if player_contacts still not found
+    unless page.has_css?("[id^='player_contacts-#{@master.id}']", wait: 10)
+      # Check for JavaScript errors
+      puts '=== Checking for JS errors ==='
+      begin
+        logs = page.driver.browser.logs.get(:browser)
+        logs.each { |log| puts "Browser log: #{log.level} - #{log.message}" }
+      rescue StandardError => e
+        puts "Could not get browser logs: #{e.message}"
+      end
+
+      debug_process_status
+      save_html_snapshot('/tmp/sublist_expanded.html')
+      raise 'Could not find player_contacts. Check /tmp/sublist_expanded.html'
+    end
+
+    expect(page).not_to have_css('.alert-danger')
+
+    # Find the player_contacts sublist filter buttons
+    within '[data-sub-list="player_contacts"] .sublist-filter-selectors' do
+      # Buttons for rank 10 and 5 should be active (in our configuration)
+      filter_10 = find('button.filter-switch[data-filter-val="10"]')
+      filter_5 = find('button.filter-switch[data-filter-val="5"]')
+      filter_other = find('button.filter-switch[data-filter-val="-1"]')
+
+      expect(filter_10[:class]).to include('active'),
+                                   'Expected filter button for rank 10 to be active based on active_sublist_values config'
+      expect(filter_5[:class]).to include('active'),
+                                  'Expected filter button for rank 5 to be active based on active_sublist_values config'
+      expect(filter_other[:class]).not_to include('active'),
+                                          'Expected filter button for rank -1 to NOT be active (not in active_sublist_values config)'
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Implements configurable default active filter buttons and sort order for sublists in master panels.

## Changes
- Added `active_sublist_values` option to `Admin::PageLayout.view_options`
  - Array of values: activates only matching filter buttons
  - `'all'`: activates all filter buttons
  - Empty array: activates no filter buttons
  - Missing key: falls back to first button active (original behavior)
- Added `sort_sublists` option to set default sort order (`'asc'` or `'desc'`)
- Updated templates: `_master_panels.html.erb`, `_dynamic_model_blocks.html.erb`, `_search_results_parts.html.erb`
- Extracted `format_active_values` helper to `PageLayoutsHelper` module

## Testing
- 6 system specs covering all configuration scenarios
- 8 unit tests for the helper method
- All tests passing

## Documentation
- Updated `page_layout_options_defs.yaml` with new options

Fixes #584