### PR TITLE
Fixed HTML entity encoding in javascript_tag heredoc blocks

### DIFF
--- a/app/helpers/edit_fields/edit_form_field_helper.rb
+++ b/app/helpers/edit_fields/edit_form_field_helper.rb
@@ -149,7 +149,7 @@ module EditFields
           got ||= ''
           got = got.html_safe
           got += javascript_tag(nonce: true) do
-            <<~END_JS
+            <<~END_JS.html_safe
               _fpa.calculate_with = _fpa.calculate_with || {};
               var cwdef = _fpa.calculate_with['#{field_name_sym}'] = #{cw.to_json.html_safe};
 

--- a/app/helpers/report_results/reports_common_result_cell.rb
+++ b/app/helpers/report_results/reports_common_result_cell.rb
@@ -327,7 +327,7 @@ module ReportResults
 
       # Script to load the content into the iframe
       loader_script = javascript_tag(nonce: true) do
-        <<~END_JS
+        <<~END_JS.html_safe
           window.setTimeout(function() {
             var c = $('#report-cell-content-#{block_id}');
             var html = c.html();

--- a/spec/helpers/edit_fields/edit_form_field_helper_spec.rb
+++ b/spec/helpers/edit_fields/edit_form_field_helper_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# EditFormFieldHelper Spec
+#
+# Tests the calculate_with JavaScript generation in edit_form_field_helper.rb.
+#
+# Test Coverage:
+# - javascript_tag with heredoc block must produce valid JavaScript (not HTML-encoded)
+#   - Verifies that single quotes in the heredoc are NOT html-entity-encoded to &#39;
+#   - Verifies that JSON content (containing double quotes) is NOT html-entity-encoded to &quot;
+#   - Regression test for bug where Rails 7.2 capture helper HTML-escaped plain String
+#     return values from javascript_tag blocks, producing invalid <script> content
+#     (e.g. _fpa.calculate_with[&#39;field&#39;] instead of _fpa.calculate_with['field'])
+
+require 'rails_helper'
+
+RSpec.describe EditFields::EditFormFieldHelper, type: :helper do
+  describe 'calculate_with script generation' do
+    # Simulate what edit_form_field_helper.rb does for the calculate_with option:
+    #   javascript_tag(nonce: true) do
+    #     <<~END_JS.html_safe
+    #       _fpa.calculate_with['#{field_name_sym}'] = #{cw.to_json.html_safe};
+    #       _fpa.utils.calc_field('#{field_name_sym}', '#{form_object_type}');
+    #     END_JS
+    #   end
+    #
+    # Without .html_safe on the heredoc, Rails 7.2's capture helper HTML-escapes
+    # plain Strings, turning ' into &#39; and " into &quot; inside the <script> tag.
+
+    before do
+      # Stub content_security_policy_nonce since we're not in a real request context
+      allow(helper).to receive(:content_security_policy_nonce).and_return('test-nonce')
+    end
+
+    it 'produces valid JavaScript without HTML entities when heredoc is marked html_safe' do
+      field_name = 'tmoca_score'
+      model_type = 'dynamic_model__play_ipa_phone_screen_tmoca_scores_rec'
+      calculate_with = { 'sum' => %w[field_a field_b field_c] }
+
+      result = helper.javascript_tag(nonce: true) do
+        <<~END_JS.html_safe
+          _fpa.calculate_with = _fpa.calculate_with || {};
+          var cwdef = _fpa.calculate_with['#{field_name}'] = #{calculate_with.to_json.html_safe};
+          _fpa.utils.calc_field('#{field_name}', '#{model_type}');
+        END_JS
+      end
+
+      # The script tag content must contain raw JavaScript, not HTML entities
+      expect(result).to include("_fpa.calculate_with['tmoca_score']")
+      expect(result).to include('"sum":["field_a","field_b","field_c"]')
+      expect(result).to include("_fpa.utils.calc_field('tmoca_score'")
+
+      # Must NOT contain HTML entities inside the script tag
+      expect(result).not_to include('&#39;')
+      expect(result).not_to include('&quot;')
+      expect(result).not_to include('&amp;')
+    end
+
+    it 'would produce HTML-encoded content without html_safe (demonstrating the bug)' do
+      field_name = 'tmoca_score'
+      calculate_with = { 'sum' => %w[field_a field_b] }
+
+      # Without .html_safe, Rails 7.2's capture helper HTML-escapes the string
+      result = helper.javascript_tag(nonce: true) do
+        <<~END_JS
+          _fpa.calculate_with['#{field_name}'] = #{calculate_with.to_json};
+        END_JS
+      end
+
+      # This demonstrates the bug: the content gets HTML-entity-encoded
+      expect(result).to include('&#39;'), 'Expected HTML-encoded single quotes (demonstrating the bug)'
+      expect(result).to include('&quot;'), 'Expected HTML-encoded double quotes (demonstrating the bug)'
+    end
+  end
+end


### PR DESCRIPTION
## Problem

In Rails 7.2, `ActionView::Helpers::CaptureHelper#capture` HTML-escapes the return value of its block when it is a plain `String`. A heredoc (`<<~END_JS`) is a plain `String`, so when returned from a `javascript_tag` block the quotes inside are double-encoded:

- `'` → `&#39;`
- `"` → `&quot;`

The browser `DOMEval` then throws `SyntaxError: Unexpected token '&'` and silently aborts the script.

## Impact

Two helpers were affected:

1. **`EditFields::EditFormFieldHelper#field_calculate_with`** – generates the `_fpa.calculate_with` setup script that binds field sum/calculation listeners for AJAX-loaded forms. When broken, calculated fields (e.g. `tmoca_score`) remain empty after user input.

2. **`ReportResults::ReportsCommonResultCell`** – generates the iframe loader script for embedded report cells.

## Fix

Append `.html_safe` to the heredoc so `capture` receives an `ActiveSupport::SafeBuffer` and skips the HTML-escaping step.

```ruby
# before
javascript_tag(nonce: true) { <<~END_JS }

# after
javascript_tag(nonce: true) { <<~END_JS.html_safe }
```

Changed files:
- `app/helpers/edit_fields/edit_form_field_helper.rb`
- `app/helpers/report_results/reports_common_result_cell.rb`

## Verification

New Rspec helper spec `spec/helpers/edit_fields/edit_form_field_helper_spec.rb` contains two examples:

1. Proves the fix: `.html_safe` heredoc produces valid JS with no `&#39;` or `&quot;` entities in the `<script>` tag.
2. Demonstrates the original bug: without `.html_safe`, entities appear and would cause a `SyntaxError` at runtime.