### PR TITLE
Fixed download button in the filestore secure viewer fails with an error when using a file field - fixes #897

### DIFF
--- a/app/controllers/concerns/secure_view/previewing.rb
+++ b/app/controllers/concerns/secure_view/previewing.rb
@@ -66,7 +66,7 @@ module SecureView
     end
 
     def secure_view_params
-      @secure_view_params ||= params[:secure_view] || {}
+      @secure_view_params ||= params[:secure_view].presence || {}
     end
   end
 end

--- a/app/controllers/nfs_store/downloads_controller.rb
+++ b/app/controllers/nfs_store/downloads_controller.rb
@@ -23,8 +23,12 @@ module NfsStore
     # Request download of a single file for download or view
     # Specify either a download_id & retrieval_type or download_path
     def show
-      for_action = :download
-      for_action = :download_or_view if params.dig(:secure_view, :preview_as).present?
+      # We have to check the secure_view responds to dig, because it may be an empty string
+      for_action = if params[:secure_view].respond_to?(:dig) && params.dig(:secure_view, :preview_as).present?
+                     :download_or_view
+                   else
+                     :download
+                   end
 
       raise FsException::NotFound, 'Requested file ID or path not found' unless @download_id
 


### PR DESCRIPTION
Fixed #897