### PR TITLE
Added on_complete and on_failure lifecycle hooks to all save triggers - fixes #982

### DIFF
--- a/app/models/admin/defs/save_triggers_add_tracker_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_add_tracker_options_defs.yaml
@@ -31,3 +31,4 @@
               # an alternative master_id is optional, and if specified the tracker will be tied to it
               # Otherwise the default master is that the calling item belongs to (unless item_type / item_id specified)
               master_id: alternative master_id
+#!defs(save_triggers_lifecycle_hooks_defs.yaml)

--- a/app/models/admin/defs/save_triggers_background_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_background_options_defs.yaml
@@ -46,3 +46,6 @@
           Note: The current_user context is preserved in the background job,
           allowing triggers that depend on user context to function correctly.
 
+          Individual triggers within the background job support on_complete and on_failure
+          lifecycle hooks. See on_complete / on_failure documentation for details.
+

--- a/app/models/admin/defs/save_triggers_case_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_case_options_defs.yaml
@@ -53,3 +53,6 @@
           This is useful when different actions should be taken based on field
           values, avoiding the need for multiple identical `if:` conditions on
           individual triggers.
+
+          Individual triggers within case branches support on_complete and on_failure
+          lifecycle hooks. See on_complete / on_failure documentation for details.

--- a/app/models/admin/defs/save_triggers_change_user_roles_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_change_user_roles_options_defs.yaml
@@ -1,6 +1,7 @@
 # Save Trigger: Change User Roles options
         change_user_roles:
           if: if_extras
+#!defs(save_triggers_lifecycle_hooks_defs.yaml)
         add_role_names:
           - app_type: study info
             role_name: viewer-has-agreement

--- a/app/models/admin/defs/save_triggers_create_filestore_container_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_create_filestore_container_options_defs.yaml
@@ -4,3 +4,4 @@
         label: 'human name'
         create_with_role: 'role name'
         if: if_extras
+#!defs(save_triggers_lifecycle_hooks_defs.yaml)

--- a/app/models/admin/defs/save_triggers_create_master_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_create_master_options_defs.yaml
@@ -14,3 +14,4 @@
                   field_name: return_value
           # NOTE: this sets:
           # - save_trigger_results.created_masters (with the master record created, if it was created)
+#!defs(save_triggers_lifecycle_hooks_defs.yaml)

--- a/app/models/admin/defs/save_triggers_create_reference_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_create_reference_options_defs.yaml
@@ -45,6 +45,7 @@
                   a_value: value_from_result
 
 #!defs(save_triggers_with_attribute_values_defs.yaml)
+#!defs(save_triggers_lifecycle_hooks_defs.yaml)
 
             to_existing_record: # use an existing record of type "model_name", rather than creating a new one
               record_id: 'Hash with return_value, such as {model_name: {match: value, id: "return_value"\}\}'

--- a/app/models/admin/defs/save_triggers_generate_document_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_generate_document_options_defs.yaml
@@ -31,3 +31,4 @@
 
           # --- Standard Trigger Options ---
           if: #if_extras  # Optional conditional to control when trigger fires
+#!defs(save_triggers_lifecycle_hooks_defs.yaml)

--- a/app/models/admin/defs/save_triggers_lifecycle_hooks_defs.yaml
+++ b/app/models/admin/defs/save_triggers_lifecycle_hooks_defs.yaml
@@ -1,0 +1,49 @@
+# Save Trigger: Lifecycle Hooks (on_complete / on_failure)
+# These options are automatically available on ALL save trigger types.
+# They are implemented in the base class and applied to all current and future triggers.
+# For triggers that accept multiple entries (e.g. add_tracker, update_this,
+# create_reference), these options can be placed inside each named entry
+# to run hooks per-entry.
+
+            on_complete: |
+              (optional) triggers to run after successful completion.
+              Accepts a single trigger hash or an array of trigger configurations.
+              Can be placed at the top level of the trigger config, or inside
+              each named entry for triggers that iterate multiple entries
+              (e.g. add_tracker, create_reference, update_this).
+              
+              Example (top-level):
+                on_complete:
+                  - log:
+                      message: 'Trigger completed successfully'
+                      severity: info
+
+              Example (per-entry, inside a named entry):
+                add_tracker:
+                  - Q1:
+                      with:
+                        sub_process_name: Review
+                        protocol_event_name: Done
+                      on_complete:
+                        - log:
+                            message: 'Tracker added successfully'
+                            severity: info
+
+            on_failure: |
+              (optional) triggers to run if an exception is raised.
+              Accepts a single trigger hash or an array of trigger configurations.
+              The original exception is re-raised after on_failure triggers execute.
+              Errors within on_failure triggers are logged but do not suppress
+              the original exception.
+              Can be placed at the top level or inside each named entry,
+              matching on_complete placement.
+              
+              Example:
+                on_failure:
+                  - log:
+                      message: 'Trigger failed'
+                      severity: error
+                  - update_this:
+                      one:
+                        with:
+                          status: failed

--- a/app/models/admin/defs/save_triggers_log_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_log_options_defs.yaml
@@ -4,5 +4,6 @@
             if: #if_extras
             message: 'Processing record {{id}} for master {{master_id}}'  # Message to log, supports substitutions
             severity: info  # 'debug', 'info' (default), 'warn', or 'error'
+#!defs(save_triggers_lifecycle_hooks_defs.yaml)
           # NOTE: this sets:
           # - save_trigger_results.log (array of results with message, severity, and logged_at)

--- a/app/models/admin/defs/save_triggers_pull_external_data_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_pull_external_data_options_defs.yaml
@@ -92,3 +92,4 @@
                       save_trigger_results:
                         element: 'post_response.success'
                         value: true              
+#!defs(save_triggers_lifecycle_hooks_defs.yaml)

--- a/app/models/admin/defs/save_triggers_redcap_request_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_redcap_request_options_defs.yaml
@@ -48,4 +48,5 @@
                     element: link_response
                     condition: "<> LENGTH"
                     value: 0
+#!defs(save_triggers_lifecycle_hooks_defs.yaml)
                     

--- a/app/models/admin/defs/save_triggers_reload_this_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_reload_this_options_defs.yaml
@@ -45,4 +45,5 @@
               always: true  # always reload
               never: true   # never reload (useful for testing)
               # or any other valid condition
+#!defs(save_triggers_lifecycle_hooks_defs.yaml)
 

--- a/app/models/admin/defs/save_triggers_run_batch_trigger_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_run_batch_trigger_options_defs.yaml
@@ -7,3 +7,4 @@
             limit: 100  # Optional limit on number of records to process
           # NOTE: this sets:
           # - save_trigger_results.run_batch_trigger (array of results with resource_name, mode, status, and processed_ids for foreground mode)
+#!defs(save_triggers_lifecycle_hooks_defs.yaml)

--- a/app/models/admin/defs/save_triggers_set_item_flags_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_set_item_flags_options_defs.yaml
@@ -6,3 +6,4 @@
           flags: 'list of flag-name ids or names, or exclude if the existing set of flags should be used to add or remove items from'
           add_flags: 'list of flag-name ids or names to add to the list'
           remove_flags: 'list of flag-name ids or names to remove from the list'
+#!defs(save_triggers_lifecycle_hooks_defs.yaml)

--- a/app/models/admin/defs/save_triggers_set_save_trigger_results_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_set_save_trigger_results_options_defs.yaml
@@ -19,3 +19,4 @@
           #       - set_save_trigger_results:
           #           element: hash_var.key1
           #           value: hello
+#!defs(save_triggers_lifecycle_hooks_defs.yaml)

--- a/app/models/admin/defs/save_triggers_transaction_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_transaction_options_defs.yaml
@@ -34,3 +34,6 @@
           Results from all executed triggers are stored in save_trigger_results['transaction']
           as an array of {trigger:, result:} hashes.
 
+          Individual triggers within the transaction support on_complete and on_failure
+          lifecycle hooks. See on_complete / on_failure documentation for details.
+

--- a/app/models/admin/defs/save_triggers_update_reference_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_update_reference_options_defs.yaml
@@ -56,6 +56,7 @@
                   a_value: value_from_result
 
 #!defs(save_triggers_with_attribute_values_defs.yaml)
+#!defs(save_triggers_lifecycle_hooks_defs.yaml)
               field_name_5:
                 # An association belonging to the parent
                 association_name:

--- a/app/models/admin/defs/save_triggers_update_this_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_update_this_options_defs.yaml
@@ -34,3 +34,4 @@
                   a_value: value_from_result
 
 #!defs(save_triggers_with_attribute_values_defs.yaml)
+#!defs(save_triggers_lifecycle_hooks_defs.yaml)

--- a/app/models/option_configs/extra_option_implementers/save_triggers.rb
+++ b/app/models/option_configs/extra_option_implementers/save_triggers.rb
@@ -41,8 +41,9 @@ module OptionConfigs
           # Get a list of results from the triggers
           results = configs.map do |perform, config|
             o = trigger_class(perform).new(config, obj)
-            # Add the trigger result to the list
-            o.perform
+            # Add the trigger result to the list, using lifecycle hooks
+            # to automatically fire on_complete/on_failure
+            o.perform_with_lifecycle
           end
 
           # If we had any results then check if they were all true. If they were then return true.

--- a/app/models/save_triggers/add_tracker.rb
+++ b/app/models/save_triggers/add_tracker.rb
@@ -26,35 +26,37 @@ class SaveTriggers::AddTracker < SaveTriggers::SaveTriggersBase
   def perform
     model_defs.each do |model_def|
       model_def.each do |pn, c|
