### PR TITLE
Added support for all HTTP verbs in pull_external_data trigger

### DIFF
--- a/app/models/save_triggers/pull_external_data.rb
+++ b/app/models/save_triggers/pull_external_data.rb
@@ -3,6 +3,9 @@
 class SaveTriggers::PullExternalData < SaveTriggers::SaveTriggersBase
   attr_accessor :response_code
 
+  BODY_METHODS = %w[put patch lock mkcol propfind proppatch unlock].freeze
+  NO_BODY_METHODS = %w[head delete options trace copy move].freeze
+
   def self.config_def(if_extras: {}); end
 
   def initialize(config, item)
@@ -84,46 +87,58 @@ class SaveTriggers::PullExternalData < SaveTriggers::SaveTriggersBase
   end
 
   def run_request
-    case method_from_config
-    when 'get'
-      pull_data
+    method = method_from_config
+    case method
+    when 'get', *NO_BODY_METHODS
+      send_no_body_request(method)
     when 'post'
       if post_data_config
-        post_data
+        send_body_request(method)
       else
         post_form
       end
+    when *BODY_METHODS
+      send_body_request(method)
     else
-      raise FphsException, "pull_external_data method '#{http_method}' is not supported"
+      raise FphsException, "pull_external_data method '#{method}' is not supported"
     end
-  end
-
-  def pull_data
-    url = url_from_config
-    response = Net::HTTP.get_response(URI.parse(url))
-    handle_response(from_config, response)
   end
 
   def post_form
-    url = url_from_config
+    uri = URI.parse(url_from_config)
     form = @this_config[:form] || {}
     form = form.deep_transform_values { |v| FieldDefaults.calculate_default @item, v }
-    response = Net::HTTP.post_form(URI.parse(url), form)
+    response = Net::HTTP.post_form(uri, form)
     handle_response(to_config, response)
   end
 
-  def post_data
-    url = url_from_config
-    data = post_data_config || {}
-    if data.is_a? Hash
-      data = data.deep_stringify_keys
-      data = data.deep_transform_values { |v| FieldDefaults.calculate_default @item, v }
-      data = data.to_json
-    else
-      data = FieldDefaults.calculate_default @item, data
-    end
-    response = Net::HTTP.post(URI.parse(url), data, header_config)
+  def send_body_request(method)
+    uri = URI.parse(url_from_config)
+    data = serialize_send_data
+
+    request_class = Net::HTTP.const_get(method.capitalize)
+    req = request_class.new(uri)
+    req.body = data
+    apply_headers(req)
+
+    response = start_http(uri).request(req)
     handle_response(to_config, response)
+  end
+
+  def send_no_body_request(method)
+    uri = URI.parse(url_from_config)
+    request_class = Net::HTTP.const_get(method.capitalize)
+    req = request_class.new(uri)
+    apply_headers(req)
+
+    response = start_http(uri).request(req)
+    handle_response(from_config || to_config, response)
+  end
+
+  def start_http(uri)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == 'https'
+    http
   end
 
   def handle_response(sub_config, response)
@@ -181,7 +196,7 @@ class SaveTriggers::PullExternalData < SaveTriggers::SaveTriggersBase
   end
 
   def post_data_config
-    @this_config[:post_data]
+    @this_config[:send_data] || @this_config[:post_data]
   end
 
   def header_config
@@ -191,5 +206,29 @@ class SaveTriggers::PullExternalData < SaveTriggers::SaveTriggersBase
 
     substitute_values_in_config(headers)
     headers.stringify_keys
+  end
+
+  private
+
+  #
+  # Serialize the send_data / post_data configuration value to a JSON string
+  # or calculate it as a default field value
+  # @return [String]
+  def serialize_send_data
+    data = post_data_config || {}
+    if data.is_a? Hash
+      data = data.deep_stringify_keys
+      data = data.deep_transform_values { |v| FieldDefaults.calculate_default @item, v }
+      data.to_json
+    else
+      FieldDefaults.calculate_default @item, data
+    end
+  end
+
+  #
+  # Apply configured headers to a Net::HTTP request object
+  # @param [Net::HTTPGenericRequest] req
+  def apply_headers(req)
+    header_config&.each { |k, v| req[k] = v }
   end
 end

--- a/spec/models/save_triggers/pull_external_data_spec.rb
+++ b/spec/models/save_triggers/pull_external_data_spec.rb
@@ -1,5 +1,13 @@
 require 'rails_helper'
 
+# Tests for SaveTriggers::PullExternalData save trigger.
+# Verifies HTTP requests to external services, including:
+# - GET/POST requests with XML and JSON formats (existing)
+# - All HTTP verbs supported by Net::HTTP (issue #928):
+#   body-sending (put, patch, lock, mkcol, propfind, proppatch, unlock),
+#   no-body (head, delete, options, trace, copy, move)
+# - Response code handling, error whitelisting, local_data storage
+# - send_data config alias for post_data
 RSpec.describe SaveTriggers::PullExternalData, type: :model do
   include ModelSupport
   include ActivityLogSupport
@@ -179,6 +187,35 @@ RSpec.describe SaveTriggers::PullExternalData, type: :model do
         headers: {},
         body: '{"requestId": "71c5#187e7d99f13","result": [{"id": 30412, "status": "updated"}],"success": true}'
       )
