### PR TITLE
Add API definitions panel to dynamic definition and report admin views - resolves #652

### DIFF
--- a/app/assets/javascripts/admin/all/admin_edit_form.js
+++ b/app/assets/javascripts/admin/all/admin_edit_form.js
@@ -20,6 +20,7 @@ _fpa_admin.all.admin_edit_form = class {
     _fpa.form_utils.setup_big_select_fields(aef.block)
     _fpa.form_utils.on_open_click(aef.block);
     _fpa.form_utils.setup_drag_and_drop(aef.block);
+    _fpa.form_utils.setup_copy_blocks(aef.block);
 
   }
 

--- a/app/assets/javascripts/app/_fpa_form_utils.js
+++ b/app/assets/javascripts/app/_fpa_form_utils.js
@@ -197,12 +197,12 @@ _fpa.form_utils = {
   setup_big_select_fields(block) {
     // First, process any JSON data elements that store big-select configuration
     // This approach avoids inline script tags that fail CSP when loaded via AJAX
-    block.find('script.big-select-data[type="application/json"]').each(function() {
+    block.find('script.big-select-data[type="application/json"]').each(function () {
       var $dataEl = $(this);
       var fieldId = $dataEl.data('field-id');
       var optionsAttr = $dataEl.attr('data-options');
       var hashAttr = $dataEl.attr('data-hash');
-      
+
       // Parse JSON from attributes (jQuery .data() may not parse HTML-escaped JSON correctly)
       var options = {};
       var hashData = {};
@@ -216,7 +216,7 @@ _fpa.form_utils = {
       } catch (e) {
         // Ignore parse errors - field will be skipped if no hash data
       }
-      
+
       var field = document.getElementById(fieldId);
       if (field) {
         field.big_select_options = field.big_select_options || options;

--- a/app/assets/javascripts/app/_fpa_form_utils.js
+++ b/app/assets/javascripts/app/_fpa_form_utils.js
@@ -2085,6 +2085,41 @@ _fpa.form_utils = {
       .addClass('made-sortable');
   },
 
+  // Set up icons to allow copy to clipboard
+  setup_copy_blocks: function (block) {
+
+    $(block).find('.copy-block-button')
+      .not('.added-copy-block-handler')
+      .each(function () {
+        $(this).on('click', function (e) {
+          e.preventDefault();
+          var text = $(this).attr('data-copy-text');
+          // Decode HTML entities
+          var textarea = document.createElement('textarea');
+          textarea.innerHTML = text;
+          text = textarea.value;
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(function () {
+              _fpa.flash_notice('Copied to clipboard');
+            }).catch(function () {
+              _fpa.flash_notice('Failed to copy to clipboard');
+            });
+          } else {
+            // Fallback for older browsers
+            textarea.value = text;
+            textarea.style.position = 'fixed';
+            textarea.style.left = '-9999px';
+            document.body.appendChild(textarea);
+            textarea.select();
+            document.execCommand('copy');
+            document.body.removeChild(textarea);
+            _fpa.flash_notice('Copied to clipboard');
+          }
+        })
+      })
+      .addClass('added-copy-block-handler');
+  },
+
   setup_sub_lists: function (block) {
     block
       .find('.sublist-filter-selectors')

--- a/app/assets/stylesheets/admin/admin.scss
+++ b/app/assets/stylesheets/admin/admin.scss
@@ -364,3 +364,26 @@ a.link-disabled {
     width: 40%;
   }
 }
+
+.copy-block-button {
+  cursor: pointer;
+  color: #777;
+  font-size: 14px;
+  margin-left: 5px;
+  vertical-align: middle;
+  display: inline-block;
+  margin-bottom: 10px;
+  border: 1px solid silver;
+  border-radius: 2px;
+  padding: 2px;
+
+  &:hover {
+    color: #337ab7;
+  }
+
+  &.in-block {
+    float: right;
+    margin-top: -25px;
+    margin-right: 3px;
+  }
+}

--- a/app/assets/stylesheets/admin/api_panel.scss
+++ b/app/assets/stylesheets/admin/api_panel.scss
@@ -1,0 +1,74 @@
+// Styles for the API definitions panel in admin dynamic definition views
+.api-panel {
+  padding: 10px 0;
+
+  label {
+    display: block;
+    margin-top: 15px;
+    font-weight: bold;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 3px;
+  }
+
+  &__endpoint {
+    margin-bottom: 5px;
+
+    p {
+      margin-bottom: 2px;
+    }
+
+    code {
+      font-size: 13px;
+    }
+
+    code:first-child {
+      color: #337ab7;
+      font-weight: bold;
+      margin-right: 5px;
+    }
+  }
+
+  &__curl-section {
+    p strong {
+      font-size: 13px;
+    }
+  }
+
+  &__curl-block,
+  &__fields-block,
+  &__save-trigger-block {
+    background-color: #f8f8f8;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    padding: 10px 12px;
+    font-size: 12px;
+    line-height: 1.5;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    margin-bottom: 2px;
+  }
+
+  &__copy-btn {
+    cursor: pointer;
+    color: #555;
+    font-size: 14px;
+    margin-left: 5px;
+    vertical-align: middle;
+    display: inline-block;
+    margin-bottom: 10px;
+    border: 1px solid silver;
+    border-radius: 2px;
+    padding: 2px;
+
+    &:hover {
+      color: #337ab7;
+    }
+
+    &.in-block {
+      float: right;
+      margin-top: -25px;
+      margin-right: 3px;
+    }
+  }
+}

--- a/app/assets/stylesheets/admin/api_panel.scss
+++ b/app/assets/stylesheets/admin/api_panel.scss
@@ -48,27 +48,4 @@
     word-wrap: break-word;
     margin-bottom: 2px;
   }
-
-  &__copy-btn {
-    cursor: pointer;
-    color: #555;
-    font-size: 14px;
-    margin-left: 5px;
-    vertical-align: middle;
-    display: inline-block;
-    margin-bottom: 10px;
-    border: 1px solid silver;
-    border-radius: 2px;
-    padding: 2px;
-
-    &:hover {
-      color: #337ab7;
-    }
-
-    &.in-block {
-      float: right;
-      margin-top: -25px;
-      margin-right: 3px;
-    }
-  }
 }

--- a/app/assets/stylesheets/admin_index.css
+++ b/app/assets/stylesheets/admin_index.css
@@ -22,6 +22,7 @@
  *= require admin/diffy
  *= require admin/activity_list
  *= require admin/admin_options
+ *= require admin/api_panel
  *= require admin/message_notification
  *= require admin/server_info
  *= require admin/sortable

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class HelpController < ApplicationController
-  ValidLibraries = %w[guest_reference admin_reference user_reference app_reference dev_reference].freeze
+  ValidLibraries = %w[guest_reference admin_reference user_reference app_reference dev_reference api_reference].freeze
   AcceptableImageFormats = %w[png jpg jpeg svg gif].freeze
   DocumentsDirectory = 'docs'
   IndexSection = 'main'

--- a/app/helpers/admin_api_definitions_helper.rb
+++ b/app/helpers/admin_api_definitions_helper.rb
@@ -173,7 +173,7 @@ module AdminApiDefinitionsHelper
           on_create:
 
             - pull_external_data:
-              - get_record:
+              - get_report:
                   local_data: get_result
                   from:
                     url: "{{base_url}}/reports/#{report.alt_resource_name}.json?#{sa}&use_app_type={{constants.api_app_type}}&user_email={{constants.api_user_email}}&user_token={{constants.api_shared_secret}}"

--- a/app/helpers/admin_api_definitions_helper.rb
+++ b/app/helpers/admin_api_definitions_helper.rb
@@ -11,11 +11,11 @@ module AdminApiDefinitionsHelper
   #
   # Generate the base API path for a definition instance.
   # @param object_instance [DynamicModel, ActivityLog, ExternalIdentifier] the definition
-  # @return [String] the base path (e.g., "/masters/{master_id}/dynamic_model/contact_infos")
+  # @return [String] the base path (e.g., "/masters/{{master_id}}/dynamic_model/contact_infos")
   def api_base_path(object_instance)
     segments = object_instance.base_route_segments
     if api_master_nested?(object_instance)
-      "/masters/{master_id}/#{segments}"
+      "/masters/{{master_id}}/#{segments}"
     else
       "/#{segments}"
     end

--- a/app/helpers/admin_api_definitions_helper.rb
+++ b/app/helpers/admin_api_definitions_helper.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+#
+# Helper methods for generating API documentation in admin definition panels.
+# Used by the admin/common/_api_panel.html.erb partial to display REST API endpoints,
+# curl examples, field definitions, and save trigger usage for dynamic definitions and reports.
+module AdminApiDefinitionsHelper
+  # Standard fields that should be excluded from API field listings
+  STANDARD_FIELDS = %w[id created_at updated_at contactid user_id master_id].freeze
+
+  #
+  # Generate the base API path for a definition instance.
+  # @param object_instance [DynamicModel, ActivityLog, ExternalIdentifier] the definition
+  # @return [String] the base path (e.g., "/masters/{master_id}/dynamic_model/contact_infos")
+  def api_base_path(object_instance)
+    segments = object_instance.base_route_segments
+    if api_master_nested?(object_instance)
+      "/masters/{master_id}/#{segments}"
+    else
+      "/#{segments}"
+    end
+  end
+
+  #
+  # Check if the resource is nested under /masters/
+  # @param object_instance [DynamicModel, ActivityLog, ExternalIdentifier] the definition
+  # @return [Boolean]
+  def api_master_nested?(object_instance)
+    if object_instance.respond_to?(:foreign_key_name)
+      object_instance.foreign_key_name.present?
+    else
+      # Activity logs and external identifiers are always master-nested
+      true
+    end
+  end
+
+  #
+  # Generate API endpoint definitions for a resource.
+  # @param object_instance [DynamicModel, ActivityLog, ExternalIdentifier] the definition
+  # @return [Array<Hash>] list of endpoint definitions with :method, :path, :description keys
+  def api_endpoints(object_instance)
+    base = api_base_path(object_instance)
+    endpoints = [
+      { method: 'GET', path: "#{base}.json", description: 'Index (list all)' },
+      { method: 'GET', path: "#{base}/{id}.json", description: 'Read (show one)' },
+      { method: 'POST', path: "#{base}.json", description: 'Create' },
+      { method: 'PUT', path: "#{base}/{id}.json", description: 'Update' }
+    ]
+
+    # Activity logs have extra_log_type sub-routes
+    if object_instance.is_a?(ActivityLog)
+      object_instance.option_configs_names&.each do |elt_name|
+        next if elt_name.in?(%i[primary blank_log])
+
+        endpoints << { method: 'POST', path: "#{base}/#{elt_name}.json",
+                       description: "Create (#{elt_name})" }
+        endpoints << { method: 'GET', path: "#{base}/#{elt_name}/{id}.json",
+                       description: "Read (#{elt_name})" }
+      end
+    end
+
+    endpoints
+  end
+
+  #
+  # Generate the user-facing fields list, excluding standard fields.
+  # @param object_instance [DynamicModel, ActivityLog, ExternalIdentifier] the definition
+  # @return [Array<Hash>] list of field definitions with :name and :type keys
+  def api_fields(object_instance)
+    return [] unless object_instance.respond_to?(:table_columns) && object_instance.table_or_view_ready?
+
+    object_instance.table_columns.filter_map do |col|
+      next if col.name.in?(STANDARD_FIELDS)
+
+      { name: col.name, type: col.type.to_s }
+    end
+  end
+
+  #
+  # Generate an unordered list of fields and types for display.
+  # @param object_instance [DynamicModel, ActivityLog, ExternalIdentifier] the definition
+  # @return [String]
+  def api_fields_list(object_instance)
+    res = '<ul class="api-panel__fields-list">'
+    api_fields(object_instance).each do |f|
+      res += "<li><code>#{f[:name]}</code>: #{f[:type]}</li>"
+    end
+    res += '</ul>'
+    res.html_safe
+  end
+
+  #
+  # Generate a YAML-like string of fields and types for display.
+  # @param object_instance [DynamicModel, ActivityLog, ExternalIdentifier] the definition
+  # @return [String]
+  def api_fields_yaml(object_instance)
+    api_fields(object_instance).map do |f|
+      "#{f[:name]}:\n  type: #{f[:type]}"
+    end.join("\n")
+  end
+
+  #
+  # Generate a sample JSON body with field names and placeholder values
+  # for use in curl examples.
+  # @param object_instance [DynamicModel, ActivityLog, ExternalIdentifier] the definition
+  # @return [String] JSON-formatted body string
+  def api_sample_json_body(object_instance)
+    fields = api_fields(object_instance)
+    return '{}' if fields.empty?
+
+    pairs = fields.map do |f|
+      value = case f[:type]
+              when 'integer', 'bigint' then '0'
+              when 'float', 'decimal' then '0.0'
+              when 'boolean' then 'false'
+              when 'date' then '"YYYY-MM-DD"'
+              when 'datetime' then '"YYYY-MM-DDTHH:MM:SS"'
+              else '""'
+              end
+      "  \"#{f[:name]}\": #{value}"
+    end
+
+    "{\n#{pairs.join(",\n")}\n}"
+  end
+
+  #
+  # Generate a curl example for a given HTTP method and path.
+  # @param method [String] HTTP method (GET, POST, PUT)
+  # @param path [String] the API path
+  # @param body [String, nil] optional JSON body
+  # @return [String] the curl command
+  def api_curl_example(method:, path:, body: nil)
+    curl = <<~CURL.chomp
+      curl -X#{method} -H "Content-Type: application/json" \\
+      "{{base_url}}"\\
+      "#{path}"\\
+      "?use_app_type={{app_type_id}}&user_email={{user_email}}&user_token={{api_token}}"
+    CURL
+    curl += " \\\n  -d '\n#{body}\n'" if body.present?
+    curl
+  end
+
+  #
+  # Generate save trigger YAML usage example for pull_external_data.
+  # @param object_instance [DynamicModel, ActivityLog, ExternalIdentifier] the definition
+  # @return [String] YAML-formatted save trigger example
+  def api_save_trigger_example(object_instance)
+    base = api_base_path(object_instance)
+    fields = api_fields(object_instance)
+    field_lines = fields.map do |f|
+      value = case f[:type]
+              when 'integer', 'bigint' then '0'
+              when 'float', 'decimal' then '0.0'
+              when 'boolean' then 'false'
+              else '""'
+              end
+      "              #{f[:name]}: #{value}"
+    end.join("\n")
+
+    <<~YAML
+      _constants:
+        api_user_email: {{user_email}}
+        api_app_type: {{app_type_id}}
+        api_shared_secret: {{api_token}}
+        master_id: {master_id}
+        item_id: {item_id}
+
+      default:
+        save_trigger:
+          on_create:
+
+            - pull_external_data:
+              - get_record:
+                  local_data: get_result
+                  from:
+                    url: "{{base_url}}#{base}/{{constants.item_id}}.json?use_app_type={{constants.api_app_type}}&user_email={{constants.api_user_email}}&user_token={{constants.api_shared_secret}}"
+                    format: json
+                    allow_empty_result: false
+
+            - pull_external_data:
+              - create_record:
+                  force_not_editable_save: true
+                  local_data: create_result
+                  to:
+                    url: "{{base_url}}#{base}.json?use_app_type={{constants.api_app_type}}&user_email={{constants.api_user_email}}&user_token={{constants.api_shared_secret}}"
+                    format: json
+                    allow_empty_result: false
+                    headers:
+                      'Content-Type': 'application/json'
+
+                  post_data:
+      #{field_lines}
+    YAML
+  end
+end

--- a/app/helpers/admin_api_definitions_helper.rb
+++ b/app/helpers/admin_api_definitions_helper.rb
@@ -141,6 +141,48 @@ module AdminApiDefinitionsHelper
   end
 
   #
+  # Generate a curl example for a report GET endpoint.
+  # @param report [Report] the report record
+  # @param format [String] the format extension ('json', 'csv', 'txt')
+  # @param sa [String] the search attributes query string (already encoded)
+  # @return [String] the curl command
+  def api_report_curl_example(report, format:, sa:)
+    <<~CURL.chomp
+      curl -XGET -H "Content-Type: application/json" \\\
+      "{{base_url}}"\\\
+      "/reports/#{report.alt_resource_name}.#{format}"\\\
+      "?#{sa}"\\\
+      "&use_app_type={{app_type_id}}&user_email={{user_email}}&user_token={{api_token}}"
+    CURL
+  end
+
+  #
+  # Generate save trigger YAML usage example for a report's pull_external_data GET.
+  # @param report [Report] the report record
+  # @param sa [String] the search attributes query string (already encoded)
+  # @return [String] YAML-formatted save trigger example
+  def api_report_save_trigger_example(report, sa:)
+    <<~YAML
+      _constants:
+        api_user_email: {{user_email}}
+        api_app_type: {{app_type_id}}
+        api_shared_secret: {{api_token}}
+
+      default:
+        save_trigger:
+          on_create:
+
+            - pull_external_data:
+              - get_record:
+                  local_data: get_result
+                  from:
+                    url: "{{base_url}}/reports/#{report.alt_resource_name}.json?#{sa}&use_app_type={{constants.api_app_type}}&user_email={{constants.api_user_email}}&user_token={{constants.api_shared_secret}}"
+                    format: json
+                    allow_empty_result: false
+    YAML
+  end
+
+  #
   # Generate save trigger YAML usage example for pull_external_data.
   # @param object_instance [DynamicModel, ActivityLog, ExternalIdentifier] the definition
   # @return [String] YAML-formatted save trigger example

--- a/app/views/admin/activity_logs/_form_info.html.erb
+++ b/app/views/admin/activity_logs/_form_info.html.erb
@@ -7,6 +7,7 @@
     <li role="presentation"><a href="#parsed-config" aria-controls="parsed-config" role="tab" data-toggle="tab">Parsed Config</a></li>
     <li role="presentation"><a href="#user-access-controls" aria-controls="user-access-controls" role="tab" data-toggle="tab">User Access Controls</a></li>
     <li role="presentation"><a href="#def-versions" aria-controls="def-versions" role="tab" data-toggle="tab">Versions</a></li>
+    <li role="presentation"><a href="#api-definitions" aria-controls="api-definitions" role="tab" data-toggle="tab">API</a></li>
   </ul>
 
   <!-- Tab panes -->
@@ -36,6 +37,10 @@
 
     <div role="tabpanel" class="tab-pane  on-open-click" id="def-versions">
       <%= render partial: 'admin/activity_logs/versions_panel', locals: {object_instance: object_instance} %>
+    </div>
+
+    <div role="tabpanel" class="tab-pane" id="api-definitions">
+      <%= render partial: 'admin/common/api_panel', locals: { object_instance: object_instance, resource_type: :activity_log } %>
     </div>
 
   </div>

--- a/app/views/admin/common/_api_panel.html.erb
+++ b/app/views/admin/common/_api_panel.html.erb
@@ -43,7 +43,7 @@
           <p>
             <code><%= endpoint[:method] %></code>
             <code><%= endpoint[:path] %></code>
-            <a class="api-panel__copy-btn glyphicon glyphicon-copy"
+            <a class="api-panel__copy-btn copy-block-button glyphicon glyphicon-copy"
                title="Copy to clipboard"
                data-copy-text="<%= endpoint[:path] %>"></a>
           </p>
@@ -59,41 +59,41 @@
         <p><strong>Read (Index)</strong></p>
         <% curl_index = api_curl_example(method: 'GET', path: "#{base}.json") %>
         <pre class="api-panel__curl-block"><%= curl_index %></pre>
-        <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+        <a class="api-panel__copy-btn copy-block-button in-block glyphicon glyphicon-copy"
            title="Copy to clipboard"
            data-copy-text="<%= ERB::Util.html_escape(curl_index) %>"></a>
 
         <p><strong>Read (Show)</strong></p>
         <% curl_show = api_curl_example(method: 'GET', path: "#{base}/{id}.json") %>
         <pre class="api-panel__curl-block"><%= curl_show %></pre>
-        <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+        <a class="api-panel__copy-btn copy-block-button in-block glyphicon glyphicon-copy"
            title="Copy to clipboard"
            data-copy-text="<%= ERB::Util.html_escape(curl_show) %>"></a>
 
         <p><strong>Create</strong></p>
         <% curl_create = api_curl_example(method: 'POST', path: "#{base}.json", body: body) %>
         <pre class="api-panel__curl-block"><%= curl_create %></pre>
-        <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+        <a class="api-panel__copy-btn copy-block-button in-block glyphicon glyphicon-copy"
            title="Copy to clipboard"
            data-copy-text="<%= ERB::Util.html_escape(curl_create) %>"></a>
 
         <p><strong>Update</strong></p>
         <% curl_update = api_curl_example(method: 'PUT', path: "#{base}/{id}.json", body: body) %>
         <pre class="api-panel__curl-block"><%= curl_update %></pre>
-        <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+        <a class="api-panel__copy-btn copy-block-button in-block glyphicon glyphicon-copy"
            title="Copy to clipboard"
            data-copy-text="<%= ERB::Util.html_escape(curl_update) %>"></a>
       </div>
 
       <label>fields</label>
       <div class="api-panel__fields-list-block"><%= api_fields_list(object_instance) %></div>
-      <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+      <a class="api-panel__copy-btn copy-block-button in-block glyphicon glyphicon-copy"
          title="Copy to clipboard"
          data-copy-text="<%= ERB::Util.html_escape(api_fields_yaml(object_instance)) %>"></a>
 
       <label>save trigger usage</label>
       <pre class="api-panel__save-trigger-block"><%= ERB::Util.html_escape(api_save_trigger_example(object_instance)) %></pre>
-      <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+      <a class="api-panel__copy-btn copy-block-button in-block glyphicon glyphicon-copy"
          title="Copy to clipboard"
          data-copy-text="<%= ERB::Util.html_escape(api_save_trigger_example(object_instance)) %>"></a>
     </div>
@@ -101,32 +101,4 @@
   <% else %>
     <p>API definitions are not available until the definition is saved and the database table is ready.</p>
   <% end %>
-<% end %>
-
-<%= javascript_tag nonce: true do %>
-  $(document).off('click.apiPanelCopy').on('click.apiPanelCopy', '.api-panel__copy-btn', function(e) {
-    e.preventDefault();
-    var text = $(this).attr('data-copy-text');
-    // Decode HTML entities
-    var textarea = document.createElement('textarea');
-    textarea.innerHTML = text;
-    text = textarea.value;
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(text).then(function() {
-        _fpa.flash_notice('Copied to clipboard');
-      }).catch(function() {
-        _fpa.flash_notice('Failed to copy to clipboard');
-      });
-    } else {
-      // Fallback for older browsers
-      textarea.value = text;
-      textarea.style.position = 'fixed';
-      textarea.style.left = '-9999px';
-      document.body.appendChild(textarea);
-      textarea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textarea);
-      _fpa.flash_notice('Copied to clipboard');
-    }
-  });
 <% end %>

--- a/app/views/admin/common/_api_panel.html.erb
+++ b/app/views/admin/common/_api_panel.html.erb
@@ -1,0 +1,132 @@
+<%#
+  API Definitions Panel
+  Displays REST API endpoints, curl examples, field definitions,
+  and save trigger usage for dynamic definitions (dynamic models,
+  activity logs, external identifiers) and reports.
+
+  Locals:
+    object_instance - the definition record (DynamicModel, ActivityLog, ExternalIdentifier)
+    resource_type   - symbol: :dynamic_model, :activity_log, :external_identifier, or :report
+%>
+<% if resource_type == :report %>
+  <%= render partial: 'admin/common/api_panel_report', locals: { object_instance: object_instance } %>
+<% else %>
+  <h4>
+    API
+  <%= link_to(
+          '',
+          help_page_path(
+            library: :api_reference,
+            section: 'main',
+            subsection: 'README',
+            display_as: :embedded
+          ),
+          class: 'glyphicon glyphicon-question-sign',
+          data: { remote: true, 
+                  toggle: 'collapse', 
+                  target: '#help-sidebar',
+                  'working-target': '#help-sidebar-body' }
+        ) %>    
+  </h4>
+  <% if object_instance.persisted? && object_instance.respond_to?(:table_or_view_ready?) && object_instance.table_or_view_ready? %>
+
+    <div class="api-panel">
+      <label>resource name</label>
+      <p><code><%= object_instance.resource_name %></code></p>
+
+      <label>endpoints</label>
+      <% api_endpoints(object_instance).each do |endpoint| %>
+        <div class="api-panel__endpoint">
+          <p>
+            <strong><%= endpoint[:description] %></strong>
+          </p>
+          <p>
+            <code><%= endpoint[:method] %></code>
+            <code><%= endpoint[:path] %></code>
+            <a class="api-panel__copy-btn glyphicon glyphicon-copy"
+               title="Copy to clipboard"
+               data-copy-text="<%= endpoint[:path] %>"></a>
+          </p>
+        </div>
+      <% end %>
+
+      <label>curl examples</label>
+
+      <div class="api-panel__curl-section">
+        <% base = api_base_path(object_instance) %>
+        <% body = api_sample_json_body(object_instance) %>
+
+        <p><strong>Read (Index)</strong></p>
+        <% curl_index = api_curl_example(method: 'GET', path: "#{base}.json") %>
+        <pre class="api-panel__curl-block"><%= curl_index %></pre>
+        <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+           title="Copy to clipboard"
+           data-copy-text="<%= ERB::Util.html_escape(curl_index) %>"></a>
+
+        <p><strong>Read (Show)</strong></p>
+        <% curl_show = api_curl_example(method: 'GET', path: "#{base}/{id}.json") %>
+        <pre class="api-panel__curl-block"><%= curl_show %></pre>
+        <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+           title="Copy to clipboard"
+           data-copy-text="<%= ERB::Util.html_escape(curl_show) %>"></a>
+
+        <p><strong>Create</strong></p>
+        <% curl_create = api_curl_example(method: 'POST', path: "#{base}.json", body: body) %>
+        <pre class="api-panel__curl-block"><%= curl_create %></pre>
+        <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+           title="Copy to clipboard"
+           data-copy-text="<%= ERB::Util.html_escape(curl_create) %>"></a>
+
+        <p><strong>Update</strong></p>
+        <% curl_update = api_curl_example(method: 'PUT', path: "#{base}/{id}.json", body: body) %>
+        <pre class="api-panel__curl-block"><%= curl_update %></pre>
+        <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+           title="Copy to clipboard"
+           data-copy-text="<%= ERB::Util.html_escape(curl_update) %>"></a>
+      </div>
+
+      <label>fields</label>
+      <div class="api-panel__fields-list-block"><%= api_fields_list(object_instance) %></div>
+      <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+         title="Copy to clipboard"
+         data-copy-text="<%= ERB::Util.html_escape(api_fields_yaml(object_instance)) %>"></a>
+
+      <label>save trigger usage</label>
+      <pre class="api-panel__save-trigger-block"><%= ERB::Util.html_escape(api_save_trigger_example(object_instance)) %></pre>
+      <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+         title="Copy to clipboard"
+         data-copy-text="<%= ERB::Util.html_escape(api_save_trigger_example(object_instance)) %>"></a>
+    </div>
+
+  <% else %>
+    <p>API definitions are not available until the definition is saved and the database table is ready.</p>
+  <% end %>
+<% end %>
+
+<%= javascript_tag nonce: true do %>
+  $(document).off('click.apiPanelCopy').on('click.apiPanelCopy', '.api-panel__copy-btn', function(e) {
+    e.preventDefault();
+    var text = $(this).attr('data-copy-text');
+    // Decode HTML entities
+    var textarea = document.createElement('textarea');
+    textarea.innerHTML = text;
+    text = textarea.value;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(function() {
+        _fpa.flash_notice('Copied to clipboard');
+      }).catch(function() {
+        _fpa.flash_notice('Failed to copy to clipboard');
+      });
+    } else {
+      // Fallback for older browsers
+      textarea.value = text;
+      textarea.style.position = 'fixed';
+      textarea.style.left = '-9999px';
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+      _fpa.flash_notice('Copied to clipboard');
+    }
+  });
+<% end %>

--- a/app/views/admin/common/_api_panel_report.html.erb
+++ b/app/views/admin/common/_api_panel_report.html.erb
@@ -114,45 +114,21 @@
     <label>curl examples</label>
     <div class="api-panel__curl-section">
       <p><strong>JSON</strong></p>
-      <%
-        curl_json = <<~CURL.chomp
-          curl -XGET -H "Content-Type: application/json" \\
-            "{{base_url}}" \\
-            "/reports/#{report.alt_resource_name}.json" \\
-            "?#{sa}" \\
-            "&use_app_type={{app_type_id}}&user_email={{user_email}}&user_token={{api_token}}"
-        CURL
-      %>
+      <% curl_json = api_report_curl_example(report, format: 'json', sa: sa) %>
       <pre class="api-panel__curl-block"><%= curl_json %></pre>
       <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
          title="Copy to clipboard"
          data-copy-text="<%= ERB::Util.html_escape(curl_json) %>"></a>
 
       <p><strong>CSV</strong></p>
-      <%
-        curl_csv = <<~CURL.chomp
-          curl -XGET -H "Content-Type: application/json" \\
-          "{{base_url}}"\\
-          "/reports/#{report.alt_resource_name}.csv"\\
-          "?#{sa}"\\
-          "&use_app_type={{app_type_id}}&user_email={{user_email}}&user_token={{api_token}}"
-        CURL
-      %>
+      <% curl_csv = api_report_curl_example(report, format: 'csv', sa: sa) %>
       <pre class="api-panel__curl-block"><%= curl_csv %></pre>
       <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
          title="Copy to clipboard"
          data-copy-text="<%= ERB::Util.html_escape(curl_csv) %>"></a>
 
       <p><strong>text</strong></p>
-      <%
-        curl_text = <<~CURL.chomp
-          curl -XGET -H "Content-Type: application/json" \\
-          "{{base_url}}"\\
-          "/reports/#{report.alt_resource_name}.txt"\\
-          "?#{sa}"\\
-          "&use_app_type={{app_type_id}}&user_email={{user_email}}&user_token={{api_token}}"
-        CURL
-      %>
+      <% curl_text = api_report_curl_example(report, format: 'txt', sa: sa) %>
       <pre class="api-panel__curl-block"><%= curl_text %></pre>
       <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
          title="Copy to clipboard"
@@ -161,25 +137,7 @@
     </div>
 
     <label>save trigger usage</label>
-    <% trigger_yaml = <<~YAML
-      _constants:
-        api_user_email: {{user_email}}
-        api_app_type: {{app_type_id}}
-        api_shared_secret: {{api_token}}
-
-      default:
-        save_trigger:
-          on_create:
-
-            - pull_external_data:
-              - get_record:
-                  local_data: get_result
-                  from:
-                    url: "{{base_url}}/reports/#{report.alt_resource_name}.json?#{sa}&use_app_type={{constants.api_app_type}}&user_email={{constants.api_user_email}}&user_token={{constants.api_shared_secret}}"
-                    format: json
-                    allow_empty_result: false
-    YAML
-    %>
+    <% trigger_yaml = api_report_save_trigger_example(report, sa: sa) %>
     <pre class="api-panel__save-trigger-block"><%= ERB::Util.html_escape(trigger_yaml) %></pre>
     <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
        title="Copy to clipboard"

--- a/app/views/admin/common/_api_panel_report.html.erb
+++ b/app/views/admin/common/_api_panel_report.html.erb
@@ -33,7 +33,7 @@
       <p>
         <code>GET</code>
         <code>/reports/<%= report.alt_resource_name %>.json</code>
-        <a class="api-panel__copy-btn glyphicon glyphicon-copy"
+        <a class="api-panel__copy-btn copy-block-button glyphicon glyphicon-copy"
            title="Copy to clipboard"
            data-copy-text="/reports/<%= report.alt_resource_name %>.json"></a>
       </p>
@@ -43,7 +43,7 @@
       <p>
         <code>GET</code>
         <code>/reports/<%= report.alt_resource_name %>.csv</code>
-        <a class="api-panel__copy-btn glyphicon glyphicon-copy"
+        <a class="api-panel__copy-btn copy-block-button glyphicon glyphicon-copy"
            title="Copy to clipboard"
            data-copy-text="/reports/<%= report.alt_resource_name %>.csv"></a>
       </p>
@@ -53,7 +53,7 @@
       <p>
         <code>GET</code>
         <code>/reports/<%= report.alt_resource_name %>.text</code>
-        <a class="api-panel__copy-btn glyphicon glyphicon-copy"
+        <a class="api-panel__copy-btn copy-block-button glyphicon glyphicon-copy"
            title="Copy to clipboard"
            data-copy-text="/reports/<%= report.alt_resource_name %>.text"></a>
       </p>
@@ -75,7 +75,7 @@
         end
       %>
       <code>?<%= sa %></code>
-      <a class="api-panel__copy-btn glyphicon glyphicon-copy"
+      <a class="api-panel__copy-btn copy-block-button glyphicon glyphicon-copy"
          title="Copy to clipboard"
          data-copy-text="?<%= sa %>"></a>
     </p>
@@ -88,7 +88,7 @@
       YAML
     %>
     <pre><%= pa_options %></pre>
-    <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+    <a class="api-panel__copy-btn copy-block-button in-block glyphicon glyphicon-copy"
         title="Copy to clipboard"
         data-copy-text="<%= ERB::Util.html_escape(pa_options) %>"></a>
 
@@ -116,21 +116,21 @@
       <p><strong>JSON</strong></p>
       <% curl_json = api_report_curl_example(report, format: 'json', sa: sa) %>
       <pre class="api-panel__curl-block"><%= curl_json %></pre>
-      <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+      <a class="api-panel__copy-btn copy-block-button in-block glyphicon glyphicon-copy"
          title="Copy to clipboard"
          data-copy-text="<%= ERB::Util.html_escape(curl_json) %>"></a>
 
       <p><strong>CSV</strong></p>
       <% curl_csv = api_report_curl_example(report, format: 'csv', sa: sa) %>
       <pre class="api-panel__curl-block"><%= curl_csv %></pre>
-      <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+      <a class="api-panel__copy-btn copy-block-button in-block glyphicon glyphicon-copy"
          title="Copy to clipboard"
          data-copy-text="<%= ERB::Util.html_escape(curl_csv) %>"></a>
 
       <p><strong>text</strong></p>
       <% curl_text = api_report_curl_example(report, format: 'txt', sa: sa) %>
       <pre class="api-panel__curl-block"><%= curl_text %></pre>
-      <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+      <a class="api-panel__copy-btn copy-block-button in-block glyphicon glyphicon-copy"
          title="Copy to clipboard"
          data-copy-text="<%= ERB::Util.html_escape(curl_text) %>"></a>
 
@@ -139,7 +139,7 @@
     <label>save trigger usage</label>
     <% trigger_yaml = api_report_save_trigger_example(report, sa: sa) %>
     <pre class="api-panel__save-trigger-block"><%= ERB::Util.html_escape(trigger_yaml) %></pre>
-    <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+    <a class="api-panel__copy-btn copy-block-button in-block glyphicon glyphicon-copy"
        title="Copy to clipboard"
        data-copy-text="<%= ERB::Util.html_escape(trigger_yaml) %>"></a>
   </div>

--- a/app/views/admin/common/_api_panel_report.html.erb
+++ b/app/views/admin/common/_api_panel_report.html.erb
@@ -1,0 +1,190 @@
+<%#
+  API Panel for Reports
+  Displays the report API endpoint paths, search attributes, and curl examples.
+
+  Locals:
+    object_instance - the Report record (same as @report in the report admin context)
+%>
+<h4>API 
+  <%= link_to(
+          '',
+          help_page_path(
+            library: :api_reference,
+            section: 'main',
+            subsection: 'README',
+            display_as: :embedded
+          ),
+          class: 'glyphicon glyphicon-question-sign',
+          data: { remote: true, 
+                  toggle: 'collapse', 
+                  target: '#help-sidebar',
+                  'working-target': '#help-sidebar-body' }
+        ) %>
+</h4>
+<% report = object_instance %>
+<% if report.persisted? %>
+  <div class="api-panel">
+    <label>resource name</label>
+    <p><code><%= report.alt_resource_name %></code></p>
+
+    <label>endpoints</label>
+    <div class="api-panel__endpoint">
+      <p><strong>JSON</strong></p>
+      <p>
+        <code>GET</code>
+        <code>/reports/<%= report.alt_resource_name %>.json</code>
+        <a class="api-panel__copy-btn glyphicon glyphicon-copy"
+           title="Copy to clipboard"
+           data-copy-text="/reports/<%= report.alt_resource_name %>.json"></a>
+      </p>
+    </div>
+    <div class="api-panel__endpoint">
+      <p><strong>CSV</strong></p>
+      <p>
+        <code>GET</code>
+        <code>/reports/<%= report.alt_resource_name %>.csv</code>
+        <a class="api-panel__copy-btn glyphicon glyphicon-copy"
+           title="Copy to clipboard"
+           data-copy-text="/reports/<%= report.alt_resource_name %>.csv"></a>
+      </p>
+    </div>
+    <div class="api-panel__endpoint">
+      <p><strong>Text</strong></p>
+      <p>
+        <code>GET</code>
+        <code>/reports/<%= report.alt_resource_name %>.text</code>
+        <a class="api-panel__copy-btn glyphicon glyphicon-copy"
+           title="Copy to clipboard"
+           data-copy-text="/reports/<%= report.alt_resource_name %>.text"></a>
+      </p>
+    </div>
+
+    <label>url search attributes</label>
+    <p class="report-item-url-search-attrs">
+      <%
+        configs = report.search_attributes_config.configurations
+        sa = configs.keys.map { |k| [k, ''] }
+        sa << ['_report_id_', ''] if sa.empty?
+        sa = sa.to_h
+
+        plain_attrs = report.report_options.view_options.use_plain_attribute_names
+        unless plain_attrs
+          sa = sa.to_query('search_attrs')
+        else
+          sa = sa.to_query
+        end
+      %>
+      <code>?<%= sa %></code>
+      <a class="api-panel__copy-btn glyphicon glyphicon-copy"
+         title="Copy to clipboard"
+         data-copy-text="?<%= sa %>"></a>
+    </p>
+    <p><label>use plain attributes</label> <%= !!plain_attrs %></p>
+    <p class="help-block">based on options configuration:</p>
+    <%
+      pa_options = <<~YAML
+        view_options:
+          use_plain_attribute_names: #{!!plain_attrs}
+      YAML
+    %>
+    <pre><%= pa_options %></pre>
+    <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+        title="Copy to clipboard"
+        data-copy-text="<%= ERB::Util.html_escape(pa_options) %>"></a>
+
+    <p><label>return formats</label></p>
+    <p class="help-block">Return JSON, CSV, or plain text based on the endpoint path extension (<code>.json</code>, <code>.csv</code>, <code>.txt</code>).
+      See the *options* help
+      <%= link_to(
+          '',
+          help_page_path(
+            library: :admin_reference,
+            section: 'reports',
+            subsection: 'detailed_options',
+            display_as: :embedded
+          ),
+          class: 'glyphicon glyphicon-question-sign',
+          data: { remote: true, 
+                  toggle: 'collapse', 
+                  target: '#help-sidebar',
+                  'working-target': '#help-sidebar-body' }
+        ) %>
+       for specific formatting related to <b>plain_text_options</b> and <b>json_options</b>.</p>
+
+    <label>curl examples</label>
+    <div class="api-panel__curl-section">
+      <p><strong>JSON</strong></p>
+      <%
+        curl_json = <<~CURL.chomp
+          curl -XGET -H "Content-Type: application/json" \\
+            "{{base_url}}" \\
+            "/reports/#{report.alt_resource_name}.json" \\
+            "?#{sa}" \\
+            "&use_app_type={{app_type_id}}&user_email={{user_email}}&user_token={{api_token}}"
+        CURL
+      %>
+      <pre class="api-panel__curl-block"><%= curl_json %></pre>
+      <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+         title="Copy to clipboard"
+         data-copy-text="<%= ERB::Util.html_escape(curl_json) %>"></a>
+
+      <p><strong>CSV</strong></p>
+      <%
+        curl_csv = <<~CURL.chomp
+          curl -XGET -H "Content-Type: application/json" \\
+          "{{base_url}}"\\
+          "/reports/#{report.alt_resource_name}.csv"\\
+          "?#{sa}"\\
+          "&use_app_type={{app_type_id}}&user_email={{user_email}}&user_token={{api_token}}"
+        CURL
+      %>
+      <pre class="api-panel__curl-block"><%= curl_csv %></pre>
+      <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+         title="Copy to clipboard"
+         data-copy-text="<%= ERB::Util.html_escape(curl_csv) %>"></a>
+
+      <p><strong>text</strong></p>
+      <%
+        curl_text = <<~CURL.chomp
+          curl -XGET -H "Content-Type: application/json" \\
+          "{{base_url}}"\\
+          "/reports/#{report.alt_resource_name}.txt"\\
+          "?#{sa}"\\
+          "&use_app_type={{app_type_id}}&user_email={{user_email}}&user_token={{api_token}}"
+        CURL
+      %>
+      <pre class="api-panel__curl-block"><%= curl_text %></pre>
+      <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+         title="Copy to clipboard"
+         data-copy-text="<%= ERB::Util.html_escape(curl_text) %>"></a>
+
+    </div>
+
+    <label>save trigger usage</label>
+    <% trigger_yaml = <<~YAML
+      _constants:
+        api_user_email: {{user_email}}
+        api_app_type: {{app_type_id}}
+        api_shared_secret: {{api_token}}
+
+      default:
+        save_trigger:
+          on_create:
+
+            - pull_external_data:
+              - get_record:
+                  local_data: get_result
+                  from:
+                    url: "{{base_url}}/reports/#{report.alt_resource_name}.json?#{sa}&use_app_type={{constants.api_app_type}}&user_email={{constants.api_user_email}}&user_token={{constants.api_shared_secret}}"
+                    format: json
+                    allow_empty_result: false
+    YAML
+    %>
+    <pre class="api-panel__save-trigger-block"><%= ERB::Util.html_escape(trigger_yaml) %></pre>
+    <a class="api-panel__copy-btn in-block glyphicon glyphicon-copy"
+       title="Copy to clipboard"
+       data-copy-text="<%= ERB::Util.html_escape(trigger_yaml) %>"></a>
+  </div>
+<% else %>
+  <p>API definitions are not available until the report is saved.</p>
+<% end %>

--- a/app/views/admin/dynamic_models/_form_info.html.erb
+++ b/app/views/admin/dynamic_models/_form_info.html.erb
@@ -8,6 +8,7 @@
     <li role="presentation"><a href="#parsed-config" aria-controls="parsed-config" role="tab" data-toggle="tab">Parsed Config</a></li>
     <li role="presentation"><a href="#user-access-controls" aria-controls="user-access-controls" role="tab" data-toggle="tab">User Access Controls</a></li>
     <li role="presentation"><a href="#def-versions" aria-controls="def-versions" role="tab" data-toggle="tab">Versions</a></li>
+    <li role="presentation"><a href="#api-definitions" aria-controls="api-definitions" role="tab" data-toggle="tab">API</a></li>
   </ul>
 
   <!-- Tab panes -->
@@ -69,6 +70,10 @@
 
     <div role="tabpanel" class="tab-pane  on-open-click" id="def-versions">
       <%= render partial: 'admin/dynamic_models/versions_panel', locals: {object_instance: object_instance} %>
+    </div>
+
+    <div role="tabpanel" class="tab-pane" id="api-definitions">
+      <%= render partial: 'admin/common/api_panel', locals: { object_instance: object_instance, resource_type: :dynamic_model } %>
     </div>
 
   </div>

--- a/app/views/admin/external_identifiers/_form_info.html.erb
+++ b/app/views/admin/external_identifiers/_form_info.html.erb
@@ -7,6 +7,7 @@
     <li role="presentation"><a href="#actions-panel" aria-controls="actions-panel" role="tab" data-toggle="tab">Actions</a></li>
     <li role="presentation"><a href="#parsed-config" aria-controls="parsed-config" role="tab" data-toggle="tab">Parsed Config</a></li>
     <li role="presentation"><a href="#user-access-controls" aria-controls="user-access-controls" role="tab" data-toggle="tab">User Access Controls</a></li>
+    <li role="presentation"><a href="#api-definitions" aria-controls="api-definitions" role="tab" data-toggle="tab">API</a></li>
   </ul>
 
   <!-- Tab panes -->
@@ -36,6 +37,10 @@
     <% else %>
     <p>Not authorized to administer user access controls</p>
     <% end %>
+    </div>
+
+    <div role="tabpanel" class="tab-pane" id="api-definitions">
+      <%= render partial: 'admin/common/api_panel', locals: { object_instance: object_instance, resource_type: :external_identifier } %>
     </div>
   </div>
 </div>

--- a/app/views/admin/reports/_def_block.html.erb
+++ b/app/views/admin/reports/_def_block.html.erb
@@ -11,37 +11,7 @@
     <%=link_to 'CSV', report_path(@report.alt_resource_name, format: 'csv', search_attrs: { _report_id_: nil }), target: '_blank', class: 'report-admin-report-path-link' %>
     <%=link_to 'Text', report_path(@report.alt_resource_name, format: 'text', search_attrs: { _report_id_: nil }), target: '_blank', class: 'report-admin-report-path-link' %>
   </p>
-  <label>url search attributes <%= link_to(
-          '',
-          help_page_path(
-            library: :admin_reference,
-            section: 'reports',
-            subsection: 'url_search_attributes',
-            display_as: :embedded
-          ),
-          class: 'glyphicon glyphicon-question-sign',
-          data: { remote: true, 
-                  toggle: 'collapse', 
-                  target: '#help-sidebar',
-                  'working-target': '#help-sidebar-body' }
-        ) %></label>
-  <p class="report-item-url-search-attrs">    
-    <%
-      configs = @report.search_attributes_config.configurations
-      sa = configs.keys.map {|k| [k, '']}
-      sa <<['_report_id_', ''] if sa.empty?
-      sa = sa.to_h
-
-      plain_attrs = @report.report_options.view_options.use_plain_attribute_names
-      unless plain_attrs
-        sa = sa.to_query('search_attrs') 
-      else
-        sa = sa.to_query
-      end
-    %>    
-    <code>?<%= sa %></code>
-  </p>
-  <p><label>use plain attributes</label> <%=!!plain_attrs%></p>
+  <p class="help-block">See the <strong>API</strong> tab for detailed endpoint usage, curl examples, and save trigger configuration.</p>
   <p class="report-item-options-test">
   <label>options</label>
   <% if @report.report_options(fail_without_exception: true) %>

--- a/app/views/admin/reports/_info_block.html.erb
+++ b/app/views/admin/reports/_info_block.html.erb
@@ -9,6 +9,7 @@
     <li role="presentation"><a href="#flags" aria-controls="flags" role="tab" data-toggle="tab">Flags</a></li>
     <li role="presentation"><a href="#subject-accuracy" aria-controls="subject-accuracy" role="tab" data-toggle="tab">Subject Accuracy</a></li>
     <li role="presentation"><a href="#user-access-controls" aria-controls="user-access-controls" role="tab" data-toggle="tab">User Access Controls</a></li>
+    <li role="presentation"><a href="#api-definitions" aria-controls="api-definitions" role="tab" data-toggle="tab">API</a></li>
   </ul>
   <!-- Tab panes -->
   <div class="tab-content">
@@ -69,6 +70,10 @@
     <% else %>
       <p>Not authorized to administer user access controls</p>
     <% end %>
+    </div>
+
+    <div role="tabpanel" class="tab-pane" id="api-definitions">
+      <%= render partial: 'admin/common/api_panel', locals: { object_instance: @report, resource_type: :report } %>
     </div>
   </div>
 </div>

--- a/app/views/layouts/admin_application.html.erb
+++ b/app/views/layouts/admin_application.html.erb
@@ -3,6 +3,8 @@
   <head>
     <title><%= Settings::PageTitle %></title>
     <%= csp_meta_tag %>
+    <%= csrf_meta_tags %>
+    <link rel="shortcut icon" type="image/png" href="/favicon.png">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <%= stylesheet_link_tag    'application', media: 'all' %>
@@ -16,8 +18,6 @@
       };
     <% end %>
     <%= render partial: "layouts/setup_app" if current_user || current_admin %>