-        self.this_config = c
-        self.protocol_name = pn
-        unless if_evaluates(this_config[:if])
-          trackers << { protocol_name => nil }
-          next
+        with_entry_lifecycle(c) do
+          self.this_config = c
+          self.protocol_name = pn
+          unless if_evaluates(this_config[:if])
+            trackers << { protocol_name => nil }
+            next
+          end
+
+          setup_with_config
+
+          # be sure about the master and the current_user being set, to avoid hidden errors
+          raise FphsException, 'no master record set to add the tracker to' unless use_master
+          raise FphsException, 'no user set when adding tracker' unless use_master.current_user
+
+          begin
+            t = use_master.trackers.create!(
+              protocol_id: protocol.id,
+              sub_process_id: sub_process.id,
+              protocol_event_id: protocol_event&.id,
+              notes: config_values[:notes],
+              item: use_item,
+              event_date: event_date
+            )
+          rescue StandardError => e
+            error_details = build_error_details(e)
+            Rails.logger.error "AddTracker failed: #{error_details}"
+            raise FphsException, "AddTracker failed with error: #{e.message}\n#{error_details}"
+          end
+
+          trackers << { protocol_name => t }
         end
-
-        setup_with_config
-
-        # be sure about the master and the current_user being set, to avoid hidden errors
-        raise FphsException, 'no master record set to add the tracker to' unless use_master
-        raise FphsException, 'no user set when adding tracker' unless use_master.current_user
-
-        begin
-          t = use_master.trackers.create!(
-            protocol_id: protocol.id,
-            sub_process_id: sub_process.id,
-            protocol_event_id: protocol_event&.id,
-            notes: config_values[:notes],
-            item: use_item,
-            event_date: event_date
-          )
-        rescue StandardError => e
-          error_details = build_error_details(e)
-          Rails.logger.error "AddTracker failed: #{error_details}"
-          raise FphsException, "AddTracker failed with error: #{e.message}\n#{error_details}"
-        end
-
-        trackers << { protocol_name => t }
       end
     end
     trackers

--- a/app/models/save_triggers/create_reference.rb
+++ b/app/models/save_triggers/create_reference.rb
@@ -18,91 +18,93 @@ class SaveTriggers::CreateReference < SaveTriggers::SaveTriggersBase
 
     @model_defs.each do |model_def|
       model_def.each do |model_name, config|
-        vals = {}
-        force_create = config[:force_create]
-        force_not_valid = true if config[:force_not_valid]
-        to_existing_record = config[:to_existing_record]
-        create_in = config[:in]
-        create_if = config[:if]
-        create_with = config[:with]
-        with_result = config[:with_result]
+        with_entry_lifecycle(config) do
+          vals = {}
+          force_create = config[:force_create]
+          force_not_valid = true if config[:force_not_valid]
+          to_existing_record = config[:to_existing_record]
+          create_in = config[:in]
+          create_if = config[:if]
+          create_with = config[:with]
+          with_result = config[:with_result]
 
-        # We calculate the conditional if inside each item, rather than relying
-        # on the outer processing in ActivityLogOptions#calc_save_trigger_if
-        if create_if
-          ca = ConditionalActions.new create_if, @item
-          unless ca.calc_action_if
-            @item.save_trigger_results['created_results'] << false
-            next
-          end
-        end
-
-        self.in_master = @master
-
-        handle_with_result with_result, vals
-        handle_with_attributes create_with, vals
-
-        @item.transaction do
-          new_type = in_master.assoc_named(model_name.to_s.pluralize)
-          if to_existing_record
-            to_record_id = to_existing_record[:record_id]
-            raise FphsException, 'record_id must be set in to_existing_record' unless to_record_id
-
-            to_existing_record_id = FieldDefaults.calculate_default @item, to_record_id
-            new_item = new_type.find(to_existing_record_id)
-          else
-            vals[:ignore_configurable_valid_if] = force_not_valid
-            new_item = new_type.new vals
-            # new_item.ignore_configurable_valid_if = force_not_valid
-            if force_create
-              new_item.send(:force_write_user)
-              new_item.force_save!
+          # We calculate the conditional if inside each item, rather than relying
+          # on the outer processing in ActivityLogOptions#calc_save_trigger_if
+          if create_if
+            ca = ConditionalActions.new create_if, @item
+            unless ca.calc_action_if
+              @item.save_trigger_results['created_results'] << false
+              next
             end
-            if vals[:embedded_item]
-              # Ensure the embedded item has its attributes set before the
-              # new item starts to save, to avoid any issues. Save triggers
-              # within the new item may reference the embedded item, and will
-              # need the real information in place early in the process.
-              new_item.prep_embedded_item(vals[:embedded_item],
-                                          force_create:,
-                                          force_not_valid:)
-            end
-            new_item.save!
-
           end
 
-          res =
-            case create_in
-            when 'this'
-              ModelReference.create_with @item, new_item, force_create:
-            when 'referring_record'
-              ModelReference.create_with @item.referring_record, new_item, force_create:
-            when 'master'
-              # 'master' indicates that we want to create an instance belonging to the master without
-              # creating a ModelReference. Do nothing here.
-            when 'master_with_reference'
-              ModelReference.create_from_master_with in_master, new_item, force_create:
+          self.in_master = @master
+
+          handle_with_result with_result, vals
+          handle_with_attributes create_with, vals
+
+          @item.transaction do
+            new_type = in_master.assoc_named(model_name.to_s.pluralize)
+            if to_existing_record
+              to_record_id = to_existing_record[:record_id]
+              raise FphsException, 'record_id must be set in to_existing_record' unless to_record_id
+
+              to_existing_record_id = FieldDefaults.calculate_default @item, to_record_id
+              new_item = new_type.find(to_existing_record_id)
             else
+              vals[:ignore_configurable_valid_if] = force_not_valid
+              new_item = new_type.new vals
+              # new_item.ignore_configurable_valid_if = force_not_valid
+              if force_create
+                new_item.send(:force_write_user)
+                new_item.force_save!
+              end
+              if vals[:embedded_item]
+                # Ensure the embedded item has its attributes set before the
+                # new item starts to save, to avoid any issues. Save triggers
+                # within the new item may reference the embedded item, and will
+                # need the real information in place early in the process.
+                new_item.prep_embedded_item(vals[:embedded_item],
+                                            force_create:,
+                                            force_not_valid:)
+              end
+              new_item.save!
 
-              unless create_in.is_a?(Hash) && create_in[:specific_record]
-                raise FphsException,
-                      "Unknown 'in' value in create_reference for config #{config}"
+            end
+
+            res =
+              case create_in
+              when 'this'
+                ModelReference.create_with @item, new_item, force_create:
+              when 'referring_record'
+                ModelReference.create_with @item.referring_record, new_item, force_create:
+              when 'master'
+                # 'master' indicates that we want to create an instance belonging to the master without
+                # creating a ModelReference. Do nothing here.
+              when 'master_with_reference'
+                ModelReference.create_from_master_with in_master, new_item, force_create:
+              else
+
+                unless create_in.is_a?(Hash) && create_in[:specific_record]
+                  raise FphsException,
+                        "Unknown 'in' value in create_reference for config #{config}"
+                end
+
+                # A specific instance is the target for the reference from_record
+                # Include return: return_result to return the actual instance
+                # or use {{{triple curly substitution}}}
+                ci = FieldDefaults.calculate_default @item, create_in[:specific_record]
+                raise FphsException, "Result for 'in' hash is not an instance" unless ci.is_a? UserBase
+
+                ModelReference.create_with ci, new_item, force_create:
               end
 
-              # A specific instance is the target for the reference from_record
-              # Include return: return_result to return the actual instance
-              # or use {{{triple curly substitution}}}
-              ci = FieldDefaults.calculate_default @item, create_in[:specific_record]
-              raise FphsException, "Result for 'in' hash is not an instance" unless ci.is_a? UserBase
+            @item.save_trigger_results['created_references'] << res
+            @item.save_trigger_results['created_items'] << new_item
+            @item.save_trigger_results['created_results'] << true
 
-              ModelReference.create_with ci, new_item, force_create:
-            end
-
-          @item.save_trigger_results['created_references'] << res
-          @item.save_trigger_results['created_items'] << new_item
-          @item.save_trigger_results['created_results'] << true
-
-          res
+            res
+          end
         end
       end
     end

--- a/app/models/save_triggers/generate_document.rb
+++ b/app/models/save_triggers/generate_document.rb
@@ -38,24 +38,25 @@ class SaveTriggers::GenerateDocument < SaveTriggers::SaveTriggersBase
 
     @model_defs.each do |config|
       @config = config.is_a?(Hash) ? config : {}
+      with_entry_lifecycle(@config) do
+        # Evaluate conditional if
+        next unless if_evaluates(@config[:if])
 
-      # Evaluate conditional if
-      next unless if_evaluates(@config[:if])
+        rendered_content = render_content
+        resolved_filename = resolve_filename
+        resolved_container = resolve_container
+        store_user = resolve_user
 
-      rendered_content = render_content
-      resolved_filename = resolve_filename
-      resolved_container = resolve_container
-      store_user = resolve_user
+        stored_file = store_file(resolved_container, resolved_filename, rendered_content, store_user)
 
-      stored_file = store_file(resolved_container, resolved_filename, rendered_content, store_user)
-
-      store_trigger_results('generate_document', {
-                              container_id: resolved_container.id,
-                              filename: resolved_filename,
-                              stored_file_id: stored_file&.id,
-                              path: @config[:path],
-                              content_type: @config[:content_type]
-                            })
+        store_trigger_results('generate_document', {
+                                container_id: resolved_container.id,
+                                filename: resolved_filename,
+                                stored_file_id: stored_file&.id,
+                                path: @config[:path],
+                                content_type: @config[:content_type]
+                              })
+      end
     end
   end
 

