### PR TITLE
Add NfsStore file attachment support to email notifications

### DIFF
--- a/app/controllers/admin/message_notifications_controller.rb
+++ b/app/controllers/admin/message_notifications_controller.rb
@@ -1,9 +1,19 @@
 class Admin::MessageNotificationsController < AdminController
   #
-  # Download a generated attachment (e.g. calendar .ics file) from a message notification.
-  # The attachment content is stored in extra_substitutions YAML column.
+  # Download a generated attachment (e.g. calendar .ics file or NfsStore file) from a message notification.
+  # Calendar invite content is stored in extra_substitutions YAML column.
+  # NfsStore attachments redirect to the NfsStore download path by stored_file_id.
   def attachment
     mn = Messaging::MessageNotification.find(params[:id])
+
+    # Handle NfsStore file attachment download by stored_file_id
+    if params[:stored_file_id].present?
+      stored_file_id = params[:stored_file_id].to_i
+      redirect_to nfs_store_download_path(stored_file_id)
+      return
+    end
+
+    # Handle calendar invite attachment download
     ci_data = mn.calendar_invite_data
 
     if ci_data&.dig('generated_content').present?

--- a/app/models/admin/defs/save_triggers_notify_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_notify_options_defs.yaml
@@ -95,6 +95,17 @@
               uid: '(optional, default: auto-generated UUID) unique event identifier - supports {{curly}} substitutions'
               sequence: '(optional, default: 0) event revision sequence number'
 
+            attachments:
+              - container_id: |
+                  NfsStore container ID containing the file to attach.
+                  Supports {{curly}} substitutions resolved at trigger time.
+                path: |
+                  (optional) path within the container (empty string for root).
+                  Supports {{curly}} substitutions resolved at trigger time.
+                file_name: |
+                  filename of the NfsStore stored file to attach.
+                  Supports {{curly}} substitutions resolved at trigger time.
+
             extra_substitutions:
               data1: 'fixed data item to be substituted into the message in `\{\{extra_substitutions.data1\}\}`'
             

--- a/app/models/messaging/message_notification.rb
+++ b/app/models/messaging/message_notification.rb
@@ -272,6 +272,7 @@ module Messaging
       @resolved_attachments = []
 
       resolve_calendar_invite_attachment
+      resolve_nfsstore_attachments
 
       save! if @resolved_attachments.any?
     end
@@ -350,6 +351,18 @@ module Messaging
     # @return [HashWithIndifferentAccess | nil]
     def calendar_invite_data
       extra_substitutions_data&.dig(:calendar_invite)
+    end
+
+    #
+    # Returns NfsStore attachment references from extra_substitutions_data.
+    # Each reference is a hash with container_id, path, file_name, stored_file_id, content_type.
+    # File content is NOT included — only metadata references.
+    # @return [Array<Hash>]
+    def nfsstore_attachment_references
+      atts = extra_substitutions_data&.dig(:attachments)
+      return [] unless atts.is_a?(Array)
+
+      atts.select { |att| att['stored_file_id'].present? }
     end
 
     private
@@ -489,6 +502,58 @@ module Messaging
         mime_type: "text/calendar; method=#{ical_method}",
         content: ics_content
       }
+    end
+
+    #
+    # Resolve NfsStore file attachments from extra_substitutions_data["attachments"].
+    # For each entry, looks up the StoredFile by container_id, path, and file_name,
+    # reads the file content from retrieval_path, builds an attachment hash for the mailer,
+    # and stores a reference (not content) back into extra_substitutions.
+    # @return [void]
+    def resolve_nfsstore_attachments
+      att_data = extra_substitutions_data&.dig(:attachments)
+      return unless att_data.is_a?(Array)
+
+      att_data.each do |entry|
+        container_id = entry['container_id']
+        path = entry['path'].to_s
+        file_name = entry['file_name']
+
+        stored_file = NfsStore::Manage::StoredFile.find_by(
+          nfs_store_container_id: container_id,
+          path: path,
+          file_name: file_name
+        )
+
+        unless stored_file
+          raise FphsException,
+                "NfsStore file not found: container_id=#{container_id}, path=#{path}, file_name=#{file_name}"
+        end
+
+        # Set current user context for file access via role-based permissions
+        stored_file.container.current_user = user
+
+        rp = stored_file.retrieval_path
+        unless rp
+          raise FphsException,
+                'NfsStore file could not be retrieved (no access): ' \
+                "container_id=#{container_id}, path=#{path}, file_name=#{file_name}"
+        end
+
+        content = File.read(rp)
+
+        @resolved_attachments << {
+          filename: stored_file.file_name,
+          mime_type: stored_file.content_type,
+          content: content
+        }
+
+        # Store reference (not content) back into extra_substitutions
+        entry['stored_file_id'] = stored_file.id
+        entry['content_type'] = stored_file.content_type
+      end
+
+      self.extra_substitutions = extra_substitutions_data.to_hash.to_yaml
     end
 
     #

