### PR TITLE
Implement case save trigger with when/then/else branching - fixes #944

### DIFF
--- a/app/models/admin/defs/extra_options_defs.yaml
+++ b/app/models/admin/defs/extra_options_defs.yaml
@@ -529,6 +529,9 @@
       - reload_this:
 #!defs(save_triggers_reload_this_options_defs.yaml)
 
+      - case:
+#!defs(save_triggers_case_options_defs.yaml)
+
       - each:
           value: # list of literal values, triple curly substitution returning a list, or hash conditional result returning a list
           do:

--- a/app/models/admin/defs/save_triggers_case_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_case_options_defs.yaml
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+#
+# YAML definition for case save trigger options
+# Used by admin panel to display configuration options
+#
+_save_triggers_case_options:
+  case: &st_case
+    - array of when/then/else branches for conditional trigger execution
+    - evaluates when conditions in order, executes the first matching then block
+    - e.g. |-
+        save_trigger:
+          on_create:
+            case:
+              - when:
+                  all:
+                    this:
+                      field1: value 1
+                then:
+                  - log:
+                      message: Matched value 1
+                  - create_reference:
+                      model_name:
+                        in: master
+              - when:
+                  all:
+                    this:
+                      field1: value 2
+                then:
+                  - update_reference:
+                      model_name:
+                        in: master
+                  - log:
+                      message: Matched value 2
+              - else:
+                  - notify:
+                      type: email
+                      role: data_coordinator
+                      subject: "No condition matched"
+    - |
+      Implements conditional branching for save triggers, similar to a
+      case/switch statement in programming.
+
+      Each branch is evaluated in order:
+      - **when:** contains a conditional expression (same format as
+        showable_if, editable_if, etc.) that is evaluated against the
+        current item
+      - **then:** contains an array of save triggers to execute if the
+        when condition is true
+      - **else:** (optional, must be last) contains an array of save triggers
+        to execute if no when condition matched
+
+      Only the first matching branch executes. If no when condition matches
+      and no else branch is provided, no triggers run.
+
+      This is useful when different actions should be taken based on field
+      values, avoiding the need for multiple identical `if:` conditions on
+      individual triggers.

--- a/app/models/admin/defs/save_triggers_case_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_case_options_defs.yaml
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 #
 # YAML definition for case save trigger options
 # Used by admin panel to display configuration options

--- a/app/models/option_configs/extra_option_implementers/save_triggers.rb
+++ b/app/models/option_configs/extra_option_implementers/save_triggers.rb
@@ -22,7 +22,8 @@ module OptionConfigs
                              log
                              transaction
                              background
-                             reload_this].freeze
+                             reload_this
+                             case].freeze
 
       class_methods do
         #

--- a/app/models/save_triggers/background.rb
+++ b/app/models/save_triggers/background.rb
@@ -54,10 +54,7 @@ class SaveTriggers::Background < SaveTriggers::SaveTriggersBase
       queued_at: Time.current
     }
 
-    # Store results for potential use by subsequent triggers
-    if @item.respond_to?(:save_trigger_results) && @item.save_trigger_results
-      @item.save_trigger_results['background'] = result
-    end
+    store_trigger_results('background', result)
 
     result
   end

--- a/app/models/save_triggers/case.rb
+++ b/app/models/save_triggers/case.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+#
+# Save trigger that implements case/when/else conditional branching.
+# Evaluates when conditions in order and executes the triggers associated
+# with the first matching condition. If no conditions match, executes
+# the else block if present.
+#
+# Example configuration:
+#   save_trigger:
+#     on_create:
+#       case:
+#         - when:
+#             all:
+#               this:
+#                 field1: value 1
+#           then:
+#             - log:
+#                 message: Matched value 1
+#             - create_reference: ...
+#         - when:
+#             all:
+#               this:
+#                 field1: value 2
+#           then:
+#             - update_reference: ...
+#             - log:
+#                 message: Matched value 2
+#         - else:
+#             - notify: ...
+#
+class SaveTriggers::Case < SaveTriggers::SaveTriggersBase
+  def initialize(config, item)
+    super
+
+    @case_configs = config
+  end
+
+  def perform
+    branches = @case_configs
+    branches = [branches] unless branches.is_a?(Array)
+
+    results = []
+
+    branches.each do |branch|
+      next unless branch.is_a?(Hash)
+
+      if branch.key?(:when)
+        # Evaluate the when condition using ConditionalActions
+        ca = ConditionalActions.new(branch[:when], @item)
+        next unless ca.calc_action_if
+
+        # Condition matched — execute the then triggers
+        results = execute_triggers(branch[:then])
+        break
+      elsif branch.key?(:else)
+        # No when matched before this — execute else triggers
+        results = execute_triggers(branch[:else])
+        break
+      end
+    end
+
+    Rails.logger.info "[SaveTrigger::Case] Completed with #{results.length} trigger results"
+
+    # Store results for potential use by subsequent triggers
+    if @item.respond_to?(:save_trigger_results) && @item.save_trigger_results
+      @item.save_trigger_results['case'] = results
+    end
+
+    results
+  end
+
+  private
+
+  #
+  # Execute an array of trigger configurations
+  # @param [Array<Hash>] trigger_list - list of trigger configs to execute
+  # @return [Array<Hash>] results from each trigger
+  def execute_triggers(trigger_list)
+    return [] unless trigger_list
+
+    trigger_list = [trigger_list] unless trigger_list.is_a?(Array)
+    results = []
+
+    trigger_list.each do |trigger_config|
+      next unless trigger_config.is_a?(Hash)
+
+      trigger_config.each do |trigger_name, config|
+        trigger_name = trigger_name.to_sym
+        klass = ::SaveTriggers.const_get(trigger_name.to_s.camelize)
+        trigger = klass.new(config, @item)
+        result = trigger.perform
+        results << { trigger: trigger_name, result: }
+      end
+    end
+
+    results
+  end
+end

