### PR TITLE
Added calendar invite (.ics) attachment support to email notifications - fixes #953

### DIFF
--- a/app/assets/javascripts/app/_fpa_loaded.js
+++ b/app/assets/javascripts/app/_fpa_loaded.js
@@ -205,7 +205,16 @@ _fpa.loaded.default = function () {
     var href = $(this).attr('href');
     var data_remote = $(this).attr('data-remote');
     if (!href || data_remote) return;
-    if (href.indexOf('/nfs_store/downloads/') >= 0) {
+
+    // Prevent the page-transition overlay for links that trigger file downloads
+    // (NFS store downloads, CSV exports, admin attachment downloads, or any link with download attribute)
+    var is_download = href.indexOf('/nfs_store/downloads/') >= 0 ||
+      href.match(/\.(csv|ics)(\?|$)/) ||
+      href.indexOf('/attachment') >= 0 ||
+      $(this).attr('download') !== undefined ||
+      $(this).hasClass('export-csv');
+
+    if (is_download) {
       $('body').addClass('prevent-page-transition');
     }
   });

--- a/app/controllers/admin/message_notifications_controller.rb
+++ b/app/controllers/admin/message_notifications_controller.rb
@@ -1,36 +1,50 @@
 class Admin::MessageNotificationsController < AdminController
+  #
+  # Download a generated attachment (e.g. calendar .ics file) from a message notification.
+  # The attachment content is stored in extra_substitutions YAML column.
+  def attachment
+    mn = Messaging::MessageNotification.find(params[:id])
+    ci_data = mn.calendar_invite_data
 
+    if ci_data&.dig('generated_content').present?
+      send_data ci_data['generated_content'],
+                filename: 'calendar.ics',
+                type: 'text/calendar',
+                disposition: 'attachment'
+    else
+      head :not_found
+    end
+  end
 
   protected
 
-    def view_folder
+  def view_folder; end
 
-    end
+  def filters
+    {
+      # message_type: ['email'],
+      app_type_id: Admin::AppType.all_by_name,
+      status: ['IS NULL', Messaging::MessageNotification::StatusInProgress,
+               Messaging::MessageNotification::StatusFailed, Messaging::MessageNotification::StatusComplete]
+    }
+  end
 
-    def filters
-      {
-        # message_type: ['email'],
-        app_type_id: Admin::AppType.all_by_name,
-        status: ['IS NULL', Messaging::MessageNotification::StatusInProgress, Messaging::MessageNotification::StatusFailed, Messaging::MessageNotification::StatusComplete]
-      }
-    end
+  def filters_on
+    %i[app_type_id status]
+  end
 
-    def filters_on
-      [:app_type_id, :status]
-    end
+  def default_index_order
+    { created_at: :desc }
+  end
 
-    def default_index_order
-      {created_at: :desc}
-    end
-
-    def no_edit
-      true
-    end
-
+  def no_edit
+    true
+  end
 
   private
-    def permitted_params
-      [:id, :app_type_id, :master_id, :user_id, :item_id, :message_type, :recipient_user_ids, :layout_template_name, :content_template_name, :subject, :data, :recipient_emails, :recipient_sms_numbers, :from_user_email, :generate_view, :status, :created_at, :updated_at]
-    end
 
+  def permitted_params
+    %i[id app_type_id master_id user_id item_id message_type recipient_user_ids layout_template_name
+       content_template_name subject data recipient_emails recipient_sms_numbers from_user_email generate_view status created_at updated_at]
+  end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -18,7 +18,7 @@ class NotificationMailer < ActionMailer::Base
 
     emails = notify.recipient_emails.select do |email|
       email ||= ''
-      res = email_has_fqdn(email)
+      res = fully_qualified_domain_name?(email)
 
       if res
         # Lookup the user email
@@ -30,7 +30,7 @@ class NotificationMailer < ActionMailer::Base
 
         unless res
           msg = "send_message_notification email #{email} - " \
-            "can not send disabled: #{user&.disabled} or do not email: #{user&.do_not_email}"
+                "can not send disabled: #{user&.disabled} or do not email: #{user&.do_not_email}"
           Rails.logger.info msg
           messages << msg
         end
@@ -38,7 +38,7 @@ class NotificationMailer < ActionMailer::Base
         res
       else
         msg = "send_message_notification email #{email} - " \
-          'can not send due to no FQDN'
+              'can not send due to no FQDN'
         Rails.logger.info msg
         messages << msg
       end
@@ -58,15 +58,23 @@ class NotificationMailer < ActionMailer::Base
     options = {
       to: emails,
       from: notify.from_user_email,
-      body: notify.generated_text,
-      content_type: 'text/html',
       subject: notify.subject
     }
 
     logger.info "Sending email options: #{options}"
     return if Rails.env.test? && !Settings::TestMail
 
-    mail(options)
+    # Add any resolved attachments (e.g. calendar .ics files)
+    notify.resolved_attachments.each do |att|
+      attachments[att[:filename]] = {
+        mime_type: att[:mime_type],
+        content: att[:content]
+      }
+    end
+
+    mail(options) do |format|
+      format.html { render html: notify.generated_text.html_safe }
+    end
   end
 
   #
@@ -75,7 +83,7 @@ class NotificationMailer < ActionMailer::Base
   # This removes '@test' and '@template'
   # @param [String] email
   # @return [Boolean]
-  def email_has_fqdn(email)
+  def fully_qualified_domain_name?(email)
     domain = email.split('@', 2)
     domain.last&.include?('.')
   end

--- a/app/models/admin/defs/save_triggers_notify_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_notify_options_defs.yaml
@@ -3,113 +3,125 @@
         # for a single trigger.  
         notify:
           - type: 'email|sms'
-          role: |
-            (optional) role name(s) to notify. Supports:
-            - literal string: 'admin'
-            - conditional reference: {this: {user_id: return_value}}
-            - simple template: '{{field_name}}' substitutes field value as string
-            - raw template: '{{{field_name}}}' substitutes field value preserving type
-          
-          users: |
-            (optional) list of user IDs to notify. Supports:
-            - literal value: 123
-            - array of literals: [123, 456]
-            - conditional reference with single value: {this: {user_id: return_value}}
-            - conditional reference with list: {activity_log__player_contact_phones: {master_id: <id>, user_id: return_value_list}}
-            - simple template: '{{user_id}}' substitutes field value as string
-            - raw template: '{{{user_id}}}' substitutes field value preserving type (e.g., Integer)
+            role: |
+              (optional) role name(s) to notify. Supports:
+              - literal string: 'admin'
+              - conditional reference: {this: {user_id: return_value}}
+              - simple template: '{{field_name}}' substitutes field value as string
+              - raw template: '{{{field_name}}}' substitutes field value preserving type
             
