### PR TITLE
FieldDefaults.calculate_default with object key handles substitutions in each value

### DIFF
--- a/app/models/concerns/field_defaults.rb
+++ b/app/models/concerns/field_defaults.rb
@@ -53,7 +53,9 @@ module FieldDefaults
       if value.length == 1 && (value.key?(:object) || value.key?('object'))
         # A Hash with a single 'object' key passes the inner value through directly,
         # allowing JSONB fields to store arbitrary objects (issue #943)
-        res = value[:object] || value['object']
+        # Recursively substitute string values within the inner object (issue #956)
+        inner = value[:object] || value['object']
+        res = substitute_value_recurse(obj, inner, allow_nil:, ignore_missing:)
       else
         ca = ConditionalActions.new value, obj
         res = ca.get_this_val
@@ -61,6 +63,28 @@ module FieldDefaults
     end
 
     parse_date_and_time(res, type)
+  end
+
+  #
+  # Recursively substitute string values within a nested structure of
+  # hashes and arrays, applying calculate_default to each string value.
+  # Non-string, non-hash, non-array values are returned as-is.
+  # @param [UserBase] obj - the instance to use data from
+  # @param [Object] value - the value to recursively substitute
+  # @param [Boolean] allow_nil - pass through to calculate_default
+  # @param [Boolean] ignore_missing - pass through to calculate_default
+  # @return [Object] the value with all string values substituted
+  def self.substitute_value_recurse(obj, value, allow_nil: false, ignore_missing: false)
+    case value
+    when Hash
+      value.transform_values { |v| substitute_value_recurse(obj, v, allow_nil:, ignore_missing:) }
+    when Array
+      value.map { |v| substitute_value_recurse(obj, v, allow_nil:, ignore_missing:) }
+    when String
+      calculate_default(obj, value, allow_nil:, ignore_missing:)
+    else
+      value
+    end
   end
 
   #

--- a/app/models/save_triggers/set_save_trigger_results.rb
+++ b/app/models/save_triggers/set_save_trigger_results.rb
@@ -52,9 +52,9 @@ class SaveTriggers::SetSaveTriggerResults < SaveTriggers::SaveTriggersBase
 
       # Calculate the value using FieldDefaults, supporting substitutions,
       # conditional actions, and object values.
-      # For object: hashes, also perform substitutions on the inner values.
+      # FieldDefaults.calculate_default handles recursive substitution within
+      # object: hashes internally (issue #956).
       calculated_value = FieldDefaults.calculate_default(@item, value, allow_nil: true)
-      calculated_value = substitute_object_values(calculated_value) if calculated_value.is_a?(Hash)
 
       # Set the value in save_trigger_results, supporting dot-notation for nested keys
       set_nested_value(element.to_s, calculated_value)
@@ -87,17 +87,6 @@ class SaveTriggers::SetSaveTriggerResults < SaveTriggers::SaveTriggersBase
         target = target[key]
       end
       target[parts.last] = value
-    end
-  end
-
-  #
-  # Recursively perform substitutions on all string values within a hash.
-  # This enables the object: key pattern to include {{substitutions}}.
-  # @param [Hash] hash_value - the hash whose values should be substituted
-  # @return [Hash] the hash with substituted string values
-  def substitute_object_values(hash_value)
-    hash_value.deep_transform_values do |v|
-      FieldDefaults.calculate_default(@item, v, allow_nil: true)
     end
   end
 

--- a/spec/models/concerns/field_defaults_spec.rb
+++ b/spec/models/concerns/field_defaults_spec.rb
@@ -4,6 +4,8 @@
 # - Verifies string substitution, date/time defaults, and tag formatting
 # - Verifies that a Hash with a single 'object' key passes the inner value through
 #   instead of treating it as a ConditionalActions query (issue #943)
+# - Verifies that string values within an 'object' hash are recursively substituted,
+#   including through nested hashes and arrays (issue #956)
 
 require 'rails_helper'
 
@@ -64,5 +66,98 @@ RSpec.describe FieldDefaults, type: :model do
     # This should NOT return the inner object; it has multiple keys
     # so it falls through to ConditionalActions processing
     expect(val.length).to eq 2
