### PR TITLE
Dynamic models admin panel index table changes - fixes #968

### DIFF
--- a/app/controllers/admin/dynamic_models_controller.rb
+++ b/app/controllers/admin/dynamic_models_controller.rb
@@ -155,21 +155,10 @@ class Admin::DynamicModelsController < AdminController
   # and whether the dynamic model is in the current app type
   def extra_index_columns
     {
-      resource_name_column: 'Resource name',
       batch_jobs_column: 'Batch jobs',
-      view_sql_column: 'View?',
+      view_sql_column: 'Is a view?',
       in_current_app_type_result_checkbox: 'In current app type'
     }
-  end
-
-  #
-  # Show the full resource name for the dynamic model
-  # @param [DynamicModel] list_item
-  # @return [String]
-  def resource_name_column(list_item)
-    return '' unless list_item.persisted?
-
-    list_item.resource_name.to_s
   end
 
   #
@@ -218,7 +207,7 @@ class Admin::DynamicModelsController < AdminController
   end
 
   def index_params
-    %i[id name table_name category position admin_id]
+    %i[id category name table_name resource_name position admin_id]
   end
 
   #

--- a/app/controllers/admin/dynamic_models_controller.rb
+++ b/app/controllers/admin/dynamic_models_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Admin::DynamicModelsController < AdminController
-  helper_method :permitted_params, :objects_instance, :human_name
+  helper_method :permitted_params, :objects_instance, :human_name,
+                :resource_name_column, :batch_jobs_column, :view_sql_column
   before_action :set_defaults
   helper_method :view_folder
   # after_action :routes_reload, only: %i[update create]
@@ -150,9 +151,59 @@ class Admin::DynamicModelsController < AdminController
   end
 
   #
-  # Show extra index column indicating if the dynamic model is in the current app type
+  # Show extra index columns for resource name, batch jobs status, view SQL indicator,
+  # and whether the dynamic model is in the current app type
   def extra_index_columns
-    { in_current_app_type_result_checkbox: 'In current app type' }
+    {
+      resource_name_column: 'Resource name',
+      batch_jobs_column: 'Batch jobs',
+      view_sql_column: 'View?',
+      in_current_app_type_result_checkbox: 'In current app type'
+    }
+  end
+
+  #
+  # Show the full resource name for the dynamic model
+  # @param [DynamicModel] list_item
+  # @return [String]
+  def resource_name_column(list_item)
+    return '' unless list_item.persisted?
+
+    list_item.resource_name.to_s
+  end
+
+  #
+  # Show the batch jobs status for the dynamic model.
+  # If batch_trigger is configured, shows the frequency.
+  # @param [DynamicModel] list_item
+  # @return [String]
+  def batch_jobs_column(list_item)
+    return '' unless list_item.persisted?
+
+    # Ensure configurations is loaded
+    list_item.option_configs unless list_item.configurations
+    bt = list_item.configurations&.dig(:batch_trigger)
+    return '' unless bt.present?
+
+    frequency = bt[:frequency]
+    frequency.present? ? frequency.to_s : 'configured'
+  rescue StandardError
+    ''
+  end
+
+  #
+  # Show a boolean checkbox if the dynamic model has view_sql configured
+  # @param [DynamicModel] list_item
+  # @return [String] HTML for checked/unchecked indicator
+  def view_sql_column(list_item)
+    return helpers.index_list_item_boolean_field(false) unless list_item.persisted?
+
+    # Ensure configurations is loaded
+    list_item.option_configs unless list_item.configurations
+    has_view_sql = list_item.configurations&.dig(:view_sql).present?
+    helpers.index_list_item_boolean_field(has_view_sql)
+  rescue StandardError
+    helpers.index_list_item_boolean_field(false)
   end
 
   def view_folder
@@ -167,9 +218,7 @@ class Admin::DynamicModelsController < AdminController
   end
 
   def index_params
-    %i[id name schema_name table_name category
-       table_key_name primary_key_name
-       foreign_key_name result_order position admin_id]
+    %i[id name table_name category position admin_id]
   end
 
   #

