### PR TITLE
Save submitted request data (body, URL, method) to save_trigger_results in pull_external_data

### DIFF
--- a/app/models/admin/defs/save_triggers_pull_external_data_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_pull_external_data_options_defs.yaml
@@ -19,6 +19,19 @@
               If *success_if:* condition is set, the following will also be set
                   \{\{save_trigger_results.identity_success_if_res\}\}
 
+              Details of the submitted request (for POST/PUT/PATCH body requests or POST form requests) will be stored as a hash in:
+                  save_trigger_results.identity_submitted_request
+
+              The submitted request hash contains:
+                  data   - the request body as a Hash (for body/form requests), or nil for requests with no body (GET, HEAD, etc.)
+                  url    - the resolved URL the request was sent to (with substitutions applied)
+                  method - the HTTP method used (e.g. 'get', 'post', 'put')
+
+              Individual elements can be accessed via substitutions, for example:
+                  \{\{save_trigger_results.identity_submitted_request.url\}\}
+                  \{\{save_trigger_results.identity_submitted_request.method\}\}
+                  \{\{save_trigger_results.identity_submitted_request.data.programName\}\}
+
               These values are also available in if conditions like:
                   if:
                     this:
@@ -37,6 +50,12 @@
                       save_trigger_results:
                         element: identity_success_if_res
                         value: true
+
+                  if:
+                    this:
+                      save_trigger_results:
+                        element: identity_submitted_request.url
+                        value: https://example.com/api/endpoint
 
             data_field: (optional) name of text or json field to update
             data_field_format: |

--- a/app/models/save_triggers/pull_external_data.rb
+++ b/app/models/save_triggers/pull_external_data.rb
@@ -34,6 +34,7 @@ class SaveTriggers::PullExternalData < SaveTriggers::SaveTriggersBase
         end
 
         @this_config = config
+        @submitted_request_data = nil
         data = run_request
         orig_data = data
 
@@ -46,6 +47,11 @@ class SaveTriggers::PullExternalData < SaveTriggers::SaveTriggersBase
         if local_data_name
           @item.save_trigger_results[local_data_name] = orig_data
           @item.save_trigger_results["#{local_data_name}_http_response_code"] = response_code
+          @item.save_trigger_results["#{local_data_name}_submitted_request"] = {
+            'data' => @submitted_request_data,
+            'url' => url_from_config,
+            'method' => method_from_config
+          }
         end
 
         # We calculate the conditional if inside each item, rather than relying
@@ -108,6 +114,7 @@ class SaveTriggers::PullExternalData < SaveTriggers::SaveTriggersBase
     uri = URI.parse(url_from_config)
     form = @this_config[:form] || {}
     form = form.deep_transform_values { |v| FieldDefaults.calculate_default @item, v }
+    @submitted_request_data = form.deep_stringify_keys
     response = Net::HTTP.post_form(uri, form)
     handle_response(to_config, response)
   end
@@ -219,9 +226,10 @@ class SaveTriggers::PullExternalData < SaveTriggers::SaveTriggersBase
     if data.is_a? Hash
       data = data.deep_stringify_keys
       data = data.deep_transform_values { |v| FieldDefaults.calculate_default @item, v }
+      @submitted_request_data = data.dup
       data.to_json
     else
-      FieldDefaults.calculate_default @item, data
+      @submitted_request_data = FieldDefaults.calculate_default(@item, data)
     end
   end
 

--- a/spec/models/save_triggers/pull_external_data_spec.rb
+++ b/spec/models/save_triggers/pull_external_data_spec.rb
@@ -8,6 +8,7 @@ require 'rails_helper'
 #   no-body (head, delete, options, trace, copy, move)
 # - Response code handling, error whitelisting, local_data storage
 # - send_data config alias for post_data
+# - Submitted request data (data, url, method) saved to save_trigger_results (issue #950)
 RSpec.describe SaveTriggers::PullExternalData, type: :model do
   include ModelSupport
   include ActivityLogSupport