-    <%= csrf_meta_tags %>
-    <link rel="shortcut icon" type="image/png" href="/favicon.png">
   </head>
   <body <%= body_classes %> id="body-top" data-user-id="<%= current_user&.id %>" data-admin-id="<%= current_admin&.id %>">
     <%= render partial: 'layouts/navbar/navbar' if @navbar_ready%>

--- a/docs/api_reference/main/README.md
+++ b/docs/api_reference/main/README.md
@@ -10,11 +10,13 @@ Simple authentication uses a shared secret. Set the following URL params in the 
 
 `use_app_type=<app-type name or id>&user_email=<api user email address>&user_token=<shared secret>`
 
-## Endpoint
+## Endpoints
 
 Since new resources may be generated through the configuration of dynamic definitions (dynamic models, external identifiers and activity logs), the API definition is not static.
 
-The available API endpoints may be generated dynamically on the target server using:
+In the admin panel, each of the dynamic definitions and the reports admin has an API tab, detailing us of the API.
+
+Additionally, all the available API endpoints may be listed dynamically on the target server using:
 
 `app-scripts/api-endpoint.sh` to generate a full set of routes
 

--- a/spec/helpers/admin_api_definitions_helper_spec.rb
+++ b/spec/helpers/admin_api_definitions_helper_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe AdminApiDefinitionsHelper, type: :helper do
       next unless dm
 
       path = helper.api_base_path(dm)