--- a/app/models/save_triggers/case.rb
+++ b/app/models/save_triggers/case.rb
@@ -40,32 +40,10 @@ class SaveTriggers::Case < SaveTriggers::SaveTriggersBase
     branches = @case_configs
     branches = [branches] unless branches.is_a?(Array)
 
-    results = []
-
-    branches.each do |branch|
-      next unless branch.is_a?(Hash)
-
-      if branch.key?(:when)
-        # Evaluate the when condition using ConditionalActions
-        ca = ConditionalActions.new(branch[:when], @item)
-        next unless ca.calc_action_if
-
-        # Condition matched — execute the then triggers
-        results = execute_triggers(branch[:then])
-        break
-      elsif branch.key?(:else)
-        # No when matched before this — execute else triggers
-        results = execute_triggers(branch[:else])
-        break
-      end
-    end
+    results = evaluate_branches(branches)
 
     Rails.logger.info "[SaveTrigger::Case] Completed with #{results.length} trigger results"
-
-    # Store results for potential use by subsequent triggers
-    if @item.respond_to?(:save_trigger_results) && @item.save_trigger_results
-      @item.save_trigger_results['case'] = results
-    end
+    store_trigger_results('case', results)
 
     results
   end
@@ -73,27 +51,23 @@ class SaveTriggers::Case < SaveTriggers::SaveTriggersBase
   private
 
   #
-  # Execute an array of trigger configurations
-  # @param [Array<Hash>] trigger_list - list of trigger configs to execute
-  # @return [Array<Hash>] results from each trigger
-  def execute_triggers(trigger_list)
-    return [] unless trigger_list
+  # Iterate through branches, evaluating when conditions and executing
+  # the first matching branch's then triggers, or the else triggers.
+  # @param [Array<Hash>] branches - ordered list of when/then or else branches
+  # @return [Array<Hash>] results from the executed triggers
+  def evaluate_branches(branches)
+    branches.each do |branch|
+      next unless branch.is_a?(Hash)
 
-    trigger_list = [trigger_list] unless trigger_list.is_a?(Array)
-    results = []
+      if branch.key?(:when)
+        next unless if_evaluates(branch[:when])
 
-    trigger_list.each do |trigger_config|
-      next unless trigger_config.is_a?(Hash)
-
-      trigger_config.each do |trigger_name, config|
-        trigger_name = trigger_name.to_sym
-        klass = ::SaveTriggers.const_get(trigger_name.to_s.camelize)
-        trigger = klass.new(config, @item)
-        result = trigger.perform
-        results << { trigger: trigger_name, result: }
+        return execute_trigger_list(branch[:then])
+      elsif branch.key?(:else)
+        return execute_trigger_list(branch[:else])
       end
     end
 
-    results
+    []
   end
 end

--- a/app/models/save_triggers/save_triggers_base.rb
+++ b/app/models/save_triggers/save_triggers_base.rb
@@ -125,5 +125,45 @@ class SaveTriggers::SaveTriggersBase
     end
   end
 
+  #
+  # Execute an array of trigger configurations sequentially.
+  # Each trigger config is a Hash like { trigger_name: config_hash }.
+  # Trigger names are validated through the central ValidSaveTriggers registry.
+  # @param [Array<Hash>] trigger_list - list of trigger configs to execute
+  # @param [Array<Symbol>] skip_keys - keys to skip (e.g. :if)
+  # @return [Array<Hash>] results from each trigger as { trigger:, result: }
+  def execute_trigger_list(trigger_list, skip_keys: [])
+    return [] unless trigger_list
+
+    trigger_list = [trigger_list] unless trigger_list.is_a?(Array)
+    results = []
+
+    trigger_list.each do |trigger_config|
+      next unless trigger_config.is_a?(Hash)
+
+      trigger_config.each do |trigger_name, config|
+        trigger_name = trigger_name.to_sym
+        next if skip_keys.include?(trigger_name)
+
+        klass = OptionConfigs::ExtraOptions.trigger_class(trigger_name)
+        trigger = klass.new(config, @item)
+        result = trigger.perform
+        results << { trigger: trigger_name, result: }
+      end
+    end
+
+    results
+  end
+
+  #
+  # Store trigger results on the item for use by subsequent triggers
+  # @param [String] key - the result key (e.g. 'case', 'transaction')
+  # @param [Object] results - the results to store
+  def store_trigger_results(key, results)
+    return unless @item.respond_to?(:save_trigger_results) && @item.save_trigger_results
+
+    @item.save_trigger_results[key] = results
+  end
+
   def self.config_def(if_extras: nil); end
 end

--- a/app/models/save_triggers/transaction.rb
+++ b/app/models/save_triggers/transaction.rb
@@ -27,36 +27,17 @@ class SaveTriggers::Transaction < SaveTriggers::SaveTriggersBase
   end
 
   def perform
-    # The config should be an array of trigger configurations
     triggers = @trigger_configs
     triggers = [triggers] unless triggers.is_a?(Array)
 
     results = []
 
     @item.transaction do
