### PR TITLE
Add action to clear all roles from a user in an app - fixes #671

### DIFF
--- a/app/controllers/admin/user_roles_controller.rb
+++ b/app/controllers/admin/user_roles_controller.rb
@@ -5,6 +5,24 @@
 class Admin::UserRolesController < AdminController
   helper_method :admin_links
   #
+  # Handle the request to clear (disable) all user roles for a user in an app type
+  def clear_user_roles
+    user_id = params[:clear_user_id]
+    app_type_id = params[:clear_app_type_id]
+
+    raise FphsException, 'A user must be selected to clear roles' if user_id.blank?
+    raise FphsException, 'An app type must be selected to clear roles' if app_type_id.blank?
+
+    user = User.active.find user_id
+    app_type = Admin::AppType.active.find app_type_id
+
+    res = Admin::UserRole.clear_user_roles(user, app_type, current_admin)
+    resc = res.length
+    flash.now[:notice] = "#{user.email} had #{resc} #{'role'.pluralize(resc)} cleared for app #{app_type.name}"
+    index
+  end
+
+  #
   # Handle the request to copy user roles from one user to another
   def copy_user_roles
     from_user_id = params[:from_user_id]

--- a/app/models/admin/user_role.rb
+++ b/app/models/admin/user_role.rb
@@ -186,6 +186,21 @@ class Admin::UserRole < Admin::AdminBase
     to_roles
   end
 
+  # Clear (disable) all active roles for a user in a specific app type.
+  # @param user [User] user whose roles will be disabled
+  # @param app_type [Admin::AppType] the app type to clear roles for
+  # @param current_admin [Admin] admin performing the action
+  # @return [Array] array of Admin::UserRole instances that were disabled
+  def self.clear_user_roles(user, app_type, current_admin)
+    raise FphsException, 'user must be specified and not nil to clear roles' if user.blank?
+    raise FphsException, 'app_type must be specified and not nil to clear roles' if app_type.blank?
+
+    active_app_roles(user, app_type:).each_with_object([]) do |role, disabled|
+      role.with_admin(current_admin).disable!
+      disabled << role
+    end
+  end
+
   # Provide a usable name for viewing
   def name
     "#{role_name} #{user&.email}"

--- a/app/views/admin/user_roles/_clear_user_roles.html.erb
+++ b/app/views/admin/user_roles/_clear_user_roles.html.erb
@@ -1,0 +1,20 @@
+<div class="col-sm-24 admin-head-block">
+  <h4><a href="#clear-roles-block" data-toggle="collapse" class="collapsed"><span class="caret caret-large"></span></a> Clear All Roles for a User</h4>
+
+  <div id="clear-roles-block" class="collapse">
+    <div class="form-group">
+      <%= form_tag admin_user_roles_clear_user_roles_path, action: :post do %>
+      <%= label_tag :clear_user_id, "User" %>
+      <%= select_tag :clear_user_id, active_user_options, include_blank: true, class: 'use-chosen' %>
+    </div>
+    <div class="form-group">
+      <%= label_tag :clear_app_type_id, "App type" %>
+      <%= select_tag :clear_app_type_id, app_type_options(default_app_type_id: app_type_select_current_item(use_current_user: true)) %>
+    </div>
+    <div class="form-group">
+      <%= hidden_filter_fields %>
+      <%= submit_tag :clear, class: "btn btn-warning" %>
+    </div>
+  </div>
+  <% end %>
+</div>

--- a/app/views/admin/user_roles/_head_info.html.erb
+++ b/app/views/admin/user_roles/_head_info.html.erb
@@ -1,5 +1,10 @@
 <div class="container-fluid admin-head-blocks panel panel-default">
   <div class="row">
-    <%= render partial: 'copy_user_roles' %>
+    <div class="col-lg-12">
+      <%= render partial: 'copy_user_roles' %>
+    </div>
+    <div class="col-lg-12">
+      <%= render partial: 'clear_user_roles' %>
+    </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
     resources :role_descriptions, except: %i[show destroy]
     resources :user_roles, except: %i[show destroy]
     post 'user_roles/copy_user_roles', to: 'user_roles#copy_user_roles'
+    post 'user_roles/clear_user_roles', to: 'user_roles#clear_user_roles'
     resources :page_layouts, except: %i[show destroy]
 
     resources :protocols, except: %i[show destroy] do

--- a/spec/models/admin/user_role_spec.rb
+++ b/spec/models/admin/user_role_spec.rb
@@ -2,6 +2,9 @@
 
 require 'rails_helper'
 
+# Model tests for Admin::UserRole, covering role assignment, querying,
+# copying roles between users, and clearing all roles for a user
+# in a specific app type (issue #671).
 RSpec.describe Admin::UserRole, type: :model do
   include ModelSupport
   include PlayerInfoSupport
