### PR TITLE
Added 'Referenced by' section to config library admin details - fixes #970

### DIFF
--- a/app/assets/stylesheets/admin/admin.scss
+++ b/app/assets/stylesheets/admin/admin.scss
@@ -387,3 +387,11 @@ a.link-disabled {
     margin-right: 3px;
   }
 }
+
+.config-library-referenced-by-list {
+  padding-inline-start: 0;
+  li{
+    margin-bottom: 8px;
+    list-style: none;
+  }
+}

--- a/app/models/admin/config_library.rb
+++ b/app/models/admin/config_library.rb
@@ -66,11 +66,73 @@ class Admin::ConfigLibrary < Admin::AdminBase
   end
 
   def parsed
-    res = if content.present? && is_yaml?
-            YAML.safe_load(c)
-          else
-            {}
-          end
+    if content.present? && is_yaml?
+      YAML.safe_load(c)
+    else
+      {}
+    end
+  end
+
+  # Find all active definitions that reference this config library
+  # via `# @library category name` in their options text.
+  # Searches ActivityLog, DynamicModel, ExternalIdentifier, and ConfigLibrary definitions.
+  # @return [Array<Hash>] array of hashes with :type, :id, :name, :admin_path keys
+  def referenced_by
+    refs = []
+    library_ref = "# @library #{category} #{name}"
+
+    ActivityLog.active.each do |item|
+      text = item.options_text
+      next unless text&.include?(library_ref)
+
+      refs << {
+        type: 'ActivityLog',
+        id: item.id,
+        name: item.name,
+        resource_name: item.resource_name,
+        admin_path: "/admin/activity_logs?filter[id]=#{item.id}&perform_action=edit"
+      }
+    end
+
+    DynamicModel.active.each do |item|
+      text = item.options_text
+      next unless text&.include?(library_ref)
+
+      refs << {
+        type: 'DynamicModel',
+        id: item.id,
+        name: item.name,
+        resource_name: item.resource_name,
+        admin_path: "/admin/dynamic_models?filter[id]=#{item.id}&perform_action=edit"
+      }
+    end
+
+    ExternalIdentifier.active.each do |item|
+      text = item.options_text
+      next unless text&.include?(library_ref)
+
+      refs << {
+        type: 'ExternalIdentifier',
+        id: item.id,
+        name: item.name,
+        resource_name: item.resource_name,
+        admin_path: "/admin/external_identifiers?filter[id]=#{item.id}&perform_action=edit"
+      }
+    end
+
+    Admin::ConfigLibrary.active.where.not(id:).each do |item|
+      next unless item.options&.include?(library_ref)
+
+      refs << {
+        type: 'ConfigLibrary',
+        id: item.id,
+        name: "#{item.category} - #{item.name}",
+        resource_name: nil,
+        admin_path: "/admin/config_libraries?filter[id]=#{item.id}&perform_action=edit"
+      }
+    end
+
+    refs
   end
 
   private

--- a/app/views/admin/config_libraries/_def_details.html.erb
+++ b/app/views/admin/config_libraries/_def_details.html.erb
@@ -2,5 +2,23 @@
 <% if object_instance.persisted? %>
   <h4>Include with</h4>
   <pre><code># @library <%=object_instance.category%> <%=object_instance.name%></code></pre>
+
+  <% refs = object_instance.referenced_by %>
+  <% if refs.present? %>
+  <h4>Referenced by</h4>
+  <ul class="config-library-referenced-by-list">
+    <% refs.each do |ref| %>
+    <li>
+      <span class="badge"><%= ref[:type].underscore.humanize %></span>
+      <%= link_to link_label_open_in_new(ref[:name]), ref[:admin_path], target: "_blank" %>
+      <% if ref[:resource_name].present? %>
+        <br/><code><%= ref[:resource_name] %></code>
+      <% end %>
+    </li>
+    <% end %>
+  </ul>
+  <% else %>
+  <p class="text-muted">Not referenced by any definitions</p>
+  <% end %>
 <% end %>
 </div>