--- a/app/models/save_triggers/notify.rb
+++ b/app/models/save_triggers/notify.rb
@@ -298,32 +298,56 @@ class SaveTriggers::Notify < SaveTriggers::SaveTriggersBase
     end
 
     merge_calendar_invite_into_extra_substitutions
+    merge_attachments_into_extra_substitutions
 
     @extra_substitutions = nil if @extra_substitutions.blank?
     @extra_substitutions
   end
 
   #
-  # Parse the calendar_invite config option, resolve {{curly}} substitutions in all string values,
+  # Parse the calendar_invite config option, resolve substitutions in all values,
   # and merge the resolved hash into extra_substitutions[:calendar_invite].
+  # Values support {{curly}} substitutions and conditional action hashes.
   # @return [void]
   def merge_calendar_invite_into_extra_substitutions
     cal_config = config[:calendar_invite]
     return unless cal_config
 
     resolved = cal_config.to_h do |k, v|
-      [k.to_s, v.is_a?(String) ? substitute_from_item(v) : v]
+      [k.to_s, substitute_from_item(v)]
     end
 
     @extra_substitutions[:calendar_invite] = resolved
   end
 
   #
-  # Substitute {{curly}} template values from the current item
-  # @param [String] value - string containing {{curly}} substitutions
-  # @return [String] resolved string
+  # Parse the attachments config option, resolve substitutions in all values,
+  # and merge the resolved array into extra_substitutions[:attachments].
+  # Each attachment entry is a hash with container_id, path, and file_name keys.
+  # Values support {{curly}} substitutions and conditional action hashes
+  # (e.g. {this: {field: return_value}}).
+  # @return [void]
+  def merge_attachments_into_extra_substitutions
+    att_config = config[:attachments]
+    return unless att_config
+
+    resolved = att_config.map do |entry|
+      entry.to_h do |k, v|
+        [k.to_s, substitute_from_item(v)]
+      end
+    end
+
+    @extra_substitutions[:attachments] = resolved
+  end
+
+  #
+  # Resolve a config value from the current item using FieldDefaults.calculate_default.
+  # Supports {{curly}} substitutions, {{{raw}}} substitutions, conditional action hashes
+  # (e.g. {this: {field: return_value}}), and literal values passed through unchanged.
+  # @param [String | Hash | Object] value - value to resolve
+  # @return [Object] resolved value
   def substitute_from_item(value)
-    Formatter::Substitution.substitute(value, data: @item, tag_subs: nil, ignore_missing: true)
+    FieldDefaults.calculate_default(@item, value, allow_nil: true, ignore_missing: true)
   end
 
   #

--- a/app/views/admin/message_notifications/_index.html.erb
+++ b/app/views/admin/message_notifications/_index.html.erb
@@ -35,9 +35,15 @@
             <% end %>
           </table>
           <% ci_data = list_item.calendar_invite_data %>
-          <% if ci_data&.dig('generated_content').present? %>
+          <% nfs_attachments = list_item.nfsstore_attachment_references %>
+          <% if ci_data&.dig('generated_content').present? || nfs_attachments.any? %>
             <p><strong>Attachments:</strong>
-              <%= link_to 'calendar.ics', attachment_admin_message_notification_path(list_item), class: 'btn btn-sm btn-default' %>
+              <% if ci_data&.dig('generated_content').present? %>
+                <%= link_to 'calendar.ics', attachment_admin_message_notification_path(list_item), class: 'btn btn-sm btn-default' %>
+              <% end %>
+              <% nfs_attachments.each do |att| %>
+                <%= link_to att['file_name'], attachment_admin_message_notification_path(list_item, stored_file_id: att['stored_file_id']), class: 'btn btn-sm btn-default' %>
+              <% end %>
             </p>
           <% end %>
           <iframe id="message-iframe-<%= list_item.id %>" src='javascript:void(0)' srcdoc="" class="iframe-message-notification if-mn-type-<%= list_item.message_type%> if-mn-status-<%= list_item.status %>" sandbox="allow-popups allow-popups-to-escape-sandbox">

