### PR TITLE
Added full config to save trigger error messages for debugging - fixes #984

### DIFF
--- a/app/controllers/admin/dynamic_models_controller.rb
+++ b/app/controllers/admin/dynamic_models_controller.rb
@@ -58,7 +58,7 @@ class Admin::DynamicModelsController < AdminController
   rescue StandardError => e
     Rails.logger.error "Batch processing failed for #{object_instance}: #{e.message}"
     Rails.logger.error e.short_string_backtrace
-    @error_message = "Batch processing failed: #{e.message}"
+    @error_message = e.message
     render partial: 'admin/dynamic_models/run_batch_now_error'
   end
 

--- a/app/models/option_configs/extra_option_implementers/save_triggers.rb
+++ b/app/models/option_configs/extra_option_implementers/save_triggers.rb
@@ -44,6 +44,8 @@ module OptionConfigs
             # Add the trigger result to the list, using lifecycle hooks
             # to automatically fire on_complete/on_failure
             o.perform_with_lifecycle
+          rescue FphsException => e
+            raise FphsException, "#{e.message}. Full config:\n#{String.yaml_dump(configs)}"
           end
 
           # If we had any results then check if they were all true. If they were then return true.
@@ -62,7 +64,7 @@ module OptionConfigs
         # Validate name
         # Use the symbol from the list of valid items, to prevent manipulation that could cause Brakeman warnings
         # @param [Symbol] name
-        # @return [<Type>] <description>
+        # @return [Symbol] validated trigger name
         def valid_save_trigger_named(name)
           trigger = ValidSaveTriggers.select { |vt| vt == name }.first
           raise FphsException, "Configuration is not valid when attempting to perform #{name}" unless trigger

--- a/app/models/save_triggers/save_triggers_base.rb
+++ b/app/models/save_triggers/save_triggers_base.rb
@@ -155,6 +155,8 @@ class SaveTriggers::SaveTriggersBase
         trigger = klass.new(config, @item)
         result = trigger.perform_with_lifecycle
         results << { trigger: trigger_name, result: }
+      rescue FphsException => e
+        raise FphsException, "#{e.message}. Full config:\n#{String.yaml_dump(trigger_list)}"
       end
     end
 
@@ -269,6 +271,8 @@ class SaveTriggers::SaveTriggersBase
         klass = OptionConfigs::ExtraOptions.trigger_class(trigger_name)
         trigger = klass.new(config, @item)
         trigger.perform_with_lifecycle
+      rescue FphsException => e
+        raise FphsException, "#{e.message}. Full config:\n#{String.yaml_dump(trigger_configs)}"
       end
     end
   end

--- a/app/views/admin/dynamic_models/_run_batch_now_error.html.erb
+++ b/app/views/admin/dynamic_models/_run_batch_now_error.html.erb
@@ -1,5 +1,6 @@
 <div class="data-results">
   <div data-result="dynamic-model--run-batch-result" class="dynamic-model--run-batch-result">
-    <%= @error_message %>
+    <h3>Batch processing failed<h3>
+    <pre><%= @error_message %></pre>
   </div>
 </div>

--- a/spec/models/save_triggers/case_spec.rb
+++ b/spec/models/save_triggers/case_spec.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
-# Tests for SaveTriggers::Case - Issue #944
+# Tests for SaveTriggers::Case - Issue #944, Issue #984
 # Implements a case/when/else save trigger block that evaluates conditions
 # and executes the triggers associated with the first matching condition,
 # or an else block if no conditions match.
 # This is similar to the transaction save trigger block but adds
 # conditional branching logic.
+#
+# Issue #984: Tests that invalid trigger configurations within case branches
+# produce error messages that include the full case configuration for debugging.
 
 require 'rails_helper'
 
@@ -380,6 +383,76 @@ RSpec.describe SaveTriggers::Case, type: :model do
 
       al = create_al_record(extra_log_type: 'case_second_test', direction: 'from player')
       expect(al.select_who).to eq 'second branch matched'