@@ -236,5 +239,71 @@ RSpec.describe Admin::UserRole, type: :model do
     # Verify all roles are now active
     active_roles = Admin::UserRole.active.where(app_type: app_type_0, user: user1).role_names.sort
     expect(active_roles).to eq ['source_role_1', 'source_role_2', 'source_role_3']
+  end
+
+  it 'clears all roles for a user in a specific app type - issue #671' do
+    create_admin
+    app_type_a = create_app_type name: 'clear_test_app_a', label: 'Clear Test App A'
+    app_type_b = create_app_type name: 'clear_test_app_b', label: 'Clear Test App B'
+    user_to_clear, = create_user
+
+    # Create roles in app_type_a
+    create_user_role 'role_alpha', user: user_to_clear, app_type: app_type_a
+    create_user_role 'role_beta', user: user_to_clear, app_type: app_type_a
+    create_user_role 'role_gamma', user: user_to_clear, app_type: app_type_a
+
+    # Create roles in app_type_b (should NOT be affected)
+    create_user_role 'role_delta', user: user_to_clear, app_type: app_type_b
+
+    # Verify active roles exist before clearing
+    active_a = Admin::UserRole.active.where(user: user_to_clear, app_type: app_type_a)
+    expect(active_a.count).to eq 3
+
+    active_b = Admin::UserRole.active.where(user: user_to_clear, app_type: app_type_b)
+    expect(active_b.count).to eq 1
+
+    # Clear all roles for app_type_a
+    result = Admin::UserRole.clear_user_roles(user_to_clear, app_type_a, @admin)
+
+    # Should return the roles that were disabled
+    expect(result.length).to eq 3
+    expect(result.map(&:role_name).sort).to eq %w[role_alpha role_beta role_gamma]
+
+    # All roles in app_type_a should now be disabled
+    active_a_after = Admin::UserRole.active.where(user: user_to_clear, app_type: app_type_a)
+    expect(active_a_after.count).to eq 0
+
+    # Roles in app_type_b should be untouched
+    active_b_after = Admin::UserRole.active.where(user: user_to_clear, app_type: app_type_b)
+    expect(active_b_after.count).to eq 1
+  end
+
+  context 'clear_user_roles guard clauses - issue #671' do
+    it 'raises an error when app_type is blank' do
+      create_admin
+      user_to_clear, = create_user
+
+      expect do
+        Admin::UserRole.clear_user_roles(user_to_clear, nil, @admin)
+      end.to raise_error(FphsException, /app_type must be specified/)
+    end
+
+    it 'raises an error when user is blank' do
+      create_admin
+      app_type_a = create_app_type name: 'clear_no_user_app', label: 'Clear No User App'
+
+      expect do
+        Admin::UserRole.clear_user_roles(nil, app_type_a, @admin)
+      end.to raise_error(FphsException, /user must be specified/)
+    end
+
+    it 'returns empty array when user has no active roles to clear' do
+      create_admin
+      app_type_empty = create_app_type name: 'clear_empty_app', label: 'Clear Empty App'
+      user_no_roles, = create_user
+
+      result = Admin::UserRole.clear_user_roles(user_no_roles, app_type_empty, @admin)
+      expect(result).to eq []
+    end
   end
 end

