### PR TITLE
Added 'disable unless re-entered' option for handle_deleted_records - fixes #677

### DIFF
--- a/app/models/redcap/data_records.rb
+++ b/app/models/redcap/data_records.rb
@@ -15,7 +15,7 @@ module Redcap
     FailedFileFieldMarker = '<<FAILED-FILE-CAPTURE>>'
 
     attr_accessor :project_admin, :records, :class_name, :errors,
-                  :created_ids, :updated_ids, :unchanged_ids, :disabled_ids, :storage_stage,
+                  :created_ids, :updated_ids, :unchanged_ids, :disabled_ids, :reenabled_ids, :storage_stage,
                   :current_admin, :retrieved_files, :upserted_records, :imported_files, :failed_files,
                   :step_count, :job, :done,
                   :integer_survey_identifier_field_name, :survey_identifier_field_name, :set_master_id_using_association,
@@ -33,6 +33,7 @@ module Redcap
       self.created_ids = []
       self.unchanged_ids = []
       self.disabled_ids = []
+      self.reenabled_ids = []
       self.skipped_ids = []
       self.errors = []
       self.current_admin = project_admin.admin
@@ -258,7 +259,7 @@ module Redcap
       end
 
       return if existing_not_in_retrieved_ids.empty? ||
-                project_admin.ignore_deleted_records? || project_admin.disable_deleted_records?
+                project_admin.ignore_deleted_records? || project_admin.disables_deleted_records?
 
       raise FphsException,
             'Redcap::DataRecords existing records were not in the retrieved records: ' \
@@ -279,7 +280,10 @@ module Redcap
     def store
       # Skip deleted records handling when using date range filter
       # since we're only retrieving a subset of updated records
-      disable_deleted_records if project_admin.disable_deleted_records? && !using_date_range_filter
+      unless using_date_range_filter
+        disable_deleted_records if project_admin.disables_deleted_records?
+        reenable_reentered_records if project_admin.disable_unless_reentered_deleted_records?
+      end
 
       upserts = []
       self.storage_stage = 'store'
@@ -451,16 +455,51 @@ module Redcap
         next if record.disabled?
 
         record.disabled = true
-        attrs = record.attributes
-                      .reject { |k, _v| k.in?(%w[id created_at updated_at user_id]) }
-                      .symbolize_keys
-
-        res = create_or_update(attrs, keep_results: false)
+        res = upsert_record_attrs(record)
         disabled_ids << res[record_id_field] if res
       end
 
       self.storage_stage = 'disable_deleted_records complete'
       update_job_request
+    end
+
+    #
+    # Re-enable records that were previously disabled but have reappeared in the
+    # retrieved REDCap data. This handles the case where a record was deleted
+    # from REDCap (causing it to be disabled locally) and then re-entered.
+    # Runs before the main upsert loop so that record_matches_retrieved
+    # encounters disabled = false and can detect actual data changes.
+    def reenable_reentered_records
+      self.storage_stage = 'reenable_reentered_records'
+      update_job_request
+
+      self.done = 0
+      existing_records.where(disabled: true).find_each do |record|
+        rec_id_attrs = record_identifier_fields.map { |f| [f, record[f].to_s] }.to_h
+        next unless retrieved_rec_ids.include?(rec_id_attrs)
+
+        self.done += 1
+        update_job_request if done % step_count == 0
+
+        record.disabled = false
+        res = upsert_record_attrs(record)
+        reenabled_ids << res[record_id_field] if res
+      end
+
+      self.storage_stage = 'reenable_reentered_records complete'
+      update_job_request
+    end
+
+    #
+    # Build upsert-ready attributes from a record and persist via create_or_update.
+    # Excludes system-managed columns (id, timestamps, user_id).
+    # @param record [ActiveRecord::Base] the record to upsert
+    # @return [Hash, nil] the upserted record attributes, or nil on failure
+    def upsert_record_attrs(record)
+      attrs = record.attributes
+                    .reject { |k, _v| k.in?(%w[id created_at updated_at user_id]) }
+                    .symbolize_keys
+      create_or_update(attrs, keep_results: false)
     end
 
     #
