### PR TITLE
Fixed tracker panel repeated items when expanding a specific protocol - fixes #939

### DIFF
--- a/app/models/master.rb
+++ b/app/models/master.rb
@@ -59,7 +59,7 @@ class Master < ActiveRecord::Base
 
   TrackerEventOrderClause =
     Arel.sql 'protocols.position ASC, event_date DESC NULLS last, trackers.updated_at DESC NULLS last '
-  TrackerHistoryEventOrderClause = Arel.sql 'event_date::date DESC NULLS last, tracker_history.id DESC'
+  TrackerHistoryEventOrderClause = Arel.sql 'event_date DESC NULLS last, tracker_history.id DESC'
   SubjectInfoRankOrderClause = Arel.sql 'rank desc nulls last '
 
   #

--- a/spec/controllers/tracker_histories_controller_spec.rb
+++ b/spec/controllers/tracker_histories_controller_spec.rb
@@ -1,3 +1,10 @@
+# frozen_string_literal: true
+
+# Tests for TrackerHistoriesController, verifying correct ordering of tracker history entries.
+# Tracker histories are ordered by full event_date timestamp DESC, then id DESC.
+# This ensures consistency between the tracker panel (tree view) and the full
+# chronological tracker history, matching the DB upsert trigger's determination
+# of which entry is "latest" for a protocol. See issue #939.
 require 'rails_helper'
 
 RSpec.describe TrackerHistoriesController, type: :controller do
@@ -15,7 +22,7 @@ RSpec.describe TrackerHistoriesController, type: :controller do
 
   describe 'GET #index' do
     context 'when requesting tracker histories for a master' do
-      it 'returns tracker histories ordered by event_date::date DESC, then id DESC' do
+      it 'returns tracker histories ordered by full event_date timestamp DESC, then id DESC' do
         master = create_master
 
         protocol = Classification::Protocol.create!(name: "Test Protocol #{rand(100_000)}", current_admin: @admin)
@@ -24,18 +31,18 @@ RSpec.describe TrackerHistoriesController, type: :controller do
                                                      current_admin: @admin)
 
         # Create trackers with specific dates to test the ordering
-        # Day 1: Two trackers on the same date (different times) - should be ordered by id DESC
+        # Day 1: Two trackers on the same date (different times) - should be ordered by timestamp DESC
         day1_time1 = 3.days.ago.beginning_of_day + 9.hours
         day1_time2 = 3.days.ago.beginning_of_day + 14.hours
 