-            Note: return_value_list retrieves an array of values from matching records
-          
-          emails: |
-            (optional) list of email addresses - not necessarily users. Supports:
-            - literal string: 'admin@example.com'
-            - array of literals: ['admin@example.com', 'manager@example.com']
-            - conditional reference with single value: {this: {email: return_value}}
-            - conditional reference with list: {player_contacts: {rec_type: email, data: return_value_list}}
-            - simple template: '{{player_contact_emails.data}}' substitutes associated record field(s)
+            users: |
+              (optional) list of user IDs to notify. Supports:
+              - literal value: 123
+              - array of literals: [123, 456]
+              - conditional reference with single value: {this: {user_id: return_value}}
+              - conditional reference with list: {activity_log__player_contact_phones: {master_id: <id>, user_id: return_value_list}}
+              - simple template: '{{user_id}}' substitutes field value as string
+              - raw template: '{{{user_id}}}' substitutes field value preserving type (e.g., Integer)
+              
+              Note: return_value_list retrieves an array of values from matching records
             
-            Note: return_value_list retrieves an array of values from matching records.
-            Template substitutions for associations return arrays (e.g., ['email1@test.com', 'email2@test.com'])
-          
-          phones: |
-            (optional) list of phone numbers to notify. Supports:
-            - literal string: '+16175550118'
-            - array of literals: ['+16175550118', '+16175550104']
-            - conditional reference with single value: {this: {phone: return_value}}
-            - conditional reference with list: {player_contacts: {rec_type: phone, data: return_value_list}}
-            - simple template: '{{data}}' substitutes field value as string
+            emails: |
+              (optional) list of email addresses - not necessarily users. Supports:
+              - literal string: 'admin@example.com'
+              - array of literals: ['admin@example.com', 'manager@example.com']
+              - conditional reference with single value: {this: {email: return_value}}
+              - conditional reference with list: {player_contacts: {rec_type: email, data: return_value_list}}
+              - simple template: '{{player_contact_emails.data}}' substitutes associated record field(s)
+              
+              Note: return_value_list retrieves an array of values from matching records.
+              Template substitutions for associations return arrays (e.g., ['email1@test.com', 'email2@test.com'])
             
-            Note: return_value_list retrieves an array of phone numbers from matching records.
-            Phone numbers are automatically cleaned and formatted with the specified default_country_code
-          phone_records: |
-            (optional) conditional reference to retrieve phone record IDs. Uses return_value_list
-            to get an array of record IDs from an associated model. Requires list_type to specify
-            the model class to use for retrieving the actual phone records.
+            phones: |
+              (optional) list of phone numbers to notify. Supports:
+              - literal string: '+16175550118'
+              - array of literals: ['+16175550118', '+16175550104']
+              - conditional reference with single value: {this: {phone: return_value}}
+              - conditional reference with list: {player_contacts: {rec_type: phone, data: return_value_list}}
+              - simple template: '{{data}}' substitutes field value as string
+              
+              Note: return_value_list retrieves an array of phone numbers from matching records.
+              Phone numbers are automatically cleaned and formatted with the specified default_country_code
+            phone_records: |
+              (optional) conditional reference to retrieve phone record IDs. Uses return_value_list
+              to get an array of record IDs from an associated model. Requires list_type to specify
+              the model class to use for retrieving the actual phone records.
+              
+              Example configuration:
+                dynamic_model__zeus_bulk_message_recipients:
+                  zeus_bulk_message_id:
+                    parent_references:
+                      dynamic_model__zeus_bulk_messages: 'id'
+                  disabled: false
+                  id: 'return_value_list'
             
-            Example configuration:
-              dynamic_model__zeus_bulk_message_recipients:
-                zeus_bulk_message_id:
-                  parent_references:
-                    dynamic_model__zeus_bulk_messages: 'id'
-                disabled: false
-                id: 'return_value_list'
-          
-          list_type: |
-            (required with phone_records) association name to use to retrieve phone records.
-            Specifies the model class that phone_records IDs belong to.
-            
-            For example: dynamic_model__zeus_bulk_message_recipients
+            list_type: |
+              (required with phone_records) association name to use to retrieve phone records.
+              Specifies the model class that phone_records IDs belong to.
+              
+              For example: dynamic_model__zeus_bulk_message_recipients
 
-          default_country_code: '(optional) country code for SMS numbers, if they are not otherwise specified'
-          from_user_email:
-            address: 'email address the message should appear to be from'
-            display_name: 'display name for email address'
-          
-          "from_user_email(alternative)": 'string email address'
-          ignore_no_recipients: nil (default) | true - don't raise an error if no recipients are specified or found in the role
-
-          layout_template: 'name of layout template'
-          content_template: 'name of content template'
-          content_template_text: |
-            alternative content template text (instead of content_template). Supports:
-            - literal string: 'Your message here'
-            - conditional reference: {this: {importance_level: return_value}}
-            - simple template: '{{field_name}}' substitutes field value into the text
+            default_country_code: '(optional) country code for SMS numbers, if they are not otherwise specified'
+            from_user_email:
+              address: 'email address the message should appear to be from'
+              display_name: 'display name for email address'
             
-            Note: Any template substitutions will be made when the content_template_text value
-            is first used. This result may include further curly templates, which
-            will be processed when the message is sent. In this way, stored records may be used to
-            represent templates, which are then rendered with current data at send time.
-          
-          subject: 'subject text'
-          extra_substitutions:
-            data1: 'fixed data item to be substituted into the message in `\{\{extra_substitutions.data1\}\}`'
-          
-          importance: |
-            transactional (default) | promotional. Supports:
-            - literal string: 'Promotional'
-            - conditional reference: {this: {importance_level: return_value}}
-            - simple template: '{{select_result}}' substitutes field value as string
+            "from_user_email(alternative)": 'string email address'
+            ignore_no_recipients: nil (default) | true - don't raise an error if no recipients are specified or found in the role
+
+            layout_template: 'name of layout template'
+            content_template: 'name of content template'
+            content_template_text: |
+              alternative content template text (instead of content_template). Supports:
+              - literal string: 'Your message here'
+              - conditional reference: {this: {importance_level: return_value}}
+              - simple template: '{{field_name}}' substitutes field value into the text
+              
+              Note: Any template substitutions will be made when the content_template_text value
+              is first used. This result may include further curly templates, which
+              will be processed when the message is sent. In this way, stored records may be used to
+              represent templates, which are then rendered with current data at send time.
             