@@ -695,6 +734,7 @@ module Redcap
         count_updated_ids: updated_ids&.length,
         count_unchanged_ids: unchanged_ids&.length,
         count_disabled_ids: disabled_ids&.length,
+        count_reenabled_ids: reenabled_ids&.length,
         count_skipped_ids: skipped_ids&.length,
         count_processed: done,
         table: project_admin.dynamic_model_table,

--- a/app/models/redcap/dynamic_storage.rb
+++ b/app/models/redcap/dynamic_storage.rb
@@ -195,7 +195,7 @@ module Redcap
       end
 
       # Add a disabled field if one is not present and we need to disable deleted records
-      @fields['disabled'] ||= { label: 'disabled' } if project_admin.data_options.handle_deleted_records == 'disabled'
+      @fields['disabled'] ||= { label: 'disabled' } if project_admin.disables_deleted_records?
 
       @fields.stringify_keys
     end
@@ -260,15 +260,15 @@ module Redcap
     end
 
     #
-    # Dfeine the extra fields to be included in a dynamic model, based on project
+    # Define the extra fields to be included in a dynamic model, based on project
     # configurations. This includes `disabled`, `master_id` and array fields summarizing
     # chosen values for multiple choice (checkbox) fields.
-    # @return [<Type>] <description>
+    # @return [Array<String>] list of extra field names
     def extra_fields
       return @extra_fields if @extra_fields
 
       @extra_fields = []
-      @extra_fields << 'disabled' if project_admin.disable_deleted_records?
+      @extra_fields << 'disabled' if project_admin.disables_deleted_records?
       @extra_fields << 'master_id' if project_admin.data_options.set_master_id_using_association
 
       return @extra_fields unless project_admin.data_options.add_multi_choice_summary_fields

--- a/app/models/redcap/project_admin.rb
+++ b/app/models/redcap/project_admin.rb
@@ -49,7 +49,7 @@ module Redcap
 
     JobQueue = 'redcap'
     RedcapSurveyIdentifierField = 'redcap_survey_identifier'
-    ValidHandleDeletedRecordsValues = [nil, false, 'disable', 'ignore'].freeze
+    ValidHandleDeletedRecordsValues = [nil, false, 'disable', 'ignore', 'disable unless re-entered'].freeze
 
     has_one :redcap_data_dictionary,
             class_name: 'Redcap::DataDictionary',
@@ -209,8 +209,8 @@ module Redcap
     #                         - false/null: (default) to prevent a request with deleted records
     #                         - disable: set the disabled attribute for deleted records
     #                         - ignore: skip any deleted records
-    #                         NOTE: with the *disabled* option, if a record subsequently "reappears" in Redcap
-    #                         then the existing DB record will be set to disabled = false and updated appropriately
+    #                         - disable unless re-entered: set disabled = true for deleted records AND
+    #                           set disabled = false when records reappear in REDCap
     # prefix_dynamic_model_config_library: category name
     #                      The "<category> <name>" string identifier for a
     #                      config library to be prefixed to the dynamic
@@ -561,6 +561,16 @@ module Redcap
 
     def disable_deleted_records?
       data_options.handle_deleted_records == 'disable'
+    end
+
+    def disable_unless_reentered_deleted_records?
+      data_options.handle_deleted_records == 'disable unless re-entered'
+    end
+
+    # Returns true when deleted records should be marked as disabled,
+    # regardless of whether re-enabling is also configured
+    def disables_deleted_records?
+      disable_deleted_records? || disable_unless_reentered_deleted_records?
     end
 
     def ignore_deleted_records?

--- a/docs/admin_reference/project_admins/detailed_options.md
+++ b/docs/admin_reference/project_admins/detailed_options.md
@@ -34,10 +34,20 @@ data_options:
   handle_deleted_records: value
     # one of
     #   - disable
+    #   - disable unless re-entered
     #   - ignore
     #   - (blank)
     #   - null
     #   - false