--- a/spec/controllers/admin/dynamic_models_index_table_spec.rb
+++ b/spec/controllers/admin/dynamic_models_index_table_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Tests for the DynamicModelsController admin panel index table changes (issue #968):
+# - Removed columns: schema_name, table_key_name, primary_key_name, foreign_key_name, result_order
+# - Added extra index columns: resource_name, batch_jobs status, view? boolean
+# - These new columns use the existing extra_index_columns mechanism
+RSpec.describe Admin::DynamicModelsController, type: :controller do
+  include ModelSupport
+  include DynamicModelSupport
+
+  before :all do
+    create_admin
+    create_user
+    change_setting('AllowDynamicMigrations', true)
+  end
+
+  after :all do
+    change_setting('AllowDynamicMigrations', false)
+  end
+
+  before :each do
+    sign_in @admin
+  end
+
+  describe 'index_params' do
+    it 'does not include schema_name, table_key_name, primary_key_name, foreign_key_name, or result_order' do
+      removed_columns = %i[schema_name table_key_name primary_key_name foreign_key_name result_order]
+      result = controller.send(:index_params)
+      removed_columns.each do |col|
+        expect(result).not_to include(col), "Expected index_params not to include #{col}"
+      end
+    end
+
+    it 'includes id, name, table_name, category, position, and admin_id' do
+      required_columns = %i[id name table_name category position admin_id]
+      result = controller.send(:index_params)
+      required_columns.each do |col|
+        expect(result).to include(col), "Expected index_params to include #{col}"
+      end
+    end
+  end
+
+  describe 'extra_index_columns' do
+    it 'includes resource_name column' do
+      result = controller.send(:extra_index_columns)
+      expect(result).to have_key(:resource_name_column)
+      expect(result[:resource_name_column]).to eq('Resource name')
+    end
+
+    it 'includes batch_jobs column' do
+      result = controller.send(:extra_index_columns)
+      expect(result).to have_key(:batch_jobs_column)
+      expect(result[:batch_jobs_column]).to eq('Batch jobs')
+    end
+
+    it 'includes view? column' do
+      result = controller.send(:extra_index_columns)
+      expect(result).to have_key(:view_sql_column)
+      expect(result[:view_sql_column]).to eq('View?')
+    end
+
+    it 'still includes in_current_app_type column' do
+      result = controller.send(:extra_index_columns)
+      expect(result).to have_key(:in_current_app_type_result_checkbox)
+      expect(result[:in_current_app_type_result_checkbox]).to eq('In current app type')
+    end
+  end
+
+  describe 'resource_name_column' do
+    it 'returns the resource name for a dynamic model' do
+      dm = DynamicModel.active.first
+      next unless dm
+
+      result = controller.send(:resource_name_column, dm)
+      expect(result).to eq(dm.resource_name)
+    end
+  end
+
+  describe 'batch_jobs_column' do
+    it 'returns empty string when dynamic model has no batch_trigger configured' do
+      dm = DynamicModel.active.first
+      next unless dm
+
+      # Ensure no batch_trigger is configured
+      allow(dm).to receive(:configurations).and_return(nil)
+      result = controller.send(:batch_jobs_column, dm)
+      expect(result).to eq('')
+    end
+
+    it 'returns a status indicator when batch_trigger is configured' do
+      dm = DynamicModel.active.first
+      next unless dm
+
+      allow(dm).to receive(:configurations).and_return({ batch_trigger: { frequency: '1 hour' } })
+      result = controller.send(:batch_jobs_column, dm)
+      expect(result).to be_present
+    end
+  end
+
+  describe 'view_sql_column' do
+    it 'returns unchecked when dynamic model has no view_sql configured' do
+      dm = DynamicModel.active.first
+      next unless dm
+
+      allow(dm).to receive(:configurations).and_return(nil)
+      result = controller.send(:view_sql_column, dm)
+      # Should render an unchecked boolean field
+      expect(result).to include('val-unchecked')
+    end
+
+    it 'returns checked when dynamic model has view_sql configured' do
+      dm = DynamicModel.active.first
+      next unless dm
+
+      allow(dm).to receive(:configurations).and_return({ view_sql: 'SELECT 1' })
+      result = controller.send(:view_sql_column, dm)
+      # Should render a checked boolean field
+      expect(result).to include('val-checked')
+    end
+  end
+end

--- a/spec/controllers/admin/dynamic_models_index_table_spec.rb
+++ b/spec/controllers/admin/dynamic_models_index_table_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 # Tests for the DynamicModelsController admin panel index table changes (issue #968):
 # - Removed columns: schema_name, table_key_name, primary_key_name, foreign_key_name, result_order
-# - Added extra index columns: resource_name, batch_jobs status, view? boolean
+# - Added resource_name to index_params as a regular column
+# - Added extra index columns: batch_jobs status, "Is a view?" boolean
 # - These new columns use the existing extra_index_columns mechanism
 RSpec.describe Admin::DynamicModelsController, type: :controller do
   include ModelSupport
@@ -33,8 +34,8 @@ RSpec.describe Admin::DynamicModelsController, type: :controller do
       end
     end
 
-    it 'includes id, name, table_name, category, position, and admin_id' do
-      required_columns = %i[id name table_name category position admin_id]
+    it 'includes id, category, name, table_name, resource_name, position, and admin_id' do
+      required_columns = %i[id category name table_name resource_name position admin_id]
       result = controller.send(:index_params)
       required_columns.each do |col|
         expect(result).to include(col), "Expected index_params to include #{col}"
@@ -43,10 +44,9 @@ RSpec.describe Admin::DynamicModelsController, type: :controller do
   end
 
   describe 'extra_index_columns' do
-    it 'includes resource_name column' do
+    it 'does not include resource_name (it is a regular index_params column)' do
       result = controller.send(:extra_index_columns)
-      expect(result).to have_key(:resource_name_column)
-      expect(result[:resource_name_column]).to eq('Resource name')
+      expect(result.keys.map(&:to_s)).not_to include('resource_name_column')
     end
 
     it 'includes batch_jobs column' do
@@ -55,26 +55,16 @@ RSpec.describe Admin::DynamicModelsController, type: :controller do
       expect(result[:batch_jobs_column]).to eq('Batch jobs')
     end
 
-    it 'includes view? column' do
+    it 'includes "Is a view?" column' do
       result = controller.send(:extra_index_columns)
       expect(result).to have_key(:view_sql_column)
-      expect(result[:view_sql_column]).to eq('View?')
+      expect(result[:view_sql_column]).to eq('Is a view?')
     end
 
     it 'still includes in_current_app_type column' do
       result = controller.send(:extra_index_columns)
       expect(result).to have_key(:in_current_app_type_result_checkbox)
       expect(result[:in_current_app_type_result_checkbox]).to eq('In current app type')
-    end
-  end
-
-  describe 'resource_name_column' do
-    it 'returns the resource name for a dynamic model' do
-      dm = DynamicModel.active.first
-      next unless dm
-
-      result = controller.send(:resource_name_column, dm)
-      expect(result).to eq(dm.resource_name)
     end
   end
 


### PR DESCRIPTION
## Summary

Modifies the dynamic models admin panel index table to show more useful columns.

### Removed columns
- schema_name
- table_key_name
- primary_key_name
- foreign_key_name
- result_order

### Added/changed columns
- **resource_name** — added as a regular index column showing the full resource name
- **Batch jobs** — extra index column showing batch trigger frequency when configured
- **Is a view?** — extra index column showing a boolean checkbox when `_configurations.view_sql` is defined
- **In current app type** — retained as an existing extra index column

### Tests
- New spec: `spec/controllers/admin/dynamic_models_index_table_spec.rb` with 10 examples covering all changes
- All existing dynamic models controller specs continue to pass

Fixes #968