-            Used for email categorization and compliance with anti-spam regulations
-          
-          when:
-            wait_until: |
-              (optional) one of
-              - ISO date
-              - {date:..., time..., zone:...}  
-                where zone is one specified in MAPPINGS @ 
-                https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html
+            subject: 'subject text'
+            calendar_invite:
+              method: '(optional, default: REQUEST) REQUEST|CANCEL - RFC 5545 method (case insensitive)'
+              summary: 'event title - supports {{curly}} substitutions'
+              description: '(optional) event description (plain text) - supports {{curly}} substitutions'
+              location: '(optional) event location - supports {{curly}} substitutions'
+              dtstart: 'start datetime (ISO format or parseable string) - supports {{curly}} substitutions'
+              dtend: '(optional if duration provided) end datetime (ISO format or parseable string) - supports {{curly}} substitutions'
+              duration: '(optional) event duration string (e.g. "90 minutes", "1 hour", "2 days") - used to calculate dtend from dtstart when dtend is not provided'
+              organizer: 'organizer email address - supports {{curly}} substitutions'
+              uid: '(optional, default: auto-generated UUID) unique event identifier - supports {{curly}} substitutions'
+              sequence: '(optional, default: 0) event revision sequence number'
 
-            wait: |
-              Time to wait from now before sending, in the form:
-              <n> seconds|minutes|hours|days|weeks|months|years
-          
-          on_complete: |
-            triggers to run when send has completed, for example update_reference:...
+            extra_substitutions:
+              data1: 'fixed data item to be substituted into the message in `\{\{extra_substitutions.data1\}\}`'
+            
+            importance: |
+              transactional (default) | promotional. Supports:
+              - literal string: 'Promotional'
+              - conditional reference: {this: {importance_level: return_value}}
+              - simple template: '{{select_result}}' substitutes field value as string
+              
+              Used for email categorization and compliance with anti-spam regulations
+            
+            when:
+              wait_until: |
+                (optional) one of
+                - ISO date
+                - {date:..., time..., zone:...}  
+                  where zone is one specified in MAPPINGS @ 
+                  https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html
 
-          if: if_extras
+              wait: |
+                Time to wait from now before sending, in the form:
+                <n> seconds|minutes|hours|days|weeks|months|years
+            
+            on_complete: |
+              triggers to run when send has completed, for example update_reference:...
 
-          app_type: optionally specify an app_type id to force the use of a batch user when perfoming actions
-          user: optionally specify a user id (or email) to force use of the specified user when perfoming actions
+            if: if_extras
+
+            app_type: optionally specify an app_type id to force the use of a batch user when perfoming actions
+            user: optionally specify a user id (or email) to force use of the specified user when perfoming actions

--- a/app/models/messaging/calendar_invite.rb
+++ b/app/models/messaging/calendar_invite.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+module Messaging
+  #
+  # Generate RFC 5545 compliant VCALENDAR/VEVENT .ics content
+  # for email notification attachments.
+  # Supports METHOD:REQUEST (invitation) and METHOD:CANCEL (cancellation).
+  #
+  # @example
+  #   config = {
+  #     'method' => 'REQUEST',
+  #     'summary' => 'Meeting Title',
+  #     'description' => 'Meeting notes',
+  #     'location' => 'Room 101',
+  #     'dtstart' => '2026-04-01 10:00:00',
+  #     'dtend' => '2026-04-01 11:00:00',
+  #     'organizer' => 'organizer@example.com',
+  #     'uid' => 'unique-id@restructure',
+  #     'sequence' => 0
+  #   }
+  #   invite = Messaging::CalendarInvite.new(config)
+  #   ics_content = invite.generate
+  class CalendarInvite
+    ValidMethods = %w[REQUEST CANCEL].freeze
+
+    attr_reader :config
+
+    # @param [Hash] config - calendar invite configuration with string keys
+    def initialize(config)
+      @config = config
+    end
+
+    #
+    # Generate an RFC 5545 compliant VCALENDAR string with a VEVENT
+    # @return [String] the .ics file content
+    def generate
+      apply_defaults!
+      validate_config!
+
+      lines = []
+      lines << 'BEGIN:VCALENDAR'
+      lines << 'VERSION:2.0'
+      lines << 'PRODID:-//ReStructure//MessageNotification//EN'
+      lines << "METHOD:#{ical_method}"
+      lines << 'BEGIN:VEVENT'
+      lines << "DTSTART:#{format_datetime(config['dtstart'])}"
+      lines << "DTEND:#{format_datetime(resolved_dtend)}"
+      lines << "DTSTAMP:#{format_datetime(Time.current)}"
+      lines << "UID:#{config['uid']}"
+      lines << "SEQUENCE:#{config['sequence'] || 0}"
+      lines << "SUMMARY:#{config['summary']}"
+      lines << "DESCRIPTION:#{config['description']}" if config['description']
+      lines << "LOCATION:#{config['location']}" if config['location']
+      lines << "ORGANIZER:mailto:#{config['organizer']}"
+      lines << 'STATUS:CANCELLED' if ical_method == 'CANCEL'
+      lines << 'END:VEVENT'
+      lines << 'END:VCALENDAR'
+
+      lines.join("\r\n") + "\r\n"
+    end
+
+    private
+
+    #
+    # Apply sensible defaults to config fields that were not provided.
+    # - method defaults to 'REQUEST'
+    # - uid defaults to a generated UUID@restructure
+    # - dtend is calculated from dtstart + duration if absent but duration is provided.
+    #   Duration is parsed by FieldDefaults.duration (e.g. "90 minutes", "1 hour").
+    # @return [void]
+    def apply_defaults!
+      config['method'] = 'REQUEST' if config['method'].blank?
+      config['uid'] = "#{SecureRandom.uuid}@restructure" if config['uid'].blank?
+
+      return unless config['dtend'].blank? && config['duration'].present?
+
+      dur = FieldDefaults.duration(config['duration'].to_s)
+      raise FphsException, "CalendarInvite: invalid duration '#{config['duration']}'" unless dur
+
+      start_time = parse_datetime(config['dtstart'])
+      config['dtend'] = (start_time + dur).iso8601
+    end
+
+    #
+    # The iCalendar method (REQUEST or CANCEL), uppercased
+    # @return [String]
+    def ical_method
+      config['method']&.upcase
+    end
+
+    #
+    # The resolved dtend value, preferring the explicit dtend over duration-calculated value
+    # @return [String]
+    def resolved_dtend
+      config['dtend']
+    end
+
+    #
+    # Parse a datetime value into a Time object
+    # @param [Time, DateTime, Date, String] value
+    # @return [Time]
+    def parse_datetime(value)
+      case value
+      when Time, DateTime
+        value.utc
+      when Date
+        value.to_time.utc
+      when String
+        Time.zone.parse(value).utc
+      else
+        raise FphsException, "CalendarInvite: unsupported datetime type #{value.class}"
+      end
+    end
+
+    #
+    # Format a datetime value to UTC YYYYMMDDTHHMMSSZ format
+    # Accepts Time, DateTime, Date, or parseable String
+    # @param [Time, DateTime, Date, String] value
+    # @return [String] formatted as YYYYMMDDTHHMMSSZ
+    def format_datetime(value)
+      parse_datetime(value).strftime('%Y%m%dT%H%M%SZ')
+    end
+
+    #
+    # Validate that required config fields are present and method is valid
+    def validate_config!
+      unless ical_method.in?(ValidMethods)
+        raise FphsException, "CalendarInvite: method must be one of #{ValidMethods.join(', ')}, got #{config['method']}"
+      end
+
+      %w[summary dtstart organizer].each do |field|
+        raise FphsException, "CalendarInvite: #{field} is required" if config[field].blank?
+      end
+
+      return unless config['dtend'].blank? && config['duration'].blank?
+
+      raise FphsException, 'CalendarInvite: dtend or duration is required'
+    end
+  end
+end