+
+    # Stubs for testing all HTTP verbs (issue #928)
+    test_api_url = 'https://rspec-test.example.com/api/resource'
+    test_json_body = ->(method) { { result: 'success', method: }.to_json }
+    test_headers = {
+      'Accept' => /.*/,
+      'Accept-Encoding' => /.*/,
+      'Host' => /.*/,
+      'User-Agent' => /.*/
+    }
+
+    # Body-sending verbs
+    %i[put patch lock mkcol propfind proppatch unlock].each do |method|
+      stub_request(method, test_api_url)
+        .with(headers: test_headers.merge('Content-Type' => 'application/json'))
+        .to_return(status: 200, body: test_json_body.call(method.to_s), headers: {})
+    end
+
+    # No-body verbs that return content
+    %i[delete options trace copy move].each do |method|
+      stub_request(method, test_api_url)
+        .with(headers: test_headers)
+        .to_return(status: 200, body: test_json_body.call(method.to_s), headers: {})
+    end
+
+    # HEAD returns empty body
+    stub_request(:head, test_api_url)
+      .with(headers: test_headers)
+      .to_return(status: 200, body: '', headers: {})
   end
 
   before :example do
@@ -473,5 +510,129 @@ RSpec.describe SaveTriggers::PullExternalData, type: :model do
     expect do
       @trigger.perform
     end.not_to raise_error
+  end
+
+  # Tests for all HTTP verbs (issue #928)
+  context 'with body-sending HTTP verbs' do
+    %w[put patch lock mkcol propfind proppatch unlock].each do |http_method|
+      it "sends data with #{http_method} method" do
+        config = {
+          this1: {
+            data_field: 'notes',
+            data_field_format: 'json',
+            method: http_method,
+            to: {
+              url: 'https://rspec-test.example.com/api/resource',
+              format: 'json',
+              headers: { 'Content-Type': 'application/json' }
+            },
+            send_data: { key: 'value' }
+          }
+        }
+
+        @trigger = SaveTriggers::PullExternalData.new(config, @al)
+        @trigger.perform
+
+        expect(@al.notes).to be_present
+        dnotes = JSON.parse(@al.notes)
+        expect(dnotes['result']).to eq 'success'
+        expect(dnotes['method']).to eq http_method
+      end
+    end
+  end
+
+  context 'with no-body HTTP verbs' do
+    %w[delete options trace copy move].each do |http_method|
+      it "sends request with #{http_method} method" do
+        config = {
+          this1: {
+            data_field: 'notes',
+            data_field_format: 'json',
+            method: http_method,
+            from: {
+              url: 'https://rspec-test.example.com/api/resource',
+              format: 'json'
+            }
+          }
+        }
+
+        @trigger = SaveTriggers::PullExternalData.new(config, @al)
+        @trigger.perform
+
+        expect(@al.notes).to be_present
+        dnotes = JSON.parse(@al.notes)
+        expect(dnotes['result']).to eq 'success'
+        expect(dnotes['method']).to eq http_method
+      end
+    end
+  end
+
+  context 'with head HTTP verb' do
+    it 'sends a head request and handles empty body' do
+      config = {
+        this1: {
+          method: 'head',
+          response_code_field: 'select_result',
+          from: {
+            url: 'https://rspec-test.example.com/api/resource',
+            format: 'json',
+            allow_empty_result: true
+          }
+        }
+      }
+
+      @trigger = SaveTriggers::PullExternalData.new(config, @al)
+      @trigger.perform
+
+      expect(@trigger.response_code).to eq 200
+      expect(@al.select_result).to eq '200'
+    end
+  end
+
+  context 'with body-sending HTTP verbs using local_data' do
+    it 'stores put response in save_trigger_results' do
+      config = {
+        this1: {
+          local_data: 'put_response',
+          data_field: 'notes',
+          data_field_format: 'json',
+          method: 'put',
+          to: {
+            url: 'https://rspec-test.example.com/api/resource',
+            format: 'json',
+            headers: { 'Content-Type': 'application/json' }
+          },
+          send_data: { key: 'updated_value' }
+        }
+      }
+
+      @trigger = SaveTriggers::PullExternalData.new(config, @al)
+      @trigger.perform
+
+      expect(@al.save_trigger_results['put_response']).to be_present
+      expect(@al.save_trigger_results['put_response']['result']).to eq 'success'
+      expect(@al.save_trigger_results['put_response_http_response_code']).to eq 200
+    end
+  end
+
+  context 'with unsupported HTTP method' do
+    it 'raises an error for an invalid method' do
+      config = {
+        this1: {
+          data_field: 'notes',
+          method: 'invalid_method',
+          from: {
+            url: 'https://rspec-test.example.com/api/resource',
+            format: 'json'
+          }
+        }
+      }
+
+      @trigger = SaveTriggers::PullExternalData.new(config, @al)
+
+      expect do
+        @trigger.perform
+      end.to raise_error(FphsException, /pull_external_data method 'invalid_method' is not supported/)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Extends `SaveTriggers::PullExternalData` to support all HTTP verbs provided by `Net::HTTP`, beyond the existing `get` and `post`.

### Changes

**Implementation (`pull_external_data.rb`):**
- Added `BODY_METHODS` constant for verbs that send a body: put, patch, lock, mkcol, propfind, proppatch, unlock
- Added `NO_BODY_METHODS` constant for verbs without a body: head, delete, options, trace, copy, move
- Added `send_body_request(method)` and `send_no_body_request(method)` using `Net::HTTP` request classes
- Extracted `serialize_send_data` and `apply_headers` private helpers to eliminate duplication
- Added `send_data` as a config alias for `post_data` (backward-compatible)
- Fixed pre-existing `NameError` bug in the unsupported method error message (`http_method` → `method`)
- Refactored `get` to use the generic `send_no_body_request` path; `post` with data uses `send_body_request`

**Tests (`pull_external_data_spec.rb`):**
- 15 new test cases covering all new HTTP verbs, head empty-body handling, local_data storage, send_data alias, and unsupported method error
- All 26 tests pass (11 existing + 15 new)

Fixes #928