-      triggers.each do |trigger_config|
-        next unless trigger_config.is_a?(Hash)
-
-        trigger_config.each do |trigger_name, config|
-          trigger_name = trigger_name.to_sym
-          # Skip non-trigger keys like 'if'
-          next if trigger_name == :if
-
-          # Get the trigger class and execute it
-          klass = ::SaveTriggers.const_get(trigger_name.to_s.camelize)
-          trigger = klass.new(config, @item)
-          result = trigger.perform
-          results << { trigger: trigger_name, result: }
-        end
-      end
+      results = execute_trigger_list(triggers, skip_keys: [:if])
     end
 
     Rails.logger.info "[SaveTrigger::Transaction] Completed #{results.length} triggers successfully"
-
-    # Store results for potential use by subsequent triggers
-    if @item.respond_to?(:save_trigger_results) && @item.save_trigger_results
-      @item.save_trigger_results['transaction'] = results
-    end
+    store_trigger_results('transaction', results)
 
     results
   rescue StandardError => e

--- a/app/models/tracker.rb
+++ b/app/models/tracker.rb
@@ -34,6 +34,10 @@ class Tracker < UserBase
   include UserHandler
   include TrackerHandler
 
+  # Explicitly set primary key since trackers is now a view
+  # and Rails cannot auto-detect the primary key from views
+  self.primary_key = 'id'
+
   has_many :tracker_histories, inverse_of: :tracker
   belongs_to :item, polymorphic: true, optional: true
 

--- a/spec/models/save_triggers/case_spec.rb
+++ b/spec/models/save_triggers/case_spec.rb
@@ -93,6 +93,31 @@ RSpec.describe SaveTriggers::Case, type: :model do
 
         expect(result).to be_present
       end
+
+      it 'executes multiple triggers in the then block - Issue #944' do
+        config = [
+          {
+            when: {
+              all: {
+                this: {
+                  select_call_direction: 'to player'
+                }
+              }
+            },
+            then: [
+              { log: { message: 'First then trigger', severity: 'info' } },
+              { log: { message: 'Second then trigger', severity: 'debug' } }
+            ]
+          }
+        ]
+
+        trigger = SaveTriggers::Case.new(config, @activity_log)
+        result = trigger.perform
+
+        expect(result.length).to eq(2)
+        expect(result[0][:trigger]).to eq(:log)
+        expect(result[1][:trigger]).to eq(:log)
+      end
     end
 
     context 'when multiple when conditions could match' do
@@ -120,6 +145,43 @@ RSpec.describe SaveTriggers::Case, type: :model do
             },
             then: [
               { log: { message: 'Second match should not run', severity: 'info' } }
+            ]
+          }
+        ]
+
+        trigger = SaveTriggers::Case.new(config, @activity_log)
+        result = trigger.perform
+
+        expect(result.length).to eq(1)
+        expect(result.first[:trigger]).to eq(:log)
+      end
+    end
+
+    context 'when the first when does not match but the second does' do
+      it 'skips the first and executes the second when block - Issue #944' do
+        config = [
+          {
+            when: {
+              all: {
+                this: {
+                  select_call_direction: 'from player'
+                }
+              }
+            },
+            then: [
+              { log: { message: 'First branch - should not run', severity: 'info' } }
+            ]
+          },
+          {
+            when: {
+              all: {
+                this: {
+                  select_who: 'user'
+                }
+              }
+            },
+            then: [
+              { log: { message: 'Second branch matched', severity: 'info' } }
             ]
           }
         ]
@@ -160,6 +222,34 @@ RSpec.describe SaveTriggers::Case, type: :model do
         expect(result.length).to eq(1)
         expect(result.first[:trigger]).to eq(:log)
       end
+
+      it 'does not execute else when a when condition matched - Issue #944' do
+        config = [
+          {
+            when: {
+              all: {
+                this: {
+                  select_call_direction: 'to player'
+                }
+              }
+            },
+            then: [
+              { log: { message: 'Matched branch', severity: 'info' } }
+            ]
+          },
+          {
+            else: [
+              { log: { message: 'Should not reach else', severity: 'info' } }
+            ]
+          }
+        ]
+
+        trigger = SaveTriggers::Case.new(config, @activity_log)
+        result = trigger.perform
+
+        # Only one trigger result from the matched when, not from else
+        expect(result.length).to eq(1)
+      end
     end
 
     context 'when no when condition matches and no else is present' do
@@ -178,6 +268,17 @@ RSpec.describe SaveTriggers::Case, type: :model do
             ]
           }
         ]
+
+        trigger = SaveTriggers::Case.new(config, @activity_log)
+        result = trigger.perform
+
+        expect(result).to eq([])
+      end
+    end
+
+    context 'with empty config' do
+      it 'handles empty array gracefully - Issue #944' do
+        config = []
 
         trigger = SaveTriggers::Case.new(config, @activity_log)
         result = trigger.perform
@@ -210,6 +311,202 @@ RSpec.describe SaveTriggers::Case, type: :model do
         expect(@activity_log.save_trigger_results['case'].length).to eq(1)
         expect(@activity_log.save_trigger_results['case'].first[:trigger]).to eq(:log)
       end
