### PR TITLE
Added standalone dynamic model support to create_reference save trigger - fixes #1003

### DIFF
--- a/app/models/admin/defs/save_triggers_create_reference_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_create_reference_options_defs.yaml
@@ -9,6 +9,7 @@
                 - referring_record (creates a reference from the record that referred to this item)
                 - master (creates the new record under the master, without creating a model reference)
                 - master_with_reference (creates the new record and a reference from the master record)
+                - none (creates the record without any model reference — useful for standalone models)
                 - specific_record: (creates a reference from a specified item, looked up by criteria)
                     resource_name:
                       criteria_field: criteria_value
@@ -19,6 +20,10 @@
               #     activity_log__player_contact_phones:
               #       id: '{{some_field_id}}'
               #       return: return_result
+              #
+              # Standalone dynamic models (no_master_association, i.e. no master_id column) are
+              # supported as targets. The record is created directly using the model class rather
+              # than through the master association. All 'in:' options work with standalone models.
 
             force_create: 'true to force the creation of a reference and referenced object, independent of user access controls'
             force_not_valid: 'true to allow valid_if checks to be ignored'

--- a/app/models/save_triggers/create_reference.rb
+++ b/app/models/save_triggers/create_reference.rb
@@ -44,7 +44,17 @@ class SaveTriggers::CreateReference < SaveTriggers::SaveTriggersBase
           handle_with_attributes create_with, vals
 
           @item.transaction do
-            new_type = in_master.assoc_named(model_name.to_s.pluralize)
+            # Resolve the target model class to check for standalone models
+            target_model = Resources::Models.find_by(resource_name: model_name.to_s.pluralize)&.dig(:model)
+            standalone = target_model&.no_master_association
+
+            # Standalone models have no master association — use the model class directly
+            new_type = if standalone
+                         target_model
+                       else
+                         in_master.assoc_named(model_name.to_s.pluralize)
+                       end
+
             if to_existing_record
               to_record_id = to_existing_record[:record_id]
               raise FphsException, 'record_id must be set in to_existing_record' unless to_record_id
@@ -52,6 +62,7 @@ class SaveTriggers::CreateReference < SaveTriggers::SaveTriggersBase
               to_existing_record_id = FieldDefaults.calculate_default @item, to_record_id
               new_item = new_type.find(to_existing_record_id)
             else
+              vals[:current_user] ||= @item.current_user if standalone
               vals[:ignore_configurable_valid_if] = force_not_valid
               new_item = new_type.new vals
               # new_item.ignore_configurable_valid_if = force_not_valid
@@ -78,9 +89,8 @@ class SaveTriggers::CreateReference < SaveTriggers::SaveTriggersBase
                 ModelReference.create_with @item, new_item, force_create:
               when 'referring_record'
                 ModelReference.create_with @item.referring_record, new_item, force_create:
-              when 'master'
-                # 'master' indicates that we want to create an instance belonging to the master without
-                # creating a ModelReference. Do nothing here.
+              when 'master', 'none'
+                # 'master' or 'none' creates the record without a ModelReference.
               when 'master_with_reference'
                 ModelReference.create_from_master_with in_master, new_item, force_create:
               else

--- a/docs/admin_reference/general/save_trigger_create_reference.md
+++ b/docs/admin_reference/general/save_trigger_create_reference.md
@@ -4,6 +4,26 @@
 
 Create a model reference (and optionally a related record) when this trigger fires.
 
+### Standalone Dynamic Models
+
+Standalone dynamic models (those defined with no `foreign_key_name`, i.e. `no_master_association`)
+are supported as targets. These models have no `master_id` column and are not associated with
+a specific master record. When `create_reference` targets a standalone model, the record is
+created directly using the model class rather than through the master association.
+
+All `in:` options are supported with standalone models. Since the target record has no
+master association, the record is always created directly. The `in:` option only determines
+whether and how a model reference is created:
+
+- `this` — creates a model reference from the current item to the new record
+- `referring_record` — creates a model reference from the referring record
+- `master_with_reference` — creates a model reference from the master record
+- `none` — creates the record only, no model reference (equivalent to `master` for standalone models)
+- `specific_record` — creates a model reference from a looked-up record
+
+The `none` option is particularly useful for standalone models where there is no master
+association involved and no model reference is needed.
+
 ```yaml
 !defs(save_triggers_create_reference_options_defs.yaml)
 ```

