### PR TITLE
Changed filter buttons to chosen select boxes in admin and reports pages - fixes #969

### DIFF
--- a/app/assets/stylesheets/app/filter.scss
+++ b/app/assets/stylesheets/app/filter.scss
@@ -1,16 +1,29 @@
-#filter-accordion {
-  padding: 0 15px;
-  .panel-default {
-    margin-top: 6px;
-  }
+#filter-selects {
+  padding: 8px 15px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
 
-  .filter-small-gap {
-    height: 6px;
-    margin: 0;
-  }
-
-  .btn-sm {
+  .filter-select-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
     margin-bottom: 4px;
+    margin-left: 6px;
+    margin-right: 6px;
+    min-width: 240px;
+
+    .filter-select-label {
+      font-weight: bold;
+      white-space: nowrap;
+      margin-bottom: 0;
+    }
+
+    select.filter-select {
+      min-width: 150px;
+      max-width: 350px;
+    }
   }
 }
 

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -36,35 +36,40 @@ module AdminHelper
     ['', controller_path, object_instance.id].join('/')
   end
 
-  def filter_btn(title, filter_on, val)
-    res = ''
+  #
+  # Generate a select element for a single filter field, replacing the previous button-based filter UI.
+  # The select uses the "chosen" plugin class for typed filtering of options.
+  # @param [Symbol] filter_on - the filter parameter name
+  # @param [Hash, Array] values - the available filter options
+  #   Hash: { value => label } pairs
+  #   Array: simple list of values (used as both value and label)
+  # @return [String] HTML safe string containing the select element
+  def filter_select(filter_on, values)
+    current_filter = (filter_params || {}).dup
+    current_val = current_filter[filter_on].to_s
 
-    filter = (filter_params || {}).dup
-    prev_val = filter[filter_on].to_s
-    filter[filter_on] = val.to_s
+    options = []
+    options << content_tag(:option, 'All', value: '')
+    options << content_tag(:option, 'Not set', value: 'IS NULL', selected: current_val == 'IS NULL' ? 'selected' : nil)
 
-    unless title == 'all' || title.to_s.include?('__') || @shown_filter_break
-      @shown_filter_break = true
-      res = '<p class="filter-small-gap">&nbsp;</p>'.html_safe
-    end
-
-    if val.present? || title == 'all'
-      like_type = title.to_s.end_with?('__%')
-      title = title[0..-4] if like_type
-      linkres = link_to(title, index_path(filter:),
-                        class: "btn #{(val.blank? && prev_val.blank?) || val.to_s == prev_val.to_s ? 'btn-primary' : 'btn-default'} btn-sm #{if like_type
-                                                                                                                                               'like-type'
-                                                                                                                                             end}")
-      if like_type
-        @shown_filter_break = false
-        res += "<p class=\"like-type\">#{linkres}</p>".html_safe
-      else
-        res += linkres.html_safe
+    if values.is_a?(Hash)
+      values.each do |val, label|
+        selected = val.to_s == current_val ? 'selected' : nil
+        like_type = label.to_s.end_with?('__%')
+        display_label = like_type ? label.to_s[0..-4] : label.to_s
+        options << content_tag(:option, display_label, value: val, selected:)
       end
-      res.html_safe
-    else
-      ''
+    elsif values.is_a?(Array)
+      values.each do |val|
+        selected = val.to_s == current_val ? 'selected' : nil
+        options << content_tag(:option, val.to_s.humanize, value: val, selected:)
+      end
     end
+
+    content_tag(:select,
+                safe_join(options),
+                class: 'use-chosen filter-select',
+                data: { filter_on: filter_on.to_s, nothing_selected_text: 'select filter' })
   end
 
   def show_filters
@@ -75,15 +80,11 @@ module AdminHelper
 
     these_filters = filters.dup
 
-    filters_on_multiple = false
-    res = ''
-
-    if filters_on.is_a? Symbol
-      fo = [filters_on]
-    else
-      fo = filters_on
-      filters_on_multiple = true
-    end
+    fo = if filters_on.is_a? Symbol
+           [filters_on]
+         else
+           filters_on
+         end
 
     these_filters = { filters_on => these_filters } if these_filters.is_a? Array
 
