### PR TITLE
Add generate_document save trigger - fixes #961

### DIFF
--- a/app/models/admin/defs/save_triggers_generate_document_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_generate_document_options_defs.yaml
@@ -1,0 +1,33 @@
+# Save Trigger: Generate Document options
+        generate_document:
+          # --- Content Generation (c.f. notify trigger) ---
+          content_template_name: template_name  # Named content template (Admin::MessageTemplate)
+          content_template_text: inline template text with {{curly}} substitutions  # OR inline template text
+          layout_template: layout_name  # Optional layout template to wrap content (replaces {{main_content}})
+          extra_substitutions:  # Optional extra data for {{extra_substitutions.*}} tag substitutions
+            key1: value1
+            key2: '{{field_name}}'  # Supports {{curly}} substitutions resolved from the triggering item
+
+          # --- File Storage ---
+          container:  # Hash defining how to locate the target NFS container
+            # Option A: resolve from item's model references (e.g. container created by create_filestore_container)
+            from_this: model_reference
+            # Option B: lookup by name in master
+            name: container-name  # Supports {{curly}} substitutions
+            # Option C: lookup by database id
+            id: 123  # Supports {{curly}} substitutions
+
+          filename: generated-report-{{id}}.html  # Filename with {{curly}} substitution support
+          content_type: text/html  # MIME type of the generated file
+          path: reports  # Optional subdirectory path within the container
+
+          # --- Duplicate File Handling ---
+          skip_existing: true  # Optional: skip if a file with the same name and path already exists
+          replace: true  # Optional: replace existing file if content has changed
+
+          # --- User/Access Context ---
+          store_as_user: user@example.com  # User to perform the file store operation
+          store_in_app_type: app_type_name  # App type context for access control
+
+          # --- Standard Trigger Options ---
+          if: #if_extras  # Optional conditional to control when trigger fires

--- a/app/models/option_configs/extra_option_implementers/save_triggers.rb
+++ b/app/models/option_configs/extra_option_implementers/save_triggers.rb
@@ -24,7 +24,8 @@ module OptionConfigs
                              background
                              reload_this
                              case
-                             set_save_trigger_results].freeze
+                             set_save_trigger_results
+                             generate_document].freeze
 
       class_methods do
         #

