### PR TITLE
Fix memcached clear breaking UI templates and template loading race condition - fixes #987

### DIFF
--- a/app/assets/javascripts/app/_fpa.js
+++ b/app/assets/javascripts/app/_fpa.js
@@ -139,8 +139,7 @@ _fpa = {
     _fpa.templates = Handlebars.templates = Handlebars.templates || {};
     _fpa.partials = Handlebars.partials = Handlebars.partials || {};
 
-    // Mark compilation complete - precompiled JS files have already registered themselves
-    $('body').removeClass('status-compiling initial-compiling').addClass('status-compiled');
+    // Note: status-compiled is set by one_time_setup after all templates are loaded
   },
 
   send_ajax_request: function (url, options) {
@@ -407,7 +406,7 @@ _fpa = {
         }
 
         new_block = html;
-        var id = new_block.attr('id');
+        var id = new_block ? new_block.attr('id') : undefined;
         // If the results has a root element with an id that exist in the DOM already,
         // TODO: !!!! this seems wrong - we don't want duplicate items !!!! and has not been created in this transaction,
         // replace it rather than placing the result before the specified block
@@ -427,7 +426,7 @@ _fpa = {
         }
 
         new_block = html;
-        var id = new_block.attr('id');
+        var id = new_block ? new_block.attr('id') : undefined;
         var existing = $('#' + id);
         // If the results has a root element with an id that exist in the DOM already,
         // replace it rather than placing the result after the specified block
@@ -443,7 +442,7 @@ _fpa = {
 
         // If the results has a root element with an id that matches the existing block,
         // replace it rather than placing the result inside the current item
-        if (block.attr('id') && block.attr('id') == new_block.attr('id')) {
+        if (new_block && block.attr('id') && block.attr('id') == new_block.attr('id')) {
           block.replaceWith(new_block);
         } else {
           // Just replace the content of the specified block
@@ -1417,13 +1416,23 @@ _fpa = {
 
   load_template_version: function (template_version, rails_env) {
     $.get({ url: `/pages/${template_version}/template`, cache: true }).done(function (data) {
-      // Inject the template HTML into the page and run any included scripts
+      // Inject the template HTML into the page and run any included scripts.
+      // Inline scripts in the appended HTML call retrieve_requested_handlebars_templates,
+      // which increments pending_template_retrieves before starting async AJAX.
       $('body').append(data);
 
-      window.setTimeout(function () {
-        _fpa.status.loaded_templates = true;
-        _fpa.one_time_setup();
-      }, 1);
+      // Wait for all pending multi file AJAX requests to complete before
+      // marking templates as loaded. This prevents the splash guard from
+      // being removed before templates are available for rendering.
+      function waitForPendingRetrieves() {
+        if (_fpa.status.pending_template_retrieves > 0) {
+          window.setTimeout(waitForPendingRetrieves, 10);
+        } else {
+          _fpa.status.loaded_templates = true;
+          _fpa.one_time_setup();
+        }
+      }
+      window.setTimeout(waitForPendingRetrieves, 1);
     }).fail(function (jqXHR, textStatus, errorThrown) {
       console.log(jqXHR, textStatus, errorThrown);
       if (rails_env != 'test') {
@@ -1440,11 +1449,17 @@ _fpa = {
 
     _fpa.status.one_time_setup_run = true;
     _fpa.compile_templates();
+    // Mark compilation complete - splash guard is removed only after all templates are loaded
+    $('body').removeClass('status-compiling initial-compiling').addClass('status-compiled');
     _fpa.reset_page_size();
     _fpa.loaded.default();
   },
 
   retrieve_requested_handlebars_templates: function (url, rails_env, file_id) {
+    // Track pending multi file AJAX requests so load_template_version knows
+    // when all templates have been fetched before removing the splash guard.
+    _fpa.status.pending_template_retrieves = (_fpa.status.pending_template_retrieves || 0) + 1;
+
     // Use $.ajax with dataType 'script' to fetch and execute the precompiled template JavaScript
     // $.getScript disables caching by default, so we use $.ajax directly
     $.ajax({
@@ -1455,6 +1470,7 @@ _fpa = {
       // Script executed - templates are now registered, just need to compile them
       _fpa.compile_templates();
       $('body').addClass(`loaded-templates--${file_id}`);
+      _fpa.status.pending_template_retrieves--;
     }).fail(function (jqXHR, textStatus, errorThrown) {
       console.log(jqXHR, textStatus, errorThrown);
       if (rails_env != 'test') {
@@ -1462,6 +1478,7 @@ _fpa = {
         $('body').removeClass('status-compiling initial-compiling').addClass('status-failed-compilation');
       }
       _fpa.cache.clean();
+      _fpa.status.pending_template_retrieves--;
     });
   },
 

--- a/app/helpers/handlebars_precompiler_helper.rb
+++ b/app/helpers/handlebars_precompiler_helper.rb
@@ -203,7 +203,7 @@ module HandlebarsPrecompilerHelper
     File.write(dir, (init_header + template_html.join("\n")).html_safe)
 
     url_path = HandlebarsPrecompiler::URL_RELATIVE_PATH
-    ["#{url_path}/multi/#{filename}", handlebars_template_ids, handlebars_partial_ids]
+    ["#{url_path}multi/#{filename}", handlebars_template_ids, handlebars_partial_ids]
   end
 
   # Compile all templates from temp directories in a single CLI call per type.

--- a/config/initializers/handlebars_precompiler.rb
+++ b/config/initializers/handlebars_precompiler.rb
@@ -71,6 +71,11 @@ Rails.application.config.after_initialize do
   HandlebarsPrecompiler.cleanup_tmp_dir
   HandlebarsPrecompiler.cleanup_public_dir
 
+  # Invalidate server_cache_version since compiled files were cleaned up.
+  # This forces browsers and fragment caches to use fresh template URLs,
+  # preventing 404s when multi files are deleted but stale URLs remain cached.
+  Rails.cache.delete('server_cache_version')
+
   unless HandlebarsPrecompiler.cli_available?
     msg = 'Handlebars CLI not found. Install with: npm install --global handlebars'
     Rails.logger.error msg

--- a/spec/helpers/handlebars_precompiler_helper_spec.rb
+++ b/spec/helpers/handlebars_precompiler_helper_spec.rb
@@ -441,4 +441,31 @@ RSpec.describe HandlebarsPrecompilerHelper, type: :helper do
       end
     end
   end
+
+  describe '#write_multiple_handlebars_templates' do
+    let(:cache_key) { 'multi123456789' }
+
+    before do
+      allow(helper).to receive(:handlebars_cache_key).and_return(cache_key)
+      allow(helper).to receive(:current_user).and_return(Struct.new(:id, :current_sign_in_at, :app_type_id).new(1, Time.at(1000000), 2))
+      allow(helper).to receive(:current_admin).and_return(nil)
+
+      HandlebarsPrecompiler.setup_directories
+      FileUtils.rm_rf(Dir.glob(HandlebarsPrecompiler::MULTI_PUBLIC_DIR.join('*.js')))
+    end
+
+    it 'generates multi file URL without double slashes' do
+      # Create a compiled template file so read_handlebars_template can find it
+      FileUtils.mkdir_p(HandlebarsPrecompiler::TEMPLATES_PUBLIC_DIR)
+      compiled_file = HandlebarsPrecompiler::TEMPLATES_PUBLIC_DIR.join("test_template-#{cache_key}.js")
+      File.write(compiled_file, '(function() { var template = Handlebars.template; })();')
+
+      templates = [{ id: 'test_template', is_partial: false, compiled_file_path: 'irrelevant' }]
+      url, = helper.write_multiple_handlebars_templates(templates)
+
+      expect(url).not_to include('//')
+      expect(url).to start_with(HandlebarsPrecompiler::URL_RELATIVE_PATH)
+      expect(url).to include('/multi/')
+    end
+  end
 end

--- a/spec/initializers/handlebars_precompiler_spec.rb
+++ b/spec/initializers/handlebars_precompiler_spec.rb
@@ -103,4 +103,23 @@ RSpec.describe HandlebarsPrecompiler do
       expect(js_files).to be_empty
     end
   end
+
+  describe 'after_initialize callback' do
+    it 'invalidates server_cache_version after cleaning up public dir' do
+      # Write a known server_cache_version to cache
+      Rails.cache.write('server_cache_version', 'old-version-123')
+      expect(Rails.cache.read('server_cache_version')).to eq('old-version-123')
+
+      # Simulate what the after_initialize block does
+      described_class.cleanup_public_dir
+      Rails.cache.delete('server_cache_version')
+
+      # The old value should no longer be in cache
+      expect(Rails.cache.read('server_cache_version')).to be_nil
+
+      # A new call to server_cache_version should generate a fresh value
+      new_version = Application.server_cache_version
+      expect(new_version).not_to eq('old-version-123')
+    end
+  end
 end

--- a/spec/system/memcached_clear_template_recovery_spec.rb
+++ b/spec/system/memcached_clear_template_recovery_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+# Memcached Clear Template Recovery System Spec - fixes #987
+#
+# Verifies that clearing memcached and cleaning compiled handlebars template files
+# does not break UI template retrieval for logged-in users.
+#
+# The bug: when memcached is cleared (e.g., from a configuration change) and
+# compiled template files are cleaned up (e.g., on server restart),
+# server_cache_version must be invalidated. Without invalidation, the same
+# template_version is generated, causing browsers to serve stale cached
+# template HTML that references deleted multi files, returning 404.
+#
+# Test Coverage:
+# - Page loads normally with templates compiled
+# - After simulated cleanup + cache invalidation, page still loads correctly
+# - server_cache_version changes after cleanup_public_dir + cache invalidation
+# - Without cache invalidation, server_cache_version remains stale (proves bug)
+
+require 'rails_helper'
+
+RSpec.describe 'Template recovery after memcached clear', type: :system, js: true, driver: $browser_driver do
+  include ModelSupport
+  include FeatureSupport
+
+  before(:all) do
+    SetupHelper.feature_setup
+    @user, = create_user
+    change_setting('TwoFactorAuthDisabledForUser', true)
+  end
+
+  before do
+    login_as(@user, scope: :user)
+  end
+
+  describe 'compiled template cleanup without server_cache_version invalidation' do
+    it 'leaves stale server_cache_version that would cause 404 on multi files' do
+      visit '/'
+      finish_page_loading
+      expect(page).to have_css('body.status-compiled', wait: 30)
+
+      # Record the current server_cache_version
+      scv_before = Application.server_cache_version
+
+      # Simulate what happens on server restart: compiled files are deleted
+      HandlebarsPrecompiler.cleanup_public_dir
+
+      # Without the fix, server_cache_version remains unchanged
+      # This means template_version stays the same, and browsers serve cached
+      # template HTML referencing deleted multi files
+      scv_after_no_fix = Application.server_cache_version
+      expect(scv_after_no_fix).to eq(scv_before),
+                                   'Bug: server_cache_version should remain stale without cache invalidation'
+
+      # Verify that compiled multi files were actually deleted
+      multi_files = Dir.glob(HandlebarsPrecompiler::MULTI_PUBLIC_DIR.join('*.js'))
+      expect(multi_files).to be_empty,
+                             'cleanup_public_dir should have deleted all multi files'
+
+      # Now apply the fix: invalidate server_cache_version
+      Rails.cache.delete('server_cache_version')
+
+      # After invalidation, a new server_cache_version is generated
+      scv_after_fix = Application.server_cache_version
+      expect(scv_after_fix).not_to eq(scv_before),
+                                   'Fix: server_cache_version must change after cache invalidation'
+    end
+  end
+
+  describe 'page recovery after cleanup with cache invalidation' do
+    it 'reloads templates successfully after cleanup_public_dir and cache invalidation' do
+      # Step 1: Load page normally - templates compile and UI works
+      visit '/'
+      finish_page_loading
+      expect(page).to have_css('body.status-compiled', wait: 30)
+
+      templates_before = page.evaluate_script('Object.keys(_fpa.templates || {}).length')
+      expect(templates_before).to be > 0
+
+      # Step 2: Simulate server restart scenario
+      # Cleanup compiled files (what happens on Rails startup)
+      HandlebarsPrecompiler.cleanup_public_dir
+      HandlebarsPrecompiler.cleanup_tmp_dir
+      # Invalidate server_cache_version (the fix from issue #987)
+      Rails.cache.delete('server_cache_version')
+
+      # Step 3: Reload - templates should recompile and work
+      visit '/'
+      finish_page_loading
+      expect(page).to have_css('body.status-compiled', wait: 30)
+
+      templates_after = page.evaluate_script('Object.keys(_fpa.templates || {}).length')
+      expect(templates_after).to be > 0
+    end
+
+    it 'loads search results templates after cleanup and cache invalidation' do
+      visit '/'
+      finish_page_loading
+
+      # Wait for the full template set to load
+      expect(page).to have_css('body.loaded-templates--masters__search_results_template', wait: 30)
+
+      # Simulate cleanup + fix
+      HandlebarsPrecompiler.cleanup_public_dir
+      HandlebarsPrecompiler.cleanup_tmp_dir
+      Rails.cache.delete('server_cache_version')
+
+      # Reload and verify search results templates loaded
+      visit '/'
+      finish_page_loading
+      expect(page).to have_css('body.loaded-templates--masters__search_results_template', wait: 30)
+
+      partials_count = page.evaluate_script('Object.keys(_fpa.partials || {}).length')
+      expect(partials_count).to be > 0
+    end
+  end
+end

--- a/spec/system/template_loading_race_condition_spec.rb
+++ b/spec/system/template_loading_race_condition_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+# Template Loading Race Condition System Spec
+#
+# Verifies that the splash guard ("loading...") does not disappear until all
+# Handlebars templates are fully loaded and available for use.
+#
+# The bug: compile_templates() is called (adding status-compiled to body, removing
+# the splash guard) before retrieve_requested_handlebars_templates AJAX completes.
+# This creates a window where the user can interact with the page (e.g. click search)
+# but templates aren't available, causing:
+#   "Cannot read properties of undefined (reading 'attr')" in _fpa.js render_template
+#
+# Root cause: load_template_version.done() sets loaded_templates=true after 1ms,
+# which triggers one_time_setup() -> compile_templates() -> status-compiled.
+# But the multi file AJAX from retrieve_requested_handlebars_templates hasn't
+# completed yet, so Handlebars.templates is still empty.
+#
+# Test Coverage:
+# - Templates must be loaded before compile_templates first runs
+# - Search works immediately after splash guard disappears without JS errors
+
+require 'rails_helper'
+
+RSpec.describe 'Template loading race condition', type: :system, js: true, driver: $browser_driver do
+  include ModelSupport
+  include FeatureSupport
+
+  before(:all) do
+    SetupHelper.feature_setup
+    @user, = create_user
+    change_setting('TwoFactorAuthDisabledForUser', true)
+  end
+
+  before do
+    login_as(@user, scope: :user)
+  end
+
+  describe 'splash guard and template loading synchronization' do
+    it 'has templates loaded before compile_templates adds status-compiled' do
+      # Use Chrome DevTools Protocol to inject JavaScript that runs BEFORE any
+      # page scripts on the next document load. A MutationObserver captures the
+      # template state at the exact moment status-compiled is added to the body,
+      # which is when the splash guard is removed and the user can interact.
+      cdp_result = page.driver.browser.execute_cdp(
+        'Page.addScriptToEvaluateOnNewDocument',
+        source: <<~JS
+          window._testCompileState = { caught: false, template_count: -1 };
+          document.addEventListener('DOMContentLoaded', function() {
+            var observer = new MutationObserver(function(mutations) {
+              if (document.body.classList.contains('status-compiled') && !window._testCompileState.caught) {
+                window._testCompileState.caught = true;
+                window._testCompileState.template_count = Object.keys(Handlebars.templates || {}).length;
+              }
+            });
+            observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+          });
+        JS
+      )
+      cdp_script_id = cdp_result['identifier']
+
+      begin
+        visit '/masters/search'
+
+        # Wait for full page load including search results template multi file
+        expect(page).to have_css('body.status-compiled', wait: 30)
+        expect(page).to have_css('body.loaded-templates--masters__search_results_template', wait: 30)
+
+        state = page.evaluate_script('window._testCompileState')
+
+        expect(state).not_to be_nil, 'CDP script should have set window._testCompileState'
+        expect(state['caught']).to be(true),
+          'MutationObserver should have captured status-compiled being set'
+
+        # Get the total template count after full page load for comparison
+        total_templates = page.evaluate_script('Object.keys(Handlebars.templates || {}).length')
+
+        # At the moment status-compiled was set (splash guard removed), ALL templates
+        # should already be loaded.
+        # Before the fix: only layout templates loaded (search results multi file still pending).
+        # After the fix: all templates loaded because status-compiled is deferred until ready.
+        expect(state['template_count']).to eq(total_templates),
+          "Only #{state['template_count']} of #{total_templates} templates were loaded " \
+          'when status-compiled was set (splash guard removed). ' \
+          'All multi file templates must be loaded before the splash guard is removed.'
+      ensure
+        page.driver.browser.execute_cdp(
+          'Page.removeScriptToEvaluateOnNewDocument',
+          identifier: cdp_script_id
+        )
+      end
+    end
+
+    it 'does not produce JS errors when searching immediately after splash guard disappears' do
+      visit '/masters/search'
+
+      # Set up error handler to catch uncaught JS exceptions from the race condition
+      page.execute_script(<<~JS)
+        window._testJsErrors = [];
+        window.addEventListener('error', function(event) {
+          window._testJsErrors.push({
+            message: event.message,
+            source: event.filename,
+            line: event.lineno,
+            col: event.colno
+          });
+        });
+      JS
+
+      # Wait ONLY for the splash guard to disappear (status-compiled class added)
+      expect(page).to have_css('body.status-compiled', wait: 30)
+
+      # Immediately attempt a search - reproducing the user's reported scenario.
+      # Without the fix, templates may not be loaded yet, causing render_template
+      # to crash when it tries to call .attr('id') on undefined html.
+      within '#simple_search_master' do
+        fill_in 'Last name', with: 'test'
+        click_button 'search'
+      end
+
+      # Allow time for the search AJAX to complete or fail
+      sleep 3
+
+      # Check for uncaught JS errors caused by templates not being loaded
+      js_errors = page.evaluate_script('window._testJsErrors || []')
+      template_errors = js_errors.select do |e|
+        e['message']&.include?('Cannot read properties') ||
+          e['message']&.include?('is not a function')
+      end
+
+      expect(template_errors).to be_empty,
+        'JS errors occurred when searching immediately after splash guard disappeared: ' \
+        "#{template_errors.map { |e| "#{e['message']} at line #{e['line']}" }.join('; ')}"
+
+      # The search results block should be present (even if showing "No Results")
+      expect(page).to have_css('#master_results_block', wait: 10)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes two related issues from #987:

### 1. Memcached clear breaks UI template retrieval (server-side)
When memcached is cleared and the server restarts, `cleanup_public_dir` deletes compiled template files but did not invalidate `server_cache_version`. This caused browsers to serve cached template HTML referencing deleted multi files (404s).

**Fix:** Added `Rails.cache.delete('server_cache_version')` after `cleanup_public_dir` in the `after_initialize` callback. Also fixed a double-slash in multi file URLs.

### 2. Template loading race condition (client-side JS)
The splash guard ("loading...") was removed before all Handlebars templates finished loading. `compile_templates()` added `status-compiled` (hiding the splash) when `load_template_version` AJAX returned, but `retrieve_requested_handlebars_templates` multi file AJAX was still in flight. Clicking search during this window caused: `Cannot read properties of undefined (reading 'attr')`.

**Fix:**
- Moved `status-compiled` class addition from `compile_templates()` to `one_time_setup()`
- `retrieve_requested_handlebars_templates` now tracks a `pending_template_retrieves` counter
- `load_template_version` polls until all pending retrieves complete before setting `loaded_templates = true`
- Added defensive null guards on `new_block` in `render_template` to prevent crashes if html is undefined

### Tests
- `spec/initializers/handlebars_precompiler_spec.rb` - tests server cache invalidation on startup
- `spec/helpers/handlebars_precompiler_helper_spec.rb` - tests multi file URL generation
- `spec/system/memcached_clear_template_recovery_spec.rb` - system spec for cache recovery
- `spec/system/template_loading_race_condition_spec.rb` - system spec using CDP MutationObserver to verify all templates are loaded before splash guard is removed
- All existing search specs pass (advanced_search, master_search_reports)