--- a/spec/system/admin/admin_user_roles_clear_spec.rb
+++ b/spec/system/admin/admin_user_roles_clear_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# System tests for the clear user roles functionality in the admin panel (issue #671).
+# Tests verify the UI workflow for disabling all roles for a specified user
+# in a specified app type, using a form similar to the "Copy Roles" form.
+#
+# NOTE: The model tests in spec/models/admin/user_role_spec.rb provide complete coverage
+# of the underlying clear_user_roles method.
+describe 'admin clear user roles', js: true, driver: $browser_driver do
+  include ModelSupport
+  include AdminActionsSetup
+  include FeatureSupport
+
+  before(:all) do
+    SetupHelper.feature_setup
+
+    @setup_admin = Admin.active.first || Admin.first || Admin.create!(
+      email: "setup_admin_#{rand(1_000_000)}@test.com",
+      password: 'Pass1234!',
+      password_confirmation: 'Pass1234!',
+      disabled: false
+    )
+
+    @app_type_1 = Admin::AppType.active.first || Admin::AppType.create!(
+      name: 'test_app',
+      label: 'Test App',
+      current_admin: @setup_admin
+    )
+  end
+
+  before(:each) do
+    make_an_admin
+    login_as(@admin, scope: :admin)
+
+    @user_with_roles, = create_user(email: "clear_user_#{rand(1_000_000_000)}@testing.com")
+
+    @role_names = %w[researcher data_entry coordinator]
+    @role_names.each do |role_name|
+      Admin::UserRole.create!(
+        user: @user_with_roles,
+        app_type: @app_type_1,
+        role_name: role_name,
+        current_admin: @admin
+      )
+    end
+  end
+
+  # Reuse the same chosen helper from the copy spec
+  def select_from_chosen_by_id(field_id, value)
+    chosen_id = "#{field_id}_chosen"
+    find("##{chosen_id}").click
+
+    results_selector = 'body > .chosen-container.chosen-with-drop .chosen-results li.active-result'
+    expect(page).to have_css(results_selector, wait: 5)
+
+    results = all(results_selector)
+    matching = results.find { |r| r.text.downcase == value.downcase }
+    raise "Could not find option '#{value}' in dropdown. Available: #{results.map(&:text).inspect}" unless matching
+
+    matching.click
+    sleep 0.3
+  end
+
+  it 'clears all roles for a user in an app type' do
+    visit admin_user_roles_path
+    finish_page_loading
+
+    expect(page).to have_content('Clear All Roles for a User')
+
+    # Expand the clear roles form
+    find('a[href="#clear-roles-block"]').click
+    sleep 0.5
+
+    # Select user
+    select_from_chosen_by_id('clear_user_id', @user_with_roles.email)
+
+    within '#clear-roles-block' do
+      # Select app type
+      app_type_select = find('select[name="clear_app_type_id"]')
+      available_options = app_type_select.all('option').reject { |o| o.text.blank? }
+      raise 'No app types available in dropdown' unless available_options.any?
+
+      select available_options.first.text, from: 'clear_app_type_id'
+
+      # Submit the form
+      click_button 'clear'
+    end
+
+    finish_page_loading
+
+    # Verify success message
+    expect(page).to have_content("#{@user_with_roles.email} had 3 #{'role'.pluralize(3)} cleared for app #{@app_type_1.name}")
+
+    # Verify roles were disabled in database
+    active_roles = Admin::UserRole.active.where(user: @user_with_roles, app_type: @app_type_1)
+    expect(active_roles.count).to eq 0
+  end
+
+  it 'shows appropriate message when user has no roles to clear' do
+    user_no_roles, = create_user(email: "no_roles_#{rand(1_000_000_000)}@testing.com")
+
+    visit admin_user_roles_path
+    finish_page_loading
+
+    find('a[href="#clear-roles-block"]').click
+    sleep 0.5
+
+    select_from_chosen_by_id('clear_user_id', user_no_roles.email)
+
+    within '#clear-roles-block' do
+      app_type_select = find('select[name="clear_app_type_id"]')
+      available_options = app_type_select.all('option').reject { |o| o.text.blank? }
+      select available_options.first.text, from: 'clear_app_type_id'
+
+      click_button 'clear'
+    end
+
+    finish_page_loading
+
+    expect(page).to have_content("#{user_no_roles.email} had 0 roles cleared for app #{@app_type_1.name}")
+  end
+
+  it 'shows an error when no user is selected' do
+    visit admin_user_roles_path
+    finish_page_loading
+
+    find('a[href="#clear-roles-block"]').click
+    sleep 0.5
+
+    within '#clear-roles-block' do
+      # Don't select a user, just pick an app type and submit
+      app_type_select = find('select[name="clear_app_type_id"]')
+      available_options = app_type_select.all('option').reject { |o| o.text.blank? }
+      select available_options.first.text, from: 'clear_app_type_id'
+
+      click_button 'clear'
+    end
+
+    finish_page_loading
+
+    expect(page).to have_content('A user must be selected to clear roles')
+  end
+end


### PR DESCRIPTION
## Summary

Adds a "Clear All Roles for a User" action to the admin User Roles page, allowing admins to disable all roles for a specified user in a specified app type with a single action.

## Changes

- **Model** (`Admin::UserRole.clear_user_roles`): New class method that disables all active roles for a user in a given app type. Validates both user and app_type are present. Returns the list of disabled roles.
- **Controller** (`Admin::UserRolesController#clear_user_roles`): New action with parameter validation that provides clear error messages.
- **Route**: `POST admin/user_roles/clear_user_roles`
- **View**: New `_clear_user_roles.html.erb` partial with user (chosen dropdown) and app type selectors, rendered alongside the existing Copy Roles form in `_head_info.html.erb`.

## Tests

- **4 model specs**: Core clearing behavior, guard clauses (blank user, blank app_type), and empty roles case
- **3 system specs**: Full UI workflow for clearing roles, zero-roles message, and missing user validation error

All 16 related tests pass (9 model + 4 copy system + 3 clear system).

Fixes #671