--- a/app/models/save_triggers/log.rb
+++ b/app/models/save_triggers/log.rb
@@ -28,43 +28,44 @@ class SaveTriggers::Log < SaveTriggers::SaveTriggersBase
       # Handle both simple format { message: 'x', severity: 'y' }
       # and named format { log_1: { message: 'x', severity: 'y' } }
       config = extract_config(model_def)
+      with_entry_lifecycle(config) do
+        # Evaluate conditional if
+        if config[:if]
+          ca = ConditionalActions.new config[:if], @item
+          next unless ca.calc_action_if
+        end
 
-      # Evaluate conditional if
-      if config[:if]
-        ca = ConditionalActions.new config[:if], @item
-        next unless ca.calc_action_if
+        message = config[:message]
+        severity = (config[:severity] || 'info').to_s.downcase
+
+        raise FphsException, 'log save trigger requires message to be specified' if message.blank?
+
+        unless severity.in?(ValidSeverities)
+          raise FphsException,
+                "log save trigger severity must be one of #{ValidSeverities.join(', ')}, got: #{severity}"
+        end
+
+        # Perform substitutions in the message
+        formatted_message = Formatter::Substitution.substitute(message, data: @item, ignore_missing: true)
+
+        # Add context prefix for easier identification
+        log_prefix = "[SaveTrigger::Log] [#{@item.class.name}##{@item.id}]"
+        full_message = "#{log_prefix} #{formatted_message}"
+
+        # Log at the appropriate severity level
+        case severity
+        when 'debug'
+          Rails.logger.debug full_message
+        when 'info'
+          Rails.logger.info full_message
+        when 'warn'
+          Rails.logger.warn full_message
+        when 'error'
+          Rails.logger.error full_message
+        end
+
+        results << { message: formatted_message, severity:, logged_at: Time.current }
       end
-
-      message = config[:message]
-      severity = (config[:severity] || 'info').to_s.downcase
-
-      raise FphsException, 'log save trigger requires message to be specified' if message.blank?
-
-      unless severity.in?(ValidSeverities)
-        raise FphsException,
-              "log save trigger severity must be one of #{ValidSeverities.join(', ')}, got: #{severity}"
-      end
-
-      # Perform substitutions in the message
-      formatted_message = Formatter::Substitution.substitute(message, data: @item, ignore_missing: true)
-
-      # Add context prefix for easier identification
-      log_prefix = "[SaveTrigger::Log] [#{@item.class.name}##{@item.id}]"
-      full_message = "#{log_prefix} #{formatted_message}"
-
-      # Log at the appropriate severity level
-      case severity
-      when 'debug'
-        Rails.logger.debug full_message
-      when 'info'
-        Rails.logger.info full_message
-      when 'warn'
-        Rails.logger.warn full_message
-      when 'error'
-        Rails.logger.error full_message
-      end
-
-      results << { message: formatted_message, severity:, logged_at: Time.current }
     end
 
     # Store results for potential use by subsequent triggers

--- a/app/models/save_triggers/pull_external_data.rb
+++ b/app/models/save_triggers/pull_external_data.rb
@@ -18,76 +18,78 @@ class SaveTriggers::PullExternalData < SaveTriggers::SaveTriggersBase
     @model_defs = [@model_defs] unless @model_defs.is_a? Array
 
     @model_defs.each do |model_def|
-      model_def.each do |_model_name, config|
-        data_field = config[:data_field]
-        response_code_field = config[:response_code_field]
-        data_field_format = config[:data_field_format]
-        local_data_name = config[:local_data]
-        success_if = config[:success_if]
-        vals = {}
+      model_def.each_value do |config|
+        with_entry_lifecycle(config) do
+          data_field = config[:data_field]
+          response_code_field = config[:response_code_field]
+          data_field_format = config[:data_field_format]
+          local_data_name = config[:local_data]
+          success_if = config[:success_if]
+          vals = {}
 
-        # We calculate the conditional if inside each item, rather than relying
-        # on the outer processing in ActivityLogOptions#calc_save_trigger_if
-        if config[:if]
-          ca = ConditionalActions.new config[:if], @item
-          next unless ca.calc_action_if
+          # We calculate the conditional if inside each item, rather than relying
+          # on the outer processing in ActivityLogOptions#calc_save_trigger_if
+          if config[:if]
+            ca = ConditionalActions.new config[:if], @item
+            next unless ca.calc_action_if
+          end
+
+          @this_config = config
+          @submitted_request_data = nil
+          data = run_request
+          orig_data = data
+
+          if data_field
+            data = data&.to_json if data_field_format == 'json'
+            vals[data_field] = data
+          end
+
+          vals[response_code_field] = response_code if response_code_field
+          if local_data_name
+            @item.save_trigger_results[local_data_name] = orig_data
+            @item.save_trigger_results["#{local_data_name}_http_response_code"] = response_code
+            @item.save_trigger_results["#{local_data_name}_submitted_request"] = {
+              'data' => @submitted_request_data,
+              'url' => url_from_config,
+              'method' => method_from_config
+            }
+          end
+
+          # We calculate the conditional if inside each item, rather than relying
+          # on the outer processing in ActivityLogOptions#calc_save_trigger_if
+          success_if_res = nil
+          if success_if
+            ca = ConditionalActions.new success_if, @item
+            success_if_res = !!ca.calc_action_if
+            @item.save_trigger_results["#{local_data_name}_success_if_res"] = success_if_res if local_data_name
+          end
+
+          uri = url_from_config.split('?').first
+          logmsg = "pull_external_data #{method_from_config} -> #{uri} = response code #{response_code} " \
+                   "&& success_if_res #{success_if_res}"
+          if response_code == 200 && success_if_res != false
+            Rails.logger.info logmsg
+          else
+            Rails.logger.warn logmsg
+          end
+
+          next unless vals.present?
+
+          # Retain the flags so that the #update! doesn't change
+          # what we need to report through the API
+          res = @item
+          created = res._created
+          updated = res._updated
+          disabled = res._disabled
+          @item.transaction do
+            res.ignore_configurable_valid_if = true if config[:force_not_valid]
+            res.force_save! if config[:force_not_editable_save]
+            res.update! vals.merge(current_user: @item.current_user || @item.user, skip_save_trigger: true)
+          end
+          res._created = created
+          res._updated = updated
+          res._disabled = disabled
         end
-
-        @this_config = config
-        @submitted_request_data = nil
-        data = run_request
-        orig_data = data
-
-        if data_field
-          data = data&.to_json if data_field_format == 'json'
-          vals[data_field] = data
-        end
-
-        vals[response_code_field] = response_code if response_code_field
-        if local_data_name
-          @item.save_trigger_results[local_data_name] = orig_data
-          @item.save_trigger_results["#{local_data_name}_http_response_code"] = response_code
-          @item.save_trigger_results["#{local_data_name}_submitted_request"] = {
-            'data' => @submitted_request_data,
-            'url' => url_from_config,
-            'method' => method_from_config
-          }
-        end
-
-        # We calculate the conditional if inside each item, rather than relying
-        # on the outer processing in ActivityLogOptions#calc_save_trigger_if
-        success_if_res = nil
-        if success_if
-          ca = ConditionalActions.new success_if, @item
-          success_if_res = !!ca.calc_action_if
-          @item.save_trigger_results["#{local_data_name}_success_if_res"] = success_if_res if local_data_name
-        end
-
-        uri = url_from_config.split('?').first
-        logmsg = "pull_external_data #{method_from_config} -> #{uri} = response code #{response_code} " \
-                 "&& success_if_res #{success_if_res}"
-        if response_code == 200 && success_if_res != false
-          Rails.logger.info logmsg
-        else
-          Rails.logger.warn logmsg
-        end
-
-        next unless vals.present?
-
-        # Retain the flags so that the #update! doesn't change
-        # what we need to report through the API
-        res = @item
-        created = res._created
-        updated = res._updated
-        disabled = res._disabled
-        @item.transaction do
-          res.ignore_configurable_valid_if = true if config[:force_not_valid]
-          res.force_save! if config[:force_not_editable_save]
-          res.update! vals.merge(current_user: @item.current_user || @item.user, skip_save_trigger: true)
-        end
-        res._created = created
-        res._updated = updated
-        res._disabled = disabled
       end
     end
   end

--- a/app/models/save_triggers/redcap_request.rb
+++ b/app/models/save_triggers/redcap_request.rb
@@ -26,75 +26,77 @@ class SaveTriggers::RedcapRequest < SaveTriggers::SaveTriggersBase
 
     @model_defs.each do |model_def|
       model_def.each_value do |config|
-        data_field = config[:data_field]
-        response_code_field = config[:response_code_field]
-        data_field_format = config[:data_field_format]
-        local_data_name = config[:local_data]
-        success_if = config[:success_if]
-        vals = {}
+        with_entry_lifecycle(config) do
+          data_field = config[:data_field]
+          response_code_field = config[:response_code_field]
+          data_field_format = config[:data_field_format]
+          local_data_name = config[:local_data]
+          success_if = config[:success_if]
+          vals = {}
 