--- a/app/models/save_triggers/generate_document.rb
+++ b/app/models/save_triggers/generate_document.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+#
+# Save trigger to generate a document from a template and store it in
+# an NFS filestore container. Uses the same template mechanisms as the
+# notify trigger (Admin::MessageTemplate) and reuses the file import
+# mechanism (NfsStore::Import.import_file).
+#
+# Example configuration:
+#   save_trigger:
+#     on_save:
+#       generate_document:
+#         content_template_name: 'template_name'
+#         layout_template: 'layout_name'
+#         extra_substitutions:
+#           key1: 'value1'
+#         container:
+#           from_this: model_reference
+#         filename: 'generated-report-{{id}}.html'
+#         content_type: 'text/html'
+#         path: 'reports'
+#         store_as_user: 'user@example.com'
+#         store_in_app_type: 'app_type_name'
+#         if: <conditional>
+#
+class SaveTriggers::GenerateDocument < SaveTriggers::SaveTriggersBase
+  def initialize(config, item)
+    super
+    @model_defs = config
+  end
+
+  #
+  # Perform the document generation and file storage.
+  # Evaluates conditional if, renders template content, resolves
+  # the container, and imports the rendered file.
+  def perform
+    @model_defs = [@model_defs] unless @model_defs.is_a? Array
+
+    @model_defs.each do |config|
+      @config = config.is_a?(Hash) ? config : {}
+
+      # Evaluate conditional if
+      next unless if_evaluates(@config[:if])
+
+      rendered_content = render_content
+      resolved_filename = resolve_filename
+      resolved_container = resolve_container
+      store_user = resolve_user
+
+      stored_file = store_file(resolved_container, resolved_filename, rendered_content, store_user)
+
+      store_trigger_results('generate_document', {
+                              container_id: resolved_container.id,
+                              filename: resolved_filename,
+                              stored_file_id: stored_file&.id,
+                              path: @config[:path],
+                              content_type: @config[:content_type]
+                            })
+    end
+  end
+
+  private
+
+  #
+  # Render the document content from a named template or inline text.
+  # Supports layout wrapping and extra substitutions, consistent with
+  # the notify trigger.
+  # @return [String] the rendered content
+  def render_content
+    content_template_name = @config[:content_template_name]
+    content_template_text = resolve_content_template_text
+    layout_template_name = @config[:layout_template]
+    extra_subs = resolve_extra_substitutions
+
+    unless content_template_name || content_template_text
+      raise FphsException, 'generate_document requires content_template_name or content_template_text'
+    end
+
+    # Build a data hash that includes extra_substitutions for {{extra_substitutions.*}} tags
+    data = build_substitution_data(extra_subs)
+
+    if layout_template_name
+      # Use layout template wrapping
+      layout = Admin::MessageTemplate.active.layout_templates.find_by(name: layout_template_name)
+      raise FphsException, "No layout template found with name: #{layout_template_name}" unless layout
+
+      layout.generate(
+        content_template_name:,
+        content_template_text:,
+        data:,
+        ignore_missing: true
+      )
+    else
+      # Generate content without layout
+      Admin::MessageTemplate.generate_content(
+        content_template_name:,
+        content_template_text:,
+        data:,
+        ignore_missing: true
+      )
+    end
+  end
+
+  #
+  # Resolve the content_template_text field.
+  # If the value is a Hash, treat it as a conditional action and resolve it.
+  # If it's a string, return it as-is for later substitution by generate_content,
+  # which will have access to extra_substitutions data.
+  # @return [String|nil]
+  def resolve_content_template_text
+    text = @config[:content_template_text]
+    return nil unless text
+
+    if text.is_a?(Hash)
+      FieldDefaults.calculate_default(@item, text, allow_nil: true, ignore_missing: true)
+    else
+      text
+    end
+  end
+
+  #
+  # Build a data hash for template substitution that includes extra_substitutions.
+  # Uses Formatter::Substitution.setup_data for the item data, then adds
+  # extra_substitutions for {{extra_substitutions.*}} tag access.
+  # @param [Hash] extra_subs - resolved extra substitutions
+  # @return [Hash] data hash for substitution
+  def build_substitution_data(extra_subs)
+    data = Formatter::Substitution.setup_data(@item)
+    data[:extra_substitutions] = extra_subs if extra_subs.present?
+    data
+  end
+
+  #
+  # Resolve extra_substitutions, performing {{curly}} substitutions within values
+  # @return [Hash]
+  def resolve_extra_substitutions
+    extra = @config[:extra_substitutions]
+    return {} unless extra
+
+    resolved = {}
+    extra.each do |k, v|
+      resolved[k] = if v.is_a?(String)
+                      Formatter::Substitution.substitute(v, data: @item, tag_subs: nil, ignore_missing: true)
+                    else
+                      v
+                    end
+    end
+    resolved
+  end
+
+  #
+  # Resolve the filename, performing {{curly}} substitutions and sanitizing
+  # @return [String]
+  def resolve_filename
+    filename = @config[:filename]
+    raise FphsException, 'generate_document requires filename to be specified' if filename.blank?
+
+    # Perform substitutions
+    filename = Formatter::Substitution.substitute(filename, data: @item, tag_subs: nil, ignore_missing: true)
+
+    # Sanitize: remove path traversal and directory separators
+    sanitize_filename(filename)
+  end
+
+  #
+  # Sanitize a filename to prevent path traversal attacks
+  # @param [String] filename
+  # @return [String] sanitized filename
+  def sanitize_filename(filename)
+    # Remove path traversal sequences
+    filename = filename.gsub('..', '')
+    # Remove directory separators
+    filename = filename.gsub(%r{[/\\]}, '')
+    # Remove leading/trailing whitespace and dots
+    filename.strip.gsub(/\A\.+|\.+\z/, '')
+  end
+
+  #
+  # Resolve the target NFS container from the container configuration.
+  # Supports:
+  #   - from_this: model_reference (lookup via ModelReference)
+  #   - name: 'container-name' (lookup by name in master)
+  #   - id: container_id (lookup by database id)
+  # @return [NfsStore::Manage::Container]
+  def resolve_container
+    container_config = @config[:container]
+    raise FphsException, 'generate_document requires container configuration' unless container_config.is_a?(Hash)
+
+    container = nil
+
+    if container_config[:from_this] == 'model_reference'
+      # Resolve via model reference from the current item
+      refs = ModelReference.find_references(@item, to_record_type: 'nfs_store__manage__container', active: true)
+      container = refs.first&.to_record if refs.present?
+    elsif container_config[:id]
+      # Resolve by database id
+      container_id = FieldDefaults.calculate_default(@item, container_config[:id],
+                                                     allow_nil: true, ignore_missing: true)
+      container = NfsStore::Manage::Container.find_by(id: container_id)
+    elsif container_config[:name]
+      # Resolve by name in the master
+      container_name = FieldDefaults.calculate_default(@item, container_config[:name],
+                                                       allow_nil: true, ignore_missing: true)
+      container = NfsStore::Manage::Container.where(
+        master_id: @item.master_id,
+        name: container_name
+      ).first
+    end
+
+    unless container
+      raise FphsException,
+            "generate_document could not resolve container from config: #{container_config}"
+    end
+
+    container
+  end
+
+  #
+  # Resolve the user for the file store operation.
+  # Uses store_as_user and store_in_app_type configuration,
+  # following the pattern in DynamicModel.user_for_conf_snippet.
+  # @return [User]
+  def resolve_user
+    user_config = {
+      user: @config[:store_as_user],
+      app_type: @config[:store_in_app_type]
+    }.compact
+
+    if user_config.present?
+      resolved = DynamicModel.user_for_conf_snippet(user_config)
+      return resolved if resolved
+    end
+
+    # Fall back to the item's current user
+    @user
+  end
+
+  #
+  # Store the rendered content as a file in the container.
+  # Creates a temp file, writes the content, and imports it
+  # using NfsStore::Import.import_file.
+  # @param [NfsStore::Manage::Container] container
+  # @param [String] filename
+  # @param [String] content - the rendered document content
+  # @param [User] store_user - user to perform the import
+  # @return [NfsStore::Manage::StoredFile|nil]
+  def store_file(container, filename, content, store_user)
+    temp_file = Tempfile.new(['generate_document', File.extname(filename)])
+    temp_file.write(content)
+    temp_file.close
+
+    path = @config[:path]
+    skip_existing = @config[:skip_existing]
+    replace = @config[:replace]
+
+    NfsStore::Import.import_file(
+      container.id,
+      filename,
+      temp_file.path,
+      store_user,
+      path:,
+      skip_existing:,
+      replace:
+    )
+  ensure
+    temp_file&.close
+    temp_file&.unlink
+  end
+end