--- a/spec/models/save_triggers/create_reference_spec.rb
+++ b/spec/models/save_triggers/create_reference_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 # - Verifies force_create, to_existing_record, master references, specific record references
 # - Verifies embedded_item creation within create_reference
 # - Verifies storing objects to JSONB fields via the object: wrapper (issue #943)
+# - Verifies create_reference for standalone dynamic models with no master_id (issue #1003)
 
 AlNameGenTestCr = 'Gen Test ELT Save'
 
@@ -576,6 +577,275 @@ RSpec.describe SaveTriggers::CreateReference, type: :model do
       expect(stored_json['attr1']).to eq 1
       expect(stored_json['attr2']).to eq 'test value'
       expect(stored_json['nested']).to eq({ 'key' => 'val' })
+    end
+  end
+
+  describe 'creating a standalone dynamic model record with no master_id (issue #1003)' do
+    before :all do
+      change_setting('AllowDynamicMigrations', true)
+
+      create_admin
+      create_user
+
+      @schema_name = 'dynamic_test'
+      @standalone_table_name = 'test_standalone_recs'
+
+      # Clean up any existing test tables and model
+      DynamicModel.active.where(table_name: @standalone_table_name).each { |dm| dm.disable!(@admin) }
+      DynamicModel.send(:remove_const, :TestStandaloneRec) if defined?(DynamicModel::TestStandaloneRec)
+
+      conn = ActiveRecord::Base.connection
+      conn.execute("DROP TABLE IF EXISTS #{@schema_name}.test_standalone_rec_history CASCADE")
+      conn.execute("DROP TABLE IF EXISTS #{@schema_name}.#{@standalone_table_name} CASCADE")
+
+      @standalone_dm = DynamicModel.create!(
+        current_admin: @admin,
+        name: 'Test Standalone Recs',
+        table_name: @standalone_table_name,
+        schema_name: @schema_name,
+        primary_key_name: :id,
+        foreign_key_name: '',
+        category: :test,
+        field_list: 'status notes',
+        options: <<~YAML
+          _db_columns:
+            status:
+              type: string
+            notes:
+              type: string
+        YAML
+      )
+
+      @standalone_dm.update_tracker_events
+      change_setting('AllowDynamicMigrations', nil)
+    end
+
+    after :all do
+      DynamicModel.active.where(table_name: @standalone_table_name).each { |dm| dm.disable!(@admin) }
+    end
+
+    before :example do
+      SetupHelper.setup_al_player_contact_phones
+      SetupHelper.setup_al_gen_tests AlNameGenTestCr, 'elt_save_test', 'player_contact'
+      create_user
+      @master = create_master
+      @player_contact = @master.player_contacts.create! data: '(617)123-1234 b', rec_type: :phone, rank: 10
+      @al = create_item master: @master
+      setup_access :dynamic_model__test_standalone_recs, user: @user
+      add_reference_def_to(@al, [
+                             {
+                               player_contacts: { from: 'this', add: 'many' },
+                               dynamic_model__test_standalone_recs: { from: 'this', add: 'many' }
+                             }
+                           ])
+      setup_access @al.resource_name, resource_type: :activity_log_type, access: :create, user: @user
+    end
+
+    it 'creates a standalone record with in: this and a model reference' do
+      config = {
+        dynamic_model__test_standalone_rec: {
+          in: 'this',
+          force_create: true,
+          with: { status: 'active', notes: 'standalone this test' }
+        }
+      }
+
+      @trigger = SaveTriggers::CreateReference.new(config, @al)
+      @trigger.perform
+
+      created_item = @al.save_trigger_results['created_items'].last
+      expect(created_item).to be_a DynamicModel::TestStandaloneRec
+      expect(created_item.status).to eq 'active'
+      expect(created_item.notes).to eq 'standalone this test'
+      expect(created_item.class.no_master_association).to be true
+
+      mr = @al.model_references(force_reload: true).last
+      expect(mr.to_record).to eq created_item
+      expect(@al.save_trigger_results['created_results'].last).to eq true
+    end
+
+    it 'creates a standalone record with in: master (no model reference)' do
+      config = {
+        dynamic_model__test_standalone_rec: {
+          in: 'master',
+          force_create: true,
+          with: { status: 'pending', notes: 'standalone master test' }
+        }
+      }
+
+      @trigger = SaveTriggers::CreateReference.new(config, @al)
+      @trigger.perform
+
+      created_item = @al.save_trigger_results['created_items'].last
+      expect(created_item).to be_a DynamicModel::TestStandaloneRec
+      expect(created_item.status).to eq 'pending'
+      expect(created_item.notes).to eq 'standalone master test'
+      expect(@al.save_trigger_results['created_references'].last).to be_nil
+      expect(@al.save_trigger_results['created_results'].last).to eq true
+    end
+
+    it 'creates a standalone record with in: master_with_reference' do
+      config = {
+        dynamic_model__test_standalone_rec: {
+          in: 'master_with_reference',
+          force_create: true,
+          with: { status: 'review', notes: 'standalone master_with_reference test' }
+        }
+      }
+
+      @trigger = SaveTriggers::CreateReference.new(config, @al)
+      @trigger.perform
+
+      created_item = @al.save_trigger_results['created_items'].last
+      expect(created_item).to be_a DynamicModel::TestStandaloneRec
+      expect(created_item.status).to eq 'review'
+
+      mr = ModelReference.order(:id).last&.reload
+      expect(mr.to_record_id).to eq created_item.id
+      expect(@al.save_trigger_results['created_results'].last).to eq true
+    end
+
+    it 'creates a standalone record with in: specific_record' do
+      al_alt = create_item master: @master
+
+      config = {
+        dynamic_model__test_standalone_rec: {
+          in: {
+            specific_record: {
+              activity_log__player_contact_phones: {
+                id: al_alt.id,
+                return: 'return_result'
+              }
+            }
+          },
+          force_create: true,
+          with: { status: 'specific', notes: 'standalone specific_record test' }
+        }
+      }
+
+      @trigger = SaveTriggers::CreateReference.new(config, @al)
+      @trigger.perform
+
+      created_item = @al.save_trigger_results['created_items'].last
+      expect(created_item).to be_a DynamicModel::TestStandaloneRec
+      expect(created_item.status).to eq 'specific'
+
+      mr = ModelReference.order(:id).last&.reload
+      expect(mr.to_record_id).to eq created_item.id
+      expect(mr.from_record_id).to eq al_alt.id
+      expect(@al.save_trigger_results['created_results'].last).to eq true
+    end
+
+    it 'creates a standalone record with force_create when user lacks access' do
+      uac = @user.has_access_to? :access, :table, :dynamic_model__test_standalone_recs
+      if uac
+        uac = Admin::UserAccessControl.find(uac.id)
+        uac.update! current_admin: @admin, user: @user, access: nil,
+                    resource_type: :table, resource_name: :dynamic_model__test_standalone_recs
+      end
+      @user.has_access_to? :access, :table, :dynamic_model__test_standalone_recs, force_reset: true
+
+      config = {
+        dynamic_model__test_standalone_rec: {
+          in: 'this',
+          force_create: true,
+          with: { status: 'forced', notes: 'standalone force_create test' }
+        }
+      }
+
+      @trigger = SaveTriggers::CreateReference.new(config, @al)
+      @trigger.perform
+
+      created_item = @al.save_trigger_results['created_items'].last
+      expect(created_item).to be_a DynamicModel::TestStandaloneRec
+      expect(created_item.status).to eq 'forced'
+      expect(@al.save_trigger_results['created_results'].last).to eq true
+    end
+
+    it 'finds an existing standalone record with to_existing_record' do
+      # First create a standalone record directly
+      standalone_class = DynamicModel::TestStandaloneRec
+      existing = standalone_class.create!(status: 'existing', notes: 'pre-existing record',
+                                          current_user: @user)
+
+      config = {
+        dynamic_model__test_standalone_rec: {
+          in: 'this',
+          force_create: true,
+          to_existing_record: {
+            record_id: existing.id
+          }
+        }
+      }
+
+      @trigger = SaveTriggers::CreateReference.new(config, @al)
+      @trigger.perform
+
+      ref_item = @al.save_trigger_results['created_items'].last
+      expect(ref_item).to eq existing
+      expect(ref_item.id).to eq existing.id
+      expect(ref_item.status).to eq 'existing'
+
+      mr = @al.model_references(force_reload: true).last
+      expect(mr.to_record).to eq existing
+      expect(@al.save_trigger_results['created_results'].last).to eq true
+    end
+
+    it 'applies with: attributes correctly to standalone record' do
+      config = {
+        dynamic_model__test_standalone_rec: {
+          in: 'this',
+          force_create: true,
+          with: { status: 'with-attrs', notes: 'testing with attributes' }
+        }
+      }
+
+      @trigger = SaveTriggers::CreateReference.new(config, @al)
+      @trigger.perform
+
+      created_item = @al.save_trigger_results['created_items'].last
+      expect(created_item).to be_a DynamicModel::TestStandaloneRec
+      expect(created_item.status).to eq 'with-attrs'
+      expect(created_item.notes).to eq 'testing with attributes'
+      expect(@al.save_trigger_results['created_results'].last).to eq true
+    end
+
+    it 'populates save_trigger_results correctly for standalone records' do
+      config = {
+        dynamic_model__test_standalone_rec: {
+          in: 'this',
+          force_create: true,
+          with: { status: 'results-test', notes: 'trigger results' }
+        }
+      }
+
+      @trigger = SaveTriggers::CreateReference.new(config, @al)
+      @trigger.perform
+
+      expect(@al.save_trigger_results['created_items']).not_to be_empty
+      expect(@al.save_trigger_results['created_items'].last).to be_a DynamicModel::TestStandaloneRec
+      expect(@al.save_trigger_results['created_results']).to include(true)
+      expect(@al.save_trigger_results['created_references']).not_to be_empty
+    end
+
+    it 'creates a standalone record with in: none (no model reference)' do
+      config = {
+        dynamic_model__test_standalone_rec: {
+          in: 'none',
+          force_create: true,
+          with: { status: 'no-ref', notes: 'standalone none test' }
+        }
+      }
+
+      @trigger = SaveTriggers::CreateReference.new(config, @al)
+      @trigger.perform
+
+      created_item = @al.save_trigger_results['created_items'].last
+      expect(created_item).to be_a DynamicModel::TestStandaloneRec
+      expect(created_item.status).to eq 'no-ref'
+      expect(created_item.notes).to eq 'standalone none test'
+      expect(@al.save_trigger_results['created_references'].last).to be_nil
+      expect(@al.save_trigger_results['created_results'].last).to eq true
     end
   end
 end