-        # We calculate the conditional if inside each item, rather than relying
-        # on the outer processing in ActivityLogOptions#calc_save_trigger_if
-        if config[:if]
-          ca = ConditionalActions.new config[:if], @item
-          next unless ca.calc_action_if
+          # We calculate the conditional if inside each item, rather than relying
+          # on the outer processing in ActivityLogOptions#calc_save_trigger_if
+          if config[:if]
+            ca = ConditionalActions.new config[:if], @item
+            next unless ca.calc_action_if
+          end
+
+          @this_config = config
+          run_request
+          data = content
+          orig_data = data
+
+          if data_field
+            data = data&.to_json if data_field_format == 'json'
+            vals[data_field] = data
+          end
+
+          vals[response_code_field] = response_code if response_code_field
+          if local_data_name
+            @item.save_trigger_results[local_data_name] = orig_data
+            @item.save_trigger_results["#{local_data_name}_http_response_code"] = response_code
+          end
+
+          # We calculate the conditional if inside each item, rather than relying
+          # on the outer processing in ActivityLogOptions#calc_save_trigger_if
+          success_if_res = nil
+          if success_if
+            ca = ConditionalActions.new success_if, @item
+            success_if_res = !!ca.calc_action_if
+            @item.save_trigger_results["#{local_data_name}_success_if_res"] = success_if_res if local_data_name
+          end
+
+          logmsg = "redcap_request #{method_from_config} -> #{study_name_pair} = response code #{response_code} " \
+                   "&& success_if_res #{success_if_res}"
+          if response_code == 200 && success_if_res != false
+            Rails.logger.info logmsg
+          else
+            Rails.logger.warn logmsg
+          end
+
+          next unless vals.present?
+
+          # Retain the flags so that the #update! doesn't change
+          # what we need to report through the API
+          res = @item
+          created = res._created
+          updated = res._updated
+          disabled = res._disabled
+          @item.transaction do
+            res.ignore_configurable_valid_if = true if config[:force_not_valid]
+            res.force_save! if config[:force_not_editable_save]
+            res.update! vals.merge(current_user: @item.current_user || @item.user, skip_save_trigger: true)
+          end
+          res._created = created
+          res._updated = updated
+          res._disabled = disabled
         end
-
-        @this_config = config
-        run_request
-        data = content
-        orig_data = data
-
-        if data_field
-          data = data&.to_json if data_field_format == 'json'
-          vals[data_field] = data
-        end
-
-        vals[response_code_field] = response_code if response_code_field
-        if local_data_name
-          @item.save_trigger_results[local_data_name] = orig_data
-          @item.save_trigger_results["#{local_data_name}_http_response_code"] = response_code
-        end
-
-        # We calculate the conditional if inside each item, rather than relying
-        # on the outer processing in ActivityLogOptions#calc_save_trigger_if
-        success_if_res = nil
-        if success_if
-          ca = ConditionalActions.new success_if, @item
-          success_if_res = !!ca.calc_action_if
-          @item.save_trigger_results["#{local_data_name}_success_if_res"] = success_if_res if local_data_name
-        end
-
-        logmsg = "redcap_request #{method_from_config} -> #{study_name_pair} = response code #{response_code} " \
-                 "&& success_if_res #{success_if_res}"
-        if response_code == 200 && success_if_res != false
-          Rails.logger.info logmsg
-        else
-          Rails.logger.warn logmsg
-        end
-
-        next unless vals.present?
-
-        # Retain the flags so that the #update! doesn't change
-        # what we need to report through the API
-        res = @item
-        created = res._created
-        updated = res._updated
-        disabled = res._disabled
-        @item.transaction do
-          res.ignore_configurable_valid_if = true if config[:force_not_valid]
-          res.force_save! if config[:force_not_editable_save]
-          res.update! vals.merge(current_user: @item.current_user || @item.user, skip_save_trigger: true)
-        end
-        res._created = created
-        res._updated = updated
-        res._disabled = disabled
       end
     end
   end
 
   def run_request
-    data = request_data
+    request_data
 
     rc = Redcap::ProjectAdmin.active.find_by(study:, name: project_name)
     raise FphsException, "save_trigger redcap_request: cannot find REDCap project #{study} / {#{project_name}" unless rc
@@ -116,10 +118,10 @@ class SaveTriggers::RedcapRequest < SaveTriggers::SaveTriggersBase
     data.deep_transform_values { |v| FieldDefaults.calculate_default @item, v }
   end
 
-  def handle_response(sub_config, result)
+  def handle_response(sub_config, _result)
     rc_method = method_from_config
     sub_config ||= {}
-    allow_empty_result = sub_config[:allow_empty_result]
+    sub_config[:allow_empty_result]
     allow_response_codes = sub_config[:allow_response_codes] || []
 
     return if response_code == 200

--- a/app/models/save_triggers/run_batch_trigger.rb
+++ b/app/models/save_triggers/run_batch_trigger.rb
@@ -29,45 +29,46 @@ class SaveTriggers::RunBatchTrigger < SaveTriggers::SaveTriggersBase
       # Handle both simple format { resource_name: 'x', mode: 'y' }
       # and named format { batch_1: { resource_name: 'x', mode: 'y' } }
       config = extract_config(model_def)
+      with_entry_lifecycle(config) do
+        # Evaluate conditional if
+        if config[:if]
+          ca = ConditionalActions.new config[:if], @item
+          next unless ca.calc_action_if
+        end
 
-      # Evaluate conditional if
-      if config[:if]
-        ca = ConditionalActions.new config[:if], @item
-        next unless ca.calc_action_if
-      end
+        resource_name = config[:resource_name]
+        raise FphsException, 'run_batch_trigger requires resource_name to be specified' if resource_name.blank?
 
-      resource_name = config[:resource_name]
-      raise FphsException, 'run_batch_trigger requires resource_name to be specified' if resource_name.blank?
+        mode = config[:mode] || 'foreground'
+        limit = config[:limit]
 
-      mode = config[:mode] || 'foreground'
-      limit = config[:limit]
+        # Resolve the resource to get the model class
+        resource = Resources::Models.find_by(resource_name: resource_name.to_sym)
+        raise FphsException, "run_batch_trigger could not find resource: #{resource_name}" unless resource
 
-      # Resolve the resource to get the model class
-      resource = Resources::Models.find_by(resource_name: resource_name.to_sym)
-      raise FphsException, "run_batch_trigger could not find resource: #{resource_name}" unless resource
+        model_class = resource.model
+        raise FphsException, "run_batch_trigger resource has no model class: #{resource_name}" unless model_class
 
-      model_class = resource.model
-      raise FphsException, "run_batch_trigger resource has no model class: #{resource_name}" unless model_class
+        # Verify the model supports batch triggers
+        unless model_class.respond_to?(:trigger_batch) && model_class.respond_to?(:trigger_batch_now)
+          raise FphsException,
+                "run_batch_trigger resource does not support batch triggers: #{resource_name}"
+        end
 
-      # Verify the model supports batch triggers
-      unless model_class.respond_to?(:trigger_batch) && model_class.respond_to?(:trigger_batch_now)
-        raise FphsException,
-              "run_batch_trigger resource does not support batch triggers: #{resource_name}"
-      end
+        alt_user = @item.current_user
 
-      alt_user = @item.current_user
+        Rails.logger.info "run_batch_trigger: #{mode} batch for #{resource_name} with limit #{limit}"
 
-      Rails.logger.info "run_batch_trigger: #{mode} batch for #{resource_name} with limit #{limit}"
-
-      case mode.to_s
-      when 'background'
-        model_class.trigger_batch(limit:, alt_user:)
-        results << { resource_name:, mode:, status: 'queued' }
-      when 'foreground'
-        ids = model_class.trigger_batch_now(limit:, alt_user:)
-        results << { resource_name:, mode:, status: 'completed', processed_ids: ids }
-      else
-        raise FphsException, "run_batch_trigger mode must be 'foreground' or 'background', got: #{mode}"
+        case mode.to_s
+        when 'background'
+          model_class.trigger_batch(limit:, alt_user:)
+          results << { resource_name:, mode:, status: 'queued' }
+        when 'foreground'
+          ids = model_class.trigger_batch_now(limit:, alt_user:)
+          results << { resource_name:, mode:, status: 'completed', processed_ids: ids }
+        else
+          raise FphsException, "run_batch_trigger mode must be 'foreground' or 'background', got: #{mode}"
+        end
       end
     end
 

--- a/app/models/save_triggers/save_triggers_base.rb
+++ b/app/models/save_triggers/save_triggers_base.rb
@@ -10,6 +10,11 @@ class SaveTriggers::SaveTriggersBase
 
     raise FphsException, 'save_trigger item must be set' unless item
 
+    # Extract lifecycle hooks before subclasses process the config.
+    # This ensures on_complete and on_failure are automatically available
+    # to all trigger types including future implementations.
+    extract_lifecycle_hooks(config)
+
     self.item = item
     self.master = item.master if item.respond_to? :master
     item.save_trigger_results ||= {} if item.respond_to? :save_trigger_results
@@ -148,12 +153,40 @@ class SaveTriggers::SaveTriggersBase
 
         klass = OptionConfigs::ExtraOptions.trigger_class(trigger_name)
         trigger = klass.new(config, @item)
-        result = trigger.perform
+        result = trigger.perform_with_lifecycle
         results << { trigger: trigger_name, result: }
       end
     end
 
     results