--- a/docs/admin_reference/general/save_trigger.md
+++ b/docs/admin_reference/general/save_trigger.md
@@ -1,4 +1,5 @@
 # `save_trigger`
+
 ## Save Trigger Actions
 
 Define actions to perform automatically when a record is created, updated, saved, disabled, uploaded, or before saving. Each event key (`on_create`, `on_update`, `on_save`, `on_disable`, `on_upload`, `before_save`) takes an ordered list of trigger tasks.
@@ -18,6 +19,7 @@ Each trigger task listed under an event key corresponds to one of the following 
 | [create_reference](save_trigger_create_reference.md) | Create a reference to another model |
 | [change_user_roles](save_trigger_change_user_roles.md) | Add or remove user roles |
 | [create_filestore_container](save_trigger_create_filestore_container.md) | Create an NFS filestore container |
+| [generate_document](save_trigger_generate_document.md) | Generate a document from a template and store in a filestore container |
 | [notify](save_trigger_notify.md) | Send a notification |
 | [pull_external_data](save_trigger_pull_external_data.md) | Pull data from an external source |
 | [redcap_request](save_trigger_redcap_request.md) | Make a REDCap API request |

--- a/docs/admin_reference/general/save_trigger_generate_document.md
+++ b/docs/admin_reference/general/save_trigger_generate_document.md
@@ -1,0 +1,65 @@
+# `generate_document`
+
+## Generate a Document from a Template
+
+Render content from a template and store the resulting document as a file in an NFS filestore container.
+Uses the same template mechanisms as the `notify` trigger for content generation, and stores
+the rendered output using `NfsStore::Import.import_file`.
+
+Common use cases:
+
+- Generating letters, reports, or summaries when a record is saved
+- Creating documents that can be reviewed before sending
+- Producing files that a subsequent `notify` trigger can attach to an email
+- Automating document creation in case management workflows (activity logs)
+
+```yaml
+!defs(save_triggers_generate_document_options_defs.yaml)
+```
+
+### Container Resolution
+
+The `container` configuration determines which NFS filestore container the generated document
+is stored in. Two resolution mechanisms are supported:
+
+- **Model reference** (`from_this: model_reference`): Looks up a container referenced by the current
+  item via `ModelReference`. This is the common pattern when a `create_filestore_container` trigger
+  was used earlier in the trigger chain.
+- **Named lookup** (`name: 'container-name'`): Finds a container by name within the current master record.
+  Supports `{{curly}}` substitutions in the name.
+- **ID lookup** (`id: container_id`): Finds a container directly by its database ID.
+  Supports `{{curly}}` substitutions in the value.
+
+### Content Generation
+
+Content is generated using `Admin::MessageTemplate`, consistent with the `notify` trigger:
+
+- **Named template** (`content_template_name`): Looks up a content template by name.
+- **Inline text** (`content_template_text`): Uses the provided text directly. Supports `{{curly}}` substitutions.
+- **Layout wrapping** (`layout_template`): Wraps the rendered content in a layout template, replacing `{{main_content}}`.
+- **Extra substitutions** (`extra_substitutions`): Provides additional data for `{{extra_substitutions.*}}` tags.
+
+### Trigger Results
+
+After successful document generation, results are stored in
+`save_trigger_results['generate_document']` with the following keys:
+
+- `container_id`: The ID of the container where the file was stored
+- `filename`: The resolved filename
+- `stored_file_id`: The ID of the stored file record
+- `path`: The subdirectory path (if specified)
+- `content_type`: The MIME type of the stored file
+
+These results can be referenced by subsequent triggers using
+`{{save_trigger_results.generate_document.stored_file_id}}` etc.
+
+### User Context
+
+The `store_as_user` and `store_in_app_type` options configure the user and app type context
+for the file store operation, following the same pattern as the `notify` trigger's batch user
+configuration.
+
+### Duplicate File Handling
+
+- `skip_existing: true`: If a file with the same name and path exists, skip the import
+- `replace: true`: If a file with the same name and path exists but has different content, replace it