--- a/spec/models/admin/config_library_referenced_by_spec.rb
+++ b/spec/models/admin/config_library_referenced_by_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+# Tests for Admin::ConfigLibrary#referenced_by
+# Verifies that a config library can identify which definitions reference it
+# via `# @library category name` in their options fields.
+# The referenced_by method should find references in:
+# - ActivityLog definitions
+# - DynamicModel definitions
+# - ExternalIdentifier definitions
+# - Other ConfigLibrary definitions
+
+require 'rails_helper'
+
+RSpec.describe Admin::ConfigLibrary, type: :model do
+  include ModelSupport
+
+  before :all do
+    change_setting('AllowDynamicMigrations', true)
+    create_admin
+  end
+
+  after :all do
+    change_setting('AllowDynamicMigrations', false)
+  end
+
+  describe '#referenced_by' do
+    before :all do
+      @rand_suffix = rand(1_000_000_000)
+      @lib_name = "test_ref_lib_#{@rand_suffix}"
+      @lib_category = "test_ref_cat_#{@rand_suffix}"
+      @config_library = Admin::ConfigLibrary.create!(
+        current_admin: @admin,
+        name: @lib_name,
+        category: @lib_category,
+        format: 'yaml',
+        options: "field_1:\n  label: Test Field"
+      )
+    end
+
+    it 'returns an empty array when no definitions reference the library' do
+      result = @config_library.referenced_by
+      expect(result).to be_an(Array)
+      # Filter to only items that would reference our specific test library
+      expect(result).to be_empty
+    end
+
+    it 'finds activity logs that reference the library' do
+      al = ActivityLog.active.first
+      skip 'No active activity logs available' unless al
+
+      original_options = al.options_text
+      skip 'Activity log has no options' unless original_options
+
+      # Check if this activity log already references our library
+      unless original_options.include?("# @library #{@lib_category} #{@lib_name}")
+        al.current_admin = @admin
+        al.update!(extra_log_types: "#{original_options}\n# @library #{@lib_category} #{@lib_name}")
+      end
+
+      result = @config_library.referenced_by
+      al_refs = result.select { |r| r[:type] == 'ActivityLog' }
+      expect(al_refs).not_to be_empty
+      expect(al_refs.first[:id]).to eq(al.id)
+      expect(al_refs.first[:name]).to be_present
+      expect(al_refs.first[:admin_path]).to be_present
+
+      # Clean up
+      al.current_admin = @admin
+      al.update!(extra_log_types: original_options)
+    end
+
+    it 'finds dynamic models that reference the library' do
+      dm = DynamicModel.active.first
+      skip 'No active dynamic models available' unless dm
+
+      original_options = dm.options_text
+      skip 'Dynamic model has no options' unless original_options
+
+      unless original_options.include?("# @library #{@lib_category} #{@lib_name}")
+        dm.current_admin = @admin
+        dm.update!(options: "#{original_options}\n# @library #{@lib_category} #{@lib_name}")
+      end
+
+      result = @config_library.referenced_by
+      dm_refs = result.select { |r| r[:type] == 'DynamicModel' }
+      expect(dm_refs).not_to be_empty
+      expect(dm_refs.first[:id]).to eq(dm.id)
+      expect(dm_refs.first[:name]).to be_present
+      expect(dm_refs.first[:admin_path]).to be_present
+
+      # Clean up
+      dm.current_admin = @admin
+      dm.update!(options: original_options)
+    end
+
+    it 'finds other config libraries that reference the library' do
+      referencing_lib = Admin::ConfigLibrary.create!(
+        current_admin: @admin,
+        name: "test_referencing_lib_#{@rand_suffix}",
+        category: @lib_category,
+        format: 'yaml',
+        options: "some_config:\n  key: value\n# @library #{@lib_category} #{@lib_name}"
+      )
+
+      result = @config_library.referenced_by
+      cl_refs = result.select { |r| r[:type] == 'ConfigLibrary' }
+      expect(cl_refs).not_to be_empty
+
+      matching = cl_refs.find { |r| r[:id] == referencing_lib.id }
+      expect(matching).to be_present
+      expect(matching[:name]).to include("test_referencing_lib_#{@rand_suffix}")
+      expect(matching[:admin_path]).to include('config_libraries')
+
+      # Clean up
+      referencing_lib.current_admin = @admin
+      referencing_lib.update!(disabled: true)
+    end
+
+    it 'returns results with type, id, name, resource_name, and admin_path' do
+      referencing_lib = Admin::ConfigLibrary.create!(
+        current_admin: @admin,
+        name: "test_ref_details_lib_#{@rand_suffix}",
+        category: @lib_category,
+        format: 'yaml',
+        options: "some_config:\n  key: value\n# @library #{@lib_category} #{@lib_name}"
+      )
+
+      result = @config_library.referenced_by
+      matching = result.find { |r| r[:id] == referencing_lib.id }
+      expect(matching).to be_present
+      expect(matching).to have_key(:type)
+      expect(matching).to have_key(:id)
+      expect(matching).to have_key(:name)
+      expect(matching).to have_key(:admin_path)
+
+      # Clean up
+      referencing_lib.current_admin = @admin
+      referencing_lib.update!(disabled: true)
+    end
+
+    it 'does not include disabled definitions' do
+      disabled_lib = Admin::ConfigLibrary.create!(
+        current_admin: @admin,
+        name: "test_disabled_ref_lib_#{@rand_suffix}",
+        category: @lib_category,
+        format: 'yaml',
+        options: "cfg:\n  key: val\n# @library #{@lib_category} #{@lib_name}",
+        disabled: true
+      )
+
+      result = @config_library.referenced_by
+      matching = result.find { |r| r[:id] == disabled_lib.id && r[:type] == 'ConfigLibrary' }
+      expect(matching).to be_nil
+    end
+  end
+end