+
+      it 'stores empty results when no branch matched - Issue #944' do
+        config = [
+          {
+            when: {
+              all: {
+                this: {
+                  select_call_direction: 'from player'
+                }
+              }
+            },
+            then: [
+              { log: { message: 'Will not match', severity: 'info' } }
+            ]
+          }
+        ]
+
+        trigger = SaveTriggers::Case.new(config, @activity_log)
+        trigger.perform
+
+        expect(@activity_log.save_trigger_results['case']).to eq([])
+      end
+    end
+  end
+
+  describe 'integration with save_trigger config' do
+    it 'runs case trigger as part of on_create save_trigger - Issue #944' do
+      al_def = ActivityLog.find_by(id: ActivityLog::PlayerContactPhone.definition.id)
+
+      al_def.extra_log_types = <<~END_DEF
+        case_test:
+          label: Case Test
+          fields:
+            - select_call_direction
+            - select_who
+          save_trigger:
+            on_create:
+              case:
+                - when:
+                    all:
+                      this:
+                        select_call_direction: 'to player'
+                  then:
+                    - update_this:
+                        one:
+                          with:
+                            select_who: 'matched to player'
+                - when:
+                    all:
+                      this:
+                        select_call_direction: 'from player'
+                  then:
+                    - update_this:
+                        one:
+                          with:
+                            select_who: 'matched from player'
+                - else:
+                    - update_this:
+                        one:
+                          with:
+                            select_who: 'no match - else'
+      END_DEF
+
+      al_def.current_admin = @admin
+      al_def.force_regenerate = true
+      al_def.updated_at = DateTime.now
+      al_def.save!
+      ActivityLog.refresh_outdated
+      al_def.reload
+      al_def.force_option_config_parse
+
+      setup_access :activity_log__player_contact_phone__case_test,
+                   resource_type: :activity_log_type, access: :create, user: @user
+
+      al_def.add_master_association
+
+      al = @master.activity_log__player_contact_phones.create!(
+        select_call_direction: 'to player',
+        select_who: 'original',
+        extra_log_type: 'case_test',
+        player_contact: @player_contact,
+        master: @master,
+        current_user: @user
+      )
+
+      expect(al.select_who).to eq 'matched to player'
+    end
+
+    it 'runs else branch when no when matches in save_trigger - Issue #944' do
+      al_def = ActivityLog.find_by(id: ActivityLog::PlayerContactPhone.definition.id)
+
+      al_def.extra_log_types = <<~END_DEF
+        case_else_test:
+          label: Case Else Test
+          fields:
+            - select_call_direction
+            - select_who
+          save_trigger:
+            on_create:
+              case:
+                - when:
+                    all:
+                      this:
+                        select_call_direction: 'something else'
+                  then:
+                    - update_this:
+                        one:
+                          with:
+                            select_who: 'should not match'
+                - else:
+                    - update_this:
+                        one:
+                          with:
+                            select_who: 'fell through to else'
+      END_DEF
+
+      al_def.current_admin = @admin
+      al_def.force_regenerate = true
+      al_def.updated_at = DateTime.now
+      al_def.save!
+      ActivityLog.refresh_outdated
+      al_def.reload
+      al_def.force_option_config_parse
+
+      setup_access :activity_log__player_contact_phone__case_else_test,
+                   resource_type: :activity_log_type, access: :create, user: @user
+
+      al_def.add_master_association
+
+      al = @master.activity_log__player_contact_phones.create!(
+        select_call_direction: 'to player',
+        select_who: 'original',
+        extra_log_type: 'case_else_test',
+        player_contact: @player_contact,
+        master: @master,
+        current_user: @user
+      )
+
+      expect(al.select_who).to eq 'fell through to else'
+    end
+
+    it 'runs second when branch in save_trigger - Issue #944' do
+      al_def = ActivityLog.find_by(id: ActivityLog::PlayerContactPhone.definition.id)
+
+      al_def.extra_log_types = <<~END_DEF
+        case_second_test:
+          label: Case Second Test
+          fields:
+            - select_call_direction
+            - select_who
+          save_trigger:
+            on_create:
+              case:
+                - when:
+                    all:
+                      this:
+                        select_call_direction: 'something else'
+                  then:
+                    - update_this:
+                        one:
+                          with:
+                            select_who: 'first branch'
+                - when:
+                    all:
+                      this:
+                        select_call_direction: 'from player'
+                  then:
+                    - update_this:
+                        one:
+                          with:
+                            select_who: 'second branch matched'
+      END_DEF
+
+      al_def.current_admin = @admin
+      al_def.force_regenerate = true
+      al_def.updated_at = DateTime.now
+      al_def.save!
+      ActivityLog.refresh_outdated
+      al_def.reload
+      al_def.force_option_config_parse
+
+      setup_access :activity_log__player_contact_phone__case_second_test,
+                   resource_type: :activity_log_type, access: :create, user: @user
+
+      al_def.add_master_association
+
+      al = @master.activity_log__player_contact_phones.create!(
+        select_call_direction: 'from player',
+        select_who: 'original',
+        extra_log_type: 'case_second_test',
+        player_contact: @player_contact,
+        master: @master,
+        current_user: @user
+      )
+
+      expect(al.select_who).to eq 'second branch matched'
     end
   end
 

--- a/spec/models/save_triggers/case_spec.rb
+++ b/spec/models/save_triggers/case_spec.rb
@@ -107,22 +107,41 @@ RSpec.describe SaveTriggers::Case, type: :model do
     )
   end
 