--- a/app/models/messaging/message_notification.rb
+++ b/app/models/messaging/message_notification.rb
@@ -69,7 +69,7 @@ module Messaging
       value = value.to_s.capitalize
       raise FphsException, "Incorrect importance: #{value}" unless value.in?(ValidImportance)
 
-      super(value)
+      super
     end
 
     #
@@ -177,7 +177,7 @@ module Messaging
     def recipient_data=(data)
       data = data.map(&:to_json) if data.is_a?(Array) && data.first.is_a?(Hash)
       @recipient_hash_from_data = nil
-      super(data)
+      super
     end
 
     #
@@ -191,7 +191,7 @@ module Messaging
         data = data.to_yaml
       end
 
-      super(data)
+      super
     end
 
     #
@@ -205,7 +205,7 @@ module Messaging
         email = formatted.format
       end
 
-      super(email)
+      super
     end
 
     #
@@ -249,6 +249,7 @@ module Messaging
     # @param [Array | nil] recipient_sms_numbers - optionally override numbers to send to
     def generate_and_send(recipient_sms_numbers: nil)
       generate
+      resolve_attachments if email?
 
       if email?
         NotificationMailer.send_message_notification(self).deliver_now
@@ -259,6 +260,28 @@ module Messaging
       else
         raise FphsException, "No recognized message type for message notification: #{message_type}"
       end
+    end
+
+    #
+    # Resolve any attachments configured in extra_substitutions.
+    # Currently handles calendar_invite (.ics) attachments.
+    # Generates .ics content via Messaging::CalendarInvite, stores the generated content
+    # back into extra_substitutions_data for admin retrieval, and persists the record.
+    # @return [void]
+    def resolve_attachments
+      @resolved_attachments = []
+
+      resolve_calendar_invite_attachment
+
+      save! if @resolved_attachments.any?
+    end
+
+    #
+    # Returns the resolved attachments for the mailer to use.
+    # Each attachment is a Hash with :filename, :mime_type, and :content keys.
+    # @return [Array<Hash>]
+    def resolved_attachments
+      @resolved_attachments || []
     end
 
     #
@@ -320,6 +343,13 @@ module Messaging
       rescue StandardError
         nil
       end
+    end
+
+    #
+    # The calendar invite data from extra_substitutions, if present.
+    # @return [HashWithIndifferentAccess | nil]
+    def calendar_invite_data
+      extra_substitutions_data&.dig(:calendar_invite)
     end
 
     private
@@ -428,12 +458,37 @@ module Messaging
 
     #
     # The hash data representation of #extra_substitutions
-    # @return [Hash]
+    # @return [HashWithIndifferentAccess | nil]
     def extra_substitutions_data
       return @extra_substitutions_data if @extra_substitutions_data
       return unless extra_substitutions
 
       @extra_substitutions_data = YAML.safe_load(extra_substitutions, permitted_classes: [Symbol])
+                                      &.with_indifferent_access
+    end
+
+    #
+    # Resolve the calendar_invite from extra_substitutions_data.
+    # Generates RFC 5545 .ics content via Messaging::CalendarInvite,
+    # stores the generated content back in extra_substitutions for admin retrieval.
+    # @return [void]
+    def resolve_calendar_invite_attachment
+      ci_data = extra_substitutions_data&.dig(:calendar_invite)
+      return unless ci_data
+
+      invite = Messaging::CalendarInvite.new(ci_data)
+      ics_content = invite.generate
+
+      # Store generated content back for admin retrieval
+      ci_data['generated_content'] = ics_content
+      self.extra_substitutions = extra_substitutions_data.to_hash.to_yaml
+
+      ical_method = ci_data['method']&.upcase || 'REQUEST'
+      @resolved_attachments << {
+        filename: 'calendar.ics',
+        mime_type: "text/calendar; method=#{ical_method}",
+        content: ics_content
+      }
     end
 
     #

--- a/app/models/save_triggers/notify.rb
+++ b/app/models/save_triggers/notify.rb
@@ -49,7 +49,7 @@ class SaveTriggers::Notify < SaveTriggers::SaveTriggersBase
       elsif @emails
         setup_emails
       else
