### PR TITLE
Fix undefined method 'definition' error when renaming or trashing filestore files - fixes #878

### DIFF
--- a/app/models/dynamic/implementation_handler.rb
+++ b/app/models/dynamic/implementation_handler.rb
@@ -69,10 +69,14 @@ module Dynamic
       end
 
       def option_type_attr_name
+        return unless respond_to?(:definition)
+
         definition.option_type_attr_name
       end
 
       def default_option_type_name
+        return unless respond_to?(:definition)
+
         definition.default_option_type_name
       end
     end
@@ -149,6 +153,8 @@ module Dynamic
     end
 
     def default_option_type_name
+      return unless self.class.respond_to?(:definition)
+
       self.class.definition.default_option_type_name
     end
 

--- a/spec/models/nfs_store/manage/container_file_spec.rb
+++ b/spec/models/nfs_store/manage/container_file_spec.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
+# Tests for NfsStore::Manage::ContainerFile (base class for StoredFile and ArchivedFile)
+#
+# This spec covers:
+# - File upload and StoredFile creation
+# - Configuration handling for stored files
+# - Embedded items based on nfs_store configuration
+# - Regression tests for Issue #878 (implementation handler method guards)
+#
+# The regression test (Issue #878) ensures that container files, which include
+# Dynamic::ImplementationHandler, do not raise errors when calling methods like
+# `default_option_type_name` that would otherwise call `definition` on classes
+# that don't have it defined.
+
 require 'rails_helper'
 require './db/table_generators/dynamic_models_table'
 
@@ -23,7 +36,7 @@ RSpec.describe NfsStore::Manage::ContainerFile, type: :model do
   end
 
   before :each do
-    seed_database && ::ActivityLog.define_models
+    seed_database && ActivityLog.define_models
 
     setup_nfs_store
     generate_test_dynamic_model
@@ -88,5 +101,28 @@ RSpec.describe NfsStore::Manage::ContainerFile, type: :model do
     # expect(af).to be_a NfsStore::Manage::ArchivedFile
     # res = af.embedded_item
     # expect(res).to be_a DynamicModel::TestCreatedByRec
+  end
+
+  # Regression test for Issue #878
+  # StoredFile and ArchivedFile include Dynamic::ImplementationHandler which has methods
+  # that call `definition` without checking if the class responds to it.
+  # This test ensures those methods don't raise errors when called on container files.
+  it 'does not raise error when calling implementation handler methods on container files' do
+    # These methods are in Dynamic::ImplementationHandler and should return nil for container files
+    # since they don't have a definition (unlike DynamicModel or ActivityLog implementations)
+    upload_new_file
+    sf = @zip_file.stored_file
+
+    # Instance method should return nil, not raise an error
+    expect(sf.default_option_type_name).to be_nil
+
+    # Class methods should also return nil, not raise an error
+    expect(NfsStore::Manage::StoredFile.option_type_attr_name).to be_nil
+    expect(NfsStore::Manage::StoredFile.default_option_type_name).to be_nil
+    expect(NfsStore::Manage::ArchivedFile.option_type_attr_name).to be_nil
+    expect(NfsStore::Manage::ArchivedFile.default_option_type_name).to be_nil
+
+    # JSON serialization should work without errors (this was the original bug)
+    expect { sf.as_json(limited_results: true) }.not_to raise_error
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -208,9 +208,11 @@ RSpec.configure do |config|
 
   # For system tests that need javascript, use selenium_chrome
   # The following avoids this needing to be specified in each spec file
-  config.before(:each, type: :system, js: true) do
+  # The js: true metadata is also set to true to ensure proper handling
+  config.before(:each, type: :system, js: true) do |example|
     driven_by $browser_driver
     Capybara.page.driver.browser.manage.window.maximize
+    example.metadata[:js] = true
   end
 
   config.before(:each) do

--- a/spec/support/feature_support.rb
+++ b/spec/support/feature_support.rb
@@ -190,6 +190,24 @@ module FeatureSupport
     have_no_css('.collapsing')
   end
 
+  # Navigate to a master record by ID
+  def navigate_to_master(master_id)
+    expect(master_id).not_to be nil
+    visit "/masters/search?nav_q_id=#{master_id}"
+    finish_page_loading
+
+    # Debug output
+    puts_debug "Page title: #{page.title}"
+    puts_debug "Page URL: #{page.current_url}"
+    debug_process_status if respond_to?(:debug_process_status)
+
+    expect(page).to have_css('.master-result', wait: 15)
+
+    # Expand the master record to see details
+    expand_master_record(master_id: master_id)
+    finish_page_loading
+  end
+
   def finish_page_loading
     if all('body.status-compiled, body.sessions, body.confirmations, body.passwords, body.registrations').present?
       return
@@ -277,14 +295,14 @@ module FeatureSupport
   end
 
   #
-  # Expand a master record tab (such as "details", "external ids", etc) by name
+  # Expand a master record tab (such as "details", "external ids", "phone log", etc) by name
   # This avoids the need to explicitly get `a[data-panel-tab="<name>"]` and click it.
   # Expectations are also enforced to ensure the tab shows.
   def expand_master_record_tab(name)
     finish_form_formatting
     tab_link = all("ul.details-tabs li a[data-panel-tab='#{name.id_underscore}']").first
     expect(tab_link).not_to be nil
