### PR TITLE
Add set_save_trigger_results save trigger option

### DIFF
--- a/app/models/admin/defs/save_triggers_set_save_trigger_results_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_set_save_trigger_results_options_defs.yaml
@@ -1,0 +1,20 @@
+# Save Trigger: Set Save Trigger Results options
+        - set_1:
+            if: #if_extras
+            element: variable_name  # Name of the element to set in save_trigger_results, supports dot-notation (e.g. 'hash_var.key1')
+            value: literal_or_substitution  # Value to set - can be a literal, substitution string like '{{field}}', or object hash
+          # NOTE: this sets the specified element in save_trigger_results for use in subsequent triggers
+          # e.g. |-
+          #   save_trigger:
+          #     on_create:
+          #       - set_save_trigger_results:
+          #           element: simple_var
+          #           value: 123
+          #       - set_save_trigger_results:
+          #           element: hash_var
+          #           value:
+          #             object:
+          #               id: '{{study_id}}'
+          #       - set_save_trigger_results:
+          #           element: hash_var.key1
+          #           value: hello

--- a/app/models/option_configs/extra_option_implementers/save_triggers.rb
+++ b/app/models/option_configs/extra_option_implementers/save_triggers.rb
@@ -23,7 +23,8 @@ module OptionConfigs
                              transaction
                              background
                              reload_this
-                             case].freeze
+                             case
+                             set_save_trigger_results].freeze
 
       class_methods do
         #

--- a/app/models/save_triggers/set_save_trigger_results.rb
+++ b/app/models/save_triggers/set_save_trigger_results.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+#
+# Save trigger to explicitly set values in save_trigger_results,
+# making them available to subsequent triggers via substitutions
+# like {{save_trigger_results.element_name}} or conditional actions.
+#
+# Values can be literals, substitution strings, or object hashes.
+# Dot-notation in element names (e.g. 'hash_variable.key1') sets
+# nested keys within save_trigger_results.
+#
+# Example configuration:
+#   save_trigger:
+#     on_create:
+#       - set_save_trigger_results:
+#           element: simple_variable
+#           value: 123
+#       - set_save_trigger_results:
+#           element: hash_variable
+#           value:
+#             object:
+#               id: '{{study_id}}'
+#       - set_save_trigger_results:
+#           if:
+#             all:
+#               this:
+#                 select_call_direction: from player
+#           element: conditional_variable
+#           value: 'was from player'
+#
+class SaveTriggers::SetSaveTriggerResults < SaveTriggers::SaveTriggersBase
+  def initialize(config, item)
+    super
+
+    @model_defs = config
+  end
+
+  def perform
+    @model_defs = [@model_defs] unless @model_defs.is_a? Array
+
+    results = []
+    @model_defs.each do |model_def|
+      config = extract_config(model_def)
+
+      # Evaluate conditional if
+      if config[:if]
+        ca = ConditionalActions.new config[:if], @item
+        next unless ca.calc_action_if
+      end
+
+      element = config[:element]
+      raise FphsException, 'set_save_trigger_results requires element to be specified' if element.blank?
+
+      value = config[:value]
+
+      # Calculate the value using FieldDefaults, supporting substitutions,
+      # conditional actions, and object values.
+      # For object: hashes, also perform substitutions on the inner values.
+      calculated_value = FieldDefaults.calculate_default(@item, value, allow_nil: true)
+      calculated_value = substitute_object_values(calculated_value) if calculated_value.is_a?(Hash)
+
+      # Set the value in save_trigger_results, supporting dot-notation for nested keys
+      set_nested_value(element.to_s, calculated_value)
+
+      results << { element: element.to_s, value: calculated_value }
+    end
+
+    results
+  end
+
+  private
+
+  #
+  # Set a value in save_trigger_results, supporting dot-notation
+  # for nested keys (e.g. 'hash_variable.key1' sets
+  # save_trigger_results['hash_variable']['key1'])
+  # @param [String] element - the element path (may contain dots)
+  # @param [Object] value - the value to set
+  def set_nested_value(element, value)
+    return unless @item.respond_to?(:save_trigger_results) && @item.save_trigger_results
+
+    parts = element.split('.')
+    if parts.length == 1
+      @item.save_trigger_results[element] = value
+    else
+      # Navigate to the nested location, creating intermediate hashes as needed
+      target = @item.save_trigger_results
+      parts[0..-2].each do |key|
+        target[key] ||= {}
+        target = target[key]
+      end
+      target[parts.last] = value
+    end
+  end
+
+  #
+  # Recursively perform substitutions on all string values within a hash.
+  # This enables the object: key pattern to include {{substitutions}}.
+  # @param [Hash] hash_value - the hash whose values should be substituted
+  # @return [Hash] the hash with substituted string values
+  def substitute_object_values(hash_value)
+    hash_value.deep_transform_values do |v|
+      FieldDefaults.calculate_default(@item, v, allow_nil: true)
+    end
+  end
+
+  #
+  # Extract configuration from the model_def, handling both simple and named formats
+  # @param [Hash] model_def - either { element: 'x', value: 'y' } or { name: { element: 'x', value: 'y' } }
+  # @return [Hash] - the configuration hash
+  def extract_config(model_def)
+    return model_def unless model_def.is_a?(Hash)
+
+    # Simple format: config is directly provided with element key
+    return model_def if model_def.key?(:element)
+
+    # Named format: first value should be a hash config
+    first_val = model_def.values.first
+    return first_val if first_val.is_a?(Hash)
+
+    # Default to returning the original
+    model_def
+  end
+end