-        raise FphsException, 'role, users or phones must be specified in save_trigger: notify: role: ...'
+        raise FphsException, 'role, users, emails or phones must be specified in save_trigger: notify: role: ...'
       end
 
       if !@receiving_user_ids&.present? && !@force_phones && !@force_emails && !@force_recip_recs
@@ -283,15 +283,47 @@ class SaveTriggers::Notify < SaveTriggers::SaveTriggersBase
   # to be substituted into the message using substitutions like {{extra_substitutions.data1}}
   # Data within the extra substitutions is substituted from the item, so may also contain its own
   # {{curly}} substitutions, set at the time the notification is created, not at the time it is sent.
+  # If a calendar_invite config is present, its values are resolved and merged into
+  # extra_substitutions[:calendar_invite] for storage on the MessageNotification record.
   # @return [Hash | nil]
   def extra_substitutions
     return @extra_substitutions if @extra_substitutions
 
-    @extra_substitutions = config[:extra_substitutions]
+    @extra_substitutions = config[:extra_substitutions] || {}
 
-    @extra_substitutions&.each do |k, v|
-      @extra_substitutions[k] = Formatter::Substitution.substitute(v, data: @item, tag_subs: nil, ignore_missing: true)
+    @extra_substitutions.each do |k, v|
+      next unless v.is_a?(String)
+
+      @extra_substitutions[k] = substitute_from_item(v)
     end
+
+    merge_calendar_invite_into_extra_substitutions
+
+    @extra_substitutions = nil if @extra_substitutions.blank?
+    @extra_substitutions
+  end
+
+  #
+  # Parse the calendar_invite config option, resolve {{curly}} substitutions in all string values,
+  # and merge the resolved hash into extra_substitutions[:calendar_invite].
+  # @return [void]
+  def merge_calendar_invite_into_extra_substitutions
+    cal_config = config[:calendar_invite]
+    return unless cal_config
+
+    resolved = cal_config.to_h do |k, v|
+      [k.to_s, v.is_a?(String) ? substitute_from_item(v) : v]
+    end
+
+    @extra_substitutions[:calendar_invite] = resolved
+  end
+
+  #
+  # Substitute {{curly}} template values from the current item
+  # @param [String] value - string containing {{curly}} substitutions
+  # @return [String] resolved string
+  def substitute_from_item(value)
+    Formatter::Substitution.substitute(value, data: @item, tag_subs: nil, ignore_missing: true)
   end
 
   #

--- a/app/views/admin/message_notifications/_index.html.erb
+++ b/app/views/admin/message_notifications/_index.html.erb
@@ -34,6 +34,12 @@
             <tr><td><%= i.humanize %>:</td><td><%= list_item.send(i) %></td></tr>
             <% end %>
           </table>
+          <% ci_data = list_item.calendar_invite_data %>
+          <% if ci_data&.dig('generated_content').present? %>
+            <p><strong>Attachments:</strong>
+              <%= link_to 'calendar.ics', attachment_admin_message_notification_path(list_item), class: 'btn btn-sm btn-default' %>
+            </p>
+          <% end %>
           <iframe id="message-iframe-<%= list_item.id %>" src='javascript:void(0)' srcdoc="" class="iframe-message-notification if-mn-type-<%= list_item.message_type%> if-mn-status-<%= list_item.status %>" sandbox="allow-popups allow-popups-to-escape-sandbox">
           </iframe>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,7 +58,11 @@ Rails.application.routes.draw do
     end
     resources :app_configurations, except: %i[show destroy]
     resources :message_templates, except: %i[show destroy]
-    resources :message_notifications, except: %i[show destroy]
+    resources :message_notifications, except: %i[show destroy] do
+      member do
+        get :attachment
+      end
+    end
 
     resources :job_reviews, except: %i[show destroy]
     post 'job_reviews/restart_failed_jobs', to: 'job_reviews#restart_failed_jobs'