-    all('ul.details-tabs').first.click_link name if tab_link['aria-expanded'] != 'true'
+    tab_link.click if tab_link['aria-expanded'] != 'true'
   end
 
   #

--- a/spec/support/nfs_store_feature_support/filestore_setup.rb
+++ b/spec/support/nfs_store_feature_support/filestore_setup.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+# Setup support for NFS Store filestore UI system specs
+# Provides methods to configure activity logs with filestore capabilities,
+# create test data, and set up proper user access controls.
+module FilestoreSetup
+  include ModelSupport
+
+  ActivityLogName = 'Filestore UI Test'
+
+  # Setup the activity log definition with filestore configuration
+  # This creates an activity log type that includes a filestore container
+  # with full user file action capabilities (upload, rename, send to trash)
+  def setup_filestore_activity_log
+    create_admin unless @admin
+
+    # Set up the filestore directory
+    @app_type = @user.app_type
+    test_dir = File.join(
+      NfsStore::Manage::Filesystem.nfs_store_directory,
+      "#{NfsStore::Manage::Group::NfsMountNamePrefix}600",
+      "app-type-#{@app_type.id}",
+      'containers'
+    )
+    FileUtils.rm_rf test_dir
+    FileUtils.mkdir_p test_dir
+
+    # Create or find the activity log definition
+    @aldef = ActivityLog.active.where(name: ActivityLogName).first
+    if @aldef
+      ActivityLogSupport.cleanup_matching_activity_logs(
+        @aldef.item_type, @aldef.rec_type, @aldef.process_name,
+        admin: @admin, excluding_id: @aldef.id
+      )
+    else
+      @aldef = ActivityLog.where(name: ActivityLogName).first
+      if @aldef
+        ActivityLogSupport.cleanup_matching_activity_logs(
+          @aldef.item_type, @aldef.rec_type, @aldef.process_name,
+          admin: @admin, excluding_id: @aldef.id
+        )
+        @aldef.update(disabled: false, current_admin: @admin)
+      else
+        SetupHelper.setup_al_gen_tests ActivityLogName, nil, 'player_contact', rec_type: 'phone'
+        @aldef = ActivityLog.active.where(name: ActivityLogName).first
+      end
+    end
+
+    raise 'Failed to set up filestore activity log definition' unless @aldef
+
+    # Configure the activity log with filestore and supporting documents
+    @aldef.extra_log_types = filestore_extra_log_types_config
+    @aldef.current_admin = @admin
+    @aldef.save!
+    @aldef.option_configs(force: true)
+
+    ActivityLog.define_models
+    ActivityLog::PlayerContactPhone.definition.option_configs(force: true)
+
+    @aldef
+  end
+
+  # Configuration for the extra log types including supporting documents
+  def filestore_extra_log_types_config
+    <<~ENDDEF
+      phone_log:
+        label: Phone Log
+        fields:
+          - select_call_direction
+          - select_who
+          - notes
+
+      supporting_documents:
+        label: Supporting Documents
+        fields:
+          - notes
+
+        save_trigger:
+          on_create:
+            create_filestore_container:
+              name:
+                - supporting files
+              label: Supporting Files
+              create_with_role: nfs_store group 600
+
+        references:
+          nfs_store__manage__container:
+            label: Files
+            from: this
+            add: one_to_this
+            view_as:
+              edit: hide
+              show: filestore
+              new: not_embedded
+
+        nfs_store:
+          pipeline:
+            - mount_archive:
+            - index_files:
+
+    ENDDEF
+  end
+
+  # Set up user access for filestore operations
+  def setup_filestore_user_access(user: nil)
+    user ||= @user
+    app_type = user.app_type
+
+    # Basic access
+    setup_access :player_contacts, user: user
+    setup_access :player_infos, user: user
+
+    # Activity log access
+    setup_access :activity_log__player_contact_phones, user: user
+    setup_access :activity_log__player_contact_phone__phone_log, resource_type: :activity_log_type, user: user
+    setup_access :activity_log__player_contact_phone__supporting_documents, resource_type: :activity_log_type, user: user
+
+    # Filestore access
+    setup_access :nfs_store__manage__containers, user: user
+    setup_access :nfs_store__manage__stored_files, user: user
+    setup_access :nfs_store__manage__archived_files, user: user
+    setup_access :download_files, resource_type: :general, access: :read, user: user
+    setup_access :send_files_to_trash, resource_type: :general, access: :read, user: user
+    setup_access :move_files, resource_type: :general, access: :read, user: user
+
+    # Role for filestore group
+    create_user_role 'nfs_store group 600', user: user, app_type: app_type
+  end
+
+  # Set up the filestore filters to allow all files
+  def setup_filestore_filters
+    resource_name = 'activity_log__player_contact_phone__supporting_documents'
+
+    # Clear existing filters
+    NfsStore::Filter::Filter.active.where(app_type: @app_type, resource_name: resource_name).update_all(disabled: true)
+
+    # Create a filter that allows all files
+    NfsStore::Filter::Filter.create!(
+      current_admin: @admin,
+      app_type: @app_type,
+      role_name: nil,
+      user: nil,
+      resource_name: resource_name,
+      filter: '.*'
+    )
+  end
+
+  # Create a test master record with phone contact
+  def create_filestore_test_data
+    @master = create_master
+    @player_contact = create_item(data: rand(10_000_000_000_000_000), rank: 10)
+    @player_contact.master.current_user = @user
+
+    @master
+  end
+
+  # Create a file for testing
+  def create_test_file_content(filename = 'test-document.txt')
+    content = "Test file content for filestore testing - #{SecureRandom.hex}"
+    { filename: filename, content: content }
+  end
+end