-      expect(path).to start_with('/masters/{master_id}/')
+      expect(path).to start_with('/masters/{{master_id}}/')
       expect(path).to include('dynamic_model/')
     end
 
@@ -40,7 +40,7 @@ RSpec.describe AdminApiDefinitionsHelper, type: :helper do
       next unless al
 
       path = helper.api_base_path(al)
-      expect(path).to start_with('/masters/{master_id}/')
+      expect(path).to start_with('/masters/{{master_id}}/')
       expect(path).to include(al.base_route_segments)
     end
 
@@ -49,7 +49,7 @@ RSpec.describe AdminApiDefinitionsHelper, type: :helper do
       next unless ei
 
       path = helper.api_base_path(ei)
-      expect(path).to start_with('/masters/{master_id}/')
+      expect(path).to start_with('/masters/{{master_id}}/')
       expect(path).to include(ei.base_route_segments)
     end
   end
@@ -243,7 +243,7 @@ RSpec.describe AdminApiDefinitionsHelper, type: :helper do
 
   describe '#api_curl_example' do
     it 'generates a curl command with placeholder variables' do
-      curl = helper.api_curl_example(method: 'GET', path: '/masters/{master_id}/test.json')
+      curl = helper.api_curl_example(method: 'GET', path: '/masters/{{master_id}}/test.json')
       expect(curl).to include('curl -XGET')
       expect(curl).to include('{{base_url}}')
       expect(curl).to include('{{app_type_id}}')