+    #
+    # 'disable': sets disabled = true for records deleted from
+    #   REDCap. Records that reappear will remain disabled.
+    # 'disable unless re-entered': sets disabled = true for
+    #   deleted records AND sets disabled = false when records
+    #   reappear in REDCap.
+    # 'ignore': skips any deleted records silently.
+    # blank/null/false: (default) raises an error if records
+    #   are missing, preventing the transfer.
   prefix_dynamic_model_config_library: category name
     # The "<category> <name>" string identifier for a
     # config library to be prefixed to the dynamic

--- a/spec/models/redcap/data_records_cache_and_date_range_spec.rb
+++ b/spec/models/redcap/data_records_cache_and_date_range_spec.rb
@@ -60,6 +60,7 @@ require './db/table_generators/dynamic_models_table'
 #    deleted records handling with date range:
 #      - skips deleted records validation when using date range filter
 #      - does not disable records when using date range filter
+#      - does not disable or re-enable records with 'disable unless re-entered' when using date range filter
 #
 # 3. Ignore Cache and Retrieve All Parameters (8 tests)
 #    --------------------------------------------------
@@ -754,6 +755,67 @@ RSpec.describe 'Redcap::DataRecords cache and date range', type: :model do
         # No records should have been disabled since we're using date range filter
         expect(dr2.disabled_ids.length).to eq 0
         expect(dm.implementation_class.where(disabled: true).count).to eq 0
+      end
+
+      it 'does not disable or re-enable records with disable unless re-entered when using date range filter' do
+        dm = create_dynamic_model_for_sample_response(disable: true)
+
+        rc = Redcap::ProjectAdmin.active.first
+        rc.current_admin = @admin
+        rc.data_options.export_only_updated_records = 'always'
+        rc.data_options.handle_deleted_records = 'disable unless re-entered'
+        rc.save!
+
+        expect(rc.disable_unless_reentered_deleted_records?).to be true
+
+        # Step 1: Store all records initially
+        stub_request_records @project[:server_url], @project[:api_key]
+        dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+        dr.retrieve
+        dr.summarize_fields
+        dr.handle_survey_identifier
+        dr.validate
+        dr.store
+
+        expect(dr.created_ids.map { |r| r[:record_id] }.sort).to eq %w[1 4 14 19 32].sort
+        expect(dm.implementation_class.where(disabled: true).count).to eq 0
+
+        # Manually disable record 4 to simulate a previous deletion
+        rec4 = dm.implementation_class.find_by(record_id: '4')
+        rec4.update_columns(disabled: true)
+        expect(dm.implementation_class.find_by(record_id: '4').disabled).to be true
+
+        # Create a successful ClientRequest to enable date range calculation
+        Redcap::ClientRequest.create!(
+          current_admin: @admin,
+          action: 'store records',
+          server_url: rc.server_url,
+          name: rc.name,
+          redcap_project_admin: rc,
+          result: { errors: [] },
+          created_at: 5.minutes.ago
+        )
+
+        # Clear cache
+        rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records, rc.records_request_options)
+
+        # Retrieve with date range (returns all 5 records via 'updated_records' fixture)
+        stub_request_records_with_date_range @project[:server_url], @project[:api_key]
+
+        dr2 = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+        dr2.retrieve
+        dr2.summarize_fields
+        dr2.handle_survey_identifier
+        dr2.validate
+        dr2.store
+
+        expect(dr2.using_date_range_filter).to be true
+
+        # Neither disable nor re-enable should have run during date range filter
+        expect(dr2.disabled_ids.length).to eq 0
+        expect(dr2.reenabled_ids.length).to eq 0
+        # Record 4 should still be disabled (not re-enabled by date range pull)
+        expect(dm.implementation_class.find_by(record_id: '4').disabled).to be true
       end
     end
   end

--- a/spec/models/redcap/data_records_spec.rb
+++ b/spec/models/redcap/data_records_spec.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
+# Test Summary: Redcap::DataRecords
+# =================================
+#
+# Tests for retrieving, validating and storing REDCap records into dynamic models.
+# Covers:
+#   - Record retrieval, validation and storage (create, update, unchanged)
+#   - File field downloads and failed file tracking
+#   - Background job retrieval
+#   - Handling of deleted records with all handle_deleted_records options:
+#     - nil/false (default): raises error when records are missing
+#     - 'ignore': silently skips missing records
+#     - 'disable': sets disabled=true for missing records (does NOT re-enable on reappearance)
+#     - 'disable unless re-entered': disables missing records AND re-enables them when they reappear
+#   - Validation of handle_deleted_records option values (accepts valid, rejects invalid)
+#   - Summary choice array fields for multi-choice checkboxes
+#   - External ID association and master_id field setting
+
 require 'rails_helper'
 require './db/table_generators/dynamic_models_table'
 