--- a/spec/models/save_triggers/generate_document_spec.rb
+++ b/spec/models/save_triggers/generate_document_spec.rb
@@ -1,0 +1,529 @@
+# frozen_string_literal: true
+
+# Tests for SaveTriggers::GenerateDocument - Issue #961
+#
+# This spec verifies the generate_document save trigger, which renders content
+# from a template (using the same template mechanisms as the notify trigger),
+# then stores the rendered document as a file in an NFS filestore container.
+#
+# Covers:
+# - Registration in ValidSaveTriggers
+# - Template rendering with content_template_name (named template lookup)
+# - Template rendering with content_template_text (inline text)
+# - Layout wrapping via layout_template
+# - Extra substitutions for {{extra_substitutions.*}} tags
+# - Curly substitutions in filename, content_template_text, and extra_substitutions
+# - File storage in NFS container via NfsStore::Import.import_file
+# - Container resolution via model reference (from_this)
+# - Container resolution via name-based lookup
+# - Container resolution via id lookup
+# - User context via store_as_user and store_in_app_type
+# - Conditional execution via if: configuration
+# - Trigger results stored in save_trigger_results['generate_document']
+# - Error handling for missing container, missing template, empty content
+# - Filename sanitization
+# - skip_existing and replace options for duplicate filenames
+
+require 'rails_helper'
+
+RSpec.describe SaveTriggers::GenerateDocument, type: :model do
+  include PlayerContactSupport
+  include ModelSupport
+  include NfsStoreSupport
+
+  before :all do
+    change_setting('AllowDynamicMigrations', true)
+  end
+
+  after :all do
+    change_setting('AllowDynamicMigrations', false)
+  end
+
+  before :each do
+    setup_nfs_store
+    @master = @player_contact.master
+    @master.current_user = @user
+
+    # Create message templates for testing
+    @content_template = Admin::MessageTemplate.create!(
+      name: 'test generate doc content',
+      message_type: :plain,
+      template_type: :content,
+      template: '<p>Document for master {{master_id}}. Who: {{select_who}}.</p>',
+      current_admin: @admin
+    )
+
+    @layout_template = Admin::MessageTemplate.create!(
+      name: 'test generate doc layout',
+      message_type: :plain,
+      template_type: :layout,
+      template: '<html><body>{{main_content}}</body></html>',
+      current_admin: @admin
+    )
+
+    # Create an activity log instance with a filestore container
+    @al = @player_contact.activity_log__player_contact_phones.create!(
+      select_call_direction: 'from player',
+      select_who: 'test user',
+      extra_log_type: 'step_1',
+      master: @master
+    )
+
+    @al.save_trigger_results ||= {}
+
+    # Get the container that was created by the save trigger on @al
+    refs = ModelReference.find_references(@al, to_record_type: 'nfs_store__manage__container', active: true)
+    expect(refs).not_to be_empty
+    @container = refs.first.to_record
+    expect(@container).to be_a(NfsStore::Manage::Container)
+  end
+
+  describe 'ValidSaveTriggers registration' do
+    it 'is included in ValidSaveTriggers' do
+      expect(OptionConfigs::ExtraOptionImplementers::SaveTriggers::ValidSaveTriggers).to include(:generate_document)
+    end
+
+    it 'can be resolved via trigger_class' do
+      klass = OptionConfigs::ExtraOptions.trigger_class(:generate_document)
+      expect(klass).to eq SaveTriggers::GenerateDocument
+    end
+  end
+
+  describe 'template rendering with content_template_name' do
+    it 'renders content from a named template and stores the file' do
+      config = {
+        content_template_name: 'test generate doc content',
+        container: { from_this: 'model_reference' },
+        filename: 'test-doc.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      trigger.perform
+
+      # Verify the file was stored
+      stored = @container.stored_files.find_by(file_name: 'test-doc.html')
+      expect(stored).not_to be_nil
+
+      # Verify content was rendered with substitutions
+      file_path = stored.retrieval_path
+      content = File.read(file_path)
+      expect(content).to include("master #{@master.id}")
+      expect(content).to include('test user')
+    end
+  end
+
+  describe 'template rendering with content_template_text' do
+    it 'renders inline template text and stores the file' do
+      config = {
+        content_template_text: '<p>Inline doc for {{master_id}}</p>',
+        container: { from_this: 'model_reference' },
+        filename: 'inline-doc.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      trigger.perform
+
+      stored = @container.stored_files.find_by(file_name: 'inline-doc.html')
+      expect(stored).not_to be_nil
+
+      file_path = stored.retrieval_path
+      content = File.read(file_path)
+      expect(content).to include(@master.id.to_s)
+    end
+  end
+
+  describe 'layout wrapping' do
+    it 'wraps content in a layout template' do
+      config = {
+        content_template_name: 'test generate doc content',
+        layout_template: 'test generate doc layout',
+        container: { from_this: 'model_reference' },
+        filename: 'layout-doc.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      trigger.perform
+
+      stored = @container.stored_files.find_by(file_name: 'layout-doc.html')
+      expect(stored).not_to be_nil
+
+      file_path = stored.retrieval_path
+      content = File.read(file_path)
+      expect(content).to include('<html><body>')
+      expect(content).to include('</body></html>')
+      expect(content).to include("master #{@master.id}")
+    end
+  end
+
+  describe 'extra substitutions' do
+    it 'supports extra_substitutions for additional tag substitutions' do
+      config = {
+        content_template_text: '<p>Report: {{extra_substitutions.report_title}}</p>',
+        extra_substitutions: {
+          report_title: 'Monthly Summary'
+        },
+        container: { from_this: 'model_reference' },
+        filename: 'extra-subs-doc.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      trigger.perform
+
+      stored = @container.stored_files.find_by(file_name: 'extra-subs-doc.html')
+      expect(stored).not_to be_nil
+
+      file_path = stored.retrieval_path
+      content = File.read(file_path)
+      expect(content).to include('Monthly Summary')
+    end
+
+    it 'substitutes item attributes within extra_substitutions values' do
+      config = {
+        content_template_text: '<p>{{extra_substitutions.ref}}</p>',
+        extra_substitutions: {
+          ref: 'master-{{master_id}}'
+        },
+        container: { from_this: 'model_reference' },
+        filename: 'extra-subs-substituted.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      trigger.perform
+
+      stored = @container.stored_files.find_by(file_name: 'extra-subs-substituted.html')
+      expect(stored).not_to be_nil
+
+      file_path = stored.retrieval_path
+      content = File.read(file_path)
+      expect(content).to include("master-#{@master.id}")
+    end
+  end
+
+  describe 'curly substitutions in filename' do
+    it 'substitutes item attributes in the filename' do
+      config = {
+        content_template_text: '<p>doc content</p>',
+        container: { from_this: 'model_reference' },
+        filename: 'report-{{id}}.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      trigger.perform
+
+      expected_filename = "report-#{@al.id}.html"
+      stored = @container.stored_files.find_by(file_name: expected_filename)
+      expect(stored).not_to be_nil
+    end
+  end
+
+  describe 'container resolution' do
+    it 'resolves container via model reference (from_this)' do
+      config = {
+        content_template_text: '<p>from_this container</p>',
+        container: { from_this: 'model_reference' },
+        filename: 'from-this-doc.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      trigger.perform
+
+      stored = @container.stored_files.find_by(file_name: 'from-this-doc.html')
+      expect(stored).not_to be_nil
+    end
+
+    it 'resolves container by name lookup' do
+      config = {
+        content_template_text: '<p>named container</p>',
+        container: { name: @container.name },
+        filename: 'named-container-doc.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      trigger.perform
+
+      # Verify the trigger stored results with the correct container info
+      results = @al.save_trigger_results['generate_document']
+      expect(results).not_to be_nil
+      expect(results[:stored_file_id]).not_to be_nil
+
+      # Verify the file exists in the resolved container
+      resolved_container = NfsStore::Manage::Container.find(results[:container_id])
+      stored = resolved_container.stored_files.find_by(file_name: 'named-container-doc.html')
+      expect(stored).not_to be_nil
+    end
+
+    it 'resolves container by id lookup' do
+      config = {
+        content_template_text: '<p>id container</p>',
+        container: { id: @container.id },
+        filename: 'id-container-doc.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      trigger.perform
+
+      results = @al.save_trigger_results['generate_document']
+      expect(results).not_to be_nil
+      expect(results[:container_id]).to eq(@container.id)
+
+      stored = @container.stored_files.find_by(file_name: 'id-container-doc.html')
+      expect(stored).not_to be_nil
+    end
+
+    it 'raises an error when container id does not exist' do
+      config = {
+        content_template_text: '<p>bad id</p>',
+        container: { id: -999 },
+        filename: 'bad-id-doc.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      expect { trigger.perform }.to raise_error(FphsException, /could not resolve container/)
+    end
+  end
+
+  describe 'file storage path' do
+    it 'stores the file in a subdirectory when path is specified' do
+      config = {
+        content_template_text: '<p>path doc</p>',
+        container: { from_this: 'model_reference' },
+        filename: 'pathed-doc.html',
+        content_type: 'text/html',
+        path: 'reports',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      trigger.perform
+
+      stored = @container.stored_files.find_by(file_name: 'pathed-doc.html', path: 'reports')
+      expect(stored).not_to be_nil
+    end
+  end
+
+  describe 'user context' do
+    it 'uses store_as_user to resolve the user for file import' do
+      config = {
+        content_template_text: '<p>user context doc</p>',
+        container: { from_this: 'model_reference' },
+        filename: 'user-context-doc.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      trigger.perform
+
+      stored = @container.stored_files.find_by(file_name: 'user-context-doc.html')
+      expect(stored).not_to be_nil
+    end
+  end
+
+  describe 'conditional execution' do
+    it 'generates document when if condition is met' do
+      config = {
+        if: {
+          all: {
+            this: {
+              select_call_direction: 'from player'
+            }
+          }
+        },
+        content_template_text: '<p>conditional doc</p>',
+        container: { from_this: 'model_reference' },
+        filename: 'conditional-doc.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      trigger.perform
+
+      stored = @container.stored_files.find_by(file_name: 'conditional-doc.html')
+      expect(stored).not_to be_nil
+    end
+
+    it 'skips document generation when if condition is not met' do
+      config = {
+        if: {
+          all: {
+            this: {
+              select_call_direction: 'nonexistent direction'
+            }
+          }
+        },
+        content_template_text: '<p>should not generate</p>',
+        container: { from_this: 'model_reference' },
+        filename: 'skipped-doc.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      trigger.perform
+
+      stored = @container.stored_files.find_by(file_name: 'skipped-doc.html')
+      expect(stored).to be_nil
+    end
+  end
+
+  describe 'trigger results' do
+    it 'stores results in save_trigger_results for subsequent triggers' do
+      config = {
+        content_template_text: '<p>results doc</p>',
+        container: { from_this: 'model_reference' },
+        filename: 'results-doc.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      trigger.perform
+
+      results = @al.save_trigger_results['generate_document']
+      expect(results).not_to be_nil
+      expect(results).to be_a(Hash)
+      expect(results[:container_id]).to eq @container.id
+      expect(results[:filename]).to eq 'results-doc.html'
+      expect(results[:stored_file_id]).not_to be_nil
+    end
+  end
+
+  describe 'error handling' do
+    it 'raises an error when container cannot be resolved' do
+      config = {
+        content_template_text: '<p>no container</p>',
+        container: { name: 'nonexistent-container-name' },
+        filename: 'error-doc.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      expect { trigger.perform }.to raise_error(FphsException, /container/i)
+    end
+
+    it 'raises an error when content_template_name references a non-existent template' do
+      config = {
+        content_template_name: 'nonexistent_template_name',
+        container: { from_this: 'model_reference' },
+        filename: 'error-template-doc.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      expect { trigger.perform }.to raise_error(FphsException, /template/i)
+    end
+
+    it 'raises an error when neither content_template_name nor content_template_text is specified' do
+      config = {
+        container: { from_this: 'model_reference' },
+        filename: 'no-content-doc.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      expect { trigger.perform }.to raise_error(FphsException, /content_template/)
+    end
+  end
+
+  describe 'filename sanitization' do
+    it 'sanitizes dangerous characters from the filename' do
+      config = {
+        content_template_text: '<p>sanitized doc</p>',
+        container: { from_this: 'model_reference' },
+        filename: 'report/../../../etc/passwd',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+      trigger.perform
+
+      # The filename should have been sanitized - no path traversal
+      results = @al.save_trigger_results['generate_document']
+      expect(results[:filename]).not_to include('..')
+      expect(results[:filename]).not_to include('/')
+    end
+  end
+
+  describe 'duplicate filename handling' do
+    it 'replaces existing file when replace option is set' do
+      base_config = {
+        content_template_text: '<p>original content</p>',
+        container: { from_this: 'model_reference' },
+        filename: 'replace-test.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      # First create
+      trigger = SaveTriggers::GenerateDocument.new(base_config, @al)
+      trigger.perform
+
+      stored1 = @container.stored_files.where(file_name: 'replace-test.html').first
+      expect(stored1).not_to be_nil
+
+      # Update with replace
+      replace_config = base_config.merge(
+        content_template_text: '<p>replaced content</p>',
+        replace: true
+      )
+
+      trigger2 = SaveTriggers::GenerateDocument.new(replace_config, @al)
+      trigger2.perform
+
+      # Should still have one file (replaced)
+      stored_count = @container.stored_files.where(file_name: 'replace-test.html').count
+      expect(stored_count).to eq 1
+    end
+
+    it 'skips file creation when skip_existing option is set and file exists' do
+      base_config = {
+        content_template_text: '<p>original content</p>',
+        container: { from_this: 'model_reference' },
+        filename: 'skip-test.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      # First create
+      trigger = SaveTriggers::GenerateDocument.new(base_config, @al)
+      trigger.perform
+
+      stored1 = @container.stored_files.where(file_name: 'skip-test.html').first
+      expect(stored1).not_to be_nil
+
+      # Try to create again with skip_existing
+      skip_config = base_config.merge(skip_existing: true)
+      trigger2 = SaveTriggers::GenerateDocument.new(skip_config, @al)
+      trigger2.perform
+
+      # Should still only have one file
+      stored_count = @container.stored_files.where(file_name: 'skip-test.html').count
+      expect(stored_count).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements the `generate_document` save trigger (issue #961), which renders content from a template and stores the resulting document as a file in an NFS filestore container.

### Key Features

- **Content generation** via `content_template_name` (named template) or `content_template_text` (inline text)
- **Layout wrapping** via `layout_template`
- **Extra substitutions** for `{{extra_substitutions.*}}` tags with curly substitution support in values
- **Container resolution** via model reference (`from_this: model_reference`), name lookup (`name:`), or id lookup (`id:`)
- **Filename substitutions** with sanitization to prevent path traversal
- **User context** via `store_as_user` / `store_in_app_type`
- **Conditional execution** via `if:` configuration
- **Duplicate handling** with `skip_existing` and `replace` options
- **Trigger results** stored in `save_trigger_results['generate_document']` for downstream triggers

### Files Changed

- `app/models/save_triggers/generate_document.rb` — new trigger implementation
- `app/models/option_configs/extra_option_implementers/save_triggers.rb` — registered in ValidSaveTriggers
- `spec/models/save_triggers/generate_document_spec.rb` — 23 RSpec examples
- `docs/admin_reference/general/save_trigger_generate_document.md` — admin reference docs
- `docs/admin_reference/general/save_trigger.md` — updated trigger types table
- `app/models/admin/defs/save_triggers_generate_document_options_defs.yaml` — YAML defs for admin panel