+  #
+  # Build a when/then branch for a case config.
+  # @param [Symbol] field - the field to match against
+  # @param [String] value - the expected value
+  # @param [Array<Hash>] triggers - trigger configs to execute on match
+  # @return [Hash] a when/then branch hash
+  def when_branch(field, value, triggers)
+    {
+      when: { all: { this: { field => value } } },
+      then: triggers
+    }
+  end
+
+  #
+  # Build an else branch for a case config.
+  # @param [Array<Hash>] triggers - trigger configs to execute
+  # @return [Hash] an else branch hash
+  def else_branch(triggers)
+    { else: triggers }
+  end
+
+  #
+  # Build a log trigger config.
+  # @param [String] message - the log message
+  # @param [String] severity - log severity level (default: 'info')
+  # @return [Hash] a log trigger config
+  def log_trigger(message, severity: 'info')
+    { log: { message:, severity: } }
+  end
+
   describe '#perform' do
     context 'when a when condition matches' do
       it 'executes the then triggers for the first matching when block - Issue #944' do
         config = [
-          {
-            when: {
-              all: {
-                this: {
-                  select_call_direction: 'to player'
-                }
-              }
-            },
-            then: [
-              { log: { message: 'Matched to player', severity: 'info' } }
-            ]
-          }
+          when_branch(:select_call_direction, 'to player', [log_trigger('Matched to player')])
         ]
 
         trigger = SaveTriggers::Case.new(config, @activity_log)
@@ -137,19 +156,10 @@ RSpec.describe SaveTriggers::Case, type: :model do
 
       it 'executes multiple triggers in the then block - Issue #944' do
         config = [
-          {
-            when: {
-              all: {
-                this: {
-                  select_call_direction: 'to player'
-                }
-              }
-            },
-            then: [
-              { log: { message: 'First then trigger', severity: 'info' } },
-              { log: { message: 'Second then trigger', severity: 'debug' } }
-            ]
-          }
+          when_branch(:select_call_direction, 'to player', [
+                        log_trigger('First then trigger'),
+                        log_trigger('Second then trigger', severity: 'debug')
+                      ])
         ]
 
         trigger = SaveTriggers::Case.new(config, @activity_log)
@@ -164,30 +174,8 @@ RSpec.describe SaveTriggers::Case, type: :model do
     context 'when multiple when conditions could match' do
       it 'executes only the first matching when block - Issue #944' do
         config = [
-          {
-            when: {
-              all: {
-                this: {
-                  select_call_direction: 'to player'
-                }
-              }
-            },
-            then: [
-              { log: { message: 'First match', severity: 'info' } }
-            ]
-          },
-          {
-            when: {
-              all: {
-                this: {
-                  select_who: 'user'
-                }
-              }
-            },
-            then: [
-              { log: { message: 'Second match should not run', severity: 'info' } }
-            ]
-          }
+          when_branch(:select_call_direction, 'to player', [log_trigger('First match')]),
+          when_branch(:select_who, 'user', [log_trigger('Second match should not run')])
         ]
 
         trigger = SaveTriggers::Case.new(config, @activity_log)
@@ -201,30 +189,8 @@ RSpec.describe SaveTriggers::Case, type: :model do
     context 'when the first when does not match but the second does' do
       it 'skips the first and executes the second when block - Issue #944' do
         config = [
-          {
-            when: {
-              all: {
-                this: {
-                  select_call_direction: 'from player'
-                }
-              }
-            },
-            then: [
-              { log: { message: 'First branch - should not run', severity: 'info' } }
-            ]
-          },
-          {
-            when: {
-              all: {
-                this: {
-                  select_who: 'user'
-                }
-              }
-            },
-            then: [
-              { log: { message: 'Second branch matched', severity: 'info' } }
-            ]
-          }
+          when_branch(:select_call_direction, 'from player', [log_trigger('First branch - should not run')]),
+          when_branch(:select_who, 'user', [log_trigger('Second branch matched')])
         ]
 
         trigger = SaveTriggers::Case.new(config, @activity_log)
@@ -238,23 +204,8 @@ RSpec.describe SaveTriggers::Case, type: :model do
     context 'when no when condition matches and else is present' do
       it 'executes the else triggers - Issue #944' do
         config = [
-          {
-            when: {
-              all: {
-                this: {
-                  select_call_direction: 'from player'
-                }
-              }
-            },
-            then: [
-              { log: { message: 'Should not match', severity: 'info' } }
-            ]
-          },
-          {
-            else: [
-              { log: { message: 'Fell through to else', severity: 'info' } }
-            ]
-          }
+          when_branch(:select_call_direction, 'from player', [log_trigger('Should not match')]),
+          else_branch([log_trigger('Fell through to else')])
         ]
 
         trigger = SaveTriggers::Case.new(config, @activity_log)
@@ -266,23 +217,8 @@ RSpec.describe SaveTriggers::Case, type: :model do
 
       it 'does not execute else when a when condition matched - Issue #944' do
         config = [
-          {
-            when: {
-              all: {
-                this: {
-                  select_call_direction: 'to player'
-                }
-              }
-            },
-            then: [
-              { log: { message: 'Matched branch', severity: 'info' } }
-            ]
-          },
-          {
-            else: [
-              { log: { message: 'Should not reach else', severity: 'info' } }
-            ]
-          }
+          when_branch(:select_call_direction, 'to player', [log_trigger('Matched branch')]),
+          else_branch([log_trigger('Should not reach else')])
         ]
 
         trigger = SaveTriggers::Case.new(config, @activity_log)