--- a/spec/helpers/admin_api_definitions_helper_spec.rb
+++ b/spec/helpers/admin_api_definitions_helper_spec.rb
@@ -1,0 +1,455 @@
+# frozen_string_literal: true
+
+# AdminApiDefinitionsHelper Spec
+#
+# Tests helper methods for generating API documentation in admin definition panels.
+# Verifies that the correct REST API endpoints, curl examples, field definitions,
+# and save trigger YAML are generated for dynamic models, activity logs,
+# and external identifiers.
+
+require 'rails_helper'
+
+RSpec.describe AdminApiDefinitionsHelper, type: :helper do
+  include ModelSupport
+
+  before(:all) do
+    SetupHelper.feature_setup
+  end
+
+  describe '#api_base_path' do
+    it 'generates a master-nested path for a dynamic model with foreign key' do
+      dm = DynamicModel.active_model_configurations.find { |d| d.foreign_key_name.present? }
+      next unless dm
+
+      path = helper.api_base_path(dm)
+      expect(path).to start_with('/masters/{master_id}/')
+      expect(path).to include('dynamic_model/')
+    end
+
+    it 'generates a non-nested path for a dynamic model without foreign key' do
+      dm = DynamicModel.active_model_configurations.find { |d| d.foreign_key_name.blank? }
+      next unless dm
+
+      path = helper.api_base_path(dm)
+      expect(path).not_to include('{master_id}')
+      expect(path).to start_with('/dynamic_model/')
+    end
+
+    it 'generates a master-nested path for an activity log' do
+      al = ActivityLog.active.first
+      next unless al
+
+      path = helper.api_base_path(al)
+      expect(path).to start_with('/masters/{master_id}/')
+      expect(path).to include(al.base_route_segments)
+    end
+
+    it 'generates a master-nested path for an external identifier' do
+      ei = ExternalIdentifier.active.first
+      next unless ei
+
+      path = helper.api_base_path(ei)
+      expect(path).to start_with('/masters/{master_id}/')
+      expect(path).to include(ei.base_route_segments)
+    end
+  end
+
+  describe '#api_master_nested?' do
+    it 'returns true for activity logs' do
+      al = ActivityLog.active.first
+      next unless al
+
+      expect(helper.api_master_nested?(al)).to be true
+    end
+
+    it 'returns true for a dynamic model with foreign_key_name present' do
+      dm = DynamicModel.active_model_configurations.find { |d| d.foreign_key_name.present? }
+      next unless dm
+
+      expect(helper.api_master_nested?(dm)).to be true
+    end
+
+    it 'returns false for a dynamic model with blank foreign_key_name' do
+      dm = DynamicModel.active_model_configurations.find { |d| d.foreign_key_name.blank? }
+      next unless dm
+
+      expect(helper.api_master_nested?(dm)).to be false
+    end
+
+    it 'returns true for external identifiers' do
+      ei = ExternalIdentifier.active.first
+      next unless ei
+
+      expect(helper.api_master_nested?(ei)).to be true
+    end
+  end
+
+  describe '#api_endpoints' do
+    it 'generates Index, Read, Create, Update endpoints' do
+      dm = DynamicModel.active_model_configurations.first
+      next unless dm
+
+      endpoints = helper.api_endpoints(dm)
+      descriptions = endpoints.map { |e| e[:description] }
+      expect(descriptions).to include('Index (list all)')
+      expect(descriptions).to include('Read (show one)')
+      expect(descriptions).to include('Create')
+      expect(descriptions).to include('Update')
+    end
+
+    it 'includes extra_log_type routes for activity logs' do
+      al = ActivityLog.active.first
+      next unless al || al.option_configs_names.blank?
+
+      endpoints = helper.api_endpoints(al)
+      methods = endpoints.map { |e| e[:method] }
+      expect(methods).to include('GET', 'POST')
+      # Should have more than the base 4 endpoints if extra log types exist
+      non_standard_names = al.option_configs_names.reject { |n| n.in?(%i[primary blank_log]) }
+      expect(endpoints.length).to be > 4 if non_standard_names.any?
+    end
+
+    it 'generates exactly 4 endpoints for an external identifier' do
+      ei = ExternalIdentifier.active.first
+      next unless ei
+
+      endpoints = helper.api_endpoints(ei)
+      expect(endpoints.length).to eq(4)
+      descriptions = endpoints.map { |e| e[:description] }
+      expect(descriptions).to include('Index (list all)', 'Read (show one)', 'Create', 'Update')
+    end
+
+    it 'generates correct HTTP methods: GET, GET, POST, PUT' do
+      dm = DynamicModel.active_model_configurations.first
+      next unless dm
+
+      endpoints = helper.api_endpoints(dm)
+      methods = endpoints.map { |e| e[:method] }
+      expect(methods).to eq(%w[GET GET POST PUT])
+    end
+  end
+
+  describe '#api_fields' do
+    it 'excludes standard fields like id, created_at, updated_at, master_id' do
+      dm = DynamicModel.active_model_configurations.find(&:table_or_view_ready?)
+      next unless dm
+
+      fields = helper.api_fields(dm)
+      field_names = fields.map { |f| f[:name] }
+      expect(field_names).not_to include('id')
+      expect(field_names).not_to include('created_at')
+      expect(field_names).not_to include('updated_at')
+      expect(field_names).not_to include('master_id')
+      expect(field_names).not_to include('user_id')
+    end
+
+    it 'includes type information for each field' do
+      dm = DynamicModel.active_model_configurations.find(&:table_or_view_ready?)
+      next unless dm
+
+      fields = helper.api_fields(dm)
+      fields.each do |f|
+        expect(f[:type]).to be_a(String)
+        expect(f[:type]).not_to be_empty
+      end
+    end
+
+    it 'excludes the contactid standard field' do
+      dm = DynamicModel.active_model_configurations.find(&:table_or_view_ready?)
+      next unless dm
+
+      fields = helper.api_fields(dm)
+      field_names = fields.map { |f| f[:name] }
+      expect(field_names).not_to include('contactid')
+    end
+  end
+
+  describe '#api_fields_list' do
+    it 'generates an HTML unordered list of fields' do
+      dm = DynamicModel.active_model_configurations.find(&:table_or_view_ready?)
+      next unless dm
+
+      html = helper.api_fields_list(dm)
+      expect(html).to include('<ul class="api-panel__fields-list">')
+      expect(html).to include('</ul>')
+      fields = helper.api_fields(dm)
+      fields.each do |f|
+        expect(html).to include(f[:name])
+        expect(html).to include(f[:type])
+      end
+    end
+
+    it 'returns an empty list when no fields are available' do
+      dm = DynamicModel.active_model_configurations.find { |d| !d.table_or_view_ready? }
+      next unless dm
+
+      html = helper.api_fields_list(dm)
+      expect(html).to include('<ul')
+      expect(html).to include('</ul>')
+      expect(html).not_to include('<li>')
+    end
+
+    it 'excludes standard fields' do
+      dm = DynamicModel.active_model_configurations.find(&:table_or_view_ready?)
+      next unless dm
+
+      html = helper.api_fields_list(dm)
+      AdminApiDefinitionsHelper::STANDARD_FIELDS.each do |sf|
+        expect(html).not_to include(">#{sf}<")
+      end
+    end
+  end
+
+  describe '#api_fields_yaml' do
+    it 'generates YAML-like field listing' do
+      dm = DynamicModel.active_model_configurations.find(&:table_or_view_ready?)
+      next unless dm
+
+      yaml = helper.api_fields_yaml(dm)
+      expect(yaml).to include('type:')
+    end
+
+    it 'returns empty string when no fields are available' do
+      dm = DynamicModel.active_model_configurations.find { |d| !d.table_or_view_ready? }
+      next unless dm
+
+      yaml = helper.api_fields_yaml(dm)
+      expect(yaml).to eq('')
+    end
+
+    it 'includes one entry per field with name and type' do
+      dm = DynamicModel.active_model_configurations.find(&:table_or_view_ready?)
+      next unless dm
+
+      yaml = helper.api_fields_yaml(dm)
+      fields = helper.api_fields(dm)
+      fields.each do |f|
+        expect(yaml).to include("#{f[:name]}:")
+        expect(yaml).to include("type: #{f[:type]}")
+      end
+    end
+  end
+
+  describe '#api_sample_json_body' do
+    it 'generates a JSON body with placeholder values' do
+      dm = DynamicModel.active_model_configurations.find(&:table_or_view_ready?)
+      next unless dm
+
+      body = helper.api_sample_json_body(dm)
+      expect(body).to start_with('{')
+      expect(body).to end_with('}')
+    end
+  end
+
+  describe '#api_curl_example' do
+    it 'generates a curl command with placeholder variables' do
+      curl = helper.api_curl_example(method: 'GET', path: '/masters/{master_id}/test.json')
+      expect(curl).to include('curl -XGET')
+      expect(curl).to include('{{base_url}}')
+      expect(curl).to include('{{app_type_id}}')
+      expect(curl).to include('{{user_email}}')
+      expect(curl).to include('{{api_token}}')
+    end
+
+    it 'includes body in POST examples' do
+      body = '{ "field": "value" }'
+      curl = helper.api_curl_example(method: 'POST', path: '/test.json', body:)
+      expect(curl).to include("-d '")
+      expect(curl).to include(body)
+    end
+  end
+
+  describe '#api_save_trigger_example' do
+    it 'generates save trigger YAML with pull_external_data' do
+      dm = DynamicModel.active_model_configurations.find(&:table_or_view_ready?)
+      next unless dm
+
+      yaml = helper.api_save_trigger_example(dm)
+      expect(yaml).to include('pull_external_data')
+      expect(yaml).to include('get_record')
+      expect(yaml).to include('create_record')
+      expect(yaml).to include('post_data')
+      expect(yaml).to include('{{base_url}}')
+    end
+
+    it 'includes the correct base path in trigger URLs' do
+      dm = DynamicModel.active_model_configurations.find(&:table_or_view_ready?)
+      next unless dm
+
+      yaml = helper.api_save_trigger_example(dm)
+      base = helper.api_base_path(dm)
+      expect(yaml).to include(base)
+    end
+
+    it 'includes _constants section with all placeholder keys' do
+      dm = DynamicModel.active_model_configurations.find(&:table_or_view_ready?)
+      next unless dm
+
+      yaml = helper.api_save_trigger_example(dm)
+      expect(yaml).to include('_constants:')
+      expect(yaml).to include('api_user_email: {{user_email}}')
+      expect(yaml).to include('api_app_type: {{app_type_id}}')
+      expect(yaml).to include('api_shared_secret: {{api_token}}')
+      expect(yaml).to include('master_id: {master_id}')
+      expect(yaml).to include('item_id: {item_id}')
+    end
+
+    it 'includes force_not_editable_save and headers in the create_record block' do
+      dm = DynamicModel.active_model_configurations.find(&:table_or_view_ready?)
+      next unless dm
+
+      yaml = helper.api_save_trigger_example(dm)
+      expect(yaml).to include('force_not_editable_save: true')
+      expect(yaml).to include("'Content-Type': 'application/json'")
+    end
+
+    it 'includes field-level post_data entries with type-appropriate values' do
+      dm = DynamicModel.active_model_configurations.find(&:table_or_view_ready?)
+      next unless dm
+
+      yaml = helper.api_save_trigger_example(dm)
+      fields = helper.api_fields(dm)
+      fields.each do |f|
+        expect(yaml).to include("#{f[:name]}:")
+      end
+    end
+  end
+
+  describe '#api_fields' do
+    it 'returns empty array when table is not ready' do
+      dm = DynamicModel.active_model_configurations.find { |d| !d.table_or_view_ready? }
+      next unless dm
+
+      fields = helper.api_fields(dm)
+      expect(fields).to eq([])
+    end
+  end
+
+  describe '#api_sample_json_body' do
+    it 'returns empty braces when no fields are available' do
+      dm = DynamicModel.active_model_configurations.find { |d| !d.table_or_view_ready? }
+      next unless dm
+
+      body = helper.api_sample_json_body(dm)
+      expect(body).to eq('{}')
+    end
+
+    it 'includes type-appropriate placeholders for each column type' do
+      dm = DynamicModel.active_model_configurations.find(&:table_or_view_ready?)
+      next unless dm
+
+      body = helper.api_sample_json_body(dm)
+      # Should be valid JSON-like structure
+      expect(body).to start_with('{')
+      expect(body).to end_with('}')
+      # Should contain field names from the table
+      fields = helper.api_fields(dm)
+      fields.each do |f|
+        expect(body).to include("\"#{f[:name]}\"")
+      end
+    end
+  end
+
+  describe '#api_curl_example' do
+    it 'does not include -d flag for GET requests' do
+      curl = helper.api_curl_example(method: 'GET', path: '/test.json')
+      expect(curl).not_to include("-d '")
+    end
+
+    it 'includes -d flag with body for PUT requests' do
+      body = '{ "field": "value" }'
+      curl = helper.api_curl_example(method: 'PUT', path: '/test/{id}.json', body: body)
+      expect(curl).to include("-d '")
+      expect(curl).to include(body)
+      expect(curl).to include('curl -XPUT')
+    end
+  end
+
+  describe '#api_endpoints' do
+    it 'generates exactly 4 base endpoints for non-activity-log definitions' do
+      dm = DynamicModel.active_model_configurations.first
+      next unless dm
+
+      endpoints = helper.api_endpoints(dm)
+      expect(endpoints.length).to eq(4)
+    end
+
+    it 'uses .json format for all endpoint paths' do
+      dm = DynamicModel.active_model_configurations.first
+      next unless dm
+
+      endpoints = helper.api_endpoints(dm)
+      endpoints.each do |ep|
+        expect(ep[:path]).to end_with('.json')
+      end
+    end
+  end
+
+  describe 'STANDARD_FIELDS constant' do
+    it 'contains the expected standard field names' do
+      expect(AdminApiDefinitionsHelper::STANDARD_FIELDS).to include('id', 'created_at', 'updated_at', 'master_id', 'user_id')
+    end
+
+    it 'includes contactid' do
+      expect(AdminApiDefinitionsHelper::STANDARD_FIELDS).to include('contactid')
+    end
+
+    it 'is frozen' do
+      expect(AdminApiDefinitionsHelper::STANDARD_FIELDS).to be_frozen
+    end
+  end
+
+  describe '#api_sample_json_body type-specific placeholders' do
+    # Lightweight stubs for table_or_view_ready? and table_columns
+    FakeColumn = Struct.new(:name, :type)
+    FakeDefinition = Struct.new(:ready, :columns) do
+      def table_or_view_ready? = ready
+      def table_columns = columns
+      def respond_to?(m, *) = %i[table_columns table_or_view_ready?].include?(m) || super
+    end
+
+    def fake_def_with_column(col_name, col_type)
+      FakeDefinition.new(true, [FakeColumn.new(col_name, col_type)])
+    end
+
+    it 'uses 0 for integer columns' do
+      body = helper.api_sample_json_body(fake_def_with_column('count', :integer))
+      expect(body).to include('"count": 0')
+    end
+
+    it 'uses 0 for bigint columns' do
+      body = helper.api_sample_json_body(fake_def_with_column('big_num', :bigint))
+      expect(body).to include('"big_num": 0')
+    end
+
+    it 'uses 0.0 for float columns' do
+      body = helper.api_sample_json_body(fake_def_with_column('score', :float))
+      expect(body).to include('"score": 0.0')
+    end
+
+    it 'uses 0.0 for decimal columns' do
+      body = helper.api_sample_json_body(fake_def_with_column('amount', :decimal))
+      expect(body).to include('"amount": 0.0')
+    end
+
+    it 'uses false for boolean columns' do
+      body = helper.api_sample_json_body(fake_def_with_column('active', :boolean))
+      expect(body).to include('"active": false')
+    end
+
+    it 'uses YYYY-MM-DD for date columns' do
+      body = helper.api_sample_json_body(fake_def_with_column('dob', :date))
+      expect(body).to include('"dob": "YYYY-MM-DD"')
+    end
+
+    it 'uses YYYY-MM-DDTHH:MM:SS for datetime columns' do
+      body = helper.api_sample_json_body(fake_def_with_column('event_at', :datetime))
+      expect(body).to include('"event_at": "YYYY-MM-DDTHH:MM:SS"')
+    end
+
+    it 'uses empty string for string / text columns' do
+      body = helper.api_sample_json_body(fake_def_with_column('notes', :string))
+      expect(body).to include('"notes": ""')
+    end
+  end
+end