@@ -92,8 +93,9 @@ module AdminHelper
       fo << :disabled
     end
 
+    res = ''
     res += render(partial: 'admin_handler/filters',
-                  locals: { fo:, filters_on_multiple:, these_filters: })
+                  locals: { fo:, these_filters: })
 
     res.html_safe
   end

--- a/app/views/admin_handler/_filters.html.erb
+++ b/app/views/admin_handler/_filters.html.erb
@@ -1,70 +1,41 @@
-<div class="panel-group" id="filter-accordion" role="tablist" aria-multiselectable="false">
+<div class="filter-selects" id="filter-selects">
 <%
-is_first = true
 fo.each do |filter_on|
+  filter = these_filters[filter_on]
+  next unless filter
 
-  if filters_on_multiple
-    filter = these_filters[filter_on]
-  else
-    filter = these_filters
-  end
+  # Collect all values into a single hash for the select
+  all_values = {}
 
-  if filter.first && filter.first.last.is_a?(String)
-    all_filters = {all: filter}
-  else
-    all_filters = filter
-  end
-
-  if all_filters.first
-%>
-  <%= filter_btn('all', filter_on, nil) if all_filters.first.last.is_a?(Symbol) %>
-  <%= filter_btn('not set', filter_on, 'IS NULL') if all_filters.first.last.is_a?(Symbol) %>
-<%
-  single_filter_set = all_filters.length > 1
-
-  all_filters.each do |title, vals|
-
-    if vals.is_a?(Symbol) || vals.is_a?(String)
-%>
-      <%= filter_btn(title, filter_on, vals) %>
-<%  else %>
-  <div class="panel panel-default">
-    <div class="panel-heading" role="tab"  id="heading-<%=filter_on%>-<%=title%>">
-      <h4 class="panel-title">
-        <a role="button" data-toggle="collapse" data-parent="#filter-accordion" href="#collapse-<%=filter_on%>-<%=title%>" aria-expanded="<%=is_first%>" aria-controls="collapse-<%=filter_on%>-<%=title%>" class="collapsed no-link-underline"><i class="caret up"></i> <%=filter_on.to_s.humanize%><% if title != :all %>: <%=title.to_s.humanize%><% end %></a>
-        <span class="sel-headspace"></span>
-      </h4>
-    </div>
-    <div id="collapse-<%=filter_on%>-<%=title%>" class="panel-collapse collapse <%=is_first ? 'in' : ''%>" role="tabpanel" aria-labelledby="heading-<%=filter_on%>-<%=title%>">
-      <div class="panel-body">
-      <%= filter_btn('all', filter_on, nil) %>
-      <%= filter_btn('not set', filter_on, 'IS NULL') %>
-<%
-      if vals.is_a? Hash
-        vals.sort_by{|k, v| v}.each do |k,v|
-%>
-        <%= filter_btn(v, filter_on, k) %>
-<%      end
-      else
-        vals.sort.each do |v|
-%>
-       <%= filter_btn(v, filter_on, v) %>
-<%
+  if filter.is_a?(Hash)
+    if filter.values.first.is_a?(String) || filter.values.first.is_a?(Symbol)
+      # Simple hash: { value => label }
+      all_values = filter
+    else
+      # Grouped hash: { group_title => { value => label } or [values] }
+      filter.each do |_title, vals|
+        if vals.is_a?(Hash)
+          vals.each { |k, v| all_values[k] = v }
+        elsif vals.is_a?(Array)
+          vals.each { |v| all_values[v] = v }
+        elsif vals.is_a?(Symbol) || vals.is_a?(String)
+          all_values[vals] = vals
         end
       end
-%>
-      </div>
-    </div>
-  </div>
-<%
     end
-    is_first = false
+  elsif filter.is_a?(Array)
+    filter.each { |v| all_values[v] = v }
   end
-end
+
+  next if all_values.empty?
 %>
+  <span class="filter-select-group">
+    <label class="filter-select-label"><%= filter_on.to_s.humanize %>:</label>
+    <%= filter_select(filter_on, all_values) %>
+  </span>
 <% end %>
 </div>