@@ -820,6 +837,150 @@ RSpec.describe Redcap::DataRecords, type: :model do
       expect(dr.disabled_ids.map { |r| r }.sort).to eq %w[4]
 
       expect(dm.implementation_class.find_by(record_id: 4)&.disabled).to be true
+    end
+
+    it 'disables then re-enables records when handle_deleted_records = disable unless re-entered' do
+      dm = create_dynamic_model_for_sample_response(disable: true)
+
+      expect(dm.implementation_class.attribute_names).to include 'disabled'
+
+      rc = Redcap::ProjectAdmin.active.first
+      rc.current_admin = @admin
+      rc.data_options.handle_deleted_records = 'disable unless re-entered'
+      rc.save!
+      expect(rc.data_options.handle_deleted_records).to eq 'disable unless re-entered'
+      expect(rc.disable_unless_reentered_deleted_records?).to be true
+
+      # Step 1: Store the initial set of records (record_ids: 1, 4, 14, 19, 32)
+      stub_request_records @project[:server_url], @project[:api_key]
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+      dr.retrieve
+      dr.summarize_fields
+      dr.handle_survey_identifier
+
+      expect { dr.validate }.not_to raise_error
+
+      dr.store
+
+      expect(dr.errors).to be_empty
+      expect(dr.created_ids.map { |r| r[:record_id] }.sort).to eq %w[1 4 14 19 32].sort
+      expect(dr.updated_ids).to be_empty
+
+      # Verify record 4 is enabled
+      expect(dm.implementation_class.find_by(record_id: '4')&.disabled).not_to be true
+
+      # Step 2: Simulate record 4 being "deleted" from REDCap (missing_record fixture)
+      WebMock.reset!
+      rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records)
+      rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records, rc.records_request_options)
+
+      stub_request_records @project[:server_url], @project[:api_key], 'missing_record'
+      Rails.cache.clear
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+      dr.retrieve
+      dr.summarize_fields
+      dr.handle_survey_identifier
+
+      expect { dr.validate }.not_to raise_error
+
+      dr.store
+
+      expect(dr.errors).to be_empty
+      expect(dr.disabled_ids).to include('4')
+      expect(dm.implementation_class.find_by(record_id: '4')&.disabled).to be true
+
+      # Step 3: Simulate record 4 "reappearing" in REDCap (back to original narrow fixture)
+      WebMock.reset!
+      rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records)
+      rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records, rc.records_request_options)
+
+      stub_request_records @project[:server_url], @project[:api_key]
+      Rails.cache.clear
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+      dr.retrieve
+      dr.summarize_fields
+      dr.handle_survey_identifier
+
+      expect { dr.validate }.not_to raise_error
+
+      dr.store
+
+      expect(dr.errors).to be_empty
+      # Record 4 should be re-enabled
+      expect(dm.implementation_class.find_by(record_id: '4')&.disabled).to be false
+      expect(dr.reenabled_ids).to include('4')
+      expect(dr.reenabled_ids.length).to eq 1
+    end
+
+    it 'does NOT re-enable records when handle_deleted_records = disable (plain)' do
+      dm = create_dynamic_model_for_sample_response(disable: true)
+
+      rc = Redcap::ProjectAdmin.active.first
+      rc.current_admin = @admin
+      rc.data_options.handle_deleted_records = 'disable'
+      rc.save!
+      expect(rc.disable_deleted_records?).to be true
+
+      # Step 1: Store initial records
+      stub_request_records @project[:server_url], @project[:api_key]
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+      dr.retrieve
+      dr.summarize_fields
+      dr.handle_survey_identifier
+      dr.store
+
+      expect(dr.created_ids.map { |r| r[:record_id] }.sort).to eq %w[1 4 14 19 32].sort
+
+      # Step 2: Simulate record 4 being deleted
+      WebMock.reset!
+      rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records)
+      rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records, rc.records_request_options)
+
+      stub_request_records @project[:server_url], @project[:api_key], 'missing_record'
+      Rails.cache.clear
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+      dr.retrieve
+      dr.summarize_fields
+      dr.handle_survey_identifier
+      dr.store
+
+      expect(dm.implementation_class.find_by(record_id: '4')&.disabled).to be true
+
+      # Step 3: Simulate record 4 "reappearing" — should stay disabled with plain 'disable'
+      WebMock.reset!
+      rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records)
+      rc.api_client.send :clear_cache, rc.api_client.send(:cache_key, :records, rc.records_request_options)
+
+      stub_request_records @project[:server_url], @project[:api_key]
+      Rails.cache.clear
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name)
+      dr.retrieve
+      dr.summarize_fields
+      dr.handle_survey_identifier
+      dr.store
+
+      # With plain 'disable', record 4 should remain disabled
+      expect(dm.implementation_class.find_by(record_id: '4')&.disabled).to be true
+    end
+
+    it 'accepts all valid handle_deleted_records option values and rejects invalid ones' do
+      # Test each valid value on a freshly loaded record to avoid
+      # config_text / update_options state interference between valid? calls
+      [nil, false, 'disable', 'ignore', 'disable unless re-entered'].each do |value|
+        rc = Redcap::ProjectAdmin.active.first
+        rc.current_admin = @admin
+        rc.data_options.handle_deleted_records = value
+        expect(rc).to be_valid, "expected handle_deleted_records=#{value.inspect} to be valid, got errors: #{rc.errors.full_messages}"
+      end
+
+      # Invalid values should fail validation
+      ['delete', 'remove', 'true', 'disabled', 'enable'].each do |value|
+        rc = Redcap::ProjectAdmin.active.first
+        rc.current_admin = @admin
+        rc.data_options.handle_deleted_records = value
+        expect(rc).not_to be_valid, "expected handle_deleted_records=#{value.inspect} to be invalid"
+        expect(rc.errors[:data_options].first).to include('handle_deleted_records must be one of')
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Adds a new `handle_deleted_records` option value: `'disable unless re-entered'`. When a record is deleted from REDCap, it gets disabled locally (like the existing `'disable'` option). When a previously deleted record reappears in REDCap, the local record is re-enabled and updated.