--- a/spec/helpers/admin_api_definitions_helper_spec.rb
+++ b/spec/helpers/admin_api_definitions_helper_spec.rb
@@ -4,8 +4,8 @@
 #
 # Tests helper methods for generating API documentation in admin definition panels.
 # Verifies that the correct REST API endpoints, curl examples, field definitions,
-# and save trigger YAML are generated for dynamic models, activity logs,
-# and external identifiers.
+# save trigger YAML, and report-specific curl/save trigger YAML are generated for
+# dynamic models, activity logs, external identifiers, and reports.
 
 require 'rails_helper'
 
@@ -382,6 +382,64 @@ RSpec.describe AdminApiDefinitionsHelper, type: :helper do
       endpoints.each do |ep|
         expect(ep[:path]).to end_with('.json')
       end
+    end
+  end
+
+  describe '#api_report_curl_example' do
+    let(:report_double) { double('Report', alt_resource_name: 'test__api_test_report') }
+
+    it 'generates a curl GET command for the given format' do
+      result = helper.api_report_curl_example(report_double, format: 'json', sa: 'last_name=test')
+      expect(result).to include('curl -XGET')
+      expect(result).to include('/reports/test__api_test_report.json')
+      expect(result).to include('{{base_url}}')
+      expect(result).to include('{{app_type_id}}')
+      expect(result).to include('{{user_email}}')
+      expect(result).to include('{{api_token}}')
+    end
+
+    it 'uses the provided format extension in the path' do
+      csv_result = helper.api_report_curl_example(report_double, format: 'csv', sa: 'q=1')
+      txt_result = helper.api_report_curl_example(report_double, format: 'txt', sa: 'q=1')
+      expect(csv_result).to include('.csv')
+      expect(csv_result).not_to include('.json')
+      expect(txt_result).to include('.txt')
+      expect(txt_result).not_to include('.json')
+    end
+
+    it 'includes the search attributes query string in the output' do
+      result = helper.api_report_curl_example(report_double, format: 'json', sa: 'last_name=foo&year=2024')
+      expect(result).to include('last_name=foo&year=2024')
+    end
+  end
+
+  describe '#api_report_save_trigger_example' do
+    let(:report_double) { double('Report', alt_resource_name: 'test__api_test_report') }
+
+    it 'generates YAML with pull_external_data get_record structure' do
+      yaml = helper.api_report_save_trigger_example(report_double, sa: 'last_name=test')
+      expect(yaml).to include('pull_external_data')
+      expect(yaml).to include('get_record')
+      expect(yaml).to include('format: json')
+      expect(yaml).to include('allow_empty_result: false')
+    end
+
+    it 'includes the _constants section with all placeholder keys' do
+      yaml = helper.api_report_save_trigger_example(report_double, sa: 'q=1')
+      expect(yaml).to include('_constants:')
+      expect(yaml).to include('api_user_email: {{user_email}}')
+      expect(yaml).to include('api_app_type: {{app_type_id}}')
+      expect(yaml).to include('api_shared_secret: {{api_token}}')
+    end
+
+    it 'includes the report alt_resource_name in the trigger URL' do
+      yaml = helper.api_report_save_trigger_example(report_double, sa: 'last_name=test')
+      expect(yaml).to include('/reports/test__api_test_report.json')
+    end
+
+    it 'includes the search attributes in the trigger URL' do
+      yaml = helper.api_report_save_trigger_example(report_double, sa: 'last_name=smith')
+      expect(yaml).to include('last_name=smith')
     end
   end
 

--- a/spec/helpers/admin_api_definitions_helper_spec.rb
+++ b/spec/helpers/admin_api_definitions_helper_spec.rb
@@ -416,10 +416,10 @@ RSpec.describe AdminApiDefinitionsHelper, type: :helper do
   describe '#api_report_save_trigger_example' do
     let(:report_double) { double('Report', alt_resource_name: 'test__api_test_report') }
 
-    it 'generates YAML with pull_external_data get_record structure' do
+    it 'generates YAML with pull_external_data get_report structure' do
       yaml = helper.api_report_save_trigger_example(report_double, sa: 'last_name=test')
       expect(yaml).to include('pull_external_data')
-      expect(yaml).to include('get_record')
+      expect(yaml).to include('get_report')
       expect(yaml).to include('format: json')
       expect(yaml).to include('allow_empty_result: false')
     end

