### PR TITLE
Added set_variables support for extra option/extra log type configs - fixes #958

### DIFF
--- a/app/models/admin/defs/extra_options_set_variables_defs.yaml
+++ b/app/models/admin/defs/extra_options_set_variables_defs.yaml
@@ -1,0 +1,24 @@
+# set_variables options
+  # Define an ordered list of variables that are evaluated at runtime and accessible via
+  # {{variables.varname}} substitutions, or `element: variables.varname` in conditional calculations.
+  # Each entry has a `name`, a `value` (which may include {{substitutions}}), and an optional
+  # `if` condition (using standard conditional syntax).
+  # Later entries with the same name override earlier ones, allowing conditional defaulting.
+  set_variables:
+    - name: varname
+      value: some default value
+    - name: varname
+      value: "some other value with {{substitution}}"
+      if:
+        all:
+          this:
+            field_name: expected_value
+    - name: hashvar
+      value:
+        object:
+          key1: value1
+          key2: "value2 {{with_substitution}}"
+      if:
+        all:
+          this:
+            field_name: expected_value

--- a/app/models/formatter/substitution.rb
+++ b/app/models/formatter/substitution.rb
@@ -351,6 +351,7 @@ module Formatter
       setup_data_for_item_user(data, item)
       setup_data_for_current_user(data, master, item)
       setup_methods_as_attributes(data)
+      setup_set_variables(data, item)
       data
     end
 
@@ -442,6 +443,46 @@ module Formatter
       ValidMethodsAsAttributes[rn].each do |tag_name|
         data[tag_name] = orig_obj.send(tag_name) if orig_obj.respond_to?(tag_name)
       end
+    end
+
+    #
+    # Evaluate set_variables from the item's option_type_config and add them to data[:variables].
+    # Variables are processed in array order. Each entry has :name, :value, and optional :if condition.
+    # Later entries with the same name override earlier ones.
+    # Values may contain {{substitution}} tags resolved against the current data.
+    # Hash values with :object key are used directly as hash values.
+    # @param [Hash] data - the substitution data hash
+    # @param [Object] item - the original item instance
+    def self.setup_set_variables(data, item)
+      return unless data.is_a?(Hash) && item.respond_to?(:option_type_config)
+
+      config = item.option_type_config
+      return unless config&.respond_to?(:set_variables) && config.set_variables.present?
+
+      variables = {}
+
+      config.set_variables.each do |entry|
+        # Evaluate the if condition when present
+        if entry[:if].present?
+          ca = ConditionalActions.new(entry[:if], item)
+          next unless ca.calc_action_if
+        end
+
+        value = entry[:value]
+
+        # Handle hash values with :object key
+        if value.is_a?(Hash) && value.key?(:object)
+          value = value[:object]
+          value = value.deep_symbolize_keys if value.respond_to?(:deep_symbolize_keys)
+        elsif value.is_a?(String) && value.include?('{{')
+          # Substitute tags in the value string
+          value = substitute(value, data:, ignore_missing: true)
+        end
+
+        variables[entry[:name].to_sym] = value
+      end
+
+      data[:variables] = variables if variables.present?
     end
 
     #
@@ -651,6 +692,9 @@ module Formatter
       elsif name == 'constants'
         # Options constants
         item.versioned_definition.options_constants&.dup if item.respond_to?(:versioned_definition)
+      elsif name == 'variables'
+        # Set variables from option type config
+        data[:variables] if data.is_a?(Hash)
       elsif name.in?(allowable_associations(item.class))
         item.send(name)
       elsif item_reference

--- a/app/models/option_configs/extra_options.rb
+++ b/app/models/option_configs/extra_options.rb
@@ -19,6 +19,7 @@ module OptionConfigs
         field_options dialog_before creatable_if editable_if showable_if add_reference_if valid_if
         filestore labels fields button_label orig_config db_configs save_trigger embed references
         show_if_condition_strings batch_trigger config_trigger preset_fields field_configs raw_field_configs
+        set_variables
       ]
     end
 
@@ -82,6 +83,7 @@ module OptionConfigs
         clean_batch_triggers
         clean_config_triggers
         clean_preset_fields
+        clean_set_variables_def
 
         # Add the cleaned values back into field_configs - save a raw version for use elsewhere
         # This needs to be "deep cloned", to avoid a simple clone just copying references
@@ -361,7 +363,7 @@ module OptionConfigs
             refitem[mn][:to_model_name_us] = to_class.to_s&.ns_underscore
             refitem[mn][:to_model_class_name] = to_class.to_s
             refitem[mn][:to_table_name] = to_class.table_name