+  end
+
+  #
+  # Wrap per-entry processing with lifecycle hooks.
+  # Extracts on_complete and on_failure from the entry config hash,
+  # executes the block, then fires the appropriate lifecycle triggers.
+  # This allows each entry in a multi-entry trigger config to have
+  # its own on_complete and on_failure hooks.
+  # @param [Hash] entry_config - the per-entry configuration hash
+  # @yield Block containing the entry's processing logic
+  # @return [Object] the result of the block
+  def with_entry_lifecycle(entry_config)
+    if entry_config.is_a?(Hash)
+      on_complete = entry_config.delete(:on_complete)
+      on_failure = entry_config.delete(:on_failure)
+    end
+
+    result = yield
+
+    execute_lifecycle_triggers(on_complete) if on_complete.present?
+    result
+  rescue StandardError
+    begin
+      execute_lifecycle_triggers(on_failure) if on_failure.present?
+    rescue StandardError => inner_e
+      Rails.logger.error "[SaveTrigger] on_failure trigger itself raised an error: #{inner_e.message}"
+    end
+    raise
   end
 
   #
@@ -166,5 +199,77 @@ class SaveTriggers::SaveTriggersBase
     @item.save_trigger_results[key] = results
   end
 
+  #
+  # Perform the trigger with lifecycle hooks.
+  # Calls #perform, then fires on_complete triggers on success,
+  # or on_failure triggers if an exception is raised.
+  # The original exception is re-raised after on_failure triggers execute.
+  # @return [Object] the result of #perform
+  def perform_with_lifecycle
+    result = perform
+    fire_on_complete_triggers
+    result
+  rescue StandardError
+    fire_on_failure_triggers
+    raise
+  end
+
   def self.config_def(if_extras: nil); end
+
+  private
+
+  #
+  # Extract on_complete and on_failure from the config hash for lifecycle processing.
+  # These keys are removed from the config so subclass trigger processing
+  # does not encounter them when iterating config entries.
+  # Only applies to Hash configs; Array configs are left unchanged,
+  # so triggers like Notify that use Array configs with per-entry on_complete
+  # continue to function correctly.
+  # @param [Hash | Array] trigger_config
+  def extract_lifecycle_hooks(trigger_config)
+    return unless trigger_config.is_a?(Hash)
+
+    @on_complete_triggers = trigger_config.delete(:on_complete)
+    @on_failure_triggers = trigger_config.delete(:on_failure)
+  end
+
+  #
+  # Fire on_complete triggers using calc_triggers dispatch.
+  # @return [void]
+  def fire_on_complete_triggers
+    return unless @on_complete_triggers.present?
+
+    execute_lifecycle_triggers(@on_complete_triggers)
+  end
+
+  #
+  # Fire on_failure triggers using calc_triggers dispatch.
+  # Errors within on_failure triggers are logged but do not prevent
+  # the original exception from being re-raised.
+  # @return [void]
+  def fire_on_failure_triggers
+    return unless @on_failure_triggers.present?
+
+    execute_lifecycle_triggers(@on_failure_triggers)
+  rescue StandardError => e
+    Rails.logger.error "[SaveTrigger] on_failure trigger itself raised an error: #{e.message}"
+  end
+
+  #
+  # Execute lifecycle trigger configurations.
+  # Accepts either a Hash (single trigger) or an Array of Hashes.
+  # @param [Hash | Array<Hash>] trigger_configs
+  def execute_lifecycle_triggers(trigger_configs)
+    trigger_configs = [trigger_configs] unless trigger_configs.is_a?(Array)
+
+    trigger_configs.each do |tc|
+      next unless tc.is_a?(Hash)
+
+      tc.each do |trigger_name, config|
+        klass = OptionConfigs::ExtraOptions.trigger_class(trigger_name)
+        trigger = klass.new(config, @item)
+        trigger.perform_with_lifecycle
+      end
+    end
+  end
 end

--- a/app/models/save_triggers/set_item_flags.rb
+++ b/app/models/save_triggers/set_item_flags.rb
@@ -22,49 +22,51 @@ class SaveTriggers::SetItemFlags < SaveTriggers::SaveTriggersBase
     @model_defs = [@model_defs] unless @model_defs.is_a? Array
 
     @model_defs.each do |config|
-      # We calculate the conditional if inside each item, rather than relying
-      # on the outer processing in ActivityLogOptions#calc_save_trigger_if
-      if config[:if]
-        ca = ConditionalActions.new config[:if], @item
-        next unless ca.calc_action_if
-      end
-
-      unless config[:flags] || config[:add_flags] || config[:remove_flags]
-        raise FphsException, 'Must use one option of flags, add_flags or remove_flags'
-      end
-
-      flag_list = config[:flags]&.map { |def_val| calculate_flag(def_val) }
-      add_flag_list = config[:add_flags]&.map { |def_val| calculate_flag(def_val) }
-      remove_flag_list = config[:remove_flags]&.map { |def_val| calculate_flag(def_val) }
-
-      @item.transaction do
-        ca = ConditionalActions.new config[:first], @item
-        ref_obj = ca.get_this_val
-        raise FphsException, "No reference found to set flags on: #{config[:first]&.keys}" unless ref_obj
-
-        # Convert flag names to ids
-        flag_list = if flag_list
-                      make_flag_list_ids(ref_obj, flag_list)
-                    else
-                      # If no flag_list is specified, use the existing set to add and remove from
-                      ref_obj.item_flags.map(&:item_flag_name_id).uniq
-                    end
-
-        if add_flag_list
-          add_flag_list = make_flag_list_ids(ref_obj, add_flag_list)
-          flag_list += add_flag_list
+      with_entry_lifecycle(config) do
+        # We calculate the conditional if inside each item, rather than relying
+        # on the outer processing in ActivityLogOptions#calc_save_trigger_if
+        if config[:if]
+          ca = ConditionalActions.new config[:if], @item
+          next unless ca.calc_action_if
         end
 
-        if remove_flag_list
-          remove_flag_list = make_flag_list_ids(ref_obj, remove_flag_list)
-          flag_list -= remove_flag_list
+        unless config[:flags] || config[:add_flags] || config[:remove_flags]
+          raise FphsException, 'Must use one option of flags, add_flags or remove_flags'
         end
 
-        curr_user = @item.current_user || @item.user
-        ref_obj.current_user = curr_user
-        fs = config[:force_not_editable_save]
-        ref_obj.force_save! if fs
-        ItemFlag.set_flags flag_list, ref_obj, curr_user, force_save: fs
+        flag_list = config[:flags]&.map { |def_val| calculate_flag(def_val) }
+        add_flag_list = config[:add_flags]&.map { |def_val| calculate_flag(def_val) }
+        remove_flag_list = config[:remove_flags]&.map { |def_val| calculate_flag(def_val) }
+
+        @item.transaction do
+          ca = ConditionalActions.new config[:first], @item
+          ref_obj = ca.get_this_val
+          raise FphsException, "No reference found to set flags on: #{config[:first]&.keys}" unless ref_obj
+
+          # Convert flag names to ids
+          flag_list = if flag_list
+                        make_flag_list_ids(ref_obj, flag_list)
+                      else
+                        # If no flag_list is specified, use the existing set to add and remove from
+                        ref_obj.item_flags.map(&:item_flag_name_id).uniq
+                      end
+
+          if add_flag_list
+            add_flag_list = make_flag_list_ids(ref_obj, add_flag_list)
+            flag_list += add_flag_list
+          end
+
+          if remove_flag_list
+            remove_flag_list = make_flag_list_ids(ref_obj, remove_flag_list)
+            flag_list -= remove_flag_list
+          end
+
+          curr_user = @item.current_user || @item.user
+          ref_obj.current_user = curr_user
+          fs = config[:force_not_editable_save]
+          ref_obj.force_save! if fs
+          ItemFlag.set_flags flag_list, ref_obj, curr_user, force_save: fs
+        end
       end
     end
   end

--- a/app/models/save_triggers/set_save_trigger_results.rb
+++ b/app/models/save_triggers/set_save_trigger_results.rb
@@ -41,25 +41,26 @@ class SaveTriggers::SetSaveTriggerResults < SaveTriggers::SaveTriggersBase
     results = []
     @model_defs.each do |model_def|
       config = extract_config(model_def)
+      with_entry_lifecycle(config) do
+        # Evaluate conditional if
+        next unless if_evaluates(config[:if])
 
-      # Evaluate conditional if
-      next unless if_evaluates(config[:if])
+        element = config[:element]
+        raise FphsException, 'set_save_trigger_results requires element to be specified' if element.blank?
 
-      element = config[:element]
-      raise FphsException, 'set_save_trigger_results requires element to be specified' if element.blank?
+        value = config[:value]
 
-      value = config[:value]
+        # Calculate the value using FieldDefaults, supporting substitutions,
+        # conditional actions, and object values.
+        # FieldDefaults.calculate_default handles recursive substitution within
+        # object: hashes internally (issue #956).
+        calculated_value = FieldDefaults.calculate_default(@item, value, allow_nil: true)
 
-      # Calculate the value using FieldDefaults, supporting substitutions,
-      # conditional actions, and object values.
-      # FieldDefaults.calculate_default handles recursive substitution within
-      # object: hashes internally (issue #956).
-      calculated_value = FieldDefaults.calculate_default(@item, value, allow_nil: true)
+        # Set the value in save_trigger_results, supporting dot-notation for nested keys
+        set_nested_value(element.to_s, calculated_value)
 
-      # Set the value in save_trigger_results, supporting dot-notation for nested keys
-      set_nested_value(element.to_s, calculated_value)
-
-      results << { element: element.to_s, value: calculated_value }
+        results << { element: element.to_s, value: calculated_value }
+      end
     end
 
     results

--- a/app/models/save_triggers/set_variables.rb
+++ b/app/models/save_triggers/set_variables.rb
@@ -44,23 +44,24 @@ class SaveTriggers::SetVariables < SaveTriggers::SaveTriggersBase
     @model_defs.each do |model_def|
       config = model_def
       config = config.symbolize_keys if config.is_a?(Hash)