--- a/spec/models/messaging/calendar_invite_spec.rb
+++ b/spec/models/messaging/calendar_invite_spec.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+
+# Tests for Messaging::CalendarInvite service class (issue #953)
+# Validates RFC 5545 compliant VCALENDAR/VEVENT .ics generation
+# supporting METHOD:REQUEST (invitation) and METHOD:CANCEL (cancellation).
+# Tests cover: defaults, case insensitivity, duration option, validation errors,
+# and optional field omission.
+
+require 'rails_helper'
+
+RSpec.describe Messaging::CalendarInvite, type: :model do
+  let(:valid_config) do
+    {
+      'method' => 'REQUEST',
+      'summary' => 'Study Review Meeting',
+      'description' => 'Discuss study progress',
+      'location' => 'Conference Room A',
+      'dtstart' => '2026-04-01 10:00:00',
+      'dtend' => '2026-04-01 11:00:00',
+      'organizer' => 'organizer@example.com',
+      'uid' => 'test-123@restructure',
+      'sequence' => 0
+    }
+  end
+
+  # Minimal config relying on defaults for method, uid, and sequence
+  let(:minimal_config) do
+    {
+      'summary' => 'Quick Sync',
+      'dtstart' => '2026-04-01 10:00:00',
+      'dtend' => '2026-04-01 11:00:00',
+      'organizer' => 'organizer@example.com'
+    }
+  end
+
+  describe '#generate' do
+    it 'generates valid RFC 5545 VCALENDAR with METHOD:REQUEST for an invitation' do
+      invite = described_class.new(valid_config)
+      ics_content = invite.generate
+
+      expect(ics_content).to include('BEGIN:VCALENDAR')
+      expect(ics_content).to include('VERSION:2.0')
+      expect(ics_content).to include('PRODID:')
+      expect(ics_content).to include('METHOD:REQUEST')
+      expect(ics_content).to include('BEGIN:VEVENT')
+      expect(ics_content).to include('SUMMARY:Study Review Meeting')
+      expect(ics_content).to include('DESCRIPTION:Discuss study progress')
+      expect(ics_content).to include('LOCATION:Conference Room A')
+      expect(ics_content).to include('UID:test-123@restructure')
+      expect(ics_content).to include('SEQUENCE:0')
+      expect(ics_content).to include('ORGANIZER:mailto:organizer@example.com')
+      expect(ics_content).to include('END:VEVENT')
+      expect(ics_content).to include('END:VCALENDAR')
+    end
+
+    it 'generates valid RFC 5545 VCALENDAR with METHOD:CANCEL for a cancellation' do
+      cancel_config = valid_config.merge('method' => 'CANCEL')
+      invite = described_class.new(cancel_config)
+      ics_content = invite.generate
+
+      expect(ics_content).to include('BEGIN:VCALENDAR')
+      expect(ics_content).to include('METHOD:CANCEL')
+      expect(ics_content).to include('BEGIN:VEVENT')
+      expect(ics_content).to include('STATUS:CANCELLED')
+      expect(ics_content).to include('UID:test-123@restructure')
+      expect(ics_content).to include('END:VEVENT')
+      expect(ics_content).to include('END:VCALENDAR')
+    end
+
+    it 'formats datetime values to UTC YYYYMMDDTHHMMSSZ format' do
+      config = valid_config.merge(
+        'dtstart' => '2026-06-15 14:30:00',
+        'dtend' => '2026-06-15 16:00:00'
+      )
+      invite = described_class.new(config)
+      ics_content = invite.generate
+
+      expect(ics_content).to include('DTSTART:20260615T143000Z')
+      expect(ics_content).to include('DTEND:20260615T160000Z')
+    end
+
+    it 'auto-generates DTSTAMP with current UTC time' do
+      freeze_time = Time.utc(2026, 3, 5, 12, 0, 0)
+      allow(Time).to receive(:current).and_return(freeze_time)
+
+      invite = described_class.new(valid_config)
+      ics_content = invite.generate
+
+      expect(ics_content).to include('DTSTAMP:20260305T120000Z')
+    end
+
+    context 'with defaults' do
+      it 'defaults method to REQUEST when not provided' do
+        invite = described_class.new(minimal_config)
+        ics_content = invite.generate
+
+        expect(ics_content).to include('METHOD:REQUEST')
+        expect(ics_content).not_to include('STATUS:CANCELLED')
+      end
+
+      it 'defaults uid to a generated value when not provided' do
+        invite = described_class.new(minimal_config)
+        ics_content = invite.generate
+
+        # Should have a UID line with some auto-generated value
+        expect(ics_content).to match(/UID:.+@restructure/)
+      end
+
+      it 'defaults sequence to 0 when not provided' do
+        invite = described_class.new(minimal_config)
+        ics_content = invite.generate
+
+        expect(ics_content).to include('SEQUENCE:0')
+      end
+    end
+
+    context 'with case-insensitive method' do
+      it 'accepts lowercase method and uppercases it in output' do
+        config = valid_config.merge('method' => 'request')
+        invite = described_class.new(config)
+        ics_content = invite.generate
+
+        expect(ics_content).to include('METHOD:REQUEST')
+      end
+
+      it 'accepts mixed-case method and uppercases it in output' do
+        config = valid_config.merge('method' => 'Cancel')
+        invite = described_class.new(config)
+        ics_content = invite.generate
+
+        expect(ics_content).to include('METHOD:CANCEL')
+        expect(ics_content).to include('STATUS:CANCELLED')
+      end
+    end
+
+    context 'with duration option' do
+      it 'calculates dtend from dtstart + duration string when dtend is absent' do
+        config = minimal_config.except('dtend').merge(
+          'duration' => '90 minutes'
+        )
+        invite = described_class.new(config)
+        ics_content = invite.generate
+
+        # dtstart is 2026-04-01 10:00:00, + 90 minutes = 11:30:00
+        expect(ics_content).to include('DTSTART:20260401T100000Z')
+        expect(ics_content).to include('DTEND:20260401T113000Z')
+      end
+
+      it 'supports hour-based duration strings' do
+        config = minimal_config.except('dtend').merge(
+          'duration' => '2 hours'
+        )
+        invite = described_class.new(config)
+        ics_content = invite.generate
+
+        # dtstart is 2026-04-01 10:00:00, + 2 hours = 12:00:00
+        expect(ics_content).to include('DTEND:20260401T120000Z')
+      end
+
+      it 'ignores duration when dtend is explicitly provided' do
+        config = valid_config.merge('duration' => '90 minutes')
+        invite = described_class.new(config)
+        ics_content = invite.generate
+
+        # dtend should be 11:00 (from config), not 11:30 (from duration)
+        expect(ics_content).to include('DTEND:20260401T110000Z')
+      end
+
+      it 'raises FphsException for an invalid duration string' do
+        config = minimal_config.except('dtend').merge('duration' => 'bogus')
+        invite = described_class.new(config)
+
+        expect { invite.generate }.to raise_error(FphsException, /invalid duration/)
+      end
+    end
+
+    context 'with optional fields omitted' do
+      it 'omits DESCRIPTION when not provided' do
+        config = valid_config.except('description')
+        invite = described_class.new(config)
+        ics_content = invite.generate
+
+        expect(ics_content).not_to include('DESCRIPTION:')
+      end
+
+      it 'omits LOCATION when not provided' do
+        config = valid_config.except('location')
+        invite = described_class.new(config)
+        ics_content = invite.generate
+
+        expect(ics_content).not_to include('LOCATION:')
+      end
+    end
+  end
+
+  describe 'validation' do
+    it 'raises FphsException for an invalid method value' do
+      config = valid_config.merge('method' => 'PUBLISH')
+      invite = described_class.new(config)
+
+      expect { invite.generate }.to raise_error(FphsException, /method must be one of/)
+    end
+
+    it 'raises FphsException when summary is missing' do
+      config = valid_config.except('summary')
+      invite = described_class.new(config)
+
+      expect { invite.generate }.to raise_error(FphsException, /summary is required/)
+    end
+
+    it 'raises FphsException when dtstart is missing' do
+      config = valid_config.except('dtstart')
+      invite = described_class.new(config)
+
+      expect { invite.generate }.to raise_error(FphsException, /dtstart is required/)
+    end
+
+    it 'raises FphsException when organizer is missing' do
+      config = valid_config.except('organizer')
+      invite = described_class.new(config)
+
+      expect { invite.generate }.to raise_error(FphsException, /organizer is required/)
+    end
+
+    it 'does not raise when dtend is absent but duration is provided' do
+      config = valid_config.except('dtend').merge('duration' => '60 minutes')
+      invite = described_class.new(config)
+
+      expect { invite.generate }.not_to raise_error
+    end
+
+    it 'raises FphsException when both dtend and duration are missing' do
+      config = valid_config.except('dtend')
+      invite = described_class.new(config)
+
+      expect { invite.generate }.to raise_error(FphsException, /dtend or duration is required/)
+    end
+  end
+end