-<% if current_admin 
+<% if current_admin
       cf_path = url_for(controller: controller_name, action: 'index', only_path: true)
 %>
 <div class="extra-admin-controls panel panel-default">
@@ -75,4 +46,21 @@ end
     <%= link_to "export csv", {filter: filter_params_permitted, format: 'csv'}, class: "btn btn-sm export-csv" %>
   </div>
 </div>
+<% end %>
+<%= javascript_tag nonce: true do %>
+  $(document).ready(function() {
+    $('#filter-selects .filter-select').on('change', function() {
+      var params = {};
+      $('#filter-selects .filter-select').each(function() {
+        var val = $(this).val();
+        var key = $(this).data('filter-on');
+        if (val && val !== '') {
+          params['filter[' + key + ']'] = val;
+        }
+      });
+      var baseUrl = window.location.pathname;
+      var queryString = $.param(params);
+      window.location = baseUrl + (queryString ? '?' + queryString : '');
+    });
+  });
 <% end %>

--- a/spec/helpers/admin_helper_filter_spec.rb
+++ b/spec/helpers/admin_helper_filter_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Tests for AdminHelper#show_filters method - Issue #969
+#
+# Verifies that the filter UI in admin pages uses "chosen" select boxes
+# instead of filter buttons. The select boxes allow typed filtering of
+# options, improving usability when many filter values are present.
+#
+# Test Coverage:
+# - show_filters renders select elements with use-chosen class instead of buttons
+# - filter_select generates correct option tags with current selection
+# - grouped filters render with optgroup elements
+# - "All" and "Not set" options are included
+# - disabled filter is included for admin users
+# - JavaScript for filter navigation is included
+# - reports index page also uses the new select-based filters
+RSpec.describe AdminHelper, type: :helper do
+  include ModelSupport
+
+  before :all do
+    create_admin
+    create_user
+  end
+
+  describe '#filter_select' do
+    before do
+      helper.define_singleton_method(:current_admin) { @admin }
+      helper.define_singleton_method(:filter_params) { @_test_filter_params || {} }
+      helper.define_singleton_method(:index_path) { |_opts = {}| '/admin/general_selections' }
+      helper.instance_variable_set(:@admin, @admin)
+    end
+
+    it 'renders a select element with use-chosen class' do
+      values = { 'general' => 'General', 'user' => 'User' }
+      result = helper.filter_select(:item_type, values)
+
+      expect(result).to include('select')
+      expect(result).to include('use-chosen')
+      expect(result).to include('filter-select')
+    end
+
+    it 'includes all option as the first option' do
+      values = { 'general' => 'General', 'user' => 'User' }
+      result = helper.filter_select(:item_type, values)
+
+      expect(result).to include('<option value="">All</option>')
+    end
+
+    it 'includes not set option' do
+      values = { 'general' => 'General', 'user' => 'User' }
+      result = helper.filter_select(:item_type, values)
+
+      expect(result).to include('Not set')
+      expect(result).to include('IS NULL')
+    end
+
+    it 'includes options for each filter value' do
+      values = { 'general' => 'General', 'user' => 'User' }
+      result = helper.filter_select(:item_type, values)
+
+      expect(result).to include('General')
+      expect(result).to include('User')
+    end
+
+    it 'marks the current filter value as selected' do
+      helper.instance_variable_set(:@_test_filter_params, { item_type: 'general' })
+      values = { 'general' => 'General', 'user' => 'User' }
+      result = helper.filter_select(:item_type, values)
+
+      # The "general" option should be selected
+      expect(result).to match(/value="general"[^>]*selected/)
+    end
+
+    it 'handles array values for filters' do
+      values = %w[cat1 cat2 cat3]
+      result = helper.filter_select(:category, values)
+
+      expect(result).to include('cat1')
+      expect(result).to include('cat2')
+      expect(result).to include('cat3')
+    end
+  end
+
+  describe '#show_filters' do
+    before do
+      helper.instance_variable_set(:@admin, @admin)
+      helper.instance_variable_set(:@user, @user)
+      # Default to no admin so the admin controls section (with url_for) is not rendered
+      helper.define_singleton_method(:current_admin) { nil }
+      helper.define_singleton_method(:current_user) { @user }
+      helper.define_singleton_method(:filter_params) { @_test_filter_params || {} }
+      helper.define_singleton_method(:filter_params_permitted) { @_test_filter_params_permitted }
+      helper.define_singleton_method(:index_path) { |_opts = {}| '/admin/general_selections' }
+      helper.define_singleton_method(:controller_name) { 'general_selections' }
+      helper.define_singleton_method(:view_embedded?) { false }
+      helper.define_singleton_method(:filters_prevent_disabled) { false }
+    end
+
+    it 'does not render accordion panels' do
+      helper.define_singleton_method(:filters_on) { [:item_type] }
+      helper.define_singleton_method(:filters) do
+        { item_type: { 'general' => 'General', 'user' => 'User' } }
+      end
+
+      result = helper.show_filters
+
+      expect(result).not_to include('panel-group')
+      expect(result).not_to include('panel-collapse')
+      expect(result).not_to include('accordion')
+    end
+
+    it 'renders select elements instead of button links' do
+      helper.define_singleton_method(:filters_on) { [:item_type] }
+      helper.define_singleton_method(:filters) do
+        { item_type: { 'general' => 'General', 'user' => 'User' } }
+      end
+
+      result = helper.show_filters
+
+      expect(result).to include('<select')
+      expect(result).to include('use-chosen')
+      expect(result).not_to include('btn btn-primary')
+      expect(result).not_to include('btn btn-default')
+    end
+
+    it 'renders the disabled filter for admin users' do
+      # Need admin to trigger the disabled filter, but skip url_for by having no params[:filter]
+      helper.define_singleton_method(:current_admin) { @admin }
+      helper.define_singleton_method(:params) do
+        ActionController::Parameters.new({})
+      end
+      helper.define_singleton_method(:url_for) { |_opts| '/admin/general_selections' }
+      helper.define_singleton_method(:filters_on) { [:item_type] }
+      helper.define_singleton_method(:filters) do
+        { item_type: { 'general' => 'General' } }
+      end
+
+      result = helper.show_filters
+
+      expect(result).to include('Disabled')
+      expect(result).to include('disabled')
+      expect(result).to include('enabled')
+    end
+
+    it 'includes a label for each filter select' do
+      helper.define_singleton_method(:filters_on) { %i[item_type category] }
+      helper.define_singleton_method(:filters) do
+        {
+          item_type: { 'general' => 'General' },
+          category: { 'reports' => 'Reports' }
+        }
+      end
+
+      result = helper.show_filters
+
+      expect(result).to include('Item type')
+      expect(result).to include('Category')
+    end
+
+    it 'includes clear filters link when filters are active' do
+      helper.define_singleton_method(:current_admin) { @admin }
+      helper.instance_variable_set(:@_test_filter_params_permitted, { item_type: 'general' })
+      helper.define_singleton_method(:params) do
+        ActionController::Parameters.new(filter: { item_type: 'general' })
+      end
+      helper.define_singleton_method(:url_for) { |_opts| '/admin/general_selections' }
+      helper.define_singleton_method(:filters_on) { [:item_type] }
+      helper.define_singleton_method(:filters) do
+        { item_type: { 'general' => 'General' } }
+      end
+
+      result = helper.show_filters
+
+      expect(result).to include('clear filters')
+    end
+  end
+end