@@ -296,18 +232,7 @@ RSpec.describe SaveTriggers::Case, type: :model do
     context 'when no when condition matches and no else is present' do
       it 'returns empty results - Issue #944' do
         config = [
-          {
-            when: {
-              all: {
-                this: {
-                  select_call_direction: 'from player'
-                }
-              }
-            },
-            then: [
-              { log: { message: 'Should not run', severity: 'info' } }
-            ]
-          }
+          when_branch(:select_call_direction, 'from player', [log_trigger('Should not run')])
         ]
 
         trigger = SaveTriggers::Case.new(config, @activity_log)
@@ -319,9 +244,7 @@ RSpec.describe SaveTriggers::Case, type: :model do
 
     context 'with empty config' do
       it 'handles empty array gracefully - Issue #944' do
-        config = []
-
-        trigger = SaveTriggers::Case.new(config, @activity_log)
+        trigger = SaveTriggers::Case.new([], @activity_log)
         result = trigger.perform
 
         expect(result).to eq([])
@@ -331,18 +254,7 @@ RSpec.describe SaveTriggers::Case, type: :model do
     context 'storing results' do
       it 'stores results in save_trigger_results - Issue #944' do
         config = [
-          {
-            when: {
-              all: {
-                this: {
-                  select_call_direction: 'to player'
-                }
-              }
-            },
-            then: [
-              { log: { message: 'Stored result test', severity: 'info' } }
-            ]
-          }
+          when_branch(:select_call_direction, 'to player', [log_trigger('Stored result test')])
         ]
 
         trigger = SaveTriggers::Case.new(config, @activity_log)
@@ -355,18 +267,7 @@ RSpec.describe SaveTriggers::Case, type: :model do
 
       it 'stores empty results when no branch matched - Issue #944' do
         config = [
-          {
-            when: {
-              all: {
-                this: {
-                  select_call_direction: 'from player'
-                }
-              }
-            },
-            then: [
-              { log: { message: 'Will not match', severity: 'info' } }
-            ]
-          }
+          when_branch(:select_call_direction, 'from player', [log_trigger('Will not match')])
         ]
 
         trigger = SaveTriggers::Case.new(config, @activity_log)

--- a/spec/models/save_triggers/case_spec.rb
+++ b/spec/models/save_triggers/case_spec.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+# Tests for SaveTriggers::Case - Issue #944
+# Implements a case/when/else save trigger block that evaluates conditions
+# and executes the triggers associated with the first matching condition,
+# or an else block if no conditions match.
+# This is similar to the transaction save trigger block but adds
+# conditional branching logic.
+
+require 'rails_helper'
+
+RSpec.describe SaveTriggers::Case, type: :model do
+  include ModelSupport
+  include PlayerContactSupport
+
+  before :each do
+    create_user
+    setup_access :player_contacts
+    let_user_create_player_contacts
+    create_item(data: rand(10_000_000_000_000_000), rank: 10)
+    @player_contact.master.current_user = @user
+    @master = @player_contact.master
+    expect(@master).not_to be nil
+
+    # Set up activity log definition with save_trigger_results support
+    al_def = ActivityLog.find_by(id: ActivityLog::PlayerContactPhone.definition.id)
+    unless al_def
+      SetupHelper.setup_al_gen_tests('Phone Log', nil, 'player_contact', rec_type: 'phone')
+      al_def = ActivityLog.active.where(item_type: 'player_contact', rec_type: 'phone').first
+    end
+
+    ActivityLog.active.where(item_type: al_def.item_type).where.not(id: al_def.id).each do |oal|
+      oal.current_admin = @admin
+      oal.disable!
+    end
+
+    al_def.extra_log_types = <<~END_DEF
+      step_1:
+        label: Step 1
+        fields:
+          - select_call_direction
+          - select_who
+    END_DEF
+
+    al_def.current_admin = @admin
+    al_def.force_regenerate = true
+    al_def.updated_at = DateTime.now
+    al_def.save!
+    ActivityLog.refresh_outdated
+    al_def.reload
+    al_def.force_option_config_parse
+
+    setup_access :activity_log__player_contact_phones, resource_type: :table, access: :create, user: @user
+    setup_access :activity_log__player_contact_phone__step_1, resource_type: :activity_log_type, access: :create,
+                                                              user: @user
+    al_def.add_master_association
+
+    @activity_log = @master.activity_log__player_contact_phones.create!(
+      select_call_direction: 'to player',
+      select_who: 'user',
+      extra_log_type: 'step_1',
+      player_contact: @player_contact,
+      master: @master,
+      current_user: @user
+    )
+    @activity_log.save_trigger_results ||= {}
+  end
+
+  describe '#perform' do
+    context 'when a when condition matches' do
+      it 'executes the then triggers for the first matching when block - Issue #944' do
+        config = [
+          {
+            when: {
+              all: {
+                this: {
+                  select_call_direction: 'to player'
+                }
+              }
+            },
+            then: [
+              { log: { message: 'Matched to player', severity: 'info' } }
+            ]
+          }
+        ]
+
+        trigger = SaveTriggers::Case.new(config, @activity_log)
+
+        expect(Rails.logger).to receive(:info).with(/Matched to player/).ordered
+        expect(Rails.logger).to receive(:info).with(/SaveTrigger::Case/).ordered
+
+        result = trigger.perform
+
+        expect(result).to be_present
+      end
+    end
+
+    context 'when multiple when conditions could match' do
+      it 'executes only the first matching when block - Issue #944' do
+        config = [
+          {
+            when: {
+              all: {
+                this: {
+                  select_call_direction: 'to player'
+                }
+              }
+            },
+            then: [
+              { log: { message: 'First match', severity: 'info' } }
+            ]
+          },
+          {
+            when: {
+              all: {
+                this: {
+                  select_who: 'user'
+                }
+              }
+            },
+            then: [
+              { log: { message: 'Second match should not run', severity: 'info' } }
+            ]
+          }
+        ]
+
+        trigger = SaveTriggers::Case.new(config, @activity_log)
+        result = trigger.perform
+
+        expect(result.length).to eq(1)
+        expect(result.first[:trigger]).to eq(:log)
+      end
+    end
+
+    context 'when no when condition matches and else is present' do
+      it 'executes the else triggers - Issue #944' do
+        config = [
+          {
+            when: {
+              all: {
+                this: {
+                  select_call_direction: 'from player'
+                }
+              }
+            },
+            then: [
+              { log: { message: 'Should not match', severity: 'info' } }
+            ]
+          },
+          {
+            else: [
+              { log: { message: 'Fell through to else', severity: 'info' } }
+            ]
+          }
+        ]
+
+        trigger = SaveTriggers::Case.new(config, @activity_log)
+        result = trigger.perform
+
+        expect(result.length).to eq(1)
+        expect(result.first[:trigger]).to eq(:log)
+      end
+    end
+
+    context 'when no when condition matches and no else is present' do
+      it 'returns empty results - Issue #944' do
+        config = [
+          {
+            when: {
+              all: {
+                this: {
+                  select_call_direction: 'from player'
+                }
+              }
+            },
+            then: [
+              { log: { message: 'Should not run', severity: 'info' } }
+            ]
+          }
+        ]
+
+        trigger = SaveTriggers::Case.new(config, @activity_log)
+        result = trigger.perform
+
+        expect(result).to eq([])
+      end
+    end
+
+    context 'storing results' do
+      it 'stores results in save_trigger_results - Issue #944' do
+        config = [
+          {
+            when: {
+              all: {
+                this: {
+                  select_call_direction: 'to player'
+                }
+              }
+            },
+            then: [
+              { log: { message: 'Stored result test', severity: 'info' } }
+            ]
+          }
+        ]
+
+        trigger = SaveTriggers::Case.new(config, @activity_log)
+        trigger.perform
+
+        expect(@activity_log.save_trigger_results['case']).to be_an(Array)
+        expect(@activity_log.save_trigger_results['case'].length).to eq(1)
+        expect(@activity_log.save_trigger_results['case'].first[:trigger]).to eq(:log)
+      end
+    end
+  end
+
+  describe 'registration' do
+    it 'is included in ValidSaveTriggers - Issue #944' do
+      expect(OptionConfigs::ExtraOptionImplementers::SaveTriggers::ValidSaveTriggers).to include(:case)
+    end
+
+    it 'can be resolved via trigger_class - Issue #944' do
+      klass = OptionConfigs::ExtraOptions.trigger_class(:case)
+      expect(klass).to eq(SaveTriggers::Case)
+    end
+  end
+end