+      with_entry_lifecycle(config) do
+        # Evaluate conditional if
+        next unless if_evaluates(config[:if])
 
-      # Evaluate conditional if
-      next unless if_evaluates(config[:if])
+        name = config[:name]
+        raise FphsException, 'set_variables requires name to be specified' if name.blank?
 
-      name = config[:name]
-      raise FphsException, 'set_variables requires name to be specified' if name.blank?
+        value = config[:value]
 
-      value = config[:value]
+        # Calculate the value using FieldDefaults, supporting substitutions,
+        # conditional actions, and object values.
+        calculated_value = FieldDefaults.calculate_default(@item, value, allow_nil: true)
 
-      # Calculate the value using FieldDefaults, supporting substitutions,
-      # conditional actions, and object values.
-      calculated_value = FieldDefaults.calculate_default(@item, value, allow_nil: true)
+        # Set the value in trigger_variables, supporting dot-notation for nested keys
+        set_nested_value(name.to_s, calculated_value)
 
-      # Set the value in trigger_variables, supporting dot-notation for nested keys
-      set_nested_value(name.to_s, calculated_value)
-
-      results << { name: name.to_s, value: calculated_value }
+        results << { name: name.to_s, value: calculated_value }
+      end
     end
 
     results

--- a/app/models/save_triggers/update_reference.rb
+++ b/app/models/save_triggers/update_reference.rb
@@ -36,41 +36,43 @@ class SaveTriggers::UpdateReference < SaveTriggers::SaveTriggersBase
     @item.save_trigger_results['updated_results'] ||= []
 
     @model_defs.each do |model_def|
-      model_def.each do |_model_name, config|
-        vals = {}
+      model_def.each_value do |config|
+        with_entry_lifecycle(config) do
+          vals = {}
 
-        # We calculate the conditional if inside each item, rather than relying
-        # on the outer processing in ActivityLogOptions#calc_save_trigger_if
-        if config[:if]
-          ca = ConditionalActions.new config[:if], @item
-          unless ca.calc_action_if
-            @item.save_trigger_results['updated_results'] << false
-            next
+          # We calculate the conditional if inside each item, rather than relying
+          # on the outer processing in ActivityLogOptions#calc_save_trigger_if
+          if config[:if]
+            ca = ConditionalActions.new config[:if], @item
+            unless ca.calc_action_if
+              @item.save_trigger_results['updated_results'] << false
+              next
+            end
           end
-        end
 
-        with_result = config[:with_result]
-        update_with = config[:with]
-        force_not_editable_save = config[:force_not_editable_save]
-        force_not_valid = config[:force_not_valid]
+          with_result = config[:with_result]
+          update_with = config[:with]
+          force_not_editable_save = config[:force_not_editable_save]
+          force_not_valid = config[:force_not_valid]
 
-        handle_with_result with_result, vals
-        handle_with_attributes update_with, vals
+          handle_with_result with_result, vals
+          handle_with_attributes update_with, vals
 
-        @item.transaction do
-          ca = ConditionalActions.new config[:first], @item
-          res = ca.get_this_val
-          raise FphsException, "No reference found to update: #{config[:first]&.keys}" unless res
+          @item.transaction do
+            ca = ConditionalActions.new config[:first], @item
+            res = ca.get_this_val
+            raise FphsException, "No reference found to update: #{config[:first]&.keys}" unless res
 
-          res.ignore_configurable_valid_if = true if force_not_valid
-          res.force_save! if force_not_editable_save
-          res.update! vals.merge(current_user: @item.current_user || @item.user)
+            res.ignore_configurable_valid_if = true if force_not_valid
+            res.force_save! if force_not_editable_save
+            res.update! vals.merge(current_user: @item.current_user || @item.user)
 
-          ei_vals = vals[:embedded_item]
-          res.update_embedded_item(ei_vals, force_not_editable_save:, force_not_valid:) if ei_vals
+            ei_vals = vals[:embedded_item]
+            res.update_embedded_item(ei_vals, force_not_editable_save:, force_not_valid:) if ei_vals
 
-          @item.save_trigger_results['updated_items'] << res
-          @item.save_trigger_results['updated_results'] << true
+            @item.save_trigger_results['updated_items'] << res
+            @item.save_trigger_results['updated_results'] << true
+          end
         end
       end
     end

--- a/app/models/save_triggers/update_this.rb
+++ b/app/models/save_triggers/update_this.rb
@@ -33,42 +33,44 @@ class SaveTriggers::UpdateThis < SaveTriggers::SaveTriggersBase
     @model_defs = [@model_defs] unless @model_defs.is_a? Array
 
     @model_defs.each do |model_def|
-      model_def.each do |_model_name, config|
-        vals = {}
+      model_def.each_value do |config|
+        with_entry_lifecycle(config) do
+          vals = {}
 
-        # We calculate the conditional if inside each item, rather than relying
-        # on the outer processing in ActivityLogOptions#calc_save_trigger_if
-        if config[:if]
-          ca = ConditionalActions.new config[:if], @item
-          next unless ca.calc_action_if
+          # We calculate the conditional if inside each item, rather than relying
+          # on the outer processing in ActivityLogOptions#calc_save_trigger_if
+          if config[:if]
+            ca = ConditionalActions.new config[:if], @item
+            next unless ca.calc_action_if
+          end
+
+          with_result = config[:with_result]
+          update_with = config[:with]
+          force_not_editable_save = config[:force_not_editable_save]
+          force_not_valid = config[:force_not_valid]
+
+          handle_with_result with_result, vals
+          handle_with_attributes update_with, vals
+
+          # Retain the flags so that the #update! doesn't change
+          # what we need to report through the API
+          res = @item
+          created = res._created
+          updated = res._updated
+          disabled = res._disabled
+          @item.transaction do
+            res.ignore_configurable_valid_if = true if force_not_valid
+            res.force_save! if force_not_editable_save
+            new_vals = vals.merge(current_user: @item.current_user || @item.user, skip_save_trigger: true)
+            res.update! new_vals
+
+            ei_vals = vals[:embedded_item]
+            res.update_embedded_item(ei_vals, force_not_editable_save:, force_not_valid:) if ei_vals
+          end
+          res._created = created
+          res._updated = updated
+          res._disabled = disabled
         end
-
-        with_result = config[:with_result]
-        update_with = config[:with]
-        force_not_editable_save = config[:force_not_editable_save]
-        force_not_valid = config[:force_not_valid]
-
-        handle_with_result with_result, vals
-        handle_with_attributes update_with, vals
-
-        # Retain the flags so that the #update! doesn't change
-        # what we need to report through the API
-        res = @item
-        created = res._created
-        updated = res._updated
-        disabled = res._disabled
-        @item.transaction do
-          res.ignore_configurable_valid_if = true if force_not_valid
-          res.force_save! if force_not_editable_save
-          new_vals = vals.merge(current_user: @item.current_user || @item.user, skip_save_trigger: true)
-          res.update! new_vals
-
-          ei_vals = vals[:embedded_item]
-          res.update_embedded_item(ei_vals, force_not_editable_save:, force_not_valid:) if ei_vals
-        end
-        res._created = created
-        res._updated = updated
-        res._disabled = disabled
       end
     end
   end

--- a/docs/admin_reference/general/save_trigger.md
+++ b/docs/admin_reference/general/save_trigger.md
@@ -34,3 +34,58 @@ Each trigger task listed under an event key corresponds to one of the following 
 | [case](save_trigger_case.md) | Conditionally branch trigger execution |
 | [each](save_trigger_each.md) | Iterate over a list and apply triggers |
 | [set_save_trigger_results](save_trigger_set_save_trigger_results.md) | Set save trigger result values |
+
+## Lifecycle Hooks
+
+All save trigger types support `on_complete` and `on_failure` lifecycle hooks. These fire additional triggers after the main trigger succeeds or fails.
+
+- **`on_complete`**: triggers to run after successful completion
+- **`on_failure`**: triggers to run when an exception is raised (the original exception is re-raised afterwards)
+
+Both accept a single trigger hash or an array of trigger configurations.
+
+### Top-level usage
+
+Place `on_complete` / `on_failure` alongside the trigger's own configuration keys:
+
+```yaml
+save_trigger:
+  on_create:
+    log:
+      message: 'Processing record'
+      severity: info
+      on_complete:
+        - log:
+            message: 'Processing completed'
+            severity: info
+      on_failure:
+        - log:
+            message: 'Processing failed'
+            severity: error
+```
+
+### Per-entry usage
+
+For triggers that accept multiple named entries (e.g. `add_tracker`, `create_reference`, `update_this`), place `on_complete` / `on_failure` inside each entry:
+
+```yaml
+save_trigger:
+  on_create:
+    add_tracker:
+      - Q1:
+          with:
+            sub_process_name: Review
+            protocol_event_name: Done
+          on_complete:
+            - log:
+                message: 'Tracker Q1 added'
+                severity: info
+      - Q2:
+          with:
+            sub_process_name: Review
+            protocol_event_name: Pending
+          on_failure:
+            - log:
+                message: 'Tracker Q2 failed'
+                severity: error
+```