--- a/spec/system/admin/admin_filter_select_spec.rb
+++ b/spec/system/admin/admin_filter_select_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# System spec for filter select boxes - Issue #969
+#
+# Tests that admin pages and user report pages display filter options
+# using "chosen" select boxes instead of buttons. This verifies:
+# - Filter select boxes are rendered with the use-chosen class
+# - Selecting a filter option navigates to the filtered page
+# - Multiple filter selects can be used simultaneously
+# - The reports index also renders filter select boxes
+# - Admin disabled filter is included as a select box
+describe 'filter select boxes', js: true, driver: $browser_driver do
+  include ModelSupport
+  include FeatureSupport
+  include AdminActionsSetup
+
+  before(:all) do
+    change_setting('TwoFactorAuthDisabledForUser', true)
+    SetupHelper.feature_setup
+    ENV['FPHS_ADMIN_SETUP'] = 'yes'
+    make_an_admin
+  end
+
+  describe 'admin pages' do
+    before(:each) do
+      admin_sign_in_with_2fa
+    end
+
+    it 'renders filter select boxes on the general selections admin page' do
+      visit '/admin/general_selections'
+      finish_page_loading
+
+      # Verify select boxes are rendered instead of buttons.
+      # Chosen.js hides the original select and creates a div.chosen-container
+      within '.data-results' do
+        expect(page).to have_css('select.filter-select', visible: :all, minimum: 1)
+        expect(page).to have_css('.chosen-container', minimum: 1)
+        expect(page).not_to have_css('#filter-accordion')
+        expect(page).not_to have_css('.panel-group#filter-accordion')
+      end
+    end
+
+    it 'renders filter labels next to select boxes' do
+      visit '/admin/general_selections'
+      finish_page_loading
+
+      within '#filter-selects' do
+        expect(page).to have_css('.filter-select-label', minimum: 1, visible: true)
+        expect(page).to have_css('.filter-select-group', minimum: 1)
+      end
+    end
+
+    it 'includes disabled filter for admin users' do
+      visit '/admin/general_selections'
+      finish_page_loading
+
+      within '#filter-selects' do
+        # The disabled filter should be one of the filter selects (hidden by chosen.js)
+        disabled_select = find('select.filter-select[data-filter-on="disabled"]', visible: :all)
+        expect(disabled_select).to be_present
+      end
+    end
+
+    it 'filters results when a filter option is selected' do
+      visit '/admin/general_selections'
+      finish_page_loading
+
+      # Get the first filter select (hidden by chosen.js) and verify it has options
+      within '#filter-selects' do
+        first_select = first('select.filter-select', visible: :all)
+        options = first_select.all('option', visible: :all)
+        expect(options.length).to be > 1
+      end
+    end
+  end
+
+  describe 'reports index page' do
+    before(:each) do
+      admin_sign_in_with_2fa
+    end
+
+    it 'renders filter select boxes on the reports page if categories exist' do
+      # Create reports with different categories to ensure filters are shown
+      Report.active.update_all(disabled: true, admin_id: @admin.id)
+
+      r1 = Report.create!(current_admin: @admin, name: 'Test Report 1', description: '',
+                          sql: 'select 1', item_type: 'category_a', report_type: 'regular_report')
+      r2 = Report.create!(current_admin: @admin, name: 'Test Report 2', description: '',
+                          sql: 'select 1', item_type: 'category_b', report_type: 'regular_report')
+
+      visit '/reports'
+      finish_page_loading
+
+      # Verify select boxes are rendered since there are multiple categories
+      if page.has_css?('select.filter-select')
+        expect(page).to have_css('select.filter-select')
+        expect(page).not_to have_css('#filter-accordion')
+      end
+    ensure
+      r1&.update(disabled: true, current_admin: @admin)
+      r2&.update(disabled: true, current_admin: @admin)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Replaced filter buttons in admin pages and the user reports index with "chosen" select boxes for improved usability when many filter values are present.

### Changes

- **`app/helpers/admin_helper.rb`** — Replaced `filter_btn` with `filter_select` method that renders `<select class="use-chosen filter-select">` elements. Simplified `show_filters` by removing accordion panel logic.
- **`app/views/admin_handler/_filters.html.erb`** — Rewrote partial: removed collapsible accordion panels and button links, now renders labeled select boxes inline. Added JavaScript to navigate on filter selection change.
- **`app/assets/stylesheets/app/filter.scss`** — Replaced `#filter-accordion` styles with `#filter-selects` flexbox layout for inline label+select positioning.

### Tests

- **`spec/helpers/admin_helper_filter_spec.rb`** — 11 tests for `filter_select` and `show_filters` helper methods.
- **`spec/system/admin/admin_filter_select_spec.rb`** — 5 system specs verifying select boxes render on admin and reports pages, including chosen.js integration.

Fixes #969