--- a/spec/system/admin/admin_api_definitions_panel_spec.rb
+++ b/spec/system/admin/admin_api_definitions_panel_spec.rb
@@ -1,0 +1,493 @@
+# frozen_string_literal: true
+
+# Admin API Definitions Panel Spec
+#
+# Tests the API tab added to dynamic definition admin panels (dynamic models,
+# activity logs, external identifiers) and reports. Verifies that the tab
+# displays correct REST API endpoints, curl examples with placeholder variables,
+# field definitions (excluding standard fields), save trigger usage examples,
+# and copy-to-clipboard buttons.
+#
+# Issue: https://github.com/consected/restructure/issues/652
+
+require 'rails_helper'
+
+describe 'admin API definitions panel', js: true, driver: $browser_driver do
+  include ModelSupport
+  include AdminActionsSetup
+  include FeatureSupport
+
+  before(:all) do
+    SetupHelper.feature_setup
+    ENV['FPHS_ADMIN_SETUP'] = 'yes'
+    make_an_admin
+  end
+
+  describe 'dynamic models' do
+    it 'displays the API tab with endpoints, curl examples, fields, and save trigger' do
+      dm = DynamicModel.active.find(&:table_or_view_ready?)
+      skip 'No active dynamic models with ready tables found' unless dm
+
+      admin_sign_in_with_2fa
+
+      visit '/admin/dynamic_models'
+      finish_page_loading
+
+      within "#admin-item-#{dm.id}" do
+        find('a.edit-entity.glyphicon-pencil').click
+      end
+
+      expect(page).to have_css('.nav-tabs', wait: 10)
+
+      # Click the API tab
+      find('.nav-tabs a[aria-controls="api-definitions"]', visible: true).click
+      expect(page).to have_css('#api-definitions', visible: true)
+      finish_page_loading
+
+      within '#api-definitions' do
+        # Verify the API heading
+        expect(page).to have_content('API')
+
+        # Verify resource name is displayed
+        expect(page).to have_css('.api-panel')
+        expect(page).to have_content('resource name')
+        expect(page).to have_content(dm.resource_name)
+
+        # Verify endpoint sections are present
+        expect(page).to have_content('endpoints')
+        expect(page).to have_content('Index (list all)')
+        expect(page).to have_content('Read (show one)')
+        expect(page).to have_content('Create')
+        expect(page).to have_content('Update')
+
+        # Verify endpoint paths contain the correct route segments
+        expect(page).to have_content(dm.base_route_segments)
+
+        # Verify paths are correctly nested under /masters/ or not
+        expect(page).to have_content('/masters/{master_id}/') if dm.foreign_key_name.present?
+
+        # Verify HTTP methods are shown
+        expect(page).to have_content('GET')
+        expect(page).to have_content('POST')
+        expect(page).to have_content('PUT')
+
+        # Verify curl examples section
+        expect(page).to have_content('curl examples')
+        expect(page).to have_css('.api-panel__curl-block', minimum: 4)
+        expect(page).to have_content('{{base_url}}')
+        expect(page).to have_content('{{app_type_id}}')
+        expect(page).to have_content('{{user_email}}')
+        expect(page).to have_content('{{api_token}}')
+
+        # Verify fields section
+        expect(page).to have_content('fields')
+        expect(page).to have_css('.api-panel__fields-list-block')
+
+        # Verify standard fields are excluded from the fields list
+        fields_block = find('.api-panel__fields-list-block')
+        fields_text = fields_block.text
+        expect(fields_text).not_to include('created_at')
+        expect(fields_text).not_to include('updated_at')
+        expect(fields_text).not_to include('master_id')
+        expect(fields_text).not_to include('user_id')
+
+        # Verify save trigger section
+        expect(page).to have_content('save trigger usage')
+        expect(page).to have_css('.api-panel__save-trigger-block')
+        trigger_block = find('.api-panel__save-trigger-block')
+        trigger_text = trigger_block.text
+        expect(trigger_text).to include('pull_external_data')
+        expect(trigger_text).to include('get_record')
+        expect(trigger_text).to include('create_record')
+
+        # Verify copy-to-clipboard buttons are present
+        expect(page).to have_css('.api-panel__copy-btn', minimum: 4)
+      end
+    end
+
+    it 'generates correct base path for master-nested definition' do
+      dm = DynamicModel.active.find { |d| d.table_or_view_ready? && d.foreign_key_name.present? }
+      skip 'No master-nested dynamic model found' unless dm
+
+      admin_sign_in_with_2fa
+
+      visit '/admin/dynamic_models'
+      finish_page_loading
+
+      within "#admin-item-#{dm.id}" do
+        find('a.edit-entity.glyphicon-pencil').click
+      end
+
+      expect(page).to have_css('.nav-tabs', wait: 10)
+
+      find('.nav-tabs a[aria-controls="api-definitions"]', visible: true).click
+      expect(page).to have_css('#api-definitions', visible: true)
+
+      within '#api-definitions' do
+        # Verify master-nested paths appear in curl examples
+        expect(page).to have_content('/masters/{master_id}/')
+      end
+    end
+
+    it 'omits /masters/ prefix for non-master-nested definition' do
+      dm = DynamicModel.active.find { |d| d.table_or_view_ready? && d.foreign_key_name.blank? }
+      skip 'No non-master-nested dynamic model found' unless dm
+
+      admin_sign_in_with_2fa
+
+      visit '/admin/dynamic_models'
+      finish_page_loading
+
+      within "#admin-item-#{dm.id}" do
+        find('a.edit-entity.glyphicon-pencil').click
+      end
+
+      expect(page).to have_css('.nav-tabs', wait: 10)
+
+      find('.nav-tabs a[aria-controls="api-definitions"]', visible: true).click
+      expect(page).to have_css('#api-definitions', visible: true)
+
+      within '#api-definitions' do
+        # Non-master-nested paths should not include /masters/{master_id}/
+        expect(page).not_to have_content('/masters/{master_id}/')
+        # But should still show routes starting with /dynamic_model/
+        expect(page).to have_content("/dynamic_model/#{dm.table_name}")
+      end
+    end
+
+    it 'shows not-available message when table is not ready' do
+      dm = DynamicModel.active.find { |d| !d.table_or_view_ready? }
+      skip 'No active dynamic model without ready table found' unless dm
+
+      admin_sign_in_with_2fa
+
+      visit '/admin/dynamic_models'
+      finish_page_loading
+
+      within "#admin-item-#{dm.id}" do
+        find('a.edit-entity.glyphicon-pencil').click
+      end
+
+      expect(page).to have_css('.nav-tabs', wait: 10)
+
+      find('.nav-tabs a[aria-controls="api-definitions"]', visible: true).click
+      expect(page).to have_css('#api-definitions', visible: true)
+
+      within '#api-definitions' do
+        expect(page).to have_content('API definitions are not available')
+        expect(page).not_to have_css('.api-panel')
+      end
+    end
+  end
+
+  describe 'activity logs' do
+    it 'displays the API tab with endpoints including extra log types' do
+      al = ActivityLog.active.first
+      skip 'No active activity logs found' unless al
+
+      admin_sign_in_with_2fa
+
+      visit '/admin/activity_logs'
+      finish_page_loading
+
+      within "#admin-item-#{al.id}" do
+        find('a.edit-entity.glyphicon-pencil').click
+      end
+
+      expect(page).to have_css('.nav-tabs', wait: 10)
+
+      find('.nav-tabs a[aria-controls="api-definitions"]', visible: true).click
+      expect(page).to have_css('#api-definitions', visible: true)
+      finish_page_loading
+
+      within '#api-definitions' do
+        # Verify API panel renders
+        expect(page).to have_css('.api-panel')
+        expect(page).to have_content('resource name')
+        expect(page).to have_content(al.resource_name)
+
+        # Verify standard endpoints
+        expect(page).to have_content('Index (list all)')
+        expect(page).to have_content('Read (show one)')
+        expect(page).to have_content('Create')
+        expect(page).to have_content('Update')
+
+        # Activity logs should always be master-nested
+        expect(page).to have_content('/masters/{master_id}/')
+        expect(page).to have_content(al.base_route_segments)
+
+        # Verify extra_log_type endpoints if present
+        non_standard = al.option_configs_names&.reject { |n| n.in?(%i[primary blank_log]) }
+        non_standard&.each do |elt_name|
+          expect(page).to have_content("Create (#{elt_name})")
+          expect(page).to have_content("Read (#{elt_name})")
+        end
+
+        # Verify curl examples
+        expect(page).to have_css('.api-panel__curl-block', minimum: 4)
+
+        # Verify fields section
+        expect(page).to have_css('.api-panel__fields-list-block')
+
+        # Verify save trigger section
+        expect(page).to have_css('.api-panel__save-trigger-block')
+      end
+    end
+  end
+
+  describe 'external identifiers' do
+    it 'displays the API tab with endpoints and fields' do
+      ei = ExternalIdentifier.active.find(&:table_or_view_ready?)
+      skip 'No active external identifiers with ready tables found' unless ei
+
+      admin_sign_in_with_2fa
+
+      visit '/admin/external_identifiers'
+      finish_page_loading
+
+      expect(page).to have_css("#admin-item-#{ei.id}", wait: 10)
+
+      within "#admin-item-#{ei.id}" do
+        find('a.edit-entity.glyphicon-pencil').click
+      end
+
+      expect(page).to have_css('.admin-edit-form', wait: 10)
+      sleep 1
+
+      within '.admin-edit-form' do
+        expect(page).to have_css('.nav-tabs', wait: 10)
+        find('.nav-tabs a[aria-controls="api-definitions"]', visible: true).click
+      end
+
+      expect(page).to have_css('#api-definitions', visible: true, wait: 10)
+      finish_page_loading
+
+      within '#api-definitions' do
+        expect(page).to have_css('.api-panel')
+        expect(page).to have_content('resource name')
+
+        # Verify endpoints
+        expect(page).to have_content('Index (list all)')
+        expect(page).to have_content('Read (show one)')
+        expect(page).to have_content('Create')
+        expect(page).to have_content('Update')
+
+        # External identifiers are always master-nested
+        expect(page).to have_content('/masters/{master_id}/')
+        expect(page).to have_content(ei.base_route_segments)
+
+        # Verify curl examples with placeholders
+        expect(page).to have_css('.api-panel__curl-block', minimum: 4)
+        expect(page).to have_content('{{base_url}}')
+
+        # Verify fields section
+        expect(page).to have_css('.api-panel__fields-list-block')
+
+        # Verify save trigger
+        expect(page).to have_css('.api-panel__save-trigger-block')
+
+        # Verify copy buttons
+        expect(page).to have_css('.api-panel__copy-btn', minimum: 4)
+      end
+    end
+  end
+
+  describe 'reports' do
+    it 'displays the API tab with report-specific endpoints and search attributes' do
+      report = Report.active.first
+      skip 'No active reports found' unless report
+
+      admin_sign_in_with_2fa
+
+      visit '/admin/reports'
+      finish_page_loading
+
+      within "#admin-item-#{report.id}" do
+        find('a.edit-entity.glyphicon-pencil').click
+      end
+
+      # The report form has a different tab structure — the info_block has the API tab
+      expect(page).to have_css('.nav-tabs', wait: 10)
+
+      find('.nav-tabs a[aria-controls="api-definitions"]', visible: true).click
+      expect(page).to have_css('#api-definitions', visible: true)
+      finish_page_loading
+
+      within '#api-definitions' do
+        expect(page).to have_css('.api-panel')
+
+        # Verify resource name
+        expect(page).to have_content('resource name')
+        expect(page).to have_content(report.alt_resource_name)
+
+        # Verify report-specific endpoints (GET only, with format variants)
+        expect(page).to have_content('JSON')
+        expect(page).to have_content('CSV')
+        expect(page).to have_content('Text')
+        expect(page).to have_content("/reports/#{report.alt_resource_name}.json")
+        expect(page).to have_content("/reports/#{report.alt_resource_name}.csv")
+        expect(page).to have_content("/reports/#{report.alt_resource_name}.text")
+
+        # Verify only GET method is shown (reports don't have POST/PUT)
+        endpoint_blocks = all('.api-panel__endpoint')
+        endpoint_blocks.each do |block|
+          expect(block).to have_content('GET')
+        end
+
+        # Verify search attributes section
+        expect(page).to have_content('url search attributes')
+        expect(page).to have_css('.report-item-url-search-attrs')
+
+        # Verify curl examples section
+        expect(page).to have_content('curl examples')
+        expect(page).to have_css('.api-panel__curl-block', minimum: 2)
+        expect(page).to have_content('{{base_url}}')
+        expect(page).to have_content('{{app_type_id}}')
+        expect(page).to have_content('{{user_email}}')
+        expect(page).to have_content('{{api_token}}')
+
+        # Verify save trigger section
+        expect(page).to have_content('save trigger usage')
+        expect(page).to have_css('.api-panel__save-trigger-block')
+
+        # Verify copy buttons
+        expect(page).to have_css('.api-panel__copy-btn', minimum: 4)
+      end
+    end
+
+    it 'shows a help note in the Definition tab pointing to the API tab' do
+      report = Report.active.first
+      skip 'No active reports found' unless report
+
+      admin_sign_in_with_2fa
+
+      visit '/admin/reports'
+      finish_page_loading
+
+      within "#admin-item-#{report.id}" do
+        find('a.edit-entity.glyphicon-pencil').click
+      end
+
+      expect(page).to have_css('.nav-tabs', wait: 10)
+
+      # The Definition tab should be active by default
+      within '#report-def' do
+        expect(page).to have_content('See the API tab')
+      end
+    end
+
+    it 'displays the use plain attributes label' do
+      report = Report.active.first
+      skip 'No active reports found' unless report
+
+      admin_sign_in_with_2fa
+
+      visit '/admin/reports'
+      finish_page_loading
+
+      within "#admin-item-#{report.id}" do
+        find('a.edit-entity.glyphicon-pencil').click
+      end
+
+      expect(page).to have_css('.nav-tabs', wait: 10)
+
+      find('.nav-tabs a[aria-controls="api-definitions"]', visible: true).click
+      expect(page).to have_css('#api-definitions', visible: true)
+
+      within '#api-definitions' do
+        expect(page).to have_content('use plain attributes')
+        # The value should be either true or false
+        plain_text = find('p', text: 'use plain attributes').text
+        expect(plain_text).to match(/true|false/)
+      end
+    end
+
+    it 'shows search attributes with correct query string format' do
+      report = Report.active.first
+      skip 'No active reports found' unless report
+
+      admin_sign_in_with_2fa
+
+      visit '/admin/reports'
+      finish_page_loading
+
+      within "#admin-item-#{report.id}" do
+        find('a.edit-entity.glyphicon-pencil').click
+      end
+
+      expect(page).to have_css('.nav-tabs', wait: 10)
+
+      find('.nav-tabs a[aria-controls="api-definitions"]', visible: true).click
+      expect(page).to have_css('#api-definitions', visible: true)
+
+      within '#api-definitions' do
+        # Search attributes should start with ?
+        attrs_el = find('.report-item-url-search-attrs code')
+        expect(attrs_el.text).to start_with('?')
+        # Should contain either search_attrs[] format or plain format
+        expect(attrs_el.text).to match(/search_attrs|=|_report_id_/)
+      end
+    end
+  end
+
+  describe 'copy-to-clipboard handler' do
+    it 'fires exactly once even after editing multiple definitions without page navigation' do
+      reports = Report.active.limit(2).to_a
+      skip 'Need at least 2 active reports' unless reports.length >= 2
+
+      admin_sign_in_with_2fa
+
+      visit '/admin/reports'
+      finish_page_loading
+
+      # --- First report: open edit, click API tab, click a copy button ---
+      first_report = reports.first
+      within "#admin-item-#{first_report.id}" do
+        find('a.edit-entity.glyphicon-pencil').click
+      end
+      expect(page).to have_css('.nav-tabs', wait: 10)
+
+      find('.nav-tabs a[aria-controls="api-definitions"]', visible: true).click
+      expect(page).to have_css('#api-definitions', visible: true)
+      finish_page_loading
+
+      # Clear any pre-existing flash notices
+      page.execute_script("$('.flash .alert').remove()")
+
+      within '#api-definitions' do
+        first('.api-panel__copy-btn').click
+      end
+
+      # Wait for the flash to appear
+      expect(page).to have_css('.flash .alert', wait: 5)
+      first_flash_count = all('.flash .alert').count
+      expect(first_flash_count).to eq(1), "Expected 1 flash after first copy, got #{first_flash_count}"
+
+      # Clear flashes before the second interaction
+      page.execute_script("$('.flash .alert').remove()")
+      expect(page).not_to have_css('.flash .alert')
+
+      # --- Second report: open edit, click API tab, click a copy button ---
+      second_report = reports.last
+      within "#admin-item-#{second_report.id}" do
+        find('a.edit-entity.glyphicon-pencil').click
+      end
+      expect(page).to have_css('.nav-tabs', wait: 10)
+
+      find('.nav-tabs a[aria-controls="api-definitions"]', visible: true).click
+      expect(page).to have_css('#api-definitions', visible: true)
+      finish_page_loading
+
+      within '#api-definitions' do
+        first('.api-panel__copy-btn').click
+      end
+
+      # Wait for the flash to appear, then verify exactly one
+      expect(page).to have_css('.flash .alert', wait: 5)
+      second_flash_count = all('.flash .alert').count
+      expect(second_flash_count).to eq(1),
+                                    "Expected 1 flash after second copy, got #{second_flash_count} " \
+                                    '(duplicate event handler bug)'
+    end
+  end
+end