--- a/spec/system/admin/admin_config_library_referenced_by_spec.rb
+++ b/spec/system/admin/admin_config_library_referenced_by_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+# Tests for the "Referenced by" section in the config library admin details block.
+# Verifies that when a config library is referenced by other definitions
+# (activity logs, dynamic models, external identifiers, or other config libraries)
+# via `# @library category name` in their options, the referencing items
+# are displayed with links in the details panel of the admin page.
+
+require 'rails_helper'
+
+describe 'admin config library referenced by', js: true, driver: $browser_driver do
+  include ModelSupport
+  include AdminActionsSetup
+  include FeatureSupport
+
+  before(:all) do
+    SetupHelper.feature_setup
+    ENV['FPHS_ADMIN_SETUP'] = 'yes'
+    make_an_admin
+
+    @rand_suffix = rand(1_000_000_000)
+    @lib_name = "test_refby_lib_#{@rand_suffix}"
+    @lib_category = "test_refby_cat_#{@rand_suffix}"
+
+    # Create the config library that will be referenced
+    @config_library = Admin::ConfigLibrary.create!(
+      current_admin: @admin,
+      name: @lib_name,
+      category: @lib_category,
+      format: 'yaml',
+      options: "field_1:\n  label: Test Field"
+    )
+
+    # Create another config library that references it
+    @referencing_lib = Admin::ConfigLibrary.create!(
+      current_admin: @admin,
+      name: "test_referencing_#{@rand_suffix}",
+      category: @lib_category,
+      format: 'yaml',
+      options: "some_config:\n  key: value\n# @library #{@lib_category} #{@lib_name}"
+    )
+  end
+
+  it 'shows the referenced by section with referencing config libraries' do
+    admin_sign_in_with_2fa
+
+    visit '/admin/config_libraries'
+    finish_page_loading
+
+    # Find and click the Edit button for our config library
+    within "#admin-item-#{@config_library.id}" do
+      find('a.edit-entity.glyphicon-pencil').click
+    end
+
+    # Wait for the edit form to load via AJAX
+    expect(page).to have_css('.nav-tabs', wait: 10)
+
+    # Check the Details tab is active and shows Referenced by section
+    within '#def-details-block' do
+      expect(page).to have_content('Referenced by')
+      expect(page).to have_css('.config-library-referenced-by-list')
+
+      within '.config-library-referenced-by-list' do
+        expect(page).to have_content("test_referencing_#{@rand_suffix}")
+        expect(page).to have_link(href: /config_libraries\?filter/)
+      end
+    end
+  end
+
+  it 'shows links that open in a new tab' do
+    admin_sign_in_with_2fa
+
+    visit '/admin/config_libraries'
+    finish_page_loading
+
+    within "#admin-item-#{@config_library.id}" do
+      find('a.edit-entity.glyphicon-pencil').click
+    end
+
+    expect(page).to have_css('.nav-tabs', wait: 10)
+
+    within '#def-details-block' do
+      within '.config-library-referenced-by-list' do
+        link = find('a', text: /test_referencing_#{@rand_suffix}/)
+        expect(link[:target]).to eq('_blank')
+      end
+    end
+  end
+
+  it 'shows a message when not referenced by anything' do
+    # Create an unreferenced config library
+    unreferenced_lib = Admin::ConfigLibrary.create!(
+      current_admin: @admin,
+      name: "test_unreferenced_#{@rand_suffix}",
+      category: @lib_category,
+      format: 'yaml',
+      options: "standalone:\n  key: value"
+    )
+
+    admin_sign_in_with_2fa
+
+    visit '/admin/config_libraries'
+    finish_page_loading
+
+    within "#admin-item-#{unreferenced_lib.id}" do
+      find('a.edit-entity.glyphicon-pencil').click
+    end
+
+    expect(page).to have_css('.nav-tabs', wait: 10)
+
+    within '#def-details-block' do
+      expect(page).to have_content('Not referenced by any definitions')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a **Referenced by** section to the config library admin details block, showing which definitions reference the library via `# @library category name` in their options.

## Changes

- **Model** (`Admin::ConfigLibrary#referenced_by`): New method that searches active ActivityLog, DynamicModel, ExternalIdentifier, and ConfigLibrary definitions for library references. Returns an array of hashes with type, id, name, resource_name, and admin_path.
- **View** (`_def_details.html.erb`): Displays the referenced-by list with badge labels, linked names opening in new tabs (`filter[id]=...&perform_action=edit`), and resource names. Shows 'Not referenced by any definitions' when empty.
- **Model spec**: 6 examples covering empty results, finding references in dynamic models and config libraries, return structure, and disabled definition exclusion.
- **System spec**: 3 examples verifying UI rendering, new-tab links, and empty state message.

Fixes #970