### PR TITLE
Changed Dalli cache store to use meta protocol - fixes #886

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,7 +38,9 @@ Rails.application.configure do
     config.action_controller.perform_caching = false
 
     # config.cache_store = :null_store
-    config.cache_store = :mem_cache_store
+    # The :meta protocol replaces the deprecated :binary protocol (removed in Dalli 5.0)
+    # and requires memcached 1.6+
+    config.cache_store = :mem_cache_store, { protocol: :meta }
 
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,9 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  config.cache_store = :mem_cache_store
+  # The :meta protocol replaces the deprecated :binary protocol (removed in Dalli 5.0)
+  # and requires memcached 1.6+
+  config.cache_store = :mem_cache_store, { protocol: :meta }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -59,14 +59,14 @@ Rails.application.configure do
   # fs_cache_path = Rails.root.join('tmp', 'cache', 'cache-fs', "paralleltests#{ENV['TEST_ENV_NUMBER']}")
   # FileUtils.mkdir_p fs_cache_path
   # config.cache_store = :file_store, fs_cache_path
-  if ENV['TEST_MEM_CACHE_STORE'] == 'true'
-    # Use Dalli memcached store with :meta protocol for cache integration testing.
-    # The :meta protocol replaces the deprecated :binary protocol (removed in Dalli 5.0)
-    # and requires memcached 1.6+
-    config.cache_store = :mem_cache_store, { protocol: :meta }
-  else
-    config.cache_store = :memory_store, { namespace: "paralleltests#{ENV.fetch('TEST_ENV_NUMBER', nil)}" }
-  end
+  config.cache_store = if ENV['TEST_MEM_CACHE_STORE'] == 'true'
+                         # Use Dalli memcached store with :meta protocol for cache integration testing.
+                         # The :meta protocol replaces the deprecated :binary protocol (removed in Dalli 5.0)
+                         # and requires memcached 1.6+
+                         [:mem_cache_store, { protocol: :meta }]
+                       else
+                         [:memory_store, { namespace: "paralleltests#{ENV.fetch('TEST_ENV_NUMBER', nil)}" }]
+                       end
 
   config.active_record.dump_schema_after_migration = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -59,7 +59,14 @@ Rails.application.configure do
   # fs_cache_path = Rails.root.join('tmp', 'cache', 'cache-fs', "paralleltests#{ENV['TEST_ENV_NUMBER']}")
   # FileUtils.mkdir_p fs_cache_path
   # config.cache_store = :file_store, fs_cache_path
-  config.cache_store = :memory_store, { namespace: "paralleltests#{ENV.fetch('TEST_ENV_NUMBER', nil)}" }
+  if ENV['TEST_MEM_CACHE_STORE'] == 'true'
+    # Use Dalli memcached store with :meta protocol for cache integration testing.
+    # The :meta protocol replaces the deprecated :binary protocol (removed in Dalli 5.0)
+    # and requires memcached 1.6+
+    config.cache_store = :mem_cache_store, { protocol: :meta }
+  else
+    config.cache_store = :memory_store, { namespace: "paralleltests#{ENV.fetch('TEST_ENV_NUMBER', nil)}" }
+  end
 
   config.active_record.dump_schema_after_migration = false
 