--- a/spec/system/admin/admin_api_definitions_panel_spec.rb
+++ b/spec/system/admin/admin_api_definitions_panel_spec.rb
@@ -64,7 +64,7 @@ describe 'admin API definitions panel', js: true, driver: $browser_driver do
         expect(page).to have_content(dm.base_route_segments)
 
         # Verify paths are correctly nested under /masters/ or not
-        expect(page).to have_content('/masters/{master_id}/') if dm.foreign_key_name.present?
+        expect(page).to have_content('/masters/{{master_id}}/') if dm.foreign_key_name.present?
 
         # Verify HTTP methods are shown
         expect(page).to have_content('GET')
@@ -125,7 +125,7 @@ describe 'admin API definitions panel', js: true, driver: $browser_driver do
 
       within '#api-definitions' do
         # Verify master-nested paths appear in curl examples
-        expect(page).to have_content('/masters/{master_id}/')
+        expect(page).to have_content('/masters/{{master_id}}/')
       end
     end
 
@@ -148,8 +148,8 @@ describe 'admin API definitions panel', js: true, driver: $browser_driver do
       expect(page).to have_css('#api-definitions', visible: true)
 
       within '#api-definitions' do
-        # Non-master-nested paths should not include /masters/{master_id}/
-        expect(page).not_to have_content('/masters/{master_id}/')
+        # Non-master-nested paths should not include /masters/{{master_id}}/
+        expect(page).not_to have_content('/masters/{{master_id}}/')
         # But should still show routes starting with /dynamic_model/
         expect(page).to have_content("/dynamic_model/#{dm.table_name}")
       end
@@ -213,7 +213,7 @@ describe 'admin API definitions panel', js: true, driver: $browser_driver do
         expect(page).to have_content('Update')
 
         # Activity logs should always be master-nested
-        expect(page).to have_content('/masters/{master_id}/')
+        expect(page).to have_content('/masters/{{master_id}}/')
         expect(page).to have_content(al.base_route_segments)
 
         # Verify extra_log_type endpoints if present
@@ -273,7 +273,7 @@ describe 'admin API definitions panel', js: true, driver: $browser_driver do
         expect(page).to have_content('Update')
 
         # External identifiers are always master-nested
-        expect(page).to have_content('/masters/{master_id}/')
+        expect(page).to have_content('/masters/{{master_id}}/')
         expect(page).to have_content(ei.base_route_segments)
 
         # Verify curl examples with placeholders

--- a/spec/system/api/save_trigger_api_endpoints_spec.rb
+++ b/spec/system/api/save_trigger_api_endpoints_spec.rb
@@ -13,6 +13,10 @@
 # Report tests:
 # 3. Creates a report with a search attribute (last_name) using use_plain_attribute_names
 # 4. Verifies GET report JSON via pull_external_data returns matching results
+#
+# Create master with associations tests (PR #929):
+# 5. POST /masters/create.json with embedded_item and nested associations via pull_external_data
+# 6. Verifies transaction rollback when association validation fails
 
 require 'rails_helper'
 
@@ -395,6 +399,192 @@ RSpec.describe 'pull_external_data save trigger API endpoints', type: :system, j
       expect(matching['rank']).to eq 10
       expect(matching['source']).to eq 'nflpa'
       expect(matching['birth_date']).to eq '1980-01-15'