@@ -633,6 +634,192 @@ RSpec.describe SaveTriggers::PullExternalData, type: :model do
       expect do
         @trigger.perform
       end.to raise_error(FphsException, /pull_external_data method 'invalid_method' is not supported/)
+    end
+  end
+
+  # Tests for submitted request data saved to save_trigger_results (issue #950)
+  context 'with submitted_request saved to save_trigger_results' do
+    it 'saves submitted request data, url, and method for a POST with send_data' do
+      config = {
+        this1: {
+          local_data: 'post_result',
+          data_field: 'notes',
+          data_field_format: 'json',
+          method: 'post',
+          to: {
+            url: "#{api_uri}/rest/v1/leads/push.json",
+            format: 'json',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: 'Bearer 123123123-ad12-1234-99ce-893645:ab'
+            }
+          },
+          send_data: {
+            programName: 'HCI Participant Import',
+            lookupField: 'email',
+            source: 'HCIQ Zeus',
+            reason: 'Changed status',
+            input: [
+              {
+                email: 'phil-test12@consected.com',
+                firstName: 'Test FN',
+                lastName: 'Test LN',
+                hCIStage: 'Invitation Email',
+                hCIStageUpdatedAt: 'now()',
+                hCIQLink: 'https://consected.com'
+              }
+            ]
+          }
+        }
+      }
+
+      @trigger = SaveTriggers::PullExternalData.new(config, @al)
+      @trigger.perform
+
+      submitted = @al.save_trigger_results['post_result_submitted_request']
+      expect(submitted).to be_present
+      expect(submitted['method']).to eq 'post'
+      expect(submitted['url']).to eq "#{api_uri}/rest/v1/leads/push.json"
+      expect(submitted['data']).to be_a Hash
+      expect(submitted['data']['programName']).to eq 'HCI Participant Import'
+      expect(submitted['data']['lookupField']).to eq 'email'
+      expect(submitted['data']['input'].first['email']).to eq 'phil-test12@consected.com'
+    end
+
+    it 'saves submitted request data for a PUT with send_data' do
+      config = {
+        this1: {
+          local_data: 'put_result',
+          data_field: 'notes',
+          data_field_format: 'json',
+          method: 'put',
+          to: {
+            url: 'https://rspec-test.example.com/api/resource',
+            format: 'json',
+            headers: { 'Content-Type': 'application/json' }
+          },
+          send_data: { key: 'updated_value' }
+        }
+      }
+
+      @trigger = SaveTriggers::PullExternalData.new(config, @al)
+      @trigger.perform
+
+      submitted = @al.save_trigger_results['put_result_submitted_request']
+      expect(submitted).to be_present
+      expect(submitted['method']).to eq 'put'
+      expect(submitted['url']).to eq 'https://rspec-test.example.com/api/resource'
+      expect(submitted['data']).to eq({ 'key' => 'updated_value' })
+    end
+
+    it 'saves submitted request with nil data for a GET request' do
+      config = {
+        this1: {
+          local_data: 'get_result',
+          data_field: 'notes',
+          from: {
+            url: 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=14760269&retmode=json',
+            format: 'json'
+          }
+        }
+      }
+
+      @trigger = SaveTriggers::PullExternalData.new(config, @al)
+      @trigger.perform
+
+      submitted = @al.save_trigger_results['get_result_submitted_request']
+      expect(submitted).to be_present
+      expect(submitted['method']).to eq 'get'
+      expect(submitted['url']).to eq 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=14760269&retmode=json'
+      expect(submitted['data']).to be_nil
+    end
+
+    it 'saves submitted request form data for a POST form request' do
+      config = {
+        this1: {
+          local_data: 'auth_result',
+          method: 'post',
+          to: {
+            url: "#{api_uri}#{client_auth_url}",
+            format: 'json'
+          }
+        }
+      }
+
+      @trigger = SaveTriggers::PullExternalData.new(config, @al)
+      @trigger.perform
+
+      submitted = @al.save_trigger_results['auth_result_submitted_request']
+      expect(submitted).to be_present
+      expect(submitted['method']).to eq 'post'
+      expect(submitted['url']).to eq "#{api_uri}#{client_auth_url}"
+      # post_form with no form config sends empty form data
+      expect(submitted['data']).to eq({})
+    end
+
+    it 'saves submitted request for each step in a multi-step request' do
+      config = {
+        this1: {
+          local_data: 'identity',
+          method: 'post',
+          to: {
+            url: "#{api_uri}#{client_auth_url}",
+            format: 'json'
+          }
+        },
+        this2: {
+          local_data: 'campaign_result',
+          data_field: 'notes',
+          data_field_format: 'json',
+          if: {
+            all: {
+              this: {
+                save_trigger_results: {
+                  element: 'identity_http_response_code',
+                  value: 200
+                }
+              }
+            }
+          },
+          from: {
+            url: "#{api_uri}/rest/v1/campaigns/1081.json?access_token={{save_trigger_results.identity.access_token}}",
+            format: 'json'
+          }
+        }
+      }
+
+      @trigger = SaveTriggers::PullExternalData.new(config, @al)
+      @trigger.perform
+
+      # First step - POST form
+      submitted1 = @al.save_trigger_results['identity_submitted_request']
+      expect(submitted1).to be_present
+      expect(submitted1['method']).to eq 'post'
+      expect(submitted1['url']).to eq "#{api_uri}#{client_auth_url}"
+
+      # Second step - GET request
+      submitted2 = @al.save_trigger_results['campaign_result_submitted_request']
+      expect(submitted2).to be_present
+      expect(submitted2['method']).to eq 'get'
+      expect(submitted2['url']).to eq "#{api_uri}/rest/v1/campaigns/1081.json?access_token=123123123-ad12-1234-99ce-893645:ab"
+      expect(submitted2['data']).to be_nil
+    end
+
+    it 'does not save submitted request when local_data is not configured' do
+      config = {
+        this1: {
+          data_field: 'notes',
+          from: {
+            url: 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=14760269&retmode=json',
+            format: 'json'
+          }
+        }
+      }
+
+      @trigger = SaveTriggers::PullExternalData.new(config, @al)
+      @trigger.perform
+
+      expect(@al.save_trigger_results).not_to have_key('_submitted_request')
     end
   end
 end