--- a/spec/models/save_triggers/case_spec.rb
+++ b/spec/models/save_triggers/case_spec.rb
@@ -66,6 +66,47 @@ RSpec.describe SaveTriggers::Case, type: :model do
     @activity_log.save_trigger_results ||= {}
   end
 
+  #
+  # Helper to reconfigure the activity log definition with a new extra_log_types YAML,
+  # set up access, and return the definition for integration tests.
+  # @param [String] extra_log_type_name - the extra log type name (e.g. 'case_test')
+  # @param [String] yaml_config - the YAML configuration string
+  def configure_al_with_save_trigger(extra_log_type_name, yaml_config)
+    al_def = ActivityLog.find_by(id: ActivityLog::PlayerContactPhone.definition.id)
+
+    al_def.extra_log_types = yaml_config
+    al_def.current_admin = @admin
+    al_def.force_regenerate = true
+    al_def.updated_at = DateTime.now
+    al_def.save!
+    ActivityLog.refresh_outdated
+    al_def.reload
+    al_def.force_option_config_parse
+
+    setup_access :"activity_log__player_contact_phone__#{extra_log_type_name}",
+                 resource_type: :activity_log_type, access: :create, user: @user
+
+    al_def.add_master_association
+    al_def
+  end
+
+  #
+  # Helper to create an activity log record for integration tests.
+  # @param [String] extra_log_type - the extra log type
+  # @param [String] direction - the select_call_direction value
+  # @param [String] who - the select_who value
+  # @return [ActivityLog::PlayerContactPhone] the created activity log record
+  def create_al_record(extra_log_type:, direction: 'to player', who: 'original')
+    @master.activity_log__player_contact_phones.create!(
+      select_call_direction: direction,
+      select_who: who,
+      extra_log_type:,
+      player_contact: @player_contact,
+      master: @master,
+      current_user: @user
+    )
+  end
+
   describe '#perform' do
     context 'when a when condition matches' do
       it 'executes the then triggers for the first matching when block - Issue #944' do
@@ -338,9 +379,7 @@ RSpec.describe SaveTriggers::Case, type: :model do
 
   describe 'integration with save_trigger config' do
     it 'runs case trigger as part of on_create save_trigger - Issue #944' do
-      al_def = ActivityLog.find_by(id: ActivityLog::PlayerContactPhone.definition.id)
-
-      al_def.extra_log_types = <<~END_DEF
+      configure_al_with_save_trigger('case_test', <<~END_DEF)
         case_test:
           label: Case Test
           fields:
@@ -374,35 +413,12 @@ RSpec.describe SaveTriggers::Case, type: :model do
                             select_who: 'no match - else'
       END_DEF
 
-      al_def.current_admin = @admin
-      al_def.force_regenerate = true
-      al_def.updated_at = DateTime.now
-      al_def.save!
-      ActivityLog.refresh_outdated
-      al_def.reload
-      al_def.force_option_config_parse
-
-      setup_access :activity_log__player_contact_phone__case_test,
-                   resource_type: :activity_log_type, access: :create, user: @user
-
-      al_def.add_master_association
-
-      al = @master.activity_log__player_contact_phones.create!(
-        select_call_direction: 'to player',
-        select_who: 'original',
-        extra_log_type: 'case_test',
-        player_contact: @player_contact,
-        master: @master,
-        current_user: @user
-      )
-
+      al = create_al_record(extra_log_type: 'case_test', direction: 'to player')
       expect(al.select_who).to eq 'matched to player'
     end
 
     it 'runs else branch when no when matches in save_trigger - Issue #944' do
-      al_def = ActivityLog.find_by(id: ActivityLog::PlayerContactPhone.definition.id)
-
-      al_def.extra_log_types = <<~END_DEF
+      configure_al_with_save_trigger('case_else_test', <<~END_DEF)
         case_else_test:
           label: Case Else Test
           fields:
@@ -427,35 +443,12 @@ RSpec.describe SaveTriggers::Case, type: :model do
                             select_who: 'fell through to else'
       END_DEF
 
-      al_def.current_admin = @admin
-      al_def.force_regenerate = true
-      al_def.updated_at = DateTime.now
-      al_def.save!
-      ActivityLog.refresh_outdated
-      al_def.reload
-      al_def.force_option_config_parse
-
-      setup_access :activity_log__player_contact_phone__case_else_test,
-                   resource_type: :activity_log_type, access: :create, user: @user
-
-      al_def.add_master_association
-
-      al = @master.activity_log__player_contact_phones.create!(
-        select_call_direction: 'to player',
-        select_who: 'original',
-        extra_log_type: 'case_else_test',
-        player_contact: @player_contact,
-        master: @master,
-        current_user: @user
-      )
-
+      al = create_al_record(extra_log_type: 'case_else_test', direction: 'to player')
       expect(al.select_who).to eq 'fell through to else'
     end
 
     it 'runs second when branch in save_trigger - Issue #944' do
-      al_def = ActivityLog.find_by(id: ActivityLog::PlayerContactPhone.definition.id)
-
-      al_def.extra_log_types = <<~END_DEF
+      configure_al_with_save_trigger('case_second_test', <<~END_DEF)
         case_second_test:
           label: Case Second Test
           fields:
@@ -484,28 +477,7 @@ RSpec.describe SaveTriggers::Case, type: :model do
                             select_who: 'second branch matched'
       END_DEF
 
-      al_def.current_admin = @admin
-      al_def.force_regenerate = true
-      al_def.updated_at = DateTime.now
-      al_def.save!
-      ActivityLog.refresh_outdated
-      al_def.reload
-      al_def.force_option_config_parse
-
-      setup_access :activity_log__player_contact_phone__case_second_test,
-                   resource_type: :activity_log_type, access: :create, user: @user
-
-      al_def.add_master_association
-
-      al = @master.activity_log__player_contact_phones.create!(
-        select_call_direction: 'from player',
-        select_who: 'original',
-        extra_log_type: 'case_second_test',
-        player_contact: @player_contact,
-        master: @master,
-        current_user: @user
-      )
-
+      al = create_al_record(extra_log_type: 'case_second_test', direction: 'from player')
       expect(al.select_who).to eq 'second branch matched'
     end
   end


### PR DESCRIPTION
## Summary

Implements a `case` block for save triggers (issue #944), similar to the existing `transaction` block. The `case` trigger evaluates a list of `when` conditions and executes corresponding `then` triggers for the first matching branch, or falls through to an optional `else` branch.

## Changes

### New Files
- **`app/models/save_triggers/case.rb`** — `SaveTriggers::Case` class implementing case/when/else conditional branching
- **`app/models/admin/defs/save_triggers_case_options_defs.yaml`** — Admin panel documentation for case trigger configuration
- **`spec/models/save_triggers/case_spec.rb`** — 15 comprehensive specs (10 unit, 3 integration, 2 registration)

### Modified Files
- **`app/models/save_triggers/save_triggers_base.rb`** — Extracted shared `execute_trigger_list` and `store_trigger_results` methods
- **`app/models/save_triggers/transaction.rb`** — Refactored to use base class shared methods
- **`app/models/save_triggers/background.rb`** — Refactored to use `store_trigger_results`
- **`app/models/option_configs/extra_option_implementers/save_triggers.rb`** — Added `:case` to `ValidSaveTriggers`
- **`app/models/admin/defs/extra_options_defs.yaml`** — Added case entry to definitions
- **`app/models/tracker.rb`** — Added `self.primary_key = 'id'` (trackers is now a VIEW from #941)

## Configuration Example

```yaml
save_trigger:
  case:
    - when:
        all:
          this:
            select_who: investigator
      then:
        - log:
            message: Investigator selected
            severity: info
    - else:
        - log:
            message: Default branch
            severity: info
```

## Testing
- All 40 save trigger specs pass (15 case + 7 transaction + 18 base)
- Full parallel test suite passes