+    end
+  end
+
+  context 'create master with associations API (PR #929)' do
+    before(:all) do
+      # Ensure general selection sources exist for player_infos, player_contacts, and addresses
+      { 'player_infos_source' => { 'CIS' => 'cis' },
+        'player_contacts_source' => { 'CIS' => 'cis' },
+        'addresses_source' => { 'NFL' => 'nfl' } }.each do |item_type, entries|
+        entries.each do |name, value|
+          unless Classification::GeneralSelection.active.exists?(item_type:, value:)
+            Classification::GeneralSelection.create!(item_type:, name:, value:,
+                                                     current_admin: @admin, create_with: true)
+          end
+        end
+      end
+      Rails.cache.clear
+
+      # Grant create_master permission
+      let_user_create_master
+
+      # Grant create access for association record types
+      let_user_create :player_infos
+      let_user_create :player_contacts
+      let_user_create :addresses
+
+      # Grant create access for the dynamic model used in associations
+      let_user_create RESOURCE_NAME
+
+      # Configure create_master_with to allow player_info as the embedded item
+      add_user_config(:create_master_with, 'player_info', for_user: @user)
+    end
+
+    it 'creates a master record with embedded item and associations via POST save trigger' do
+      # This tests the POST /masters/create.json endpoint from PR #929:
+      #   url: "{{base_url}}/masters/create.json
+      #         ?use_app_type={{constants.api_app_type}}
+      #         &user_email={{constants.api_user_email}}
+      #         &user_token={{constants.api_shared_secret}}"
+      #   post_data:
+      #     master:
+      #       embedded_item: { first_name, last_name, source }
+      #       associations:
+      #         player_contacts: { "0": { data, rec_type, rank, source } }
+      #         addresses: { "0": { street, city, state, zip, rank, source } }
+      #         dynamic_model__<table_name>: { "0": { field1, field2 } }
+
+      trigger_item = @impl_class.create!(
+        current_user: @user,
+        master: @master,
+        name: 'trigger item create master',
+        description: 'item that fires the create master save trigger'
+      )
+
+      last_master_id = Master.reorder('').last.id
+
+      config = {
+        create_master: {
+          local_data: 'create_master_result',
+          force_not_editable_save: true,
+          method: 'post',
+          to: {
+            url: "#{server_url}/masters/create.json?#{api_auth_params}",
+            format: 'json',
+            allow_empty_result: false,
+            headers: {
+              'Content-Type': 'application/json'
+            }
+          },
+          post_data: {
+            master: {
+              embedded_item: {
+                first_name: 'apifirst',
+                last_name: 'apilast',
+                source: 'cis'
+              },
+              associations: {
+                player_contacts: {
+                  '0' => { data: '(617)555-0100', rec_type: 'phone', rank: 10, source: 'cis' }
+                },
+                addresses: {
+                  '0' => { street: '99 api street', city: 'boston', state: 'ma', zip: '02101',
+                           rank: 10, source: 'nfl' }
+                },
+                RESOURCE_NAME => {
+                  '0' => { name: 'api assoc dm', description: 'created as association' }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      trigger = SaveTriggers::PullExternalData.new(config, trigger_item)
+      trigger.perform
+
+      result = trigger_item.save_trigger_results['create_master_result']
+      expect(result).to be_present
+      expect(trigger.response_code).to eq 200
+
+      # Verify the master record was created
+      expect(result['master']).to be_present, "Expected master in response, got: #{result}"
+      expect(result['master']['id']).to be > last_master_id
+
+      new_master = Master.find(result['master']['id'])
+      new_master.current_user = @user
+
+      # Verify player_info (embedded item) was created
+      player_infos = new_master.player_infos.reload
+      expect(player_infos.count).to eq 1
+      expect(player_infos.first.first_name).to eq 'apifirst'
+      expect(player_infos.first.last_name).to eq 'apilast'
+
+      # Verify player_contact was created
+      player_contacts = new_master.player_contacts.reload
+      expect(player_contacts.count).to eq 1
+      expect(player_contacts.first.data).to eq '(617)555-0100'
+      expect(player_contacts.first.rec_type).to eq 'phone'
+
+      # Verify address was created
+      addresses = new_master.addresses.reload
+      expect(addresses.count).to eq 1
+      expect(addresses.first.street).to eq '99 api street'
+      expect(addresses.first.city).to eq 'boston'
+
+      # Verify dynamic model record was created
+      dm_recs = new_master.send(RESOURCE_NAME.to_s.pluralize).reload
+      expect(dm_recs.count).to eq 1
+      expect(dm_recs.first.name).to eq 'api assoc dm'
+      expect(dm_recs.first.description).to eq 'created as association'
+    end
+
+    it 'rolls back all records when an association fails validation' do
+      # When any association record fails validation, the entire transaction should roll back:
+      # no master, no embedded item, no other associations should be persisted.
+
+      trigger_item = @impl_class.create!(
+        current_user: @user,
+        master: @master,
+        name: 'trigger item rollback',
+        description: 'item that fires a failing create master trigger'
+      )
+
+      master_count_before = Master.count
+
+      config = {
+        create_master_rollback: {
+          local_data: 'rollback_result',
+          force_not_editable_save: true,
+          method: 'post',
+          to: {
+            url: "#{server_url}/masters/create.json?#{api_auth_params}",
+            format: 'json',
+            allow_empty_result: false,
+            allow_response_codes: [400],
+            headers: {
+              'Content-Type': 'application/json'
+            }
+          },
+          post_data: {
+            master: {
+              embedded_item: {
+                first_name: 'rollfirst',
+                last_name: 'rolllast',
+                source: 'cis'
+              },
+              associations: {
+                # Invalid address — rank is required but missing, causing validation failure
+                addresses: {
+                  '0' => { street: '456 bad street', city: 'boston', state: 'ma', zip: '02101' }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      trigger = SaveTriggers::PullExternalData.new(config, trigger_item)
+      trigger.perform
+
+      # When allow_response_codes includes 400, PullExternalData sets response_code
+      # but returns nil data (no body parsed). Verify the error response code.
+      expect(trigger.response_code).to eq 400
+
+      # No new master record should have been created (transaction rolled back)
+      expect(Master.count).to eq master_count_before
     end
   end
 end

--- a/spec/system/api/save_trigger_api_endpoints_spec.rb
+++ b/spec/system/api/save_trigger_api_endpoints_spec.rb
@@ -1,0 +1,400 @@
+# frozen_string_literal: true
+
+# Tests that the API URL patterns shown in the admin API panels' "save trigger usage"
+# sections can actually retrieve and send data via pull_external_data save triggers.
+#
+# Exercises both the pull_external_data client (save trigger mechanism) and the
+# server's REST API endpoints end-to-end.
+#
+# Dynamic model tests:
+# 1. Creates a dynamic model with auto-migrated table in the dynamic_test schema
+# 2. Verifies GET show, GET index, and POST create via pull_external_data
+#
+# Report tests:
+# 3. Creates a report with a search attribute (last_name) using use_plain_attribute_names
+# 4. Verifies GET report JSON via pull_external_data returns matching results
+
+require 'rails_helper'
+
+RSpec.describe 'pull_external_data save trigger API endpoints', type: :system, js: true, driver: $browser_driver do
+  include ModelSupport
+  include MasterSupport
+
+  TABLE_NAME = 'test_api_trigger_recs'
+  SCHEMA_NAME = 'dynamic_test'
+  RESOURCE_NAME = :"dynamic_model__#{TABLE_NAME}"
+
+  before(:all) do
+    SetupHelper.feature_setup
+    create_admin
+
+    # Enable dynamic migrations so the DM create automatically generates the DB table
+    change_setting('AllowDynamicMigrations', true)
+
+    # Create the dynamic model definition — after_create generates the DB table via migration,
+    # after_save generates the model class, after_create_commit reloads routes
+    @dm = DynamicModel.create!(
+      table_name: TABLE_NAME,
+      schema_name: SCHEMA_NAME,
+      name: 'Test API Trigger Records',
+      description: 'Test pull_external_data save trigger API endpoints',
+      primary_key_name: 'id',
+      foreign_key_name: 'master_id',
+      category: 'test',
+      field_list: 'name description notes',
+      result_order: 'id',
+      current_admin: @admin
+    )
+
+    @dm.update_tracker_events
+
+    # Verify model generation succeeded
+    dm_class_name = @dm.implementation_class.name
+    expect(DynamicModel.const_defined?(dm_class_name)).to be_truthy,
+                                                          "DynamicModel::#{dm_class_name} was not generated"
+
+    # Ensure routes are loaded for the new DM so the Capybara server can handle requests
+    DynamicModel.routes_load
+
+    # Create a user with API token
+    @user, @good_password = create_user(nil, '', create_master: true)
+    expect(@user_authentication_token).to be_present
+
+    # Create a master record
+    @master = create_master
+
+    # Set up DM access for the user (create access satisfies the :access combo check)
+    setup_access RESOURCE_NAME, user: @user
+    expect(@user.has_access_to?(:access, :table, RESOURCE_NAME)).to be_truthy
+
+    # Create the implementation class and a target record for GET tests
+    @impl_class = @dm.implementation_class
+    @target_record = @impl_class.create!(
+      current_user: @user,
+      master: @master,
+      name: 'target record',
+      description: 'record to be retrieved by get'
+    )
+
+    expect(@target_record).to be_persisted
+    expect(@target_record.id).to be_present
+  end
+
+  #
+  # Capybara test server URL (e.g., "http://127.0.0.1:12345")
+  # @return [String]
+  def server_url
+    "http://#{Capybara.current_session.server.host}:#{Capybara.current_session.server.port}"
+  end
+
+  #
+  # URL query string for API authentication, matching the pattern in
+  # AdminApiDefinitionsHelper#api_save_trigger_example
+  # @return [String]
+  def api_auth_params
+    "use_app_type=#{@user.app_type_id}&user_email=#{@user.email}&user_token=#{@user_authentication_token}"
+  end
+
+  #
+  # API base path matching AdminApiDefinitionsHelper#api_base_path output
+  # @return [String] e.g., "/masters/1/dynamic_model/test_api_trigger_recs"
+  def dm_api_base_path
+    "/masters/#{@master.id}/dynamic_model/#{TABLE_NAME}"
+  end
+
+  #
+  # JSON response key from the controller's full_object_name.
+  # Uses double underscore (e.g., "dynamic_model__test_api_trigger_rec")
+  # @return [String]
+  def response_key
+    @dm.implementation_class.resource_name.singularize
+  end
+
+  #
+  # POST param wrapper key from the controller's primary_params_name.
+  # Uses single underscore (e.g., "dynamic_model_test_api_trigger_rec")
+  # @return [String]
+  def param_key
+    @dm.implementation_class.resource_name.gsub('__', '_').singularize
+  end
+
+  it 'retrieves an existing record via GET using the save trigger URL pattern' do
+    # This tests the GET URL pattern from AdminApiDefinitionsHelper#api_save_trigger_example:
+    #   url: "{{base_url}}/masters/{master_id}/dynamic_model/table_name/{{constants.item_id}}.json
+    #         ?use_app_type={{constants.api_app_type}}
+    #         &user_email={{constants.api_user_email}}
+    #         &user_token={{constants.api_shared_secret}}"
+
+    # Build a trigger item: the record that would "run" the save trigger
+    trigger_item = @impl_class.create!(
+      current_user: @user,
+      master: @master,
+      name: 'trigger item get',
+      description: 'item that fires the get save trigger'
+    )
+
+    config = {
+      get_record: {
+        local_data: 'get_result',
+        from: {
+          url: "#{server_url}#{dm_api_base_path}/#{@target_record.id}.json?#{api_auth_params}",
+          format: 'json',
+          allow_empty_result: false
+        }
+      }
+    }
+
+    trigger = SaveTriggers::PullExternalData.new(config, trigger_item)
+    trigger.perform
+
+    # Verify the GET result contains the target record's data
+    get_result = trigger_item.save_trigger_results['get_result']
+    expect(get_result).to be_present
+
+    # The JSON response format is: { "<response_key>" => { field data }, "_control" => { ... } }
+    record_data = get_result[response_key]
+    expect(record_data).to be_present
+    expect(record_data['id']).to eq @target_record.id
+    expect(record_data['name']).to eq 'target record'
+    expect(record_data['description']).to eq 'record to be retrieved by get'
+    expect(trigger.response_code).to eq 200
+  end
+
+  it 'creates a new record via POST using the save trigger URL pattern' do
+    # This tests the POST URL pattern from AdminApiDefinitionsHelper#api_save_trigger_example:
+    #   url: "{{base_url}}/masters/{master_id}/dynamic_model/table_name.json
+    #         ?use_app_type={{constants.api_app_type}}
+    #         &user_email={{constants.api_user_email}}
+    #         &user_token={{constants.api_shared_secret}}"
+    #   post_data:
+    #     <param_key>:
+    #       name: "value"
+    #       description: "value"
+
+    trigger_item = @impl_class.create!(
+      current_user: @user,
+      master: @master,
+      name: 'trigger item post',
+      description: 'item that fires the post save trigger'
+    )
+
+    config = {
+      create_record: {
+        local_data: 'create_result',
+        force_not_editable_save: true,
+        method: 'post',
+        to: {
+          url: "#{server_url}#{dm_api_base_path}.json?#{api_auth_params}",
+          format: 'json',
+          allow_empty_result: false,
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        },
+        post_data: {
+          param_key => {
+            'name' => 'api created record',
+            'description' => 'created via post save trigger'
+          }
+        }
+      }
+    }
+
+    initial_count = @impl_class.where(master: @master).count
+
+    trigger = SaveTriggers::PullExternalData.new(config, trigger_item)
+    trigger.perform
+
+    # Verify the POST result contains the created record's data
+    create_result = trigger_item.save_trigger_results['create_result']
+    expect(create_result).to be_present
+    expect(create_result[response_key]).to be_present
+
+    created_data = create_result[response_key]
+    expect(created_data['name']).to eq 'api created record'
+    expect(created_data['description']).to eq 'created via post save trigger'
+    expect(created_data['id']).to be_present
+    expect(trigger.response_code).to eq 200
+
+    # Verify the record was actually created in the database
+    new_count = @impl_class.where(master: @master).count
+    expect(new_count).to eq initial_count + 1
+
+    created_record = @impl_class.find(created_data['id'])
+    expect(created_record.name).to eq 'api created record'
+    expect(created_record.master_id).to eq @master.id
+  end
+
+  it 'retrieves a list of records via GET index using the save trigger URL pattern' do
+    # This tests the index GET URL pattern:
+    #   url: "{{base_url}}/masters/{master_id}/dynamic_model/table_name.json?..."
+
+    trigger_item = @impl_class.create!(
+      current_user: @user,
+      master: @master,
+      name: 'trigger item index',
+      description: 'item that fires the index save trigger'
+    )
+
+    config = {
+      list_records: {
+        local_data: 'index_result',
+        from: {
+          url: "#{server_url}#{dm_api_base_path}.json?#{api_auth_params}",
+          format: 'json',
+          allow_empty_result: false
+        }
+      }
+    }
+
+    trigger = SaveTriggers::PullExternalData.new(config, trigger_item)
+    trigger.perform
+
+    index_result = trigger_item.save_trigger_results['index_result']
+    expect(index_result).to be_present
+    expect(trigger.response_code).to eq 200
+
+    # The index response is an array of records (or a hash with the plural key)
+    # Verify at least one record is present
+    records = index_result.is_a?(Array) ? index_result : index_result.values.first
+    expect(records).to be_present
+    expect(records.length).to be >= 1
+  end
+
+  context 'report API' do
+    before(:all) do
+      # Grant player_infos create access so we can create test records
+      setup_access :player_infos, user: @user
+
+      # Ensure valid source selections exist for player_infos
+      gs = Classification::GeneralSelection.active.where(item_type: 'player_infos_source', value: %w[nfl nflpa])
+      if gs.empty?
+        Classification::GeneralSelection.create!(item_type: 'player_infos_source', name: 'NFL', value: 'nfl',
+                                                 current_admin: @admin, create_with: true)
+        Classification::GeneralSelection.create!(item_type: 'player_infos_source', name: 'NFLPA', value: 'nflpa',
+                                                 current_admin: @admin, create_with: true)
+      else
+        gs.update_all(create_with: true)
+      end
+      Rails.cache.clear
+
+      # Create a player_info record with a known last_name for the report query
+      @test_last_name = "apitriggertest#{SecureRandom.hex(4)}"
+      @player_info = PlayerInfo.create!(
+        master: @master,
+        current_user: @user,
+        first_name: 'api',
+        last_name: @test_last_name,
+        rank: 10,
+        source: 'nflpa',
+        birth_date: Date.new(1980, 1, 15)
+      )
+
+      # Create a report with use_plain_attribute_names and a last_name search attribute
+      report_sql = <<~SQL.squish
+        select first_name, last_name, rank, source, birth_date
+        from player_infos
+        where last_name = :last_name
+      SQL
+
+      search_attrs_yaml = <<~YAML
+        last_name:
+          string:
+            label: Last Name
+      YAML
+
+      options_yaml = <<~YAML
+        view_options:
+          use_plain_attribute_names: true
+      YAML
+
+      @report = Report.create!(
+        current_admin: @admin,
+        name: "API Trigger Test Report #{SecureRandom.hex(4)}",
+        item_type: 'test',
+        sql: report_sql,
+        search_attrs: search_attrs_yaml,
+        options: options_yaml,
+        report_type: 'regular_report',
+        searchable: true
+      )
+
+      # Grant the user access to view reports and this specific report
+      unless @user.has_access_to?(:read, :general, :view_reports)
+        Admin::UserAccessControl.create!(
+          app_type: @user.app_type, access: :read,
+          resource_type: :general, resource_name: :view_reports,
+          current_admin: @admin
+        )
+      end
+
+      Admin::UserAccessControl.create!(
+        app_type: @user.app_type, access: :read,
+        resource_type: :report, resource_name: @report.alt_resource_name,
+        current_admin: @admin
+      )
+    end
+
+    #
+    # Report API base path matching the pattern in _api_panel_report.html.erb
+    # @return [String] e.g., "/reports/test__api_trigger_test_report_abc123"
+    def report_api_path
+      "/reports/#{@report.alt_resource_name}"
+    end
+
+    #
+    # URL search attributes with plain attribute names (not wrapped in search_attrs[])
+    # @return [String] e.g., "last_name=apitriggertest1234abcd"
+    def report_search_params
+      { last_name: @test_last_name }.to_query
+    end
+
+    it 'retrieves report results via GET using the save trigger URL pattern' do
+      # This tests the report GET URL pattern from _api_panel_report.html.erb save trigger usage:
+      #   url: "{{base_url}}/reports/<alt_resource_name>.json
+      #         ?<search_attrs>
+      #         &use_app_type={{constants.api_app_type}}
+      #         &user_email={{constants.api_user_email}}
+      #         &user_token={{constants.api_shared_secret}}"
+
+      trigger_item = @impl_class.create!(
+        current_user: @user,
+        master: @master,
+        name: 'trigger item report',
+        description: 'item that fires the report save trigger'
+      )
+
+      config = {
+        get_report: {
+          local_data: 'report_result',
+          from: {
+            url: "#{server_url}#{report_api_path}.json?#{report_search_params}&#{api_auth_params}",
+            format: 'json',
+            allow_empty_result: false
+          }
+        }
+      }
+
+      trigger = SaveTriggers::PullExternalData.new(config, trigger_item)
+      trigger.perform
+
+      report_result = trigger_item.save_trigger_results['report_result']
+      expect(report_result).to be_present
+      expect(trigger.response_code).to eq 200
+
+      # Default JSON format is { "results" => [...], "search_attributes" => {...} }
+      expect(report_result).to have_key('results')
+      results = report_result['results']
+      expect(results).to be_present
+      expect(results.length).to be >= 1
+
+      # Verify the result contains the expected player_info data
+      matching = results.find { |r| r['last_name'] == @test_last_name }
+      expect(matching).to be_present
+      expect(matching['first_name']).to eq 'api'
+      expect(matching['rank']).to eq 10
+      expect(matching['source']).to eq 'nflpa'
+      expect(matching['birth_date']).to eq '1980-01-15'
+    end
+  end
+end

--- a/spec/system/api/save_trigger_api_endpoints_spec.rb
+++ b/spec/system/api/save_trigger_api_endpoints_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe 'pull_external_data save trigger API endpoints', type: :system, j
 
   it 'retrieves an existing record via GET using the save trigger URL pattern' do
     # This tests the GET URL pattern from AdminApiDefinitionsHelper#api_save_trigger_example:
-    #   url: "{{base_url}}/masters/{master_id}/dynamic_model/table_name/{{constants.item_id}}.json
+    #   url: "{{base_url}}/masters/{{master_id}}/dynamic_model/table_name/{{constants.item_id}}.json
     #         ?use_app_type={{constants.api_app_type}}
     #         &user_email={{constants.api_user_email}}
     #         &user_token={{constants.api_shared_secret}}"
@@ -166,7 +166,7 @@ RSpec.describe 'pull_external_data save trigger API endpoints', type: :system, j
 
   it 'creates a new record via POST using the save trigger URL pattern' do
     # This tests the POST URL pattern from AdminApiDefinitionsHelper#api_save_trigger_example:
-    #   url: "{{base_url}}/masters/{master_id}/dynamic_model/table_name.json
+    #   url: "{{base_url}}/masters/{{master_id}}/dynamic_model/table_name.json
     #         ?use_app_type={{constants.api_app_type}}
     #         &user_email={{constants.api_user_email}}
     #         &user_token={{constants.api_shared_secret}}"
@@ -231,7 +231,7 @@ RSpec.describe 'pull_external_data save trigger API endpoints', type: :system, j
 
   it 'retrieves a list of records via GET index using the save trigger URL pattern' do
     # This tests the index GET URL pattern:
-    #   url: "{{base_url}}/masters/{master_id}/dynamic_model/table_name.json?..."
+    #   url: "{{base_url}}/masters/{{master_id}}/dynamic_model/table_name.json?..."
 
     trigger_item = @impl_class.create!(
       current_user: @user,


### PR DESCRIPTION
## Summary

Adds an **API Definitions** tab to the admin edit panels for dynamic models, activity logs, external identifiers, and reports. The panel gives admins everything they need to call an endpoint without leaving the admin UI.

## What's included

### UI panel (per dynamic definition / report)
- **Resource name** — the canonical resource identifier
- **Endpoints** — full list of REST paths with HTTP methods (activity logs include extra_log_type sub-routes)
- **curl examples** — ready-to-paste GET/POST/PUT commands with placeholder variables
- **Fields** — typed field list and copyable YAML fragment (standard fields excluded)
- **Save trigger usage** — complete `pull_external_data` YAML block for use in save trigger configs

### Report-specific panel
- JSON / CSV / text endpoint paths
- Search attribute query string (plain or `search_attrs[]` wrapped, based on `use_plain_attribute_names`)
- curl examples for all three formats
- Save trigger YAML using `get_report:` key

### Copy-to-clipboard
- Copy button on every code block
- Clipboard logic moved into `_fpa_form_utils.js` (shared JS utility) — removed duplicate inline `<script>` from the partial
- CSS class generalised from `api-panel__copy-btn` to a reusable utility class in `admin.scss`

### Helper (`AdminApiDefinitionsHelper`)
- `api_base_path`, `api_endpoints`, `api_curl_example`, `api_save_trigger_example` — for DM / AL / EI
- `api_report_curl_example`, `api_report_save_trigger_example` — for reports
- curl `{master_id}` placeholder corrected to `{{master_id}}` for consistency with other Handlebars-style vars

## Tests

### Helper spec (`spec/helpers/admin_api_definitions_helper_spec.rb`)
- 54 examples covering all helper methods, field filtering, type-specific placeholders, and YAML output

### System spec — admin panel (`spec/system/admin/admin_api_definitions_panel_spec.rb`)
- 11 examples verifying the panel renders with correct content for a real dynamic model and report

### System spec — end-to-end API calls (`spec/system/api/save_trigger_api_endpoints_spec.rb`)
- DM GET show, GET index, POST create — verifies real HTTP round-trip via `pull_external_data`
- Report GET — verifies report JSON endpoint returns expected results
- Create master with associations (PR #929) — success path and transaction rollback on validation failure

All 60 examples pass, 0 failures.

## Resolves
- Closes #652