--- a/spec/support/nfs_store_feature_support/filestore_ui_actions.rb
+++ b/spec/support/nfs_store_feature_support/filestore_ui_actions.rb
@@ -1,0 +1,292 @@
+# frozen_string_literal: true
+
+# UI action helpers for NFS Store filestore system specs.
+# Provides methods to interact with the filestore browser UI including
+# file upload, rename, move, download, and send to trash operations.
+#
+# This module provides helper methods for common filestore operations:
+# - File upload (single and multiple)
+# - File selection and menu interactions
+# - File rename, move, and trash operations
+# - File and folder downloads
+# - Folder navigation and expansion
+module FilestoreUiActions
+  include FeatureHelper
+
+  # Create a new supporting documents activity log entry
+  def add_supporting_documents_activity
+    # Find and click the add button for supporting documents
+    add_btn = find('a.add-item-button', text: /Supporting Documents/i, wait: 10)
+    scroll_into_view(add_btn)
+    add_btn.click
+    finish_page_loading
+    finish_form_formatting
+  end
+
+  # Save the current activity log form
+  def save_supporting_documents_form
+    # Find and click the save button
+    save_btn = find('button[type="submit"], input[type="submit"]', text: /save/i, wait: 10)
+    scroll_into_view(save_btn)
+    save_btn.click
+    finish_page_loading
+  end
+
+  # Wait for the filestore container to be visible
+  def wait_for_filestore_container
+    # Wait for the container browser outer div which contains the filestore UI
+    expect(page).to have_css('.container-browser-outer', wait: 15)
+    finish_page_loading
+  end
+
+  # Upload a file using the filestore uploader
+  # @param file_path [String] path to the file to upload
+  # @param wait_for_processing [Boolean] wait for file to appear in the list
+  def upload_file_to_filestore(file_path, wait_for_processing: true)
+    # Find the file input - it's a visible file input with class nfs-store-fileupload
+    file_input = find('input.nfs-store-fileupload[type="file"]', visible: :all, wait: 10)
+
+    # Attach the file
+    file_input.attach_file(file_path, make_visible: true)
+
+    return unless wait_for_processing
+
+    # Wait for the upload to complete and file to appear
+    filename = File.basename(file_path)
+    expect(page).to have_css('.container-browser .container-entry', text: filename, wait: 30)
+    finish_page_loading
+  end
+
+  # Upload multiple files to the filestore in a single request
+  # @param file_paths [Array<String>] array of paths to files to upload
+  # @param wait_for_processing [Boolean] wait for all files to appear in the list
+  def upload_multiple_files_to_filestore(file_paths, wait_for_processing: true)
+    # Find the file input - it supports multiple file selection
+    file_input = find('input.nfs-store-fileupload[type="file"]', visible: :all, wait: 10)
+
+    # Attach all files at once
+    file_input.attach_file(file_paths, make_visible: true)
+
+    return unless wait_for_processing
+
+    # Wait for all uploads to complete
+    file_paths.each do |file_path|
+      filename = File.basename(file_path)
+      expect(page).to have_css('.container-browser .container-entry', text: filename, wait: 30)
+    end
+    finish_page_loading
+  end
+
+  # Create a temporary test file for upload
+  # @param filename [String] name for the file
+  # @param content [String] content to put in the file
+  # @return [String] path to the created file
+  def create_temp_test_file(filename: 'test-document.txt', content: nil)
+    content ||= "Test file content - #{SecureRandom.hex}"
+    temp_dir = Rails.root.join('tmp', 'test_files')
+    FileUtils.mkdir_p(temp_dir)
+    file_path = temp_dir.join(filename)
+    File.write(file_path, content)
+    file_path.to_s
+  end
+
+  # Select a file in the filestore browser by clicking its checkbox
+  # @param filename [String] name of the file to select
+  def select_file_in_browser(filename)
+    file_row = find('.container-browser .container-entry', text: filename, wait: 10)
+    checkbox = file_row.find('input[type="checkbox"]', visible: :all)
+    scroll_into_view(file_row)
+    # Use JavaScript to check the checkbox since it may be hidden
+    page.execute_script('arguments[0].click();', checkbox)
+    sleep 0.5
+  end
+
+  # Open the hamburger menu in the filestore browser
+  def open_filestore_menu
+    hamburger_btn = find('.nfs-store-container-block button.hamburger', wait: 10)
+    scroll_into_view(hamburger_btn)
+    hamburger_btn.click
+    sleep 0.5
+    expect(page).to have_css('.dropdown-menu', visible: true)
+  end
+
+  # Click "Rename file" in the hamburger menu
+  def click_rename_file_menu_item
+    rename_link = find('.dropdown-menu a.container-browse-rename-file', text: /Rename file/i, wait: 5)
+    rename_link.click
+    finish_page_loading
+    # Wait for the modal to appear
+    expect(page).to have_css('#primary-modal', visible: true, wait: 10)
+  end
+
+  # Enter a new name in the rename dialog and submit
+  # @param new_name [String] the new filename
+  def rename_file_to(new_name)
+    within '#primary-modal' do
+      # Fill in the new name
+      new_name_input = find('input[name="new_name"]', wait: 10)
+      new_name_input.set(new_name)
+
+      # Click the rename button
+      rename_btn = find('.container-browse-rename-file-submit', wait: 5)
+      rename_btn.click
+    end
+    finish_page_loading
+  end
+
+  # Click "Send to trash" in the hamburger menu
+  def click_send_to_trash_menu_item
+    trash_link = find('.dropdown-menu a.container-browse-trash-submit', text: /Send to trash/i, wait: 5)
+    trash_link.click
+    finish_page_loading
+  end
+
+  # Click the refresh list button in the filestore browser
+  def refresh_filestore_list
+    refresh_btn = find('.refresh-container-list', visible: :all, wait: 10)
+    scroll_into_view(refresh_btn)
+    refresh_btn.click
+    finish_page_loading
+    sleep 1 # Allow time for the list to refresh
+  end
+
+  # Check if a file exists in the filestore browser
+  # @param filename [String] name of the file to check
+  # @return [Boolean] true if the file exists
+  def file_exists_in_browser?(filename)
+    has_css?('.container-browser .container-entry', text: filename, wait: 5)
+  end
+
+  # Check for error alerts on the page
+  # @return [Boolean] true if an error alert is present
+  def has_error_alert?
+    has_css?('.flash .alert-warning', wait: 2) || has_css?('.flash .alert-danger', wait: 2)
+  end
+
+  # Get the text of any error alerts
+  # @return [String] the error message text
+  def error_alert_text
+    if has_css?('.flash .alert-warning', wait: 1)
+      find('.flash .alert-warning').text
+    elsif has_css?('.flash .alert-danger', wait: 1)
+      find('.flash .alert-danger').text
+    else
+      ''
+    end
+  end
+
+  # Click "Move Files" in the hamburger menu
+  def click_move_files_menu_item
+    move_link = find('.dropdown-menu a.container-browse-move-files', text: /Move Files/i, wait: 5)
+    move_link.click
+    finish_page_loading
+    # Wait for the move form to appear
+    expect(page).to have_css('#primary-modal', visible: true, wait: 10)
+  end
+
+  # Enter a folder name and submit the move files action
+  # @param folder_name [String] the destination folder name (can be new or existing)
+  def move_files_to_folder(folder_name)
+    within '#primary-modal' do
+      # Fill in the new folder path
+      folder_input = find('input[name="new_path"], input[name="new_folder"]', wait: 10)
+      folder_input.set(folder_name)
+
+      # Click the move button
+      move_btn = find('.container-browse-move-files-submit', wait: 5)
+      move_btn.click
+    end
+    finish_page_loading
+
+    # Wait for the modal to close
+    expect(page).not_to have_css('#primary-modal.in', wait: 10)
+    sleep 1 # Allow time for the move to complete
+  end
+
+  # Click the download button in the filestore browser
+  # Downloads currently selected files - single file downloads directly,
+  # multiple files download as a zip archive
+  def click_download_button
+    download_btn = find('button.container-browse-download', wait: 10)
+    scroll_into_view(download_btn)
+    download_btn.click
+    finish_page_loading
+  end
+
+  # Check if a folder exists in the filestore browser
+  # @param folder_name [String] name of the folder to check
+  # @return [Boolean] true if the folder exists
+  def folder_exists_in_browser?(folder_name)
+    has_css?('.container-browser .container-folder', text: folder_name, wait: 5)
+  end
+
+  # Check if an archive folder exists (extracted archive contents)
+  # Archive folders have a special "(extracted archive files)" label
+  # @param archive_name [String] base name of the archive file (e.g., "dicoms.zip")
+  # @return [Boolean] true if the extracted archive folder exists
+  def archive_folder_exists_in_browser?(archive_name)
+    # Archive folders contain the archive name and have the special tag
+    has_css?('.container-browser .container-folder-is-archive', text: archive_name, wait: 30) ||
+      has_css?('.container-browser .container-folder', text: /#{Regexp.escape(archive_name)}.*extracted archive/i, wait: 5)
+  end
+
+  # Expand a collapsed folder in the filestore browser
+  # @param folder_name [String] name of the folder to expand
+  def expand_folder(folder_name)
+    folder_row = find('.container-browser .container-folder', text: folder_name, wait: 10)
+    folder_icon = folder_row.find('.folder-icon[data-toggle="collapse"]', wait: 5)
+    scroll_into_view(folder_icon)
+    folder_icon.click
+    finish_page_loading
+    sleep 0.5 # Allow expansion animation
+  end
+
+  # Wait for archive extraction to complete
+  # After uploading a zip file, the filestore processes it to extract contents
+  # @param archive_name [String] the archive filename (e.g., "dicoms.zip")
+  # @param timeout [Integer] max seconds to wait for extraction
+  def wait_for_archive_extraction(archive_name, timeout: 60)
+    # First wait for the archive file to appear
+    expect(page).to have_css('.container-browser .container-entry', text: archive_name, wait: 30)
+
+    # Poll for the extracted folder to appear
+    start_time = Time.now
+    loop do
+      refresh_filestore_list
+      break if archive_folder_exists_in_browser?(archive_name)
+      break if (Time.now - start_time) > timeout
+
+      sleep 2
+    end
+
+    expect(archive_folder_exists_in_browser?(archive_name)).to be(true),
+                                                               "Archive '#{archive_name}' was not extracted within #{timeout} seconds"
+  end
+
+  # Count files in the filestore browser
+  # @return [Integer] number of files visible in the browser
+  def count_files_in_browser
+    all('.container-browser .container-entry').count
+  end
+
+  # Get a list of all filenames in the filestore browser
+  # @return [Array<String>] array of filenames
+  def list_files_in_browser
+    all('.container-browser .container-entry .browse-filename').map(&:text)
+  end
+
+  # Select multiple files in the filestore browser
+  # @param filenames [Array<String>] array of filenames to select
+  def select_multiple_files_in_browser(filenames)
+    filenames.each do |filename|
+      select_file_in_browser(filename)
+    end
+  end
+
+  # Get path to a fixture file
+  # @param relative_path [String] path relative to spec/fixtures/files/
+  # @return [String] absolute path to the fixture file
+  def fixture_file_path(relative_path)
+    Rails.root.join('spec', 'fixtures', 'files', relative_path).to_s
+  end
+end

--- a/spec/support/nfs_store_feature_support/z_filestore_feature_main.rb
+++ b/spec/support/nfs_store_feature_support/z_filestore_feature_main.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Main module for NFS Store filestore system specs.
+# Combines setup and UI action modules for comprehensive filestore testing.
+#
+# Usage:
+#   describe 'Filestore operations', type: :system do
+#     include FilestoreFeatureMain
+#     ...
+#   end
+require_relative '../nfs_store_support'
+require_relative 'filestore_setup'
+require_relative 'filestore_ui_actions'
+
+module FilestoreFeatureMain
+  include FeatureHelper
+  include FeatureSupport
+  include ModelSupport
+  include MasterDataSupport
+  include PlayerContactSupport
+  include UserActionsSetup
+  include NfsStoreSupport
+
+  include FilestoreSetup
+  include FilestoreUiActions
+end

--- a/spec/system/nfs_store/filestore_operations_spec.rb
+++ b/spec/system/nfs_store/filestore_operations_spec.rb
@@ -1,0 +1,453 @@
+# frozen_string_literal: true
+
+# Feature: Filestore file operations
+#   As a user
+#   I want to upload, rename, move, download, and send files to trash in the filestore
+#   In order that I can manage supporting documents and files
+#
+# This spec tests the filestore UI operations, specifically:
+#   - Uploading single and multiple files to a filestore container
+#   - Uploading ZIP archives and verifying extraction
+#   - Renaming a file in the filestore
+#   - Moving files between folders
+#   - Downloading single and multiple files
+#   - Sending a file to trash
+#
+# Regression test for Issue #878:
+#   Error when renaming or sending files to trash due to
+#   "undefined method 'definition' for class NfsStore::Manage::StoredFile"
+#
+# The issue was that the JSON serialization of the action result (containing StoredFile objects)
+# was calling methods from Dynamic::ImplementationHandler that expected a 'definition' class
+# method to exist, which is only present on ActivityLog/DynamicModel implementations.
+#
+# NOTE: The core bug fix for Issue #878 is validated by the unit test in:
+#   spec/models/nfs_store/manage/container_file_spec.rb
+#
+# This system spec provides UI-level regression testing for the filestore operations.
+
+require 'rails_helper'
+require_relative '../../support/nfs_store_feature_support/z_filestore_feature_main'
+
+describe 'Filestore file operations', js: true, driver: $browser_driver, type: :system do
+  include FilestoreFeatureMain
+
+  # rubocop:disable Lint/ConstantDefinitionInBlock
+  ActivityLogName = 'AL Filter Test 2'
+  # rubocop:enable Lint/ConstantDefinitionInBlock
+
+  def set_up_user_access
+    puts_debug 'set up user access'
+    setup_access :player_contacts, user: @user
+    setup_access :activity_log__player_contact_phones, user: @user
+    setup_access :activity_log__player_contact_phone__step_1, resource_type: :activity_log_type, user: @user
+
+    # NFS Store access
+    setup_access :nfs_store__manage__containers, user: @user
+    setup_access :nfs_store__manage__stored_files, user: @user
+    setup_access :nfs_store__manage__archived_files, user: @user
+    setup_access :download_files, resource_type: :general, access: :read, user: @user
+    setup_access :send_files_to_trash, resource_type: :general, access: :read, user: @user
+    setup_access :move_files, resource_type: :general, access: :read, user: @user
+
+    # Create NFS store role
+    create_user_role 'nfs_store group 600', user: @user, app_type: @user.app_type
+
+    expect(@user.has_access_to?(:read, :general, :app_type)).to be_truthy
+    expect(@user.has_access_to?(:access, :table, :player_contacts)).to be_truthy
+
+    puts_debug 'done setting up user access'
+  end
+
+  def expand_phone_log_tab
+    expand_master_record_tab('activity_log__player_contact_phones')
+  end
+
+  before :all do
+    change_setting('TwoFactorAuthDisabledForUser', true)
+    change_setting('TwoFactorAuthDisabledForAdmin', true)
+
+    # Setup activity log definitions first
+    SetupHelper.setup_al_gen_tests ActivityLogName, nil, 'player_contact', rec_type: 'phone'
+
+    # Create user first
+    create_user(create_master: false)
+    expect(@user.has_access_to?(:read, :general, :app_type)).to be_truthy
+
+    SetupHelper.feature_setup
+
+    # Create admin for configuring activity log
+    create_admin unless @admin
+
+    @app_type = @user.app_type
+
+    # Setup filestore directories
+    test_dir = File.join(
+      NfsStore::Manage::Filesystem.nfs_store_directory,
+      "#{NfsStore::Manage::Group::NfsMountNamePrefix}600",
+      "app-type-#{@app_type.id}",
+      'containers'
+    )
+    FileUtils.rm_rf test_dir
+    FileUtils.mkdir_p test_dir
+
+    # Find and configure the activity log definition
+    @aldef = ActivityLog.active.where(name: ActivityLogName).first
+    expect(@aldef).not_to be_nil
+
+    # Configure step_1 with filestore
+    @aldef.extra_log_types = <<~ENDDEF
+      step_1:
+        label: Step 1
+        fields:
+          - select_call_direction
+          - select_who
+
+        save_trigger:
+          on_create:
+            create_filestore_container:
+              name:
+                - session files
+                - select_scanner
+              label: Session Files
+              create_with_role: nfs_store group 600
+
+        references:
+          nfs_store__manage__container:
+            label: Files
+            from: this
+            add: one_to_this
+            view_as:
+              edit: hide
+              show: filestore
+              new: not_embedded
+
+        nfs_store:
+          pipeline:
+            - mount_archive:
+            - index_files:
+          can:
+            send_files_to_trash_if:
+              always: true
+            move_files_if:
+              always: true
+            user_file_actions_if:
+              always: true
+    ENDDEF
+
+    @aldef.current_admin = @admin
+    @aldef.save!
+    @aldef.option_configs(force: true)
+    ActivityLog.define_models
+    ActivityLog::PlayerContactPhone.definition.option_configs(force: true)
+
+    # Set up user access before creating test data
+    set_up_user_access
+
+    # Setup NFS store filters
+    resource_name = 'activity_log__player_contact_phone__step_1'
+    NfsStore::Filter::Filter.active.where(app_type: @app_type, resource_name:).update_all(disabled: true)
+    NfsStore::Filter::Filter.create!(
+      current_admin: @admin,
+      app_type: @app_type,
+      role_name: nil,
+      user: nil,
+      resource_name:,
+      filter: '.*'
+    )
+
+    # Create test data in before :all so it's committed to the database
+    # and visible to the browser's HTTP requests (which use a separate connection)
+    @master = create_master
+    @player_contact = @master.player_contacts.create!(
+      data: rand(10_000_000_000_000_000),
+      rank: 10,
+      rec_type: :phone
+    )
+    @player_contact.master.current_user = @user
+
+    # Create the activity log with filestore
+    @activity_log = ActivityLog::PlayerContactPhone.create!(
+      select_call_direction: 'from player',
+      select_who: 'user',
+      extra_log_type: :step_1,
+      player_contact: @player_contact,
+      master: @master
+    )
+    expect(@activity_log).to be_persisted
+    @container = @activity_log.model_references&.first&.to_record
+    expect(@container).to be_a(NfsStore::Manage::Container)
+  end
+
+  before :each do
+    # Re-use the user created in before :all (don't create a new one)
+    # This follows the pattern from switch_id_display_spec.rb
+    validate_setup
+    login
+    expect(User.find(@user.id).app_type_id).to eq @app_type.id
+  end
+
+  after :all do
+    # Clean up temp files
+    temp_dir = Rails.root.join('tmp', 'test_files')
+    FileUtils.rm_rf(temp_dir)
+  end
+
+  describe 'File upload and rename' do
+    it 'uploads a file and renames it without errors (regression for issue #878)' do
+      # Navigate to the master record
+      navigate_to_master(@master.id)
+
+      # Expand the phone log tab
+      expand_phone_log_tab
+
+      # Wait for activity log entries to load
+      expect(page).to have_css('.activity-log--player-contact-phones-block', wait: 15)
+
+      # The filestore should already be visible in the step_1 activity log entry
+      # Wait for the filestore container to be visible
+      wait_for_filestore_container
+
+      # Create and upload a test file
+      original_filename = "test-doc-#{SecureRandom.hex(4)}.txt"
+      test_file_path = create_temp_test_file(filename: original_filename)
+      upload_file_to_filestore(test_file_path)
+
+      # Verify the file appears in the browser
+      expect(file_exists_in_browser?(original_filename)).to be true
+
+      # Select the file
+      select_file_in_browser(original_filename)
+
+      # Open the hamburger menu
+      open_filestore_menu
+
+      # Click rename file
+      click_rename_file_menu_item
+
+      # Enter new name and submit
+      new_filename = "renamed-doc-#{SecureRandom.hex(4)}.txt"
+      rename_file_to(new_filename)
+
+      # Verify no error occurred (this was the bug in issue #878)
+      expect(has_error_alert?).to be(false), "Unexpected error: #{error_alert_text}"
+
+      # Refresh the list and verify the renamed file appears
+      refresh_filestore_list
+      expect(file_exists_in_browser?(new_filename)).to be true
+      expect(file_exists_in_browser?(original_filename)).to be false
+    end
+  end
+
+  describe 'Send file to trash' do
+    it 'sends a file to trash without errors (regression for issue #878)' do
+      # Navigate to the master record
+      navigate_to_master(@master.id)
+
+      # Expand the phone log tab
+      expand_phone_log_tab
+
+      # Wait for the filestore container to be visible
+      wait_for_filestore_container
+
+      # Create and upload a test file
+      filename = "trash-test-#{SecureRandom.hex(4)}.txt"
+      test_file_path = create_temp_test_file(filename:)
+      upload_file_to_filestore(test_file_path)
+
+      # Verify the file appears in the browser
+      expect(file_exists_in_browser?(filename)).to be true
+
+      # Select the file
+      select_file_in_browser(filename)
+
+      # Open the hamburger menu
+      open_filestore_menu
+
+      # Click send to trash
+      click_send_to_trash_menu_item
+
+      # Verify no error occurred (this was the bug in issue #878)
+      expect(has_error_alert?).to be(false), "Unexpected error: #{error_alert_text}"
+
+      # Refresh the list and verify the file is gone
+      refresh_filestore_list
+      expect(file_exists_in_browser?(filename)).to be false
+    end
+  end
+
+  describe 'Multiple file upload' do
+    it 'uploads multiple files in a single request' do
+      # Navigate to the master record
+      navigate_to_master(@master.id)
+
+      # Expand the phone log tab
+      expand_phone_log_tab
+
+      # Wait for the filestore container to be visible
+      wait_for_filestore_container
+
+      # Create multiple test files
+      file1 = create_temp_test_file(filename: "multi-file1-#{SecureRandom.hex(4)}.txt", content: 'File 1 content')
+      file2 = create_temp_test_file(filename: "multi-file2-#{SecureRandom.hex(4)}.txt", content: 'File 2 content')
+      file3 = create_temp_test_file(filename: "multi-file3-#{SecureRandom.hex(4)}.txt", content: 'File 3 content')
+
+      # Upload all files at once
+      upload_multiple_files_to_filestore([file1, file2, file3])
+
+      # Verify all files appear in the browser
+      expect(file_exists_in_browser?(File.basename(file1))).to be true
+      expect(file_exists_in_browser?(File.basename(file2))).to be true
+      expect(file_exists_in_browser?(File.basename(file3))).to be true
+
+      # Verify no errors occurred
+      expect(has_error_alert?).to be(false), "Unexpected error: #{error_alert_text}"
+    end
+  end
+
+  describe 'ZIP archive upload and extraction' do
+    it 'uploads dicoms.zip and verifies its contents are extracted' do
+      # Navigate to the master record
+      navigate_to_master(@master.id)
+
+      # Expand the phone log tab
+      expand_phone_log_tab
+
+      # Wait for the filestore container to be visible
+      wait_for_filestore_container
+
+      # Upload the dicoms.zip fixture file
+      dicoms_zip_path = fixture_file_path('dicom/dicoms.zip')
+      expect(File.exist?(dicoms_zip_path)).to be(true), "Fixture file not found: #{dicoms_zip_path}"
+
+      upload_file_to_filestore(dicoms_zip_path, wait_for_processing: true)
+
+      # Verify the zip file appears in the browser
+      expect(file_exists_in_browser?('dicoms.zip')).to be true
+
+      # Verify no errors occurred during upload
+      expect(has_error_alert?).to be(false), "Unexpected error during upload: #{error_alert_text}"
+
+      # Wait for the archive to be extracted (this may take some time)
+      # The pipeline processes zip files and extracts their contents
+      wait_for_archive_extraction('dicoms.zip', timeout: 90)
+
+      # Verify the extracted archive folder exists
+      expect(archive_folder_exists_in_browser?('dicoms.zip')).to be true
+    end
+  end
+
+  describe 'Move file to folder' do
+    it 'moves a file from one directory to another' do
+      # Navigate to the master record
+      navigate_to_master(@master.id)
+
+      # Expand the phone log tab
+      expand_phone_log_tab
+
+      # Wait for the filestore container to be visible
+      wait_for_filestore_container
+
+      # Create and upload a test file
+      filename = "move-test-#{SecureRandom.hex(4)}.txt"
+      test_file_path = create_temp_test_file(filename:)
+      upload_file_to_filestore(test_file_path)
+
+      # Verify the file appears in the browser
+      expect(file_exists_in_browser?(filename)).to be true
+
+      # Select the file
+      select_file_in_browser(filename)
+
+      # Open the hamburger menu
+      open_filestore_menu
+
+      # Click move files
+      click_move_files_menu_item
+
+      # Move to a new folder
+      new_folder_name = "test-folder-#{SecureRandom.hex(4)}"
+      move_files_to_folder(new_folder_name)
+
+      # Verify no error occurred
+      expect(has_error_alert?).to be(false), "Unexpected error: #{error_alert_text}"
+
+      # Refresh the list
+      refresh_filestore_list
+
+      # Verify the folder exists
+      expect(folder_exists_in_browser?(new_folder_name)).to be true
+
+      # Expand the folder and verify the file is inside
+      expand_folder(new_folder_name)
+      expect(file_exists_in_browser?(filename)).to be true
+    end
+  end
+
+  describe 'File download' do
+    it 'downloads a single file' do
+      # Navigate to the master record
+      navigate_to_master(@master.id)
+
+      # Expand the phone log tab
+      expand_phone_log_tab
+
+      # Wait for the filestore container to be visible
+      wait_for_filestore_container
+
+      # Create and upload a test file
+      filename = "download-single-#{SecureRandom.hex(4)}.txt"
+      content = "Test content for download - #{SecureRandom.hex}"
+      test_file_path = create_temp_test_file(filename:, content:)
+      upload_file_to_filestore(test_file_path)
+
+      # Verify the file appears in the browser
+      expect(file_exists_in_browser?(filename)).to be true
+
+      # Select the file
+      select_file_in_browser(filename)
+
+      # Click the download button
+      # Note: In headless mode, the download happens but we can't easily verify
+      # the file was saved. We verify that the button click doesn't cause errors.
+      click_download_button
+
+      # Verify no error occurred
+      expect(has_error_alert?).to be(false), "Unexpected error: #{error_alert_text}"
+    end
+
+    it 'downloads multiple files as a zip' do
+      # Navigate to the master record
+      navigate_to_master(@master.id)
+
+      # Expand the phone log tab
+      expand_phone_log_tab
+
+      # Wait for the filestore container to be visible
+      wait_for_filestore_container
+
+      # Create and upload multiple test files
+      file1_name = "download-multi1-#{SecureRandom.hex(4)}.txt"
+      file2_name = "download-multi2-#{SecureRandom.hex(4)}.txt"
+      file1_path = create_temp_test_file(filename: file1_name, content: 'Multi download file 1')
+      file2_path = create_temp_test_file(filename: file2_name, content: 'Multi download file 2')
+
+      upload_file_to_filestore(file1_path)
+      upload_file_to_filestore(file2_path)
+
+      # Verify both files appear in the browser
+      expect(file_exists_in_browser?(file1_name)).to be true
+      expect(file_exists_in_browser?(file2_name)).to be true
+
+      # Select both files
+      select_multiple_files_in_browser([file1_name, file2_name])
+
+      # Click the download button
+      # When multiple files are selected, they download as a zip archive
+      click_download_button
+
+      # Verify no error occurred
+      expect(has_error_alert?).to be(false), "Unexpected error: #{error_alert_text}"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Fixes #878 - Error sending filestore files to trash

## Problem
When users tried to rename or send files to trash in the filestore, they received the error:
```
undefined method 'definition' for class NfsStore::Manage::StoredFile
```

## Root Cause
The `NfsStore::Manage::ContainerFile` (parent of StoredFile/ArchivedFile) includes `Dynamic::ImplementationHandler`, which has methods that call `self.class.definition` without checking if the class responds to that method. Unlike `DynamicModel` or `ActivityLog` implementations, `StoredFile`/`ArchivedFile` don't have a `definition` class method.

## Solution
Added `respond_to?(:definition)` guards to three methods in `Dynamic::ImplementationHandler`:
- Instance method `default_option_type_name` (line 155)
- Class method `option_type_attr_name` (line 72)
- Class method `default_option_type_name` (line 76)

These methods now return `nil` early when the class doesn't have a `definition` method, preventing the NoMethodError.

## Testing
- Added unit test in `spec/models/nfs_store/manage/container_file_spec.rb` to verify the fix
- Added comprehensive system specs for filestore UI operations (7 tests):
  - File upload (single and multiple)
  - File rename (regression test)
  - Send to trash (regression test)
  - ZIP archive upload and extraction
  - Move files between folders
  - Single and multiple file downloads

All tests pass locally.