### PR TITLE
Fix report admin preview showing incorrect column names (#1000)

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -3,6 +3,12 @@
 class Admin::ReportsController < AdminController
   SearchAttrBrowserCacheSeconds = 48.hours.to_i
 
+  helper_method :embedded_report, :search_attrs_params_hash
+
+  def self.local_prefixes
+    super + ['reports']
+  end
+
   def search_attr_definer
     cache_key = Digest::SHA256.hexdigest(helpers.partial_cache_key('report_search_attr_definer'))
     response.headers['Cache-Control'] = "max-age=#{SearchAttrBrowserCacheSeconds}"
@@ -10,6 +16,19 @@ class Admin::ReportsController < AdminController
     return unless stale?(etag: cache_key)
 
     render partial: 'admin/reports/form/search_attr_definer'
+  end
+
+  def preview
+    @report = Report.find(params[:id])
+    @report.current_user = current_user if current_user
+    @runner = @report.runner
+    @embedded_report = true
+    @force_view_as = 'table'
+
+    @runner.search_attr_values = search_attrs_params_hash
+    @results = @runner.run(search_attrs_params_hash, current_admin)
+
+    render partial: 'reports/results'
   end
 
   protected
@@ -47,5 +66,17 @@ class Admin::ReportsController < AdminController
 
   def index_params
     %i[name item_type category report_type auto searchable admin_id]
+  end
+
+  def embedded_report
+    @embedded_report
+  end
+
+  def search_attrs_params_hash
+    @search_attrs_params_hash ||= if params[:search_attrs].blank?
+                                    { _use_defaults_: '_use_defaults_' }
+                                  else
+                                    params.require(:search_attrs).permit!.to_h.dup
+                                  end
   end
 end

--- a/app/helpers/report_results/reports_table_helper.rb
+++ b/app/helpers/report_results/reports_table_helper.rb
@@ -20,7 +20,7 @@ module ReportResults
     def report_table_header_cache_key
       sn = @runner.data_reference.schema_name
       tn = @runner.data_reference.table_name
-      partial_cache_key("report_table_header--#{@report.id}--#{@report.updated_at}--#{sn}--#{tn}")
+      partial_cache_key("report_table_header--#{@report.id}--#{@report.updated_at}--#{sn}--#{tn}--#{editable?}")
     end
 
     #

--- a/app/views/admin/reports/form/_admin_criteria_view.html.erb
+++ b/app/views/admin/reports/form/_admin_criteria_view.html.erb
@@ -5,7 +5,7 @@
     @view_options = @report.report_options(fail_without_exception: true)&.view_options
 %>  
   <div class="admin-view report-criteria">
-  <%= form_tag report_path(@report.id), 
+  <%= form_tag preview_admin_report_path(@report.id), 
         method: :get, 
         class: 'form-formatted search_report', 
         id: "report_query_form", 

--- a/app/views/admin/reports/form/_edit_table_block.html.erb
+++ b/app/views/admin/reports/form/_edit_table_block.html.erb
@@ -1,5 +1,5 @@
 <% edit_table_configured = f.object.edit_model.present? || f.object.edit_field_names.present? || f.object.selection_fields.present? %>
-<p><a href="#edit_table_block" class="collapsed btn btn-default <%= 'btn-info' if edit_table_configured %>" data-toggle="collapse"><span class="caret"></span> Edit table data?<%= ' <span class="glyphicon glyphicon-ok"></span>'.html_safe if edit_table_configured %></a></p>
+<p><a href="#edit_table_block" class="collapsed btn <%= edit_table_configured ? 'btn-info' : 'btn-default' %>" data-toggle="collapse"><span class="caret"></span> Edit table data?<%= ' <span class="glyphicon glyphicon-ok"></span>'.html_safe if edit_table_configured %></a></p>
 <div class="collapse well" id="edit_table_block">
   <div class="help-block">
     <p>Entering an edit table name enables data editing for this report. Users authorized to edit report data can edit rows in a report, when viewed as a table.</p>

--- a/app/views/admin/reports/form/_edit_table_block.html.erb
+++ b/app/views/admin/reports/form/_edit_table_block.html.erb
@@ -1,4 +1,5 @@
-<p><a href="#edit_table_block" class="collapsed btn btn-default" data-toggle="collapse"><span class="caret"></span> Edit table data?</a>  </p>
+<% edit_table_configured = f.object.edit_model.present? || f.object.edit_field_names.present? || f.object.selection_fields.present? %>
+<p><a href="#edit_table_block" class="collapsed btn btn-default <%= 'btn-info' if edit_table_configured %>" data-toggle="collapse"><span class="caret"></span> Edit table data?<%= ' <span class="glyphicon glyphicon-ok"></span>'.html_safe if edit_table_configured %></a></p>
 <div class="collapse well" id="edit_table_block">
   <div class="help-block">
     <p>Entering an edit table name enables data editing for this report. Users authorized to edit report data can edit rows in a report, when viewed as a table.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,11 @@ Rails.application.routes.draw do
     resources :master_records, only: %i[index show]
     resources :external_identifiers, except: %i[show destroy]
     get :external_identifier_details, to: 'external_identifiers#details'
-    resources :reports, except: %i[show destroy]
+    resources :reports, except: %i[show destroy] do
+      member do
+        get :preview
+      end
+    end
     get :report_search_attr_definer, to: 'reports#search_attr_definer'
     resources :config_libraries, except: %i[show destroy] do
       member do

--- a/spec/helpers/report_results/reports_table_helper_spec.rb
+++ b/spec/helpers/report_results/reports_table_helper_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+# ReportResults::ReportsTableHelper Spec - Issue #1000
+#
+# Tests that report_table_header_cache_key produces different cache keys
+# when the editable? state differs (e.g., embedded vs non-embedded context).
+#
+# The bug: the cache key does not include whether the report is editable
+# in the current context. When a user views a report with edit_model configured
+# (non-embedded), the header is cached WITH an extra <th> for the edit button.
+# When the admin preview renders the same report (@embedded_report=true),
+# editable? returns nil, but the same cache key is used, so the stale header
+# with the extra <th> is served. Data rows don't have the extra <td>, causing
+# all column headers to be shifted by one position.
+#
+# Test Coverage:
+# - report_table_header_cache_key returns different keys for editable vs non-editable contexts
+# - This test FAILS against the current code because editable? is not part of the cache key
+
+require 'rails_helper'
+
+RSpec.describe ReportResults::ReportsTableHelper, type: :helper do
+  include ModelSupport
+
+  before(:all) do
+    create_admin
+    create_user
+
+    @report = Report.create!(
+      current_admin: @admin,
+      name: "Cache Key Test #{SecureRandom.hex(4)}",
+      description: 'Test report for cache key editable state',
+      sql: 'select * from player_infos limit 1',
+      search_attrs: '',
+      disabled: false,
+      report_type: 'regular_report',
+      auto: false,
+      searchable: false,
+      position: nil,
+      edit_model: 'player_infos',
+      edit_field_names: 'first_name,last_name'
+    )
+  end
+
+  after(:all) do
+    @report&.update(disabled: true, current_admin: @admin) if @report&.persisted?
+  end
+
+  describe '#report_table_header_cache_key' do
+    let(:data_reference) do
+      double('DataReference', schema_name: 'ml_app', table_name: 'player_infos')
+    end
+
+    let(:runner) do
+      double('Runner', data_reference: data_reference)
+    end
+
+    before do
+      # Set up the instance variables the helper expects
+      helper.instance_variable_set(:@report, @report)
+      helper.instance_variable_set(:@runner, runner)
+
+      # Stub current_user/current_admin so partial_cache_key works
+      helper.define_singleton_method(:current_user) { @user }
+      helper.define_singleton_method(:current_admin) { nil }
+      helper.instance_variable_set(:@user, @user)
+    end
+
+    it 'produces different cache keys when editable? returns different values' do
+      # Non-embedded context: editable? returns true (edit_model is set, admin/user has access)
+      helper.instance_variable_set(:@embedded_report, nil)
+      helper.define_singleton_method(:current_admin) { @admin }
+      helper.instance_variable_set(:@admin, @admin)
+      non_embedded_key = helper.report_table_header_cache_key
+
+      # Reset memoized state that partial_cache_key may have cached
+      helper.instance_variable_set(:@item_updates, nil)
+
+      # Embedded context: editable? returns nil (short-circuits because @embedded_report is set)
+      helper.instance_variable_set(:@embedded_report, true)
+      embedded_key = helper.report_table_header_cache_key
+
+      # These should be DIFFERENT because the header content differs based on editable? state.
+      # This assertion FAILS with the current code because the cache key does not include
+      # the editable? state — both contexts produce the same key, causing stale headers.
+      expect(non_embedded_key).not_to eq(embedded_key),
+        'Cache keys should differ between embedded (non-editable) and non-embedded (editable) contexts, ' \
+        "but both produced: #{non_embedded_key}"
+    end
+  end
+end

--- a/spec/system/admin/admin_report_preview_columns_spec.rb
+++ b/spec/system/admin/admin_report_preview_columns_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+# Admin Report Preview Columns Spec - Issue #1000
+#
+# Tests that the admin report page results preview shows column headers
+# that are correctly aligned with the actual data columns returned by the query.
+#
+# The bug: the admin preview form submits an AJAX request to the user-facing
+# ReportsController, which requires user authentication via UserBaseController's
+# `before_action :authenticate_user!`. When an admin is signed in only as admin
+# (no user session), the AJAX request fails and column headers are not shown
+# correctly. The fix routes the preview through the admin controller instead.
+
+require 'rails_helper'
+
+describe 'admin report preview columns - Issue #1000', js: true, driver: $browser_driver do
+  include ModelSupport
+  include AdminActionsSetup
+  include FeatureSupport
+
+  before(:all) do
+    SetupHelper.feature_setup
+    ENV['FPHS_ADMIN_SETUP'] = 'yes'
+    make_an_admin
+
+    # Get the actual column names from the player_infos table as they would
+    # appear in a `select *` query result
+    @expected_columns = ActiveRecord::Base.connection.columns('player_infos').map(&:name)
+
+    # Ensure there is data in player_infos for the preview to return results
+    unless PlayerInfo.exists?
+      create_user
+      create_master
+      PlayerInfo.create!(
+        master: @master,
+        first_name: 'test',
+        last_name: 'user',
+        current_user: @user
+      )
+    end
+
+    # Create a simple report for testing column alignment
+    @report = Report.create!(
+      current_admin: @admin,
+      name: "Preview Columns Test #{SecureRandom.hex(4)}",
+      description: 'Test report for column alignment in admin preview',
+      sql: 'select * from player_infos limit 10',
+      search_attrs: '',
+      disabled: false,
+      report_type: 'regular_report',
+      auto: false,
+      searchable: false,
+      position: nil
+    )
+  end
+
+  after(:all) do
+    @report&.update(disabled: true, current_admin: @admin) if @report&.persisted?
+  end
+
+  it 'shows column headers matching the actual query columns in the correct order' do
+    admin_sign_in_with_2fa
+
+    visit '/admin/reports'
+    finish_page_loading
+
+    # Click the edit button for our test report
+    within "#admin-item-#{@report.id}" do
+      find('a.edit-entity.glyphicon-pencil').click
+    end
+
+    # Wait for the edit form to load via AJAX
+    expect(page).to have_css('#report_query_form', wait: 10)
+
+    # Click the "run" button to execute the preview
+    within '#report_query_form' do
+      click_button 'run'
+    end
+
+    # Wait for the AJAX response to load results into #embed_results_block
+    expect(page).to have_css('#embed_results_block table.report-table', wait: 15)
+    finish_page_loading
+
+    within '#embed_results_block table.report-table' do
+      # Check ALL th elements (including any edit-button columns) align with ALL td elements.
+      all_header_cells = all('thead tr th')
+      first_row_cells = all('tbody tr:first-child td')
+
+      expect(all_header_cells.length).to eq(first_row_cells.length),
+        "Header row has #{all_header_cells.length} columns but data row has #{first_row_cells.length} — " \
+        'columns are visually misaligned'
+
+      # Collect just the data column headers (with data-col-type attribute)
+      data_header_cells = all('thead th.table-header')
+      header_col_types = data_header_cells.map { |th| th[:'data-col-type'] }
+
+      # Verify we got headers for all expected columns
+      expect(data_header_cells.length).to eq(@expected_columns.length),
+        "Expected #{@expected_columns.length} column headers but found #{data_header_cells.length}"
+
+      # Verify each header's data-col-type matches the expected column name in order
+      @expected_columns.each_with_index do |expected_col, i|
+        expect(header_col_types[i]).to eq(expected_col),
+          "Header at position #{i} has data-col-type '#{header_col_types[i]}' " \
+          "but expected '#{expected_col}'. " \
+          "Full header order: #{header_col_types.inspect}"
+      end
+
+      # Verify the first data row's td data-col-type values align positionally with headers
+      data_cells = all('tbody tr:first-child td.report-el')
+      expect(data_cells.length).to eq(@expected_columns.length),
+        "Expected #{@expected_columns.length} data cells but found #{data_cells.length}"
+
+      data_cells.each_with_index do |td, i|
+        td_col_type = td[:'data-col-type']
+        expect(td_col_type).to eq(header_col_types[i]),
+          "Data cell at position #{i} has data-col-type '#{td_col_type}' " \
+          "but header has '#{header_col_types[i]}'"
+      end
+    end
+  end
+end

--- a/spec/system/admin/admin_report_preview_columns_spec.rb
+++ b/spec/system/admin/admin_report_preview_columns_spec.rb
@@ -5,11 +5,18 @@
 # Tests that the admin report page results preview shows column headers
 # that are correctly aligned with the actual data columns returned by the query.
 #
-# The bug: the admin preview form submits an AJAX request to the user-facing
-# ReportsController, which requires user authentication via UserBaseController's
-# `before_action :authenticate_user!`. When an admin is signed in only as admin
-# (no user session), the AJAX request fails and column headers are not shown
-# correctly. The fix routes the preview through the admin controller instead.
+# Test 1 (existing): Basic column alignment for a simple report without edit_model.
+#   The admin preview form submits an AJAX request through the admin controller.
+#   Verifies th count == td count and data-col-type values align positionally.
+#
+# Test 2 (edit_model cache key bug): When a report has edit_model configured,
+#   the table header is cached. The cache key does NOT include the editable? state.
+#   When a non-embedded view caches the header WITH an extra <th> for the edit button,
+#   and then the admin preview renders the same report (where @embedded_report=true
+#   suppresses the edit column), the stale cached header is served with the extra <th>
+#   but data rows don't have the extra <td>. This causes all column headers to be
+#   shifted by one position. This test verifies header/data column counts match
+#   even when edit_model is configured.
 
 require 'rails_helper'
 
@@ -116,6 +123,90 @@ describe 'admin report preview columns - Issue #1000', js: true, driver: $browse
         expect(td_col_type).to eq(header_col_types[i]),
           "Data cell at position #{i} has data-col-type '#{td_col_type}' " \
           "but header has '#{header_col_types[i]}'"
+      end
+    end
+  end
+
+  context 'with edit_model configured on the report' do
+    before(:all) do
+      # Create a report WITH edit_model so that editable? returns true in non-embedded contexts
+      @editable_report = Report.create!(
+        current_admin: @admin,
+        name: "Editable Preview Test #{SecureRandom.hex(4)}",
+        description: 'Test report for editable column alignment in admin preview',
+        sql: 'select * from player_infos limit 10',
+        search_attrs: '',
+        disabled: false,
+        report_type: 'regular_report',
+        auto: false,
+        searchable: false,
+        position: nil,
+        edit_model: 'player_infos',
+        edit_field_names: 'first_name,last_name'
+      )
+
+      # Clear the cache to remove any stale entries from previous test runs,
+      # so we get a clean slate for testing cache behavior.
+      Rails.cache.clear
+    end
+
+    after(:all) do
+      @editable_report&.update(disabled: true, current_admin: @admin) if @editable_report&.persisted?
+    end
+
+    it 'shows header column count matching data column count even with edit_model set' do
+      admin_sign_in_with_2fa
+
+      visit '/admin/reports'
+      finish_page_loading
+
+      # Click the edit button for our editable test report
+      within "#admin-item-#{@editable_report.id}" do
+        find('a.edit-entity.glyphicon-pencil').click
+      end
+
+      # Wait for the edit form to load via AJAX
+      expect(page).to have_css('#report_query_form', wait: 10)
+
+      # Click the "run" button to execute the preview
+      within '#report_query_form' do
+        click_button 'run'
+      end
+
+      # Wait for the AJAX response to load results into #embed_results_block
+      expect(page).to have_css('#embed_results_block table.report-table', wait: 15)
+      finish_page_loading
+
+      within '#embed_results_block table.report-table' do
+        # The critical assertion: th count must equal td count in the first data row.
+        # If the cache key doesn't include editable state, a stale cached header with
+        # the edit-button-column <th> will be served but data rows won't have the
+        # matching <td>, causing a count mismatch.
+        all_header_cells = all('thead tr th')
+        first_row_cells = all('tbody tr:first-child td')
+
+        expect(all_header_cells.length).to eq(first_row_cells.length),
+          "Header row has #{all_header_cells.length} columns but data row has #{first_row_cells.length} — " \
+          'column misalignment detected (likely stale cached header with edit-button-column <th>)'
+
+        # The admin preview should NOT have an edit-button-column header since @embedded_report is set
+        edit_button_headers = all('thead th.edit-button-column', minimum: 0)
+        expect(edit_button_headers.length).to eq(0),
+          'Admin preview should not show edit-button-column header when @embedded_report is set'
+
+        # Verify positional alignment of data column headers with data cells
+        data_header_cells = all('thead th.table-header')
+        data_cells = all('tbody tr:first-child td.report-el')
+        expect(data_header_cells.length).to eq(data_cells.length),
+          "Data header count (#{data_header_cells.length}) != data cell count (#{data_cells.length})"
+
+        data_header_cells.each_with_index do |th, i|
+          th_col = th[:'data-col-type']
+          td_col = data_cells[i][:'data-col-type']
+          expect(th_col).to eq(td_col),
+            "Header at position #{i} has data-col-type '#{th_col}' " \
+            "but data cell has '#{td_col}' — columns are shifted"
+        end
       end
     end
   end

--- a/spec/system/admin/admin_report_preview_columns_spec.rb
+++ b/spec/system/admin/admin_report_preview_columns_spec.rb
@@ -209,5 +209,27 @@ describe 'admin report preview columns - Issue #1000', js: true, driver: $browse
         end
       end
     end
+
+    it 'shows a visual indicator on the Edit table data button when fields are configured' do
+      admin_sign_in_with_2fa
+
+      visit '/admin/reports'
+      finish_page_loading
+
+      # Click the edit button for our editable test report (which has edit_model set)
+      within "#admin-item-#{@editable_report.id}" do
+        find('a.edit-entity.glyphicon-pencil').click
+      end
+
+      # Wait for the edit form to load
+      expect(page).to have_css('#report_query_form', wait: 10)
+
+      # The "Edit table data?" button should have a visual indicator (btn-info class and check icon)
+      edit_table_btn = find('a[href="#edit_table_block"]')
+      expect(edit_table_btn[:class]).to include('btn-info'),
+        'Edit table data button should have btn-info class when edit table fields are configured'
+      expect(edit_table_btn).to have_css('.glyphicon-ok'),
+        'Edit table data button should show a check icon when edit table fields are configured'
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #1000 — Report admin page results preview shows incorrect column names when "Edit table data?" is configured.

### Root causes & fixes

**1. Admin preview auth issue**
The admin report preview form submitted AJAX requests to the user-facing `ReportsController`, which requires user authentication. When an admin is only signed in as admin (no user session), the request fails. Added a `preview` action to `Admin::ReportsController` and routed the form to it instead.

**2. Cache key missing editable state (core bug)**
The table header cache key (`report_table_header_cache_key`) did not include the `editable?` state. When a report has `edit_model` configured, a user-facing view caches the header WITH an extra `<th>` for the edit button column. The admin preview (`@embedded_report=true`) suppresses the edit column, but reuses the same cached header — causing all column headers to shift by one position. Fixed by including `editable?` in the cache key.

**3. Visual indicator on Edit table data button**
The "Edit table data?" collapse toggle now shows `btn-info` styling and a check icon when any of its fields (`edit_model`, `edit_field_names`, `selection_fields`) are populated, giving admins immediate visibility into whether edit-table configuration exists.

### Files changed
- `app/controllers/admin/reports_controller.rb` — Added `preview` action, `helper_method`, `local_prefixes`
- `app/views/admin/reports/form/_admin_criteria_view.html.erb` — Changed form target to admin preview route
- `config/routes.rb` — Added `get :preview` member route on admin reports
- `app/helpers/report_results/reports_table_helper.rb` — Cache key includes `editable?` state
- `app/views/admin/reports/form/_edit_table_block.html.erb` — Visual indicator on button

### Tests
- `spec/helpers/report_results/reports_table_helper_spec.rb` — Unit test confirming cache key differentiates editable vs non-editable contexts
- `spec/system/admin/admin_report_preview_columns_spec.rb` — 3 system specs: basic column alignment, alignment with edit_model, visual indicator on button