--- a/spec/models/messaging/message_notification_spec.rb
+++ b/spec/models/messaging/message_notification_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Messaging::MessageNotification, type: :model do
     @rec_user, = create_user
     create_user
     seed_database
-    ::ActivityLog.define_models
+    ActivityLog.define_models
     setup_access :player_contacts
     create_item(data: rand(10_000_000_000_000_000), rank: 10)
     @player_contact.master.current_user = @user
@@ -162,7 +162,7 @@ RSpec.describe Messaging::MessageNotification, type: :model do
 
       mn.reload
       res = mn.generated_text
-      expected_name = @activity_log.select_who
+      @activity_log.select_who
 
       expected_text = "<html><head><style>body {font-family: sans-serif;}</style></head><body><h1>Test Email</h1><div><p>This is some new content in a text template.</p><p>Related to a dynamic model #{dm.data}. This is the info: #{dm.info}.</p></div></body></html>"
 
@@ -182,7 +182,7 @@ RSpec.describe Messaging::MessageNotification, type: :model do
     it 'sets up a notification to be sent, where substitution data is a hash' do
       t = '<p>This is some new content in a text template.</p><p>Related to another master_id {{master_id}}. This is a name: {{select_who}}.</p>'
 
-      master = @activity_log.master
+      @activity_log.master
       layout = @layout
 
       # NOTE: do not specify app_type when using data rather than setting an item
@@ -197,7 +197,7 @@ RSpec.describe Messaging::MessageNotification, type: :model do
 
       mn.reload
       res = mn.generated_text
-      expected_name = @activity_log.select_who
+      @activity_log.select_who
 
       expected_text = '<html><head><style>body {font-family: sans-serif;}</style></head><body><h1>Test Email</h1><div><p>This is some new content in a text template.</p><p>Related to another master_id 1234. This is a name: henry anderson.</p></div></body></html>'
 
@@ -358,9 +358,9 @@ RSpec.describe Messaging::MessageNotification, type: :model do
 
       sleep 1
 
-      res = nil
+      nil
       10.times.each do
-        break if Delayed::Job.count == 0
+        break if Delayed::Job.none?
 
         sleep 2
         # puts "Waiting again"
@@ -369,6 +369,112 @@ RSpec.describe Messaging::MessageNotification, type: :model do
       # This doesn't work in test environment since delayed job doesn't run. Need to mock to test this
       # res = testcnx.exec_query "select status, id from  ml_app.message_notifications order by id desc limit 1;"
       # expect(res.rows.first[0]).to eq 'complete'
+    end
+  end
+
+  # Shared calendar invite test data for issue #953 specs
+  let(:calendar_invite_data) do
+    {
+      'method' => 'REQUEST',
+      'summary' => 'Study Review Meeting',
+      'description' => 'Discuss study progress',
+      'location' => 'Conference Room A',
+      'dtstart' => '2026-04-01 10:00:00',
+      'dtend' => '2026-04-01 11:00:00',
+      'organizer' => 'organizer@example.com',
+      'uid' => 'test-123@restructure',
+      'sequence' => 0
+    }
+  end
+
+  # Helper to create a message notification with optional calendar invite
+  def create_test_notification(with_calendar_invite: false)
+    attrs = {
+      app_type: @user.app_type,
+      user: @user,
+      recipient_user_ids: [@rec_user],
+      layout_template_name: @layout.name,
+      content_template_name: @content.name,
+      item_type: @activity_log.class.name,
+      item_id: @activity_log.id,
+      master: @activity_log.master,
+      message_type: :email
+    }
+    attrs[:extra_substitutions] = { calendar_invite: calendar_invite_data } if with_calendar_invite
+    Messaging::MessageNotification.create!(attrs)
+  end
+
+  describe 'resolve_attachments with calendar_invite (issue #953)' do
+    before :example do
+      setup_messaging_test
+      mock_notification_mailer
+    end
+
+    after :example do
+      unmock_notification_mailer
+    end
+
+    it 'reads calendar_invite from extra_substitutions, generates .ics content, and stores it back' do
+      mn = create_test_notification(with_calendar_invite: true)
+
+      mn.resolve_attachments
+      resolved = mn.resolved_attachments
+
+      expect(resolved).to be_a(Array)
+      expect(resolved.length).to eq(1)
+      attachment = resolved.first
+      expect(attachment[:filename]).to eq('calendar.ics')
+      expect(attachment[:mime_type]).to eq('text/calendar; method=REQUEST')
+      expect(attachment[:content]).to include('BEGIN:VCALENDAR')
+      expect(attachment[:content]).to include('METHOD:REQUEST')
+      expect(attachment[:content]).to include('SUMMARY:Study Review Meeting')
+      expect(attachment[:content]).to include('END:VCALENDAR')
+
+      # Verify generated content is stored back in extra_substitutions
+      mn.reload
+      expect(mn.calendar_invite_data['generated_content']).to include('BEGIN:VCALENDAR')
+    end
+  end
+
+  describe 'NotificationMailer attachment support (issue #953)' do
+    before :example do
+      setup_messaging_test
+      change_setting('TestMail', true)
+    end
+
+    after :example do
+      change_setting('TestMail', false)
+    end
+
+    it 'includes .ics attachment in the email when resolved_attachments is present' do
+      mn = create_test_notification(with_calendar_invite: true)
+
+      mn.generate
+      mn.resolve_attachments
+
+      # Build the mail message using the real mailer
+      mail = NotificationMailer.send_message_notification(mn)
+
+      # Verify the mail has an attachment
+      expect(mail.attachments.size).to eq(1)
+      attachment = mail.attachments['calendar.ics']
+      expect(attachment).not_to be_nil
+      expect(attachment.content_type).to include('text/calendar')
+      expect(attachment.body.decoded).to include('BEGIN:VCALENDAR')
+      expect(attachment.body.decoded).to include('METHOD:REQUEST')
+    end
+
+    it 'sends email without attachments when no resolved_attachments present (backward compatibility)' do
+      mn = create_test_notification(with_calendar_invite: false)
+
+      mn.generate
+
+      # Build the mail message using the real mailer
+      mail = NotificationMailer.send_message_notification(mn)
+
+      # Verify the mail has no attachments
+      expect(mail.attachments.size).to eq(0)
+      expect(mail.body.to_s).to include('This is some content')
     end
   end
 end