--- a/spec/models/cache_store_spec.rb
+++ b/spec/models/cache_store_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Tests for Dalli memcached cache store configuration (issue #886).
+#
+# These specs verify that when the TEST_MEM_CACHE_STORE environment variable
+# is set, the cache store switches from :memory_store to :mem_cache_store
+# using the :meta protocol. This ensures the Dalli binary protocol deprecation
+# warning is resolved and the app is compatible with Dalli 5.0.
+#
+# To run these tests with an active memcached connection:
+#   TEST_MEM_CACHE_STORE=true bundle exec rspec spec/models/cache_store_spec.rb
+
+require 'rails_helper'
+
+RSpec.describe 'Cache store configuration', type: :model do
+  context 'when TEST_MEM_CACHE_STORE is set', memcached: true do
+    before do
+      skip 'Set TEST_MEM_CACHE_STORE=true to run Dalli/memcached tests' unless ENV['TEST_MEM_CACHE_STORE'] == 'true'
+    end
+
+    it 'uses MemCacheStore as the cache store' do
+      expect(Rails.cache).to be_a(ActiveSupport::Cache::MemCacheStore)
+    end
+
+    it 'can write and read a cache entry' do
+      key = "dalli_test_#{SecureRandom.hex(8)}"
+      Rails.cache.write(key, 'hello from dalli')
+      expect(Rails.cache.read(key)).to eq('hello from dalli')
+      Rails.cache.delete(key)
+    end
+
+    it 'can delete a cache entry' do
+      key = "dalli_test_#{SecureRandom.hex(8)}"
+      Rails.cache.write(key, 'to be deleted')
+      Rails.cache.delete(key)
+      expect(Rails.cache.read(key)).to be_nil
+    end
+
+    it 'does not emit a Dalli binary protocol deprecation warning' do
+      key = "dalli_test_#{SecureRandom.hex(8)}"
+      stderr_output = StringIO.new
+      original_stderr = $stderr
+      $stderr = stderr_output
+
+      begin
+        Rails.cache.write(key, 'deprecation check')
+        Rails.cache.read(key)
+        Rails.cache.delete(key)
+      ensure
+        $stderr = original_stderr
+      end
+
+      expect(stderr_output.string).not_to include('[DEPRECATION]')
+      expect(stderr_output.string).not_to include('binary protocol is deprecated')
+    end
+  end
+
+  context 'when TEST_MEM_CACHE_STORE is not set' do
+    it 'uses MemoryStore as the default test cache store' do
+      skip 'This test verifies default behavior when TEST_MEM_CACHE_STORE is not set' if ENV['TEST_MEM_CACHE_STORE'] == 'true'
+      expect(Rails.cache).to be_a(ActiveSupport::Cache::MemoryStore)
+    end
+  end
+end

--- a/spec/models/cache_store_spec.rb
+++ b/spec/models/cache_store_spec.rb
@@ -7,12 +7,19 @@
 # using the :meta protocol. This ensures the Dalli binary protocol deprecation
 # warning is resolved and the app is compatible with Dalli 5.0.
 #
-# To run these tests with an active memcached connection:
+# Run with memcached:
 #   TEST_MEM_CACHE_STORE=true bundle exec rspec spec/models/cache_store_spec.rb
+#
+# Run without memcached (default, memcached tests are skipped):
+#   bundle exec rspec spec/models/cache_store_spec.rb
 
 require 'rails_helper'
 
 RSpec.describe 'Cache store configuration', type: :model do
+  def unique_cache_key
+    "dalli_test_#{SecureRandom.hex(8)}"
+  end
+
   context 'when TEST_MEM_CACHE_STORE is set', memcached: true do
     before do
       skip 'Set TEST_MEM_CACHE_STORE=true to run Dalli/memcached tests' unless ENV['TEST_MEM_CACHE_STORE'] == 'true'
@@ -23,21 +30,21 @@ RSpec.describe 'Cache store configuration', type: :model do
     end
 
     it 'can write and read a cache entry' do
-      key = "dalli_test_#{SecureRandom.hex(8)}"
+      key = unique_cache_key
       Rails.cache.write(key, 'hello from dalli')
       expect(Rails.cache.read(key)).to eq('hello from dalli')
       Rails.cache.delete(key)
     end
 
     it 'can delete a cache entry' do
-      key = "dalli_test_#{SecureRandom.hex(8)}"
+      key = unique_cache_key
       Rails.cache.write(key, 'to be deleted')
       Rails.cache.delete(key)
       expect(Rails.cache.read(key)).to be_nil
     end
 
     it 'does not emit a Dalli binary protocol deprecation warning' do
-      key = "dalli_test_#{SecureRandom.hex(8)}"
+      key = unique_cache_key
       stderr_output = StringIO.new
       original_stderr = $stderr
       $stderr = stderr_output
@@ -57,7 +64,10 @@ RSpec.describe 'Cache store configuration', type: :model do
 
   context 'when TEST_MEM_CACHE_STORE is not set' do
     it 'uses MemoryStore as the default test cache store' do
-      skip 'This test verifies default behavior when TEST_MEM_CACHE_STORE is not set' if ENV['TEST_MEM_CACHE_STORE'] == 'true'
+      if ENV['TEST_MEM_CACHE_STORE'] == 'true'
+        skip 'Verifies default behavior; not applicable when TEST_MEM_CACHE_STORE is set'
+      end
+
       expect(Rails.cache).to be_a(ActiveSupport::Cache::MemoryStore)
     end
   end

--- a/spec/system/admin/server_info_spec.rb
+++ b/spec/system/admin/server_info_spec.rb
@@ -121,6 +121,57 @@ RSpec.describe 'Admin Server Info', js: true, type: :system do
     expect(page).to have_content('Timeout')
   end
 
+  # Tests for issue #886 - Memcached connection with meta protocol
+  # These tests require TEST_MEM_CACHE_STORE=true and a running memcached 1.6+ instance.
+  # Run with: TEST_MEM_CACHE_STORE=true app-scripts/not_headless_rspec.sh spec/system/admin/server_info_spec.rb -e 'Issue886'
+  describe 'Memcached connection panel with live memcached', memcached: true do
+    before do
+      unless ENV['TEST_MEM_CACHE_STORE'] == 'true'
+        skip 'Set TEST_MEM_CACHE_STORE=true to run live memcached system tests'
+      end
+    end
+
+    it 'shows connected status when memcached is running - Issue886' do
+      visit '/admin/server_info'
+      finish_page_loading
+
+      # Expand Memcached Connection panel
+      find('a[href="#collapse-memcached"]').click
+      sleep 0.5
+
+      expect(page).to have_css('.si-memcached-status', text: 'connected')
+    end
+
+    it 'displays server stats when memcached is connected - Issue886' do
+      visit '/admin/server_info'
+      finish_page_loading
+
+      # Expand Memcached Connection panel
+      find('a[href="#collapse-memcached"]').click
+      sleep 0.5
+
+      # Should show stats table rows beyond the status row
+      within('.si-memcached-stats') do
+        expect(page).to have_css('tr', minimum: 2)
+        # Server stats are rendered as YAML in a <pre> tag
+        expect(page).to have_css('pre')
+      end
+    end
+
+    it 'shows the memcached server address in stats - Issue886' do
+      visit '/admin/server_info'
+      finish_page_loading
+
+      find('a[href="#collapse-memcached"]').click
+      sleep 0.5
+
+      within('.si-memcached-stats') do
+        # Dalli connects to localhost:11211 by default (may resolve to 127.0.0.1)
+        expect(page).to have_content(':11211')
+      end
+    end
+  end
+
   # Tests for issue #896 - NFS mountpoint info display
   describe 'NFS mountpoint information display' do
     it 'displays source filesystem status separately - Issue896' do


### PR DESCRIPTION
## Summary

Resolves the Dalli binary protocol deprecation warning (#886) by explicitly configuring `protocol: :meta` on all `:mem_cache_store` cache store declarations.

## Changes

- **config/environments/production.rb**: Added `{ protocol: :meta }` to `:mem_cache_store`
- **config/environments/development.rb**: Added `{ protocol: :meta }` to `:mem_cache_store`
- **config/environments/test.rb**: Added `TEST_MEM_CACHE_STORE` env var toggle — when set to `true`, switches from `:memory_store` to `:mem_cache_store` with `protocol: :meta` for integration testing
- **spec/models/cache_store_spec.rb**: New spec verifying cache store type, read/write/delete operations, and absence of deprecation warnings

## Testing

- `bundle exec rspec spec/models/cache_store_spec.rb` — default mode, memcached tests skipped (4 pending, 1 pass)
- `TEST_MEM_CACHE_STORE=true bundle exec rspec spec/models/cache_store_spec.rb` — all 4 Dalli tests pass, no deprecation warning

## Requirements

- memcached 1.6+ (required by the `:meta` protocol)
- Prepares for Dalli 5.0 which removes the binary protocol entirely