--- a/spec/models/messaging/message_notification_spec.rb
+++ b/spec/models/messaging/message_notification_spec.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# Tests for Messaging::MessageNotification
+# Covers message generation, template rendering, recipient handling (email/SMS/records),
+# calendar invite attachment resolution (#953), NfsStore file attachment resolution (#954),
+# and NotificationMailer integration with attachment support.
+
 require 'rails_helper'
 
 RSpec.describe Messaging::MessageNotification, type: :model do
@@ -475,6 +480,159 @@ RSpec.describe Messaging::MessageNotification, type: :model do
       # Verify the mail has no attachments
       expect(mail.attachments.size).to eq(0)
       expect(mail.body.to_s).to include('This is some content')
+    end
+  end
+
+  describe 'resolve_attachments with NfsStore file attachments (issue #954)' do
+    before :example do
+      setup_messaging_test
+      mock_notification_mailer
+    end
+
+    after :example do
+      unmock_notification_mailer
+    end
+
+    it 'resolves NfsStore file attachments from extra_substitutions, reads file content, and builds attachment hash' do
+      # Create a mock stored file
+      stored_file = instance_double(
+        NfsStore::Manage::StoredFile,
+        id: 101,
+        file_name: 'report.pdf',
+        content_type: 'application/pdf',
+        retrieval_path: Rails.root.join('tmp/agent-tmp/test_report.pdf').to_s
+      )
+
+      # Create a temporary file to read
+      FileUtils.mkdir_p(Rails.root.join('tmp/agent-tmp'))
+      File.write(Rails.root.join('tmp/agent-tmp/test_report.pdf'), 'PDF file content here')
+
+      allow(NfsStore::Manage::StoredFile).to receive(:find_by)
+        .with(nfs_store_container_id: 42, path: 'reports', file_name: 'report.pdf')
+        .and_return(stored_file)
+      allow(stored_file).to receive(:current_user=)
+      allow(stored_file).to receive(:container).and_return(
+        instance_double(NfsStore::Manage::Container, current_user: nil, 'current_user=' => nil)
+      )
+
+      mn = create_test_notification(with_calendar_invite: false)
+      mn.extra_substitutions = {
+        attachments: [
+          { 'container_id' => 42, 'path' => 'reports', 'file_name' => 'report.pdf' }
+        ]
+      }.to_yaml
+      mn.save!
+
+      mn.resolve_attachments
+      resolved = mn.resolved_attachments
+
+      expect(resolved).to be_a(Array)
+      # Find the NfsStore attachment (not calendar)
+      nfs_attachment = resolved.find { |a| a[:filename] == 'report.pdf' }
+      expect(nfs_attachment).not_to be_nil
+      expect(nfs_attachment[:mime_type]).to eq('application/pdf')
+      expect(nfs_attachment[:content]).to eq('PDF file content here')
+
+      # Verify reference (not content) is stored back in extra_substitutions
+      mn.reload
+      es_data = YAML.safe_load(mn.extra_substitutions, permitted_classes: [Symbol])
+      att_ref = es_data['attachments'].first
+      expect(att_ref['stored_file_id']).to eq(101)
+      expect(att_ref['content_type']).to eq('application/pdf')
+      # File content should NOT be stored in DB
+      expect(att_ref).not_to have_key('content')
+    ensure
+      FileUtils.rm_f(Rails.root.join('tmp/agent-tmp/test_report.pdf'))
+    end
+
+    it 'handles NfsStore attachment alongside calendar_invite attachment' do
+      stored_file = instance_double(
+        NfsStore::Manage::StoredFile,
+        id: 202,
+        file_name: 'data.csv',
+        content_type: 'text/csv',
+        retrieval_path: Rails.root.join('tmp/agent-tmp/test_data.csv').to_s
+      )
+
+      FileUtils.mkdir_p(Rails.root.join('tmp/agent-tmp'))
+      File.write(Rails.root.join('tmp/agent-tmp/test_data.csv'), 'col1,col2\nval1,val2')
+
+      allow(NfsStore::Manage::StoredFile).to receive(:find_by)
+        .with(nfs_store_container_id: 10, path: '', file_name: 'data.csv')
+        .and_return(stored_file)
+      allow(stored_file).to receive(:current_user=)
+      allow(stored_file).to receive(:container).and_return(
+        instance_double(NfsStore::Manage::Container, current_user: nil, 'current_user=' => nil)
+      )
+
+      mn = create_test_notification(with_calendar_invite: true)
+      # Merge NfsStore attachments into the existing extra_substitutions
+      es_data = YAML.safe_load(mn.extra_substitutions, permitted_classes: [Symbol])
+      es_data['attachments'] = [
+        { 'container_id' => 10, 'path' => '', 'file_name' => 'data.csv' }
+      ]
+      mn.extra_substitutions = es_data.to_yaml
+      mn.save!
+
+      # Clear memoized extra_substitutions_data so resolve_attachments sees updated data
+      mn.extra_substitutions_data = nil
+
+      mn.resolve_attachments
+      resolved = mn.resolved_attachments
+
+      # Should have both calendar invite and NfsStore file attachments
+      expect(resolved.length).to eq(2)
+      calendar_att = resolved.find { |a| a[:filename] == 'calendar.ics' }
+      nfs_att = resolved.find { |a| a[:filename] == 'data.csv' }
+      expect(calendar_att).not_to be_nil
+      expect(nfs_att).not_to be_nil
+      expect(nfs_att[:mime_type]).to eq('text/csv')
+    ensure
+      FileUtils.rm_f(Rails.root.join('tmp/agent-tmp/test_data.csv'))
+    end
+
+    it 'raises an error when NfsStore file is not found' do
+      allow(NfsStore::Manage::StoredFile).to receive(:find_by)
+        .with(nfs_store_container_id: 999, path: '', file_name: 'missing.pdf')
+        .and_return(nil)
+
+      mn = create_test_notification(with_calendar_invite: false)
+      mn.extra_substitutions = {
+        attachments: [
+          { 'container_id' => 999, 'path' => '', 'file_name' => 'missing.pdf' }
+        ]
+      }.to_yaml
+      mn.save!
+
+      expect { mn.resolve_attachments }.to raise_error(FphsException, /NfsStore file not found/)
+    end
+
+    it 'raises an error when NfsStore file has no retrieval_path' do
+      stored_file = instance_double(
+        NfsStore::Manage::StoredFile,
+        id: 303,
+        file_name: 'no_access.pdf',
+        content_type: 'application/pdf',
+        retrieval_path: nil
+      )
+
+      allow(NfsStore::Manage::StoredFile).to receive(:find_by)
+        .with(nfs_store_container_id: 50, path: '', file_name: 'no_access.pdf')
+        .and_return(stored_file)
+      allow(stored_file).to receive(:current_user=)
+      allow(stored_file).to receive(:container).and_return(
+        instance_double(NfsStore::Manage::Container, current_user: nil, 'current_user=' => nil)
+      )
+
+      mn = create_test_notification(with_calendar_invite: false)
+      mn.extra_substitutions = {
+        attachments: [
+          { 'container_id' => 50, 'path' => '', 'file_name' => 'no_access.pdf' }
+        ]
+      }.to_yaml
+      mn.save!
+
+      expect { mn.resolve_attachments }.to raise_error(FphsException, /could not be retrieved/)
     end
   end
 end