-            tsn = nil
+            nil
 
             if to_class.respond_to?(:definition)
               cd = to_class.definition
@@ -450,6 +452,29 @@ module OptionConfigs
     def clean_preset_fields
       self.preset_fields ||= {}
       self.preset_fields = self.preset_fields.symbolize_keys
+    end
+
+    #
+    # Validate and clean the set_variables definition.
+    # set_variables accepts an ordered array of variable definitions,
+    # each with :name, :value, and optional :if condition.
+    def clean_set_variables_def
+      return if set_variables.blank?
+
+      unless set_variables.is_a?(Array)
+        failed_config :set_variables, 'must be an array of variable definitions'
+        self.set_variables = []
+        return
+      end
+
+      self.set_variables = set_variables.map do |entry|
+        entry = entry.symbolize_keys if entry.is_a?(Hash)
+        unless entry.is_a?(Hash) && entry[:name].present? && entry.key?(:value)
+          failed_config :set_variables, "each entry must have 'name' and 'value' keys"
+          next nil
+        end
+        entry
+      end.compact
     end
 
     def clean_field_configs
@@ -604,7 +629,7 @@ module OptionConfigs
 
       config_text = prepend_standard_definitions(config_text)
       config_text = include_libraries(config_text)
-      config_text = config_text.gsub(/^---.*\n/, '')
+      config_text.gsub(/^---.*\n/, '')
     end
 
     #

--- a/docs/admin_reference/activity_logs/detailed_options.md
+++ b/docs/admin_reference/activity_logs/detailed_options.md
@@ -35,6 +35,7 @@ These options appear outside any `default:` or extra log type key.
 - [save_action](../general/save_action.md) — post-save UI actions
 - [field_options](../general/field_options.md) — per-field configuration (values, validators, edit_as, big-select)
 - [preset_fields](../general/preset_fields.md) — preset multiple fields from related items on initialisation
+- [set_variables](../general/set_variables.md) — runtime variables with conditional logic and substitutions
 - [dialog_before](../general/dialog_before.md) — confirmation dialogs before submit
 
 ## Conditional Access Options

--- a/docs/admin_reference/dynamic_models/detailed_options.md
+++ b/docs/admin_reference/dynamic_models/detailed_options.md
@@ -33,6 +33,7 @@ These options appear outside the `default:` key.
 - [save_action](../general/save_action.md) — post-save UI actions
 - [field_options](../general/field_options.md) — per-field configuration (values, validators, edit_as, big-select)
 - [preset_fields](../general/preset_fields.md) — preset multiple fields from related items on initialisation
+- [set_variables](../general/set_variables.md) — runtime variables with conditional logic and substitutions
 - [dialog_before](../general/dialog_before.md) — confirmation dialogs before submit
 
 ## Conditional Access Options

--- a/docs/admin_reference/external_identifiers/detailed_options.md
+++ b/docs/admin_reference/external_identifiers/detailed_options.md
@@ -33,6 +33,7 @@ These options appear outside the `default:` key.
 - [save_action](../general/save_action.md) — post-save UI actions
 - [field_options](../general/field_options.md) — per-field configuration (values, validators, edit_as, big-select)
 - [preset_fields](../general/preset_fields.md) — preset multiple fields from related items on initialisation
+- [set_variables](../general/set_variables.md) — runtime variables with conditional logic and substitutions
 - [dialog_before](../general/dialog_before.md) — confirmation dialogs before submit
 
 ## Conditional Access Options

--- a/docs/admin_reference/general/set_variables.md
+++ b/docs/admin_reference/general/set_variables.md
@@ -1,0 +1,32 @@
+# `set_variables`
+## Runtime Variables with Conditional Logic
+
+Define an ordered list of variables within each extra log type or `default:` option type. Unlike `_constants` (which are global and static), `set_variables` are evaluated per option type at runtime and can use substitutions and conditional logic.
+
+Variables are accessible via `{{variables.varname}}` or `{{variables.hashvar.key1}}` substitutions, and through `element: variables.varname` in conditional calculations.
+
+### How it works
+
+- Each entry specifies a `name` and a `value`
+- Values may include `{{substitution}}` tags resolved against the current item's data
+- An optional `if` condition (using [standard conditional syntax](conditions.md)) controls whether the variable is set
+- Entries are processed **in order** — later entries with the same name override earlier ones
+- This allows a default value to be set first, then conditionally overridden
+
+### Value types
+
+- **String**: a plain string or a string with `{{substitution}}` tags
+- **Hash/Object**: use the `object:` key to define structured data, accessible with dot notation (e.g. `{{variables.config.key1}}`)
+
+### Comparison with `_constants`
+
+| Feature | `_constants` | `set_variables` |
+|---|---|---|
+| Scope | Global (all option types) | Per option type |
+| Values | Static key-value pairs | Dynamic (supports substitutions) |
+| Conditions | No | Yes (`if:` conditions) |
+| Access | `{{constants.name}}` | `{{variables.name}}` |
+
+```yaml
+!defs(extra_options_set_variables_defs.yaml)
+```