+    end
+  end
+
+  describe 'error reporting for invalid configuration' do
+    context 'when a then block contains an invalid trigger name' do
+      it 'raises an error that includes the full trigger list configuration - Issue #984' do
+        invalid_config = [
+          {
+            when: { always: true },
+            then: [
+              { bad_trigger_name: { message: 'this should fail' } }
+            ]
+          }
+        ]
+
+        trigger = SaveTriggers::Case.new(invalid_config, @activity_log)
+
+        expect { trigger.perform }.to raise_error(FphsException) do |error|
+          expect(error.message).to include('bad_trigger_name')
+          expect(error.message).to include('Full config')
+          # The full config should be present in the error so admins can debug
+          expect(error.message).to include('this should fail')
+        end
+      end
+    end
+
+    context 'when a YAML anchor merge produces an invalid config' do
+      it 'includes the full config in the error for debugging - Issue #984' do
+        # Simulates the scenario where <<: *embed_something resolves to bad keys
+        invalid_config = [
+          {
+            when: { always: true },
+            then: [
+              { some_nonexistent_trigger: { key: 'value' } }
+            ]
+          }
+        ]
+
+        trigger = SaveTriggers::Case.new(invalid_config, @activity_log)
+
+        expect { trigger.perform }.to raise_error(FphsException) do |error|
+          expect(error.message).to include('some_nonexistent_trigger')
+          expect(error.message).to include('Configuration is not valid')
+          expect(error.message).to include('value')
+        end
+      end
+    end
+
+    context 'when an else block contains an invalid trigger' do
+      it 'includes full config in the error - Issue #984' do
+        invalid_config = [
+          {
+            when: { all: { this: { select_call_direction: 'no match' } } },
+            then: [log_trigger('OK')]
+          },
+          {
+            else: [
+              { invalid_else_trigger: { data: 'test' } }
+            ]
+          }
+        ]
+
+        trigger = SaveTriggers::Case.new(invalid_config, @activity_log)
+
+        expect { trigger.perform }.to raise_error(FphsException) do |error|
+          expect(error.message).to include('invalid_else_trigger')
+          expect(error.message).to include('Full config')
+          expect(error.message).to include('test')
+        end
+      end
     end
   end
 

--- a/spec/models/save_triggers/save_triggers_base_spec.rb
+++ b/spec/models/save_triggers/save_triggers_base_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
       al_def.force_regenerate = true
       al_def.updated_at = DateTime.now # force a save
       al_def.save!
-      ::ActivityLog.refresh_outdated
+      ActivityLog.refresh_outdated
       al_def.reload
       al_def.force_option_config_parse
 
@@ -345,7 +345,7 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
       al_def.force_regenerate = true
       al_def.updated_at = DateTime.now # force a save
       al_def.save!
-      ::ActivityLog.refresh_outdated
+      ActivityLog.refresh_outdated
       al_def.reload
       al_def.force_option_config_parse
 
@@ -513,7 +513,7 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
       al_def.force_regenerate = true
       al_def.updated_at = DateTime.now # force a save
       al_def.save!
-      ::ActivityLog.refresh_outdated
+      ActivityLog.refresh_outdated
       al_def.reload
       al_def.force_option_config_parse
 
@@ -634,7 +634,7 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
       al_def.force_regenerate = true
       al_def.updated_at = DateTime.now # force a save
       al_def.save!
-      ::ActivityLog.refresh_outdated
+      ActivityLog.refresh_outdated
       al_def.reload
       al_def.force_option_config_parse
 
@@ -669,7 +669,7 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
 
       expect(al.select_who).to eq 'created value'
       expect(al2.select_who).to eq 'user'
-      all_recs = al.class.all.pluck(:id)[0, 1]
+      al.class.all.pluck(:id)[0, 1]
 
       al.reload
       al.skip_save_trigger = false
@@ -762,7 +762,7 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
       Delayed::Worker.delay_jobs = true
       al_def.save!
       Delayed::Worker.delay_jobs = false
-      ::ActivityLog.refresh_outdated
+      ActivityLog.refresh_outdated
       al_def.reload
       al_def.force_option_config_parse
 
@@ -791,7 +791,7 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
 
       expect(al.select_who).to eq 'created value'
       expect(al2.select_who).to eq 'user'
-      all_recs = al.class.all.pluck(:id)
+      al.class.all.pluck(:id)
 
       al.reload
       al.skip_save_trigger = false
@@ -801,7 +801,7 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
       al2.skip_save_trigger = false
       al2.current_user = @master.current_user
 
-      res = al.class.trigger_batch
+      al.class.trigger_batch
 
       al.reload
       al2.reload
@@ -927,7 +927,7 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
       Delayed::Worker.delay_jobs = true
       al_def.save!
       Delayed::Worker.delay_jobs = false
-      ::ActivityLog.refresh_outdated
+      ActivityLog.refresh_outdated
       al_def.reload
       al_def.force_option_config_parse
 
@@ -1002,7 +1002,7 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
       Delayed::Worker.delay_jobs = true
       al_def.save!
       Delayed::Worker.delay_jobs = false