--- a/spec/models/save_triggers/notify_spec.rb
+++ b/spec/models/save_triggers/notify_spec.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# Tests for SaveTriggers::Notify
+# Covers notification trigger configuration parsing, role/user setup, message creation,
+# template substitutions, conditional actions, return_value_list references,
+# calendar invite integration (#953), and NfsStore file attachment config parsing (#954).
+
 require 'rails_helper'
 
 AlNameGenTestN = 'Gen Test ELT 2'
@@ -918,6 +923,94 @@ RSpec.describe SaveTriggers::Notify, type: :model do
         expect(ci_data['location']).to eq('Room 101')
         expect(ci_data['organizer']).to eq('organizer@example.com')
         expect(ci_data['uid']).to eq("#{@al.id}-#{@al.master_id}@restructure")
+      end
+    end
+
+    context 'with attachments config (issue #954)' do
+      before :example do
+        # Mock NfsStore file resolution so the inline job doesn't fail
+        # (the actual resolution is tested in message_notification_spec)
+        allow_any_instance_of(Messaging::MessageNotification).to receive(:resolve_nfsstore_attachments)
+      end
+
+      it 'parses attachments config, resolves substitutions, and merges into extra_substitutions' do
+        config = {
+          type: 'email',
+          role: 'test',
+          layout_template: @layout.name,
+          content_template: @content.name,
+          subject: 'Report Delivery',
+          attachments: [
+            {
+              container_id: '{{master_id}}',
+              path: 'reports',
+              file_name: 'summary.pdf'
+            },
+            {
+              container_id: 42,
+              path: '',
+              file_name: 'static_file.txt'
+            }
+          ]
+        }
+
+        @trigger = SaveTriggers::Notify.new(config, @al)
+        @trigger.perform
+
+        new_mn = MessageNotification.order(id: :desc).first
+        es_data = YAML.safe_load(new_mn.extra_substitutions, permitted_classes: [Symbol])
+                      &.with_indifferent_access
+        attachments_data = es_data['attachments']
+
+        expect(attachments_data).to be_a(Array)
+        expect(attachments_data.length).to eq(2)
+
+        # First attachment should have {{master_id}} resolved
+        expect(attachments_data[0]['container_id']).to eq(@al.master_id.to_s)
+        expect(attachments_data[0]['path']).to eq('reports')
+        expect(attachments_data[0]['file_name']).to eq('summary.pdf')
+
+        # Second attachment should have literal values preserved
+        expect(attachments_data[1]['container_id']).to eq(42)
+        expect(attachments_data[1]['path']).to eq('')
+        expect(attachments_data[1]['file_name']).to eq('static_file.txt')
+      end
+
+      it 'works with both attachments and calendar_invite in the same config' do
+        config = {
+          type: 'email',
+          role: 'test',
+          layout_template: @layout.name,
+          content_template: @content.name,
+          subject: 'Combined Notification',
+          calendar_invite: {
+            method: 'REQUEST',
+            summary: 'Meeting',
+            dtstart: '2026-04-01 10:00:00',
+            dtend: '2026-04-01 11:00:00',
+            organizer: 'org@example.com'
+          },
+          attachments: [
+            {
+              container_id: 99,
+              path: '',
+              file_name: 'report.pdf'
+            }
+          ]
+        }
+
+        @trigger = SaveTriggers::Notify.new(config, @al)
+        @trigger.perform
+
+        new_mn = MessageNotification.order(id: :desc).first
+        es_data = YAML.safe_load(new_mn.extra_substitutions, permitted_classes: [Symbol])
+                      &.with_indifferent_access
+
+        # Both should be present
+        expect(es_data['calendar_invite']).to be_a(Hash)
+        expect(es_data['attachments']).to be_a(Array)
+        expect(es_data['attachments'].length).to eq(1)
+        expect(es_data['attachments'][0]['file_name']).to eq('report.pdf')
       end
     end
   end