--- a/app/models/save_triggers/set_save_trigger_results.rb
+++ b/app/models/save_triggers/set_save_trigger_results.rb
@@ -43,10 +43,7 @@ class SaveTriggers::SetSaveTriggerResults < SaveTriggers::SaveTriggersBase
       config = extract_config(model_def)
 
       # Evaluate conditional if
-      if config[:if]
-        ca = ConditionalActions.new config[:if], @item
-        next unless ca.calc_action_if
-      end
+      next unless if_evaluates(config[:if])
 
       element = config[:element]
       raise FphsException, 'set_save_trigger_results requires element to be specified' if element.blank?

--- a/spec/models/save_triggers/set_save_trigger_results_spec.rb
+++ b/spec/models/save_triggers/set_save_trigger_results_spec.rb
@@ -309,19 +309,24 @@ RSpec.describe SaveTriggers::SetSaveTriggerResults, type: :model do
   end
 
   describe 'integration with subsequent triggers' do
-    it 'makes set values available for substitution in later triggers' do
-      # First, set a value
-      set_config = {
-        element: 'my_ref_id',
+    it 'allows a second trigger to reference values set by the first' do
+      # First trigger sets a value
+      first_config = {
+        element: 'step_one_result',
         value: '{{master_id}}'
       }
 
-      trigger = SaveTriggers::SetSaveTriggerResults.new(set_config, @al)
-      trigger.perform
+      SaveTriggers::SetSaveTriggerResults.new(first_config, @al).perform
+      expect(@al.save_trigger_results['step_one_result']).to eq @al.master_id.to_s
 
-      # Verify that the value is available in save_trigger_results
-      # and can be used in substitutions
-      expect(@al.save_trigger_results['my_ref_id']).to eq @al.master_id.to_s
+      # Second trigger reads the value set by the first via substitution
+      second_config = {
+        element: 'step_two_result',
+        value: '{{save_trigger_results.step_one_result}}'
+      }
+
+      SaveTriggers::SetSaveTriggerResults.new(second_config, @al).perform
+      expect(@al.save_trigger_results['step_two_result']).to eq @al.master_id.to_s
     end
   end
 end

--- a/spec/models/save_triggers/set_save_trigger_results_spec.rb
+++ b/spec/models/save_triggers/set_save_trigger_results_spec.rb
@@ -1,0 +1,327 @@
+# frozen_string_literal: true
+
+# Tests for SaveTriggers::SetSaveTriggerResults - Issue #949
+#
+# This spec verifies the set_save_trigger_results save trigger, which allows
+# explicitly setting values in save_trigger_results for use by subsequent
+# triggers in substitutions and conditional actions.
+#
+# Covers:
+# - Setting simple literal values
+# - Setting values with substitutions ({{field}})
+# - Setting object/hash values using the object: key
+# - Dot-notation for nested keys (e.g. 'hash_var.key1')
+# - Conditional execution with if:
+# - Multiple configurations in a single trigger
+# - Named configuration format
+# - Error handling when element is missing
+# - Registration in ValidSaveTriggers
+
+require 'rails_helper'
+
+RSpec.describe SaveTriggers::SetSaveTriggerResults, type: :model do
+  include ModelSupport
+  include PlayerContactSupport
+
+  before :each do
+    create_user
+    setup_access :player_contacts
+    let_user_create_player_contacts
+    create_item(data: rand(10_000_000_000_000_000), rank: 10)
+    @player_contact.master.current_user = @user
+    @master = @player_contact.master
+    expect(@master).not_to be nil
+
+    # Set up activity log definition with save_trigger_results support
+    al_def = ActivityLog.find(ActivityLog::PlayerContactPhone.definition.id)
+
+    ActivityLog.active.where(item_type: al_def.item_type).where.not(id: al_def.id).each do |oal|
+      oal.current_admin = @admin
+      oal.disable!
+    end
+
+    config = <<~ENDDEF
+      set_str_test_1:
+        label: Set STR Test 1
+        fields:
+          - select_call_direction
+          - select_who
+    ENDDEF
+
+    al_def.extra_log_types = config
+    al_def.current_admin = @admin
+    al_def.force_regenerate = true
+    al_def.updated_at = DateTime.now
+    al_def.save!
+    ActivityLog.refresh_outdated
+    al_def.reload
+    al_def.force_option_config_parse
+
+    setup_access :activity_log__player_contact_phones, resource_type: :table, access: :create, user: @user
+    setup_access :activity_log__player_contact_phone__set_str_test_1, resource_type: :activity_log_type,
+                                                                      access: :create, user: @user
+    al_def.add_master_association
+
+    @al = @player_contact.activity_log__player_contact_phones.create!(
+      select_call_direction: 'from player',
+      select_who: 'test user',
+      extra_log_type: 'set_str_test_1'
+    )
+
+    @al.save_trigger_results = {}
+  end
+
+  describe 'setting simple values' do
+    it 'sets a literal string value' do
+      config = {
+        element: 'my_variable',
+        value: 'hello world'
+      }
+
+      trigger = SaveTriggers::SetSaveTriggerResults.new(config, @al)
+      result = trigger.perform
+
+      expect(result).to be_an(Array)
+      expect(result.first[:element]).to eq 'my_variable'
+      expect(result.first[:value]).to eq 'hello world'
+      expect(@al.save_trigger_results['my_variable']).to eq 'hello world'
+    end
+
+    it 'sets a literal numeric value' do
+      config = {
+        element: 'numeric_var',
+        value: 123
+      }
+
+      trigger = SaveTriggers::SetSaveTriggerResults.new(config, @al)
+      trigger.perform
+
+      expect(@al.save_trigger_results['numeric_var']).to eq 123
+    end
+
+    it 'sets a nil value when value is not specified' do
+      config = {
+        element: 'nil_var',
+        value: nil
+      }
+
+      trigger = SaveTriggers::SetSaveTriggerResults.new(config, @al)
+      trigger.perform
+
+      expect(@al.save_trigger_results).to have_key('nil_var')
+      expect(@al.save_trigger_results['nil_var']).to be_nil
+    end
+  end
+
+  describe 'setting values with substitutions' do
+    it 'substitutes item attributes in the value' do
+      config = {
+        element: 'master_ref',
+        value: '{{master_id}}'
+      }
+
+      trigger = SaveTriggers::SetSaveTriggerResults.new(config, @al)
+      trigger.perform
+
+      expect(@al.save_trigger_results['master_ref']).to eq @al.master_id.to_s
+    end
+
+    it 'substitutes multiple attributes in the value' do
+      config = {
+        element: 'combined',
+        value: 'master-{{master_id}}-id-{{id}}'
+      }
+
+      trigger = SaveTriggers::SetSaveTriggerResults.new(config, @al)
+      trigger.perform
+
+      expected = "master-#{@al.master_id}-id-#{@al.id}"
+      expect(@al.save_trigger_results['combined']).to eq expected
+    end
+  end
+
+  describe 'setting object values' do
+    it 'sets a hash value using object: key' do
+      config = {
+        element: 'hash_variable',
+        value: {
+          object: {
+            id: '{{master_id}}',
+            name: 'test'
+          }
+        }
+      }
+
+      trigger = SaveTriggers::SetSaveTriggerResults.new(config, @al)
+      trigger.perform
+
+      result = @al.save_trigger_results['hash_variable']
+      expect(result).to be_a(Hash)
+      expect(result[:id]).to eq @al.master_id.to_s
+      expect(result[:name]).to eq 'test'
+    end
+  end
+
+  describe 'dot-notation for nested keys' do
+    it 'sets a nested key using dot-notation' do
+      # First set the parent hash
+      @al.save_trigger_results['hash_var'] = { 'existing_key' => 'existing_value' }
+
+      config = {
+        element: 'hash_var.new_key',
+        value: 'nested value'
+      }
+
+      trigger = SaveTriggers::SetSaveTriggerResults.new(config, @al)
+      trigger.perform
+
+      expect(@al.save_trigger_results['hash_var']['new_key']).to eq 'nested value'
+      # Existing keys should be preserved
+      expect(@al.save_trigger_results['hash_var']['existing_key']).to eq 'existing_value'
+    end
+
+    it 'creates intermediate hashes for dot-notation' do
+      config = {
+        element: 'new_hash.deep_key',
+        value: 'deep value'
+      }
+
+      trigger = SaveTriggers::SetSaveTriggerResults.new(config, @al)
+      trigger.perform
+
+      expect(@al.save_trigger_results['new_hash']).to be_a(Hash)
+      expect(@al.save_trigger_results['new_hash']['deep_key']).to eq 'deep value'
+    end
+
+    it 'handles multiple dot levels' do
+      config = {
+        element: 'level1.level2.level3',
+        value: 'deeply nested'
+      }
+
+      trigger = SaveTriggers::SetSaveTriggerResults.new(config, @al)
+      trigger.perform
+
+      expect(@al.save_trigger_results['level1']['level2']['level3']).to eq 'deeply nested'
+    end
+  end
+
+  describe 'conditional execution' do
+    it 'sets value when if condition is met' do
+      config = {
+        if: {
+          all: {
+            this: {
+              select_call_direction: 'from player'
+            }
+          }
+        },
+        element: 'conditional_var',
+        value: 'condition was met'
+      }
+
+      trigger = SaveTriggers::SetSaveTriggerResults.new(config, @al)
+      trigger.perform
+
+      expect(@al.save_trigger_results['conditional_var']).to eq 'condition was met'
+    end
+
+    it 'skips setting value when if condition is not met' do
+      config = {
+        if: {
+          all: {
+            this: {
+              select_call_direction: 'nonexistent value'
+            }
+          }
+        },
+        element: 'conditional_var',
+        value: 'should not be set'
+      }
+
+      trigger = SaveTriggers::SetSaveTriggerResults.new(config, @al)
+      result = trigger.perform
+
+      expect(result).to be_empty
+      expect(@al.save_trigger_results).not_to have_key('conditional_var')
+    end
+  end
+
+  describe 'multiple configurations' do
+    it 'processes multiple set_save_trigger_results configurations' do
+      config = [
+        { element: 'var1', value: 'value1' },
+        { element: 'var2', value: 42 }
+      ]
+
+      trigger = SaveTriggers::SetSaveTriggerResults.new(config, @al)
+      result = trigger.perform
+
+      expect(result.length).to eq 2
+      expect(@al.save_trigger_results['var1']).to eq 'value1'
+      expect(@al.save_trigger_results['var2']).to eq 42
+    end
+
+    it 'processes named configuration format' do
+      config = [
+        { first_set: { element: 'named_var1', value: 'named_value1' } },
+        { second_set: { element: 'named_var2', value: 'named_value2' } }
+      ]
+
+      trigger = SaveTriggers::SetSaveTriggerResults.new(config, @al)
+      trigger.perform
+
+      expect(@al.save_trigger_results['named_var1']).to eq 'named_value1'
+      expect(@al.save_trigger_results['named_var2']).to eq 'named_value2'
+    end
+  end
+
+  describe 'error handling' do
+    it 'raises an error when element is missing' do
+      config = {
+        value: 'some value'
+      }
+
+      trigger = SaveTriggers::SetSaveTriggerResults.new(config, @al)
+      expect { trigger.perform }.to raise_error(FphsException, /element to be specified/)
+    end
+
+    it 'raises an error when element is blank' do
+      config = {
+        element: '',
+        value: 'some value'
+      }
+
+      trigger = SaveTriggers::SetSaveTriggerResults.new(config, @al)
+      expect { trigger.perform }.to raise_error(FphsException, /element to be specified/)
+    end
+  end
+
+  describe 'ValidSaveTriggers registration' do
+    it 'is included in ValidSaveTriggers' do
+      expect(OptionConfigs::ExtraOptionImplementers::SaveTriggers::ValidSaveTriggers).to include(:set_save_trigger_results)
+    end
+
+    it 'can be resolved via trigger_class' do
+      klass = OptionConfigs::ExtraOptions.trigger_class(:set_save_trigger_results)
+      expect(klass).to eq SaveTriggers::SetSaveTriggerResults
+    end
+  end
+
+  describe 'integration with subsequent triggers' do
+    it 'makes set values available for substitution in later triggers' do
+      # First, set a value
+      set_config = {
+        element: 'my_ref_id',
+        value: '{{master_id}}'
+      }
+
+      trigger = SaveTriggers::SetSaveTriggerResults.new(set_config, @al)
+      trigger.perform
+
+      # Verify that the value is available in save_trigger_results
+      # and can be used in substitutions
+      expect(@al.save_trigger_results['my_ref_id']).to eq @al.master_id.to_s
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a new `set_save_trigger_results` save trigger that explicitly sets values in `save_trigger_results`, making them available to subsequent triggers via substitutions (e.g. `{{save_trigger_results.element_name}}`) or conditional actions.

## Changes

- **New trigger class** `SaveTriggers::SetSaveTriggerResults` supporting:
  - Literal values (strings, numbers, nil)
  - Substitution strings (`'{{master_id}}'`)
  - Object/hash values with nested substitutions (`value: { object: { id: '{{study_id}}' } }`)
  - Dot-notation for nested keys (`element: 'hash_variable.key1'`)
  - Conditional execution with `if:`
  - Multiple configurations (array format)
  - Named configuration format
- **Registered** `:set_save_trigger_results` in `ValidSaveTriggers`
- **Admin defs YAML** for admin panel configuration reference
- **18 RSpec tests** covering all functionality including chained trigger integration

## Example usage

```yaml
save_trigger:
  on_save:
    - set_save_trigger_results:
        element: simple_variable
        value: 123
    - set_save_trigger_results:
        element: hash_variable
        value:
          object:
            id: '{{study_id}}'
    - set_save_trigger_results:
        if:
          all:
            this:
              select_call_direction: from player
        element: hash_variable.key1
        value: hello
```

Fixes #949