### PR DESCRIPTION
## Summary

Resolves #950

When `local_data` is configured on a `pull_external_data` save trigger, the details of the outgoing request are now saved to `save_trigger_results.<local_data_name>_submitted_request` for debugging and use in subsequent trigger steps.

## Changes

### `app/models/save_triggers/pull_external_data.rb`
- Reset `@submitted_request_data` to `nil` before each request in `perform`
- Capture serialized body data in `serialize_send_data` (body-sending methods: POST with `send_data`, PUT, PATCH, etc.)
- Capture form fields in `post_form` (POST form requests)
- When `local_data` is set, write `<local_data_name>_submitted_request` hash to `save_trigger_results` containing:
  - `data` — request body as a Hash, or `nil` for no-body requests (GET, HEAD, etc.)
  - `url` — resolved URL (substitutions applied)
  - `method` — HTTP method used

### `app/models/admin/defs/save_triggers_pull_external_data_options_defs.yaml`
- Updated `local_data` documentation to describe the new `_submitted_request` key, its fields, substitution examples, and `if` condition usage

### `spec/models/save_triggers/pull_external_data_spec.rb`
- Added 6 new examples under context `with submitted_request saved to save_trigger_results`:
  - POST with `send_data` — verifies data hash, url, method captured correctly
  - PUT with `send_data` — verifies body-sending verbs capture data
  - GET request — verifies `data` is `nil`, url and method captured
  - POST form request — verifies form data captured
  - Multi-step request — verifies each step gets its own `_submitted_request` with resolved URL
  - No `local_data` — verifies nothing is saved when `local_data` not configured

## Test results

32 examples, 0 failures