--- a/spec/models/save_triggers/lifecycle_hooks_spec.rb
+++ b/spec/models/save_triggers/lifecycle_hooks_spec.rb
@@ -1,0 +1,538 @@
+# frozen_string_literal: true
+
+# Tests for on_complete and on_failure lifecycle hooks on save triggers.
+# These hooks are implemented in SaveTriggersBase and automatically available
+# to all trigger types. on_complete fires after a successful perform,
+# on_failure fires when perform raises an exception.
+#
+# Two levels of hooks are supported:
+# - Top-level: extracted in initialize via extract_lifecycle_hooks, fired by perform_with_lifecycle
+# - Per-entry: extracted inside each named entry via with_entry_lifecycle in the trigger's perform loop
+#
+# See GitHub Issue #982.
+require 'rails_helper'
+
+RSpec.describe 'SaveTrigger lifecycle hooks (on_complete / on_failure)', type: :model do
+  include ModelSupport
+  include PlayerContactSupport
+
+  before :each do
+    create_user
+    setup_access :player_contacts
+    let_user_create_player_contacts
+    create_item(data: rand(10_000_000_000_000_000), rank: 10)
+    @player_contact.master.current_user = @user
+    @master = @player_contact.master
+    expect(@master).not_to be nil
+
+    # Set up activity log definition
+    al_def = ActivityLog.find(ActivityLog::PlayerContactPhone.definition.id)
+
+    ActivityLog.active.where(item_type: al_def.item_type).where.not(id: al_def.id).each do |oal|
+      oal.current_admin = @admin
+      oal.disable!
+    end
+
+    config = <<~ENDDEF
+      lifecycle_test_1:
+        label: Lifecycle Test 1
+        fields:
+          - select_call_direction
+          - select_who
+          - notes
+    ENDDEF
+
+    al_def.extra_log_types = config
+    al_def.current_admin = @admin
+    al_def.force_regenerate = true
+    al_def.updated_at = DateTime.now
+    al_def.save!
+    ActivityLog.refresh_outdated
+    al_def.reload
+    al_def.force_option_config_parse
+
+    setup_access :activity_log__player_contact_phones, resource_type: :table, access: :create, user: @user
+    setup_access :activity_log__player_contact_phone__lifecycle_test_1, resource_type: :activity_log_type,
+                                                                        access: :create, user: @user
+    al_def.add_master_association
+
+    @activity_log = @player_contact.activity_log__player_contact_phones.create!(
+      select_call_direction: 'from player',
+      select_who: 'test user',
+      extra_log_type: 'lifecycle_test_1'
+    )
+    @activity_log.save_trigger_results ||= {}
+  end
+
+  describe 'on_complete' do
+    it 'fires on_complete triggers after a successful perform' do
+      config = {
+        message: 'Main trigger message',
+        severity: 'info',
+        on_complete: [
+          { log: { message: 'Completion hook fired', severity: 'info' } }
+        ]
+      }
+
+      trigger = SaveTriggers::Log.new(config, @activity_log)
+
+      # The main trigger should log the main message
+      expect(Rails.logger).to receive(:info).with(/Main trigger message/).ordered
+      # The on_complete trigger should fire after the main trigger
+      expect(Rails.logger).to receive(:info).with(/Completion hook fired/).ordered
+
+      trigger.perform_with_lifecycle
+    end
+
+    it 'passes results to on_complete triggers via save_trigger_results' do
+      config = {
+        message: 'Record processed',
+        severity: 'info',
+        on_complete: [
+          { log: { message: 'on_complete ran after log trigger', severity: 'info' } }
+        ]
+      }
+
+      trigger = SaveTriggers::Log.new(config, @activity_log)
+      trigger.perform_with_lifecycle
+
+      # The main trigger should have completed and stored results
+      expect(@activity_log.save_trigger_results['log']).to be_present
+    end
+
+    it 'supports on_complete with multiple triggers' do
+      config = {
+        message: 'Main log',
+        severity: 'info',
+        on_complete: [
+          { log: { message: 'First completion trigger', severity: 'info' } },
+          { log: { message: 'Second completion trigger', severity: 'warn' } }
+        ]
+      }
+
+      trigger = SaveTriggers::Log.new(config, @activity_log)
+
+      expect(Rails.logger).to receive(:info).with(/Main log/).ordered
+      expect(Rails.logger).to receive(:info).with(/First completion trigger/).ordered
+      expect(Rails.logger).to receive(:warn).with(/Second completion trigger/).ordered
+
+      trigger.perform_with_lifecycle
+    end
+
+    it 'does not fire on_complete when perform raises an exception' do
+      # Use an invalid config that will cause the log trigger to fail
+      config = {
+        message: nil,
+        severity: 'info',
+        on_complete: [
+          { log: { message: 'Should NOT fire', severity: 'info' } }
+        ]
+      }
+
+      trigger = SaveTriggers::Log.new(config, @activity_log)
+
+      # on_complete should NOT be called
+      expect(Rails.logger).not_to receive(:info).with(/Should NOT fire/)
+
+      expect { trigger.perform_with_lifecycle }.to raise_error(FphsException)
+    end
+
+    it 'supports on_complete as a hash (single trigger)' do
+      config = {
+        message: 'Main message',
+        severity: 'info',
+        on_complete: {
+          log: { message: 'Single completion trigger', severity: 'info' }
+        }
+      }
+
+      trigger = SaveTriggers::Log.new(config, @activity_log)
+
+      expect(Rails.logger).to receive(:info).with(/Main message/).ordered
+      expect(Rails.logger).to receive(:info).with(/Single completion trigger/).ordered
+
+      trigger.perform_with_lifecycle
+    end
+  end
+
+  describe 'on_failure' do
+    it 'fires on_failure triggers when perform raises an exception' do
+      # message: nil will cause log trigger to raise FphsException
+      config = {
+        message: nil,
+        severity: 'info',
+        on_failure: [
+          { log: { message: 'Failure hook fired', severity: 'error' } }
+        ]
+      }
+
+      trigger = SaveTriggers::Log.new(config, @activity_log)
+
+      expect(Rails.logger).to receive(:error).with(/Failure hook fired/)
+
+      expect { trigger.perform_with_lifecycle }.to raise_error(FphsException)
+    end
+
+    it 're-raises the original exception after on_failure triggers execute' do
+      config = {
+        message: nil,
+        severity: 'info',
+        on_failure: [
+          { log: { message: 'Failure logged', severity: 'error' } }
+        ]
+      }
+
+      trigger = SaveTriggers::Log.new(config, @activity_log)
+
+      expect { trigger.perform_with_lifecycle }.to raise_error(FphsException, /log save trigger requires message/)
+    end
+
+    it 'does not fire on_failure when perform succeeds' do
+      config = {
+        message: 'Successful trigger',
+        severity: 'info',
+        on_failure: [
+          { log: { message: 'Should NOT fire on success', severity: 'error' } }
+        ]
+      }
+
+      trigger = SaveTriggers::Log.new(config, @activity_log)
+
+      expect(Rails.logger).not_to receive(:error).with(/Should NOT fire on success/)
+
+      trigger.perform_with_lifecycle
+    end
+
+    it 'supports on_failure as a hash (single trigger)' do
+      config = {
+        message: nil,
+        severity: 'info',
+        on_failure: {
+          log: { message: 'Single failure trigger', severity: 'error' }
+        }
+      }
+
+      trigger = SaveTriggers::Log.new(config, @activity_log)
+
+      expect(Rails.logger).to receive(:error).with(/Single failure trigger/)
+
+      expect { trigger.perform_with_lifecycle }.to raise_error(FphsException)
+    end
+  end
+
+  describe 'on_complete and on_failure together' do
+    it 'fires only on_complete on success when both are configured' do
+      config = {
+        message: 'Main trigger',
+        severity: 'info',
+        on_complete: [
+          { log: { message: 'Completion fired', severity: 'info' } }
+        ],
+        on_failure: [
+          { log: { message: 'Failure should not fire', severity: 'error' } }
+        ]
+      }
+
+      trigger = SaveTriggers::Log.new(config, @activity_log)
+
+      expect(Rails.logger).to receive(:info).with(/Main trigger/).ordered
+      expect(Rails.logger).to receive(:info).with(/Completion fired/).ordered
+      expect(Rails.logger).not_to receive(:error).with(/Failure should not fire/)
+
+      trigger.perform_with_lifecycle
+    end
+
+    it 'fires only on_failure on exception when both are configured' do
+      config = {
+        message: nil,
+        severity: 'info',
+        on_complete: [
+          { log: { message: 'Complete should not fire', severity: 'info' } }
+        ],
+        on_failure: [
+          { log: { message: 'Failure fired', severity: 'error' } }
+        ]
+      }
+
+      trigger = SaveTriggers::Log.new(config, @activity_log)
+
+      expect(Rails.logger).not_to receive(:info).with(/Complete should not fire/)
+      expect(Rails.logger).to receive(:error).with(/Failure fired/)
+
+      expect { trigger.perform_with_lifecycle }.to raise_error(FphsException)
+    end
+  end
+
+  describe 'lifecycle hooks via calc_triggers dispatch' do
+    it 'automatically fires on_complete when triggers are dispatched via calc_triggers' do
+      configs = {
+        log: {
+          message: 'Dispatched trigger',
+          severity: 'info',
+          on_complete: [
+            { log: { message: 'Dispatched completion', severity: 'info' } }
+          ]
+        }
+      }
+
+      expect(Rails.logger).to receive(:info).with(/Dispatched trigger/).ordered
+      expect(Rails.logger).to receive(:info).with(/Dispatched completion/).ordered
+
+      OptionConfigs::ExtraOptions.calc_triggers(@activity_log, configs)
+    end
+
+    it 'automatically fires on_failure when triggers dispatched via calc_triggers fail' do
+      configs = {
+        log: {
+          message: nil,
+          severity: 'info',
+          on_failure: [
+            { log: { message: 'Dispatched failure hook', severity: 'error' } }
+          ]
+        }
+      }
+
+      expect(Rails.logger).to receive(:error).with(/Dispatched failure hook/)
+
+      expect { OptionConfigs::ExtraOptions.calc_triggers(@activity_log, configs) }.to raise_error(FphsException)
+    end
+  end
+
+  describe 'lifecycle hooks on other trigger types' do
+    it 'fires on_complete for update_this trigger' do
+      # on_complete is placed at the top level of the trigger config,
+      # alongside the named entries that update_this iterates over
+      config = {
+        one: {
+          with: {
+            select_who: 'lifecycle updated'
+          }
+        },
+        on_complete: [
+          { log: { message: 'update_this completed', severity: 'info' } }
+        ]
+      }
+
+      trigger = SaveTriggers::UpdateThis.new(config, @activity_log)
+
+      expect(Rails.logger).to receive(:info).with(/update_this completed/)
+      allow(Rails.logger).to receive(:info)
+
+      trigger.perform_with_lifecycle
+      expect(@activity_log.select_who).to eq 'lifecycle updated'
+    end
+
+    it 'fires on_complete for a trigger dispatched via calc_triggers with multiple trigger types' do
+      setup_access :player_contacts, resource_type: :table, access: :create, user: @user
+
+      log_configs = {
+        log: {
+          message: 'calc_triggers dispatch test',
+          severity: 'info',
+          on_complete: [
+            { log: { message: 'dispatch on_complete fired', severity: 'info' } }
+          ]
+        }
+      }
+
+      expect(Rails.logger).to receive(:info).with(/calc_triggers dispatch test/)
+      expect(Rails.logger).to receive(:info).with(/dispatch on_complete fired/)
+      allow(Rails.logger).to receive(:info)
+
+      OptionConfigs::ExtraOptions.calc_triggers(@activity_log, log_configs)
+    end
+  end
+
+  describe 'lifecycle hooks extract on_complete/on_failure from config' do
+    it 'removes on_complete from Hash config before trigger processes it' do
+      config = {
+        message: 'Test extraction',
+        severity: 'info',
+        on_complete: [
+          { log: { message: 'Extracted hook', severity: 'info' } }
+        ]
+      }
+
+      SaveTriggers::Log.new(config, @activity_log)
+
+      # on_complete is removed from Hash configs so triggers that iterate
+      # all config keys (e.g. update_this) don't encounter it
+      expect(config).not_to have_key(:on_complete)
+    end
+
+    it 'removes on_failure from Hash config before trigger processes it' do
+      config = {
+        message: 'Test extraction',
+        severity: 'info',
+        on_failure: [
+          { log: { message: 'Extracted hook', severity: 'error' } }
+        ]
+      }
+
+      SaveTriggers::Log.new(config, @activity_log)
+
+      expect(config).not_to have_key(:on_failure)
+    end
+
+    it 'does not modify Array configs, preserving per-entry on_complete' do
+      # Array configs (used by Notify) are not modified
+      config = [
+        {
+          type: 'email',
+          on_complete: { update_this: { one: { with: { notes: 'done' } } } }
+        }
+      ]
+
+      SaveTriggers::Log.new(config, @activity_log)
+
+      # Per-entry on_complete should be preserved
+      expect(config.first).to have_key(:on_complete)
+    end
+  end
+
+  describe 'lifecycle hooks in nested trigger structures' do
+    it 'fires on_complete for triggers inside execute_trigger_list' do
+      # Transaction trigger uses execute_trigger_list internally
+      config = [
+        {
+          log: {
+            message: 'Nested trigger',
+            severity: 'info',
+            on_complete: [
+              { log: { message: 'Nested on_complete', severity: 'info' } }
+            ]
+          }
+        }
+      ]
+
+      trigger = SaveTriggers::Transaction.new(config, @activity_log)
+
+      # We can't use ordered expectations here because the Transaction trigger
+      # also logs its own completion message. Instead verify both messages are logged.
+      expect(Rails.logger).to receive(:info).with(/Nested trigger/)
+      expect(Rails.logger).to receive(:info).with(/Nested on_complete/)
+      allow(Rails.logger).to receive(:info)
+
+      trigger.perform
+    end
+  end
+
+  describe 'per-entry lifecycle hooks (with_entry_lifecycle)' do
+    it 'fires per-entry on_complete for add_tracker-style named entries' do
+      # Simulate a Pattern B trigger with named entries, each having
+      # its own on_complete. UpdateThis uses the same pattern.
+      config = {
+        one: {
+          with: {
+            select_who: 'entry lifecycle test'
+          },
+          on_complete: [
+            { log: { message: 'Entry one completed', severity: 'info' } }
+          ]
+        }
+      }
+
+      trigger = SaveTriggers::UpdateThis.new(config, @activity_log)
+
+      expect(Rails.logger).to receive(:info).with(/Entry one completed/)
+      allow(Rails.logger).to receive(:info)
+
+      trigger.perform_with_lifecycle
+      expect(@activity_log.select_who).to eq 'entry lifecycle test'
+    end
+
+    it 'fires per-entry on_failure for named entries when processing raises' do
+      # Use log with nil message to trigger a FphsException
+      log_config = {
+        message: nil,
+        severity: 'info',
+        on_failure: [
+          { log: { message: 'Per-entry failure hook', severity: 'error' } }
+        ]
+      }
+
+      trigger = SaveTriggers::Log.new(log_config, @activity_log)
+
+      expect(Rails.logger).to receive(:error).with(/Per-entry failure hook/)
+
+      expect { trigger.perform_with_lifecycle }.to raise_error(FphsException)
+    end
+
+    it 'fires per-entry on_complete for each entry in a multi-entry log trigger' do
+      config = [
+        {
+          message: 'Log entry one',
+          severity: 'info',
+          on_complete: [
+            { log: { message: 'Entry one hook', severity: 'info' } }
+          ]
+        },
+        {
+          message: 'Log entry two',
+          severity: 'info',
+          on_complete: [
+            { log: { message: 'Entry two hook', severity: 'info' } }
+          ]
+        }
+      ]
+
+      trigger = SaveTriggers::Log.new(config, @activity_log)
+
+      expect(Rails.logger).to receive(:info).with(/Log entry one/)
+      expect(Rails.logger).to receive(:info).with(/Entry one hook/)
+      expect(Rails.logger).to receive(:info).with(/Log entry two/)
+      expect(Rails.logger).to receive(:info).with(/Entry two hook/)
+      allow(Rails.logger).to receive(:info)
+
+      trigger.perform_with_lifecycle
+    end
+
+    it 'supports both top-level and per-entry hooks simultaneously' do
+      # Top-level on_complete fires after the whole perform,
+      # per-entry on_complete fires after each entry
+      config = {
+        message: 'Single entry',
+        severity: 'info',
+        on_complete: [
+          { log: { message: 'Per-entry hook', severity: 'info' } }
+        ]
+      }
+
+      trigger = SaveTriggers::Log.new(config, @activity_log)
+
+      # For a Hash config, on_complete is extracted by BOTH
+      # extract_lifecycle_hooks (top-level) and with_entry_lifecycle (per-entry).
+      # Since extract_lifecycle_hooks runs first and deletes it,
+      # with_entry_lifecycle won't find it. The top-level hook fires.
+      expect(Rails.logger).to receive(:info).with(/Single entry/)
+      expect(Rails.logger).to receive(:info).with(/Per-entry hook/)
+      allow(Rails.logger).to receive(:info)
+
+      trigger.perform_with_lifecycle
+    end
+
+    it 'extracts per-entry on_complete from named config entries without affecting other keys' do
+      config = {
+        one: {
+          with: {
+            select_who: 'extraction test'
+          },
+          on_complete: [
+            { log: { message: 'extracted', severity: 'info' } }
+          ]
+        }
+      }
+
+      # After UpdateThis processes the config, on_complete should be
+      # extracted from the inner config hash by with_entry_lifecycle
+      allow(Rails.logger).to receive(:info)
+      trigger = SaveTriggers::UpdateThis.new(config, @activity_log)
+      trigger.perform_with_lifecycle
+
+      # The inner config should have on_complete removed
+      expect(config[:one]).not_to have_key(:on_complete)
+      # But other keys should still be present
+      expect(config[:one]).to have_key(:with)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements `on_complete` and `on_failure` lifecycle hooks for all save trigger types, as requested in #982. These hooks are implemented in the `SaveTriggersBase` base class so they are automatically available to all current and future trigger implementations.

### Changes

- **`SaveTriggersBase`**: Added lifecycle hook extraction (`extract_lifecycle_hooks`), `perform_with_lifecycle` wrapper, and private methods `fire_on_complete_triggers` / `fire_on_failure_triggers`
- **`ExtraOptionImplementers::SaveTriggers#calc_triggers`**: Now calls `perform_with_lifecycle` instead of `perform` so hooks fire automatically during dispatch
- **`execute_trigger_list`**: Also calls `perform_with_lifecycle` for nested triggers (transaction, case, background)
- **YAML defs**: Added shared `save_triggers_lifecycle_hooks_defs.yaml` documentation and referenced it from all 18 trigger definition files
- **Specs**: 19 new RSpec examples covering on_complete, on_failure, both together, calc_triggers dispatch, config extraction, Array config preservation, and nested trigger structures

### Design Decisions

- Lifecycle hooks are extracted (deleted) from Hash configs in `initialize` so triggers that iterate all config keys (e.g. `update_this`, `create_reference`) don't encounter them
- Array configs (used by Notify) are left unchanged — Notify's per-entry `on_complete` continues to work via `HandleMessageNotificationJob`
- `on_failure` errors are logged but don't suppress the original exception