### PR DESCRIPTION
## Summary

Adds support for attaching NfsStore stored files to email notifications via the `save_trigger` `notify` configuration.

### Changes

- **SaveTriggers::Notify**: Added `merge_attachments_into_extra_substitutions` to parse `attachments` config (supporting `container_id`, `path`, `file_name` with template substitutions). Changed `substitute_from_item` to use `FieldDefaults.calculate_default` for flexible substitution including conditional actions and `return_value`.
- **Messaging::MessageNotification**: Added `resolve_nfsstore_attachments` to look up NfsStore stored files by container/path/filename, read file content via `retrieval_path`, and include them as email attachments. Added `nfsstore_attachment_references` for admin UI display.
- **Admin controller/view**: Extended attachment action to handle NfsStore `stored_file_id` redirects. Added NfsStore file links in message notification index.
- **YAML defs**: Documented the `attachments` config option in save_triggers_notify_options_defs.yaml.

### Configuration Example

```yaml
notify:
  type: email
  attachments:
    - container_id: '{{nfs_store_container_id}}'
      path: uploads
      file_name: '{{attachment_filename}}'
  # ... other notify options
```

### Tests

- 2 new specs in `notify_spec.rb` covering attachments config parsing with substitutions
- 4 new specs in `message_notification_spec.rb` covering NfsStore file resolution, combined attachments + calendar invites, and error handling

Fixes #954