### PR TITLE
Add user context to Mounter flag file error messages - resolves #649

### DIFF
--- a/app/models/nfs_store/archive/mounter.rb
+++ b/app/models/nfs_store/archive/mounter.rb
@@ -84,7 +84,7 @@ module NfsStore
           sf.process_new_file
         rescue SystemCallError, IOError => e
           raise_flag_file_error("mount_all for stored file '#{sf&.file_name}' (id: #{sf&.id})",
-                                sf&.retrieval_path, e)
+                                sf&.retrieval_path, e, stored_file: sf)
         end
       end
 
@@ -401,27 +401,48 @@ module NfsStore
       # Raise a descriptive FsException::Action when a flag file operation fails
       # due to a filesystem error (e.g. permission denied, I/O error).
       # The message includes the method name, the flag file path, the original
-      # error details, and a hint about likely causes.
+      # error details, user context, and a hint about likely causes.
       # Defined as a class method so both instance and class methods (e.g. mount_all) can use it.
       # @param method_name [String] the name of the method that failed
       # @param flag_path [String] the path to the flag file that caused the error
       # @param original_error [Exception] the original filesystem error
+      # @param stored_file [NfsStore::Manage::ContainerFile, nil] the stored file associated with the failure
       # @raise [FsException::Action]
-      def self.raise_flag_file_error(method_name, flag_path, original_error)
+      def self.raise_flag_file_error(method_name, flag_path, original_error, stored_file: nil)
         raise FsException::Action,
               "#{method_name} failed for flag file '#{flag_path}': " \
               "#{original_error.class} - #{original_error.message}. " \
+              "#{stored_file_user_context(stored_file)}" \
               'This may indicate a filesystem mount/connection issue, or that the current user ' \
               "does not have access to the container's files through the available roles. " \
               "Original backtrace: #{original_error.short_string_backtrace}"
       end
       private_class_method :raise_flag_file_error
 
+      # Format user context from a stored file for inclusion in error messages.
+      # Returns an empty string if the stored file is nil or context cannot be retrieved.
+      # @param stored_file [NfsStore::Manage::ContainerFile, nil]
+      # @return [String]
+      def self.stored_file_user_context(stored_file)
+        return '' unless stored_file
+
+        cu = stored_file.container&.current_user
+        'Stored file user context - ' \
+          "role_names: #{stored_file.current_user_role_names}, " \
+          "current_user_id: #{cu&.id}, " \
+          "current_user_email: #{cu&.email}, " \
+          "app_type_id: #{cu&.app_type_id}. "
+      rescue StandardError
+        ''
+      end
+      private_class_method :stored_file_user_context
+
       private
 
-      # Instance-level delegate to the class method for convenience
-      def raise_flag_file_error(...)
-        self.class.send(:raise_flag_file_error, ...)
+      # Instance-level delegate to the class method, automatically injecting the stored_file
+      # so all instance rescue blocks include user context without modification
+      def raise_flag_file_error(method_name, flag_path, original_error)
+        self.class.send(:raise_flag_file_error, method_name, flag_path, original_error, stored_file:)
       end
 
       # Extract files from an archive and add them to the database in a single bulk import

--- a/spec/models/nfs_store/archive/mounter_flag_file_errors_spec.rb
+++ b/spec/models/nfs_store/archive/mounter_flag_file_errors_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 # Tests for Issue #911: Improved error handling in NfsStore::Archive::Mounter flag file operations.
+# Updated for Issue #649: Enhanced error messages to include user context (role names,
+# current_user id/email, and app_type_id) from the stored_file associated with the failure.
 #
 # When flag file operations (touch, rm_f, read, write, exist?, mtime) fail due to
 # filesystem errors (e.g. permission denied, I/O errors), the original low-level
@@ -9,6 +11,7 @@
 # - the method name
 # - the flag file path
 # - the original error details
+# - user context (role names, current_user id, email, app_type_id)
 # - a hint about likely causes (filesystem mount issues or role/access problems)
 #
 # These tests use a stubbed stored_file to avoid requiring actual NFS filesystem setup.
@@ -19,11 +22,21 @@ RSpec.describe NfsStore::Archive::Mounter, 'flag file error handling - Issue911'
   let(:fake_archive_path) { '/nfs_store/gid600/containers/test_archive.zip' }
   let(:fake_file_name) { 'test_archive.zip' }
 
+  let(:fake_current_user) do
+    instance_double('User', id: 99, email: 'testuser@example.com', app_type_id: 1)
+  end
+
+  let(:fake_container) do
+    instance_double('NfsStore::Manage::Container', current_user: fake_current_user)
+  end
+
   let(:stored_file) do
     instance_double(
       'NfsStore::Manage::StoredFile',
       retrieval_path: fake_archive_path,
-      file_name: fake_file_name
+      file_name: fake_file_name,
+      container: fake_container,
+      current_user_role_names: %w[file_store_role]
     )
   end
 
@@ -54,6 +67,13 @@ RSpec.describe NfsStore::Archive::Mounter, 'flag file error handling - Issue911'
       expect { subject }.to raise_error(
         FsException::Action,
         %r{filesystem mount/connection issue.*does not have access to the container's files}
+      )
+    end
+
+    it 'includes user context with role names, user id, email and app type id' do
+      expect { subject }.to raise_error(
+        FsException::Action,
+        /Stored file user context.*role_names:.*current_user_id:.*current_user_email:.*app_type_id:/
       )
     end
   end
@@ -221,7 +241,9 @@ RSpec.describe NfsStore::Archive::Mounter, 'flag file error handling - Issue911'
         instance_double(
           'NfsStore::Manage::StoredFile',
           retrieval_path: failed_path,
-          file_name: "#{fake_file_name}#{described_class::FailedArchiveSuffix}"
+          file_name: "#{fake_file_name}#{described_class::FailedArchiveSuffix}",
+          container: fake_container,
+          current_user_role_names: %w[file_store_role]
         )
       end
 
@@ -314,7 +336,9 @@ RSpec.describe NfsStore::Archive::Mounter, 'flag file error handling - Issue911'
         'NfsStore::Manage::StoredFile',
         retrieval_path: fake_archive_path,
         file_name: fake_file_name,
-        id: 42
+        id: 42,
+        container: fake_container,
+        current_user_role_names: %w[file_store_role]
       )
     end
 


### PR DESCRIPTION
## Summary

Enhanced `raise_flag_file_error` in `NfsStore::Archive::Mounter` to include user context (role names, current_user id/email, and app_type_id) in error messages when flag file operations fail due to filesystem errors.

## Changes

### `app/models/nfs_store/archive/mounter.rb`
- Added `stored_file:` keyword argument to `self.raise_flag_file_error` (backwards-compatible, defaults to nil)
- Added `self.stored_file_user_context` private class method that formats user context from a stored file, with a `rescue StandardError` fallback returning empty string
- Updated the instance-level delegate to auto-inject `stored_file:` from the instance — all 9 instance rescue blocks automatically include user context without changes
- Updated the `mount_all` class method call to pass `stored_file: sf`

### `spec/models/nfs_store/archive/mounter_flag_file_errors_spec.rb`
- Added `fake_current_user` and `fake_container` test doubles
- Updated all stored file instance doubles to stub `container` and `current_user_role_names`
- Added shared example asserting user context (role_names, current_user_id, current_user_email, app_type_id) appears in error messages (14 new assertions)
- Updated file header comment to reference issue #649

## Test Results
- **78 examples, 0 failures** (flag file error spec)
- **8 examples, 0 failures** (mounter integration spec)