-      ::ActivityLog.refresh_outdated
+      ActivityLog.refresh_outdated
       al_def.reload
       al_def.force_option_config_parse
 
@@ -1028,6 +1028,95 @@ RSpec.describe SaveTriggers::SaveTriggersBase, type: :model do
 
       expect(al.class.definition.configurations[:batch_trigger][:frequency]).to eq '1 day'
       expect(al.class.definition.configurations[:batch_trigger][:run_at]).to eq '13:00'
+    end
+  end
+
+  describe 'error reporting for invalid trigger configurations - Issue #984' do
+    before :each do
+      create_user
+      setup_access :player_contacts
+      let_user_create_player_contacts
+      create_item(data: rand(10_000_000_000_000_000), rank: 10)
+      @player_contact.master.current_user = @user
+      @master = @player_contact.master
+      expect(@master).not_to be nil
+
+      al_def = ActivityLog.find_by(id: ActivityLog::PlayerContactPhone.definition.id)
+      unless al_def
+        SetupHelper.setup_al_gen_tests('Phone Log', nil, 'player_contact', rec_type: 'phone')
+        al_def = ActivityLog.active.where(item_type: 'player_contact', rec_type: 'phone').first
+      end
+
+      ActivityLog.active.where(item_type: al_def.item_type).where.not(id: al_def.id).each do |oal|
+        oal.current_admin = @admin
+        oal.disable!
+      end
+
+      al_def.extra_log_types = <<~END_DEF
+        step_1:
+          label: Step 1
+          fields:
+            - select_call_direction
+            - select_who
+      END_DEF
+
+      al_def.current_admin = @admin
+      al_def.force_regenerate = true
+      al_def.updated_at = DateTime.now
+      al_def.save!
+      ActivityLog.refresh_outdated
+      al_def.reload
+      al_def.force_option_config_parse
+
+      setup_access :activity_log__player_contact_phones, resource_type: :table, access: :create, user: @user
+      setup_access :activity_log__player_contact_phone__step_1, resource_type: :activity_log_type, access: :create,
+                                                                user: @user
+      al_def.add_master_association
+
+      @activity_log = @master.activity_log__player_contact_phones.create!(
+        select_call_direction: 'to player',
+        select_who: 'user',
+        extra_log_type: 'step_1',
+        player_contact: @player_contact,
+        master: @master,
+        current_user: @user
+      )
+      @activity_log.save_trigger_results ||= {}
+    end
+
+    describe '#execute_trigger_list' do
+      it 'includes the full trigger config in the error when a trigger name is invalid - Issue #984' do
+        trigger_list = [
+          { invalid_trigger_xyz: { message: 'bad config data' } }
+        ]
+
+        # Use a valid trigger (log) to get a SaveTriggersBase instance to call execute_trigger_list
+        base_trigger = SaveTriggers::Log.new({ message: 'test' }, @activity_log)
+
+        expect { base_trigger.send(:execute_trigger_list, trigger_list) }.to raise_error(FphsException) do |error|
+          expect(error.message).to include('invalid_trigger_xyz')
+          expect(error.message).to include('bad config data')
+        end
+      end
+    end
+
+    describe '.calc_triggers' do
+      it 'includes the full trigger config in the error when a trigger name is invalid - Issue #984' do
+        configs = { nonexistent_trigger: { key: 'value123' } }
+
+        error = nil
+        begin
+          OptionConfigs::ExtraOptionImplementers::SaveTriggers::ClassMethods
+            .instance_method(:calc_triggers)
+            .bind_call(OptionConfigs::ExtraOptions, @activity_log, configs)
+        rescue FphsException => e
+          error = e
+        end
+
+        expect(error).to be_a(FphsException)
+        expect(error.message).to include('nonexistent_trigger')
+        expect(error.message).to include('value123')
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

When a save trigger has an invalid configuration (e.g. from bad YAML anchor merges), the error message now includes the full trigger configuration for easier debugging.

Fixes #984

### Changes

- **save_triggers.rb** (`calc_triggers`): Rescue `FphsException` and re-raise with the full configs YAML appended
- **save_triggers_base.rb** (`execute_trigger_list`, `execute_lifecycle_triggers`): Rescue `FphsException` and re-raise with the full trigger list YAML appended
- **case_spec.rb**: Added 3 tests for invalid trigger error reporting within case branches
- **save_triggers_base_spec.rb**: Added 2 tests for `execute_trigger_list` and `calc_triggers` error reporting
- **dynamic_models_controller.rb / run_batch_now_error view**: Reformatted batch error messages (user cleanup)