+  end
+
+  it 'substitutes string values within the object hash recursively - issue #956' do
+    data = {
+      id: 100,
+      something: 'this string',
+      data_val: {
+        'a' => 3,
+        'b' => 2
+      }
+    }
+
+    # Simple string substitution inside an object hash
+    val = { object: { key1: '{{something}}', key2: 42 } }
+    res = FieldDefaults.calculate_default(data, val)
+    expect(res).to eq({ key1: 'this string', key2: 42 })
+
+    # Nested hash with string substitutions
+    # Note: {{id}} through Formatter::Substitution returns a string
+    val = { object: { top: 'literal', nested: { deep: '{{something}}', id_val: '{{id}}' } } }
+    res = FieldDefaults.calculate_default(data, val)
+    expect(res).to eq({ top: 'literal', nested: { deep: 'this string', id_val: '100' } })
+
+    # Array with string substitutions
+    val = { object: ['{{something}}', 'plain', '{{id}}'] }
+    res = FieldDefaults.calculate_default(data, val)
+    expect(res).to eq(['this string', 'plain', '100'])
+
+    # Mixed nested hash and array
+    val = { object: { arr: ['{{something}}', 123], nested: { deep: '{{id}}' } } }
+    res = FieldDefaults.calculate_default(data, val)
+    expect(res).to eq({ arr: ['this string', 123], nested: { deep: '100' } })
+
+    # Non-string values remain unchanged
+    val = { object: { num: 42, bool: true, nothing: nil } }
+    res = FieldDefaults.calculate_default(data, val, allow_nil: true)
+    expect(res).to eq({ num: 42, bool: true, nothing: nil })
+
+    # Plain object substitution on strings within an array of hashes
+    val = { object: [{ name: '{{something}}' }, { count: '{{id}}' }] }
+    res = FieldDefaults.calculate_default(data, val)
+    expect(res).to eq([{ name: 'this string' }, { count: '100' }])
+
+    # Special defaults like today() work inside object values
+    val = { object: { date: 'today()' } }
+    res = FieldDefaults.calculate_default(data, val)
+    expected_date = DateTime.now.iso8601.split('T').first
+    expect(res).to eq({ date: expected_date })
+
+    # Triple-brace substitution returns the actual object for a value
+    val = { object: { data: '{{{data_val}}}' } }
+    res = FieldDefaults.calculate_default(data, val)
+    expect(res).to eq({ data: { 'a' => 3, 'b' => 2 } })
+
+    # String key 'object' also gets substitutions
+    val = { 'object' => { 'key' => '{{something}}' } }
+    res = FieldDefaults.calculate_default(data, val)
+    expect(res).to eq({ 'key' => 'this string' })
+  end
+
+  it 'substitutes triple-brace values within object to return plain objects - issue #956' do
+    data = {
+      id: 100,
+      something: 'this string',
+      hash_val: { 'a' => 3, 'b' => 2 },
+      array_val: [10, 20, 30],
+      int_val: 42
+    }
+
+    # Triple-brace substitution returning a Hash inside an object hash
+    val = { object: { result: '{{{hash_val}}}' } }
+    res = FieldDefaults.calculate_default(data, val)
+    expect(res).to eq({ result: { 'a' => 3, 'b' => 2 } })
+
+    # Triple-brace substitution returning an Array inside an object hash
+    val = { object: { items: '{{{array_val}}}' } }
+    res = FieldDefaults.calculate_default(data, val)
+    expect(res).to eq({ items: [10, 20, 30] })
+
+    # Triple-brace substitution returning an Integer inside an object hash
+    val = { object: { count: '{{{int_val}}}' } }
+    res = FieldDefaults.calculate_default(data, val)
+    expect(res).to eq({ count: 42 })
+
+    # Triple-brace substitution within an array
+    val = { object: ['{{{hash_val}}}', '{{{array_val}}}', '{{{int_val}}}'] }
+    res = FieldDefaults.calculate_default(data, val)
+    expect(res).to eq([{ 'a' => 3, 'b' => 2 }, [10, 20, 30], 42])
+
+    # Mixed triple-brace and double-brace within the same object
+    val = { object: { name: '{{something}}', data: '{{{hash_val}}}', num: '{{{int_val}}}' } }
+    res = FieldDefaults.calculate_default(data, val)
+    expect(res).to eq({ name: 'this string', data: { 'a' => 3, 'b' => 2 }, num: 42 })
   end
 end


### PR DESCRIPTION
## Summary

`FieldDefaults.calculate_default` with an `object:` key now recursively substitutes string values within the inner object, traversing nested hashes and arrays.

## Changes

- Added `FieldDefaults.substitute_value_recurse` to recursively walk hashes/arrays and apply `calculate_default` to each string value
- The `object:` key handler in `calculate_default` now calls `substitute_value_recurse` instead of returning the inner value verbatim
- Removed redundant `substitute_object_values` from `SetSaveTriggerResults` (now handled internally by `calculate_default`)
- Added comprehensive specs covering: double-brace substitutions, triple-brace substitutions (Hash, Array, Integer), nested structures, mixed types, and special defaults like `today()`

Fixes #956