### PR DESCRIPTION
## Summary

Support standalone dynamic models (those with `no_master_association`, i.e. no `master_id` column) as targets in the `create_reference` save trigger. Previously, `create_reference` always resolved the target model through `Master#assoc_named`, which raised `FphsException: non-existent model association` for standalone models.

Fixes #1003

### Changes

- **`app/models/save_triggers/create_reference.rb`**: Resolve target model class via `Resources::Models.find_by` and check `no_master_association`. For standalone models, use the model class directly instead of `Master#assoc_named`. Set `current_user` on standalone records. Added `in: 'none'` option (creates record without any `ModelReference`).
- **`spec/models/save_triggers/create_reference_spec.rb`**: Added 9 new tests covering standalone model creation with all `in:` options (`this`, `master`, `master_with_reference`, `specific_record`, `none`), `force_create`, `to_existing_record`, `with:` attributes, and `save_trigger_results` population. All 19 tests pass (10 existing + 9 new).
- **`docs/admin_reference/general/save_trigger_create_reference.md`**: Added Standalone Dynamic Models section documenting behavior of each `in:` option with standalone targets.
- **`app/models/admin/defs/save_triggers_create_reference_options_defs.yaml`**: Added `none` option and standalone model support note.

### Testing

- 19 RSpec examples, 0 failures
- All existing tests continue to pass (no regression)
- Rubocop: no new offenses