Fixes #677

### Changes

**`app/models/redcap/project_admin.rb`**
- Added `'disable unless re-entered'` to `ValidHandleDeletedRecordsValues`
- Added `disable_unless_reentered_deleted_records?` predicate method
- Added `disables_deleted_records?` predicate that combines both disable options to reduce duplication
- Updated documentation comment for `handle_deleted_records`

**`app/models/redcap/data_records.rb`**
- Added `reenabled_ids` accessor to track re-enabled records
- Updated `validate` method to allow the new option value
- Updated `store` method to call both `disable_deleted_records` and `reenable_reentered_records` when using the new option (skipped during date range filter pulls)
- Added `reenable_reentered_records` private method that finds disabled records matching retrieved REDCap data and re-enables them
- Extracted `upsert_record_attrs` helper to DRY the shared attribute-building pattern
- Added `count_reenabled_ids` to job request tracking

**`app/models/redcap/dynamic_storage.rb`**
- Fixed bug: `fields` and `extra_fields` methods used string comparison (`== 'disabled'`) instead of predicate methods — now uses `disables_deleted_records?`
- Fixed YARD `@return` placeholder in `extra_fields`

**`docs/admin_reference/project_admins/detailed_options.md`**
- Documented the new option and clarified all `handle_deleted_records` values

**`spec/models/redcap/data_records_spec.rb`**
- Added test for full disable → re-enable lifecycle
- Added test confirming plain `'disable'` does NOT re-enable
- Added validation test for valid/invalid option values

**`spec/models/redcap/data_records_cache_and_date_range_spec.rb`**
- Added test confirming date range filter skips both disable and re-enable logic