--- a/spec/models/save_triggers/notify_spec.rb
+++ b/spec/models/save_triggers/notify_spec.rb
@@ -420,9 +420,9 @@ RSpec.describe SaveTriggers::Notify, type: :model do
     expect(@trigger.send(:content_template_text)).to eq 'Custom message for {{select_who}}'
   end
 
-  it 'uses template reference for content_template_text with existing field' do
-    # Use the data field (phone number) in content_template_text
-    # This should be substituted and preserved as a template for later rendering
+  it 'uses conditional reference for content_template_text with existing field' do
+    # Use a conditional hash reference to retrieve the notes field value.
+    # This should be substituted and preserved as a template for later rendering.
     @al.notes = 'Custom message for {{select_who}}'
     @al.select_who = 'notify test person'
     @al.current_user = @user
@@ -808,7 +808,7 @@ RSpec.describe SaveTriggers::Notify, type: :model do
     expect(alstep2_last_sent_msg.item_id).to eq alstep2.id
 
     tsub = "<html><head><style>body {font-family: sans-serif;}</style></head><body><h1>Test Email</h1><div><p>This is some content in a template testing save_trigger notifications.</p><p>Related to master_id #{alstep1.master}. This is a name: #{alstep1.select_who} in #{alstep1.id}.</p> 1\n</div></body></html>"
-    ctt = t = "<p>This is some content in a template testing save_trigger notifications.</p><p>Related to master_id #{alstep1.master}. This is a name: #{alstep1.select_who} in #{alstep1.id}.</p>"
+    ctt = "<p>This is some content in a template testing save_trigger notifications.</p><p>Related to master_id #{alstep1.master}. This is a name: #{alstep1.select_who} in #{alstep1.id}.</p>"
     expect(alstep1_first_sent_msg.item_id).to eq alstep1.id
     expect(alstep1_first_sent_msg.status).to eq 'complete'
     expect(alstep1_first_sent_msg.role_name).to eq 'test'
@@ -825,7 +825,7 @@ RSpec.describe SaveTriggers::Notify, type: :model do
     expect(alstep1_last_sent_msg.generated_content).to eq tsub
 
     tsub = "<html><head><style>body {font-family: sans-serif;}</style></head><body><h1>Test Email</h1><div><p>This is some content in a template testing save_trigger notifications.</p><p>Related to master_id #{alstep2.master}. This is a name: #{alstep2.select_who} in #{alstep2.id}.</p> 1\n</div></body></html>"
-    ctt = t = "<p>This is some content in a template testing save_trigger notifications.</p><p>Related to master_id #{alstep2.master}. This is a name: #{alstep2.select_who} in #{alstep2.id}.</p>"
+    ctt = "<p>This is some content in a template testing save_trigger notifications.</p><p>Related to master_id #{alstep2.master}. This is a name: #{alstep2.select_who} in #{alstep2.id}.</p>"
 
     expect(alstep2_first_sent_msg.item_id).to eq alstep2.id
     expect(alstep2_first_sent_msg.status).to eq 'complete'
@@ -882,6 +882,42 @@ RSpec.describe SaveTriggers::Notify, type: :model do
         expect do
           notify.send(:calc_field_or_return, hash_config)
         end.not_to raise_error
+      end
+    end
+
+    context 'with calendar_invite config (issue #953)' do
+      it 'parses calendar_invite config, resolves substitutions, and merges into extra_substitutions' do
+        config = {
+          type: 'email',
+          role: 'test',
+          layout_template: @layout.name,
+          content_template: @content.name,
+          subject: 'Meeting Invite',
+          calendar_invite: {
+            method: 'REQUEST',
+            summary: 'Review Meeting for {{master_id}}',
+            description: 'Notes about {{select_who}}',
+            location: 'Room 101',
+            dtstart: '2026-04-01 10:00:00',
+            dtend: '2026-04-01 11:00:00',
+            organizer: 'organizer@example.com',
+            uid: '{{id}}-{{master_id}}@restructure',
+            sequence: 0
+          }
+        }
+
+        @trigger = SaveTriggers::Notify.new(config, @al)
+        @trigger.perform
+
+        new_mn = MessageNotification.order(id: :desc).first
+        ci_data = new_mn.calendar_invite_data
+        expect(ci_data).to be_a(Hash)
+        expect(ci_data['method']).to eq('REQUEST')
+        expect(ci_data['summary']).to eq("Review Meeting for #{@al.master_id}")
+        expect(ci_data['description']).to eq("Notes about #{@al.select_who}")
+        expect(ci_data['location']).to eq('Room 101')
+        expect(ci_data['organizer']).to eq('organizer@example.com')
+        expect(ci_data['uid']).to eq("#{@al.id}-#{@al.master_id}@restructure")
       end
     end
   end


### PR DESCRIPTION
## Summary

Adds RFC 5545 compliant calendar invite (.ics) attachment support to the save trigger notify email system.

## Changes

- **`Messaging::CalendarInvite`** (new): Service class generating VCALENDAR/VEVENT .ics content for METHOD:REQUEST and METHOD:CANCEL
  - Defaults: method (REQUEST), uid (auto-generated UUID), sequence (0)
  - Case-insensitive method handling
  - Duration support via `FieldDefaults.duration` (e.g. '90 minutes', '1 hour')
  - Validation for required fields and valid method values

- **`SaveTriggers::Notify`**: Parses `calendar_invite` config block, resolves {{curly}} substitutions, merges into `extra_substitutions`

- **`Messaging::MessageNotification`**: `resolve_attachments` generates .ics content and stores it; public `calendar_invite_data` accessor

- **`NotificationMailer`**: Refactored to block-form `mail()` to support `attachments[]` API

- **Admin UI**: Added attachment viewer route and link for message notifications

- **Page-transition fix**: Extended download link detection in `_fpa_loaded.js` to prevent overlay on .ics/.csv/download links

- **YAML docs**: Updated `save_triggers_notify_options_defs.yaml` with full calendar_invite option documentation

## Tests

- 21 specs in `calendar_invite_spec.rb`: generation, defaults, case insensitivity, duration, optional fields, validation errors
- 3 specs in `message_notification_spec.rb`: resolve_attachments, mailer attachment, backward compatibility
- 1 spec in `notify_spec.rb`: calendar_invite config parsing with substitutions

Fixes #953