-        tracker1 = master.trackers.create!(
+        master.trackers.create!(
           protocol_id: protocol.id,
           sub_process_id: sub_process.id,
           event_date: day1_time1,
           notes: 'Day 1 - Morning'
         )
 
-        tracker2 = master.trackers.create!(
+        master.trackers.create!(
           protocol_id: protocol.id,
           sub_process_id: sub_process.id,
           event_date: day1_time2,
@@ -43,7 +50,7 @@ RSpec.describe TrackerHistoriesController, type: :controller do
         )
 
         # Day 2: One tracker
-        tracker3 = master.trackers.create!(
+        master.trackers.create!(
           protocol_id: protocol.id,
           sub_process_id: sub_process.id,
           event_date: 1.day.ago.beginning_of_day + 10.hours,
@@ -66,19 +73,15 @@ RSpec.describe TrackerHistoriesController, type: :controller do
         # Day 2 (most recent date) should come first
         expect(our_histories[0]['notes']).to eq('Day 2 - Single')
 
-        # Day 1 entries should come after, ordered by id DESC (later created first)
-        # tracker2 was created after tracker1, so it should come first
+        # Day 1 entries should come after, ordered by timestamp DESC
+        # Afternoon (14:00) has a later timestamp than Morning (09:00), so it comes first
         expect(our_histories[1]['notes']).to eq('Day 1 - Afternoon')
         expect(our_histories[2]['notes']).to eq('Day 1 - Morning')
-
-        # Verify IDs: within same date, higher ID comes first
-        day1_histories = our_histories.select { |th| th['notes']&.start_with?('Day 1') }
-        expect(day1_histories[0]['id']).to be > day1_histories[1]['id'] if day1_histories.length == 2
       end
     end
 
     context 'when requesting tracker histories for a specific tracker' do
-      it 'returns tracker histories ordered by event_date::date DESC, then id DESC' do
+      it 'returns tracker histories ordered by full event_date timestamp DESC, then id DESC' do
         master = create_master
 
         protocol = Classification::Protocol.create!(name: "Test Protocol #{rand(100_000)}", current_admin: @admin)
@@ -96,7 +99,7 @@ RSpec.describe TrackerHistoriesController, type: :controller do
 
         # Update with different dates to create history entries
         tracker.update!(event_date: 2.days.ago.beginning_of_day + 11.hours, notes: 'Updated to 2 days ago - first')
-        # Create another update on the same date to test id DESC ordering within same date
+        # Create another update on the same date to test ordering within same date
         tracker.update!(event_date: 2.days.ago.beginning_of_day + 15.hours, notes: 'Updated to 2 days ago - second')
         tracker.update!(event_date: 1.day.ago.beginning_of_day + 12.hours, notes: 'Updated to 1 day ago')
 
@@ -110,20 +113,19 @@ RSpec.describe TrackerHistoriesController, type: :controller do
         expect(tracker_histories).to be_an(Array)
         expect(tracker_histories.length).to be >= 4
 
-        # Verify ordering: most recent event_date::date first
-        dates = tracker_histories.map { |th| th['event_date'] ? Date.parse(th['event_date']) : nil }.compact
+        # Verify ordering: full timestamps should be in descending order
+        dates = tracker_histories.map { |th| th['event_date'] ? DateTime.parse(th['event_date']) : nil }.compact
         expect(dates).to eq(dates.sort.reverse)
 
-        # Verify id DESC within same date: find entries from 2 days ago
+        # Verify within same date: entry with later timestamp should come first
         same_date_entries = tracker_histories.select do |th|
           th['notes']&.include?('2 days ago')
         end
 
-        # Within same date, higher ID (later created) should come first
+        # Within same date, the one with the later timestamp (15:00) should come before (11:00)
         if same_date_entries.length == 2
           expect(same_date_entries[0]['notes']).to eq('Updated to 2 days ago - second')
           expect(same_date_entries[1]['notes']).to eq('Updated to 2 days ago - first')
-          expect(same_date_entries[0]['id']).to be > same_date_entries[1]['id']
         end
       end
 
@@ -163,6 +165,67 @@ RSpec.describe TrackerHistoriesController, type: :controller do
         # Verify the first entry from the ordered list is not included
         returned_ids = tracker_histories.map { |th| th['id'] }
         expect(returned_ids).not_to include(first_entry_id)
+      end
+
+      it 'orders tracker history consistently with the tracker panel view (issue #939)' do
+        # Reproduces issue #939: when events share the same date but have
+        # different timestamps, the history ordering should match the
+        # upsert trigger's "latest" determination (full timestamp comparison).
+        master = create_master
+
+        protocol = Classification::Protocol.create!(name: "Test Protocol #{rand(100_000)}", current_admin: @admin)
+        sub_process1 = protocol.sub_processes.create!(name: "Sent #{rand(100_000)}",
+                                                      disabled: false,
+                                                      current_admin: @admin)
+        sub_process2 = protocol.sub_processes.create!(name: "Complete #{rand(100_000)}",
+                                                      disabled: false,
+                                                      current_admin: @admin)
+
+        event_day = 2.days.ago.beginning_of_day
+
+        # Create entries with timestamps that don't match their insertion order
+        # Entry 1: event_date 08:00 (earliest timestamp, lowest ID)
+        master.trackers.create!(
+          protocol_id: protocol.id,
+          sub_process_id: sub_process1.id,
+          event_date: event_day + 8.hours,
+          notes: 'Sent, Invitation Email'
+        )
+
+        # Entry 2: event_date 09:00 (middle timestamp, middle ID)
+        master.trackers.create!(
+          protocol_id: protocol.id,
+          sub_process_id: sub_process1.id,
+          event_date: event_day + 9.hours,
+          notes: 'Sent, Marketo Email'
+        )
+
+        # Entry 3: event_date 15:00 (latest timestamp, highest ID)
+        master.trackers.create!(
+          protocol_id: protocol.id,
+          sub_process_id: sub_process2.id,
+          event_date: event_day + 15.hours,
+          notes: 'Complete, Redcap'
+        )
+
+        # The tracker panel (upsert trigger) should show 'Complete, Redcap'
+        # as the current entry for this protocol (latest by timestamp)
+        current_tracker = master.trackers.where(protocol_id: protocol.id).first
+        expect(current_tracker.notes).to eq('Complete, Redcap')
+
+        # The full history should be ordered by timestamp DESC,
+        # matching the tracker panel's view
+        get :index, params: { master_id: master.id, tracker_id: current_tracker.id }
+
+        json_response = JSON.parse(response.body)
+        tracker_histories = json_response['tracker_histories']
+
+        our_histories = tracker_histories.select { |th| th['notes']&.match?(/Sent|Complete/) }
+
+        # Verify order matches the tracker panel: latest timestamp first
+        expect(our_histories[0]['notes']).to eq('Complete, Redcap')
+        expect(our_histories[1]['notes']).to eq('Sent, Marketo Email')
+        expect(our_histories[2]['notes']).to eq('Sent, Invitation Email')
       end
     end
   end

--- a/spec/models/tracker_spec.rb
+++ b/spec/models/tracker_spec.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
+# Tests for the Tracker model, covering creation, validation, upsert merging,
+# completions, and tracker_histories association ordering.
+# The ordering tests verify that tracker histories are sorted by full event_date
+# timestamp DESC (not date-only), then id DESC, ensuring consistency between
+# the tracker panel view and the DB upsert trigger's ordering. See issue #939.
 require 'rails_helper'
 
 RSpec.describe Tracker, type: :model do
   include MasterSupport
   include ModelSupport
+
   before(:each) do
     create_user
     create_admin
@@ -95,56 +101,100 @@ RSpec.describe Tracker, type: :model do
   end
 
   describe 'tracker_histories association' do
-    it 'orders tracker histories by event_date::date DESC, then id DESC' do
+    it 'orders tracker histories by full event_date timestamp DESC, then id DESC' do
       master = create_master
-      
+
       # Create multiple tracker entries to test the ordering
       # Day 1: Two entries on the same date (different times)
       day1_time1 = 3.days.ago.beginning_of_day + 9.hours
       day1_time2 = 3.days.ago.beginning_of_day + 14.hours
-      
-      tracker1 = master.trackers.create!(
+
+      master.trackers.create!(
         protocol_id: @p1.id,
         sub_process_id: @sp1_1.id,
         event_date: day1_time1,
         notes: 'Day 1 - Morning'
       )
-      
-      tracker2 = master.trackers.create!(
+
+      master.trackers.create!(
         protocol_id: @p1.id,
         sub_process_id: @sp1_1.id,
         event_date: day1_time2,
         notes: 'Day 1 - Afternoon'
       )
-      
+
       # Day 2: One entry (most recent date)
-      tracker3 = master.trackers.create!(
+      master.trackers.create!(
         protocol_id: @p1.id,
         sub_process_id: @sp1_1.id,
         event_date: 1.day.ago.beginning_of_day + 10.hours,
         notes: 'Day 2 - Single'
       )
-      
+
       # Get tracker histories via the association
       histories = master.tracker_histories.to_a
-      
+
       expect(histories.length).to be >= 3
-      
+
       # Find our test histories
       our_histories = histories.select { |h| h.notes&.start_with?('Day') }
-      
+
       # Day 2 (most recent date) should come first
       expect(our_histories[0].notes).to eq('Day 2 - Single')
-      
-      # Day 1 entries should follow, ordered by id DESC within the same date
-      # tracker2 was created after tracker1, so it should come first
+
+      # Day 1 entries should follow, ordered by full timestamp DESC
+      # The Afternoon entry (14:00) has a later timestamp than Morning (09:00), so it comes first
       day1_histories = our_histories.select { |h| h.notes&.start_with?('Day 1') }
       expect(day1_histories.length).to eq(2)
       expect(day1_histories[0].notes).to eq('Day 1 - Afternoon')
       expect(day1_histories[1].notes).to eq('Day 1 - Morning')
-      
-      # Verify within same date, higher ID comes first
-      expect(day1_histories[0].id).to be > day1_histories[1].id
+    end
+
+    it 'orders consistently with the tracker upsert trigger when events share the same date' do
+      # This test verifies issue #939: the tracker panel and full tracker history
+      # should show items in the same order. The upsert trigger determines "latest"
+      # using the full event_date timestamp, so the history ordering must also
+      # use the full timestamp to be consistent.
+      master = create_master
+
+      # Insert an entry with an earlier timestamp first (gets a lower ID)
+      master.trackers.create!(
+        protocol_id: @p1.id,
+        sub_process_id: @sp1_1.id,
+        event_date: 2.days.ago.beginning_of_day + 9.hours,
+        notes: 'Sent, Marketo Email'
+      )
+
+      # Insert an entry with a later timestamp second (gets a higher ID)
+      master.trackers.create!(
+        protocol_id: @p1.id,
+        sub_process_id: @sp1_1.id,
+        event_date: 2.days.ago.beginning_of_day + 15.hours,
+        notes: 'Complete, Redcap'
+      )
+
+      # Insert another entry with a different earlier timestamp (gets a yet higher ID)
+      master.trackers.create!(
+        protocol_id: @p1.id,
+        sub_process_id: @sp1_1.id,
+        event_date: 2.days.ago.beginning_of_day + 8.hours,
+        notes: 'Sent, Invitation Email'
+      )
+
+      histories = master.tracker_histories.to_a
+      our_histories = histories.select { |h| h.notes&.match?(/Sent|Complete/) }
+
+      # The tracker upsert trigger uses full timestamp ordering.
+      # The history should match: 'Complete, Redcap' (15:00) first,
+      # then 'Sent, Marketo Email' (09:00), then 'Sent, Invitation Email' (08:00).
+      expect(our_histories[0].notes).to eq('Complete, Redcap')
+      expect(our_histories[1].notes).to eq('Sent, Marketo Email')
+      expect(our_histories[2].notes).to eq('Sent, Invitation Email')
+
+      # The current top tracker entry (determined by upsert trigger) should be
+      # the same as the first item in the history
+      current_tracker = master.trackers.where(protocol_id: @p1.id).first
+      expect(current_tracker.notes).to eq('Complete, Redcap')
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes the tracker panel showing items in an inconsistent order when expanding a specific protocol's history, when multiple events share the same calendar date but have different timestamps.

## Root Cause

The `TrackerHistoryEventOrderClause` used `event_date::date DESC` which cast the timestamp to date-only, losing the time component. Within the same day, ordering fell back to `id DESC`. But the DB upsert trigger (which determines the "latest" tracker entry for the panel view) uses the full timestamp. This mismatch caused the two views to disagree on ordering.

## Fix

Removed the `::date` cast from the ordering clause so the full timestamp is used:
- **Before:** `event_date::date DESC NULLS last, tracker_history.id DESC`
- **After:** `event_date DESC NULLS last, tracker_history.id DESC`

## Changes

- **app/models/master.rb** — Removed `::date` cast from `TrackerHistoryEventOrderClause`
- **spec/models/tracker_spec.rb** — Updated ordering tests; added test reproducing issue #939 scenario
- **spec/controllers/tracker_histories_controller_spec.rb** — Updated ordering tests; added test reproducing issue #939 scenario

## Testing

All 12 tracker specs pass. RuboCop clean.