--- a/spec/models/formatter/substitution_set_variables_spec.rb
+++ b/spec/models/formatter/substitution_set_variables_spec.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+# Tests for the set_variables feature in option type configurations (issue #958).
+#
+# set_variables allows extra option or extra log type configurations to define
+# an ordered list of variables with name, value (supporting substitutions),
+# and optional conditional (if) logic. Variables are accessible through
+# curly brace substitutions {{variables.varname}} or {{variables.hashvar.key1}},
+# and via the element config in conditional calculations.
+#
+# These tests cover:
+# - Basic variable substitution with {{variables.varname}}
+# - Variables with substitution values (e.g. value: "{{some_field}}")
+# - Conditional variables using the if form
+# - Hash/object variable values with dot-notation access
+# - Variable ordering (later entries override earlier ones for the same name)
+# - Variables coexisting with existing _constants
+
+require 'rails_helper'
+
+RSpec.describe Formatter::Substitution, 'set_variables', type: :model do
+  include MasterSupport
+  include ModelSupport
+  include PlayerContactSupport
+
+  AlNameSetVarsTest = 'Set Variables Test ELT'
+
+  before :context do
+    SetupHelper.setup_al_gen_tests AlNameSetVarsTest, 'set_vars', 'player_contact'
+  end
+
+  before :example do
+    @al_def = ActivityLog.active.where(name: AlNameSetVarsTest).first
+
+    create_admin
+    create_user
+    create_master
+    setup_access :player_infos, user: @user
+
+    @player_info = @master.build_player_info(first_name: 'testfn', last_name: 'testln', birth_date: (Time.now - 30.years + 1.day))
+    @player_info.force_save!
+    @player_info.save!
+    create_items
+
+    let_user_create :player_contacts
+    create_item
+    @master.current_user = @user
+
+    setup_access :activity_log__player_contact_set_vars, user: @user
+  end
+
+  def setup_activity_log_with_config(extra_log_types_yaml)
+    @al_def.extra_log_types = extra_log_types_yaml
+    @al_def.current_admin = @admin
+    @al_def.save!
+
+    setup_access :activity_log__player_contact_set_var__vars_step,
+                 resource_type: :activity_log_type, access: :create, user: @user
+
+    @al_def.reload
+
+    @activity_log = @player_contact.activity_log__player_contact_set_vars.create!(
+      select_call_direction: 'from player',
+      select_who: 'user',
+      master: @master,
+      extra_log_type: 'vars_step'
+    )
+  end
+
+  it 'substitutes basic set_variables values' do
+    setup_activity_log_with_config(<<~YAML)
+      vars_step:
+        label: Vars Step
+        set_variables:
+          - name: greeting
+            value: hello world
+        caption_before:
+          all_fields: '{{variables.greeting}}'
+    YAML
+
+    caption = @activity_log.extra_log_type_config.caption_before[:all_fields][:caption]
+    res = Formatter::Substitution.substitute(caption, data: @activity_log, tag_subs: nil)
+
+    expect(res).to eq '<p>hello world</p>'
+  end
+
+  it 'substitutes variables with embedded substitution values' do
+    setup_activity_log_with_config(<<~YAML)
+      vars_step:
+        label: Vars Step
+        set_variables:
+          - name: user_greeting
+            value: "hello {{select_who}}"
+        caption_before:
+          all_fields: '{{variables.user_greeting}}'
+    YAML
+
+    caption = @activity_log.extra_log_type_config.caption_before[:all_fields][:caption]
+    res = Formatter::Substitution.substitute(caption, data: @activity_log, tag_subs: nil)
+
+    expect(res).to eq '<p>hello user</p>'
+  end
+
+  it 'substitutes hash/object variables with dot-notation access' do
+    setup_activity_log_with_config(<<~YAML)
+      vars_step:
+        label: Vars Step
+        set_variables:
+          - name: config
+            value:
+              object:
+                key1: value1
+                key2: value2
+        caption_before:
+          all_fields: '{{variables.config.key1}} and {{variables.config.key2}}'
+    YAML
+
+    caption = @activity_log.extra_log_type_config.caption_before[:all_fields][:caption]
+    res = Formatter::Substitution.substitute(caption, data: @activity_log, tag_subs: nil)
+
+    expect(res).to eq '<p>value1 and value2</p>'
+  end
+
+  it 'processes variables in order with later entries overriding earlier ones' do
+    setup_activity_log_with_config(<<~YAML)
+      vars_step:
+        label: Vars Step
+        set_variables:
+          - name: status
+            value: default status
+          - name: status
+            value: overridden status
+        caption_before:
+          all_fields: '{{variables.status}}'
+    YAML
+
+    caption = @activity_log.extra_log_type_config.caption_before[:all_fields][:caption]
+    res = Formatter::Substitution.substitute(caption, data: @activity_log, tag_subs: nil)
+
+    expect(res).to eq '<p>overridden status</p>'
+  end
+
+  it 'conditionally sets variables based on if conditions' do
+    setup_activity_log_with_config(<<~YAML)
+      vars_step:
+        label: Vars Step
+        set_variables:
+          - name: result
+            value: default result
+          - name: result
+            value: matched result
+            if:
+              all:
+                this:
+                  select_who: user
+        caption_before:
+          all_fields: '{{variables.result}}'
+    YAML
+
+    caption = @activity_log.extra_log_type_config.caption_before[:all_fields][:caption]
+    res = Formatter::Substitution.substitute(caption, data: @activity_log, tag_subs: nil)
+
+    expect(res).to eq '<p>matched result</p>'
+  end
+
+  it 'keeps earlier value when conditional does not match' do
+    setup_activity_log_with_config(<<~YAML)
+      vars_step:
+        label: Vars Step
+        set_variables:
+          - name: result
+            value: default result
+          - name: result
+            value: should not match
+            if:
+              all:
+                this:
+                  select_who: nonexistent_value
+        caption_before:
+          all_fields: '{{variables.result}}'
+    YAML
+
+    caption = @activity_log.extra_log_type_config.caption_before[:all_fields][:caption]
+    res = Formatter::Substitution.substitute(caption, data: @activity_log, tag_subs: nil)
+
+    expect(res).to eq '<p>default result</p>'
+  end
+
+  it 'works alongside existing _constants' do
+    setup_activity_log_with_config(<<~YAML)
+      _constants:
+        fixed_val: constant value
+
+      vars_step:
+        label: Vars Step
+        set_variables:
+          - name: dynamic_val
+            value: variable value
+        caption_before:
+          all_fields: '{{constants.fixed_val}} and {{variables.dynamic_val}}'
+    YAML
+
+    caption = @activity_log.extra_log_type_config.caption_before[:all_fields][:caption]
+    res = Formatter::Substitution.substitute(caption, data: @activity_log, tag_subs: nil)
+
+    expect(res).to eq '<p>constant value and variable value</p>'
+  end
+
+  it 'parses set_variables attribute on the option type config' do
+    setup_activity_log_with_config(<<~YAML)
+      vars_step:
+        label: Vars Step
+        set_variables:
+          - name: test_var
+            value: test_value
+    YAML
+
+    config = @activity_log.extra_log_type_config
+    expect(config.set_variables).to be_an(Array)
+    expect(config.set_variables.length).to eq 1
+    expect(config.set_variables.first[:name]).to eq 'test_var'
+    expect(config.set_variables.first[:value]).to eq 'test_value'
+  end
+end


### PR DESCRIPTION
## Summary

Implements `set_variables` for extra option and extra log type configurations (issue #958).

### Changes

**Implementation:**
- Added `set_variables` to `ExtraOptions` key attributes with validation in `clean_set_variables_def`
- Added `setup_set_variables` method in `Formatter::Substitution` to evaluate variables at substitution time
- Added `variables` handling in `associated_reference` for dot-notation access (`{{variables.name}}`)
- Variables support: string values, `{{substitution}}` in values, `object:` hash values, conditional `if:` logic, ordered evaluation with override

**Documentation:**
- Created `docs/admin_reference/general/set_variables.md`
- Created `app/models/admin/defs/extra_options_set_variables_defs.yaml`
- Added links in all three `detailed_options.md` files (activity_logs, dynamic_models, external_identifiers)

**Tests:**
- 8 RSpec tests covering basic substitution, embedded substitutions, hash/object values, ordering, conditionals, coexistence with `_constants`, and config parsing
- All 44 related existing tests pass with no regressions