### PR TITLE
Fixed multi-file caching for Handlebars templates - fixes #1004

### DIFF
--- a/app/helpers/handlebars_precompiler_helper.rb
+++ b/app/helpers/handlebars_precompiler_helper.rb
@@ -170,39 +170,75 @@ module HandlebarsPrecompilerHelper
     relative_path
   end
 
+  # Compute an access-control version string for multi-file caching.
+  # Combines user role timestamps, access control timestamps, and handlebars_cache_key
+  # into a stable identifier that changes only when access controls or template
+  # definitions change — NOT on every login.
+  # @return [String] 13-character hex string (truncated SHA256)
+  def access_control_version
+    @access_control_version ||= begin
+      u = current_user || current_admin
+      app_type_id = u&.app_type_id if u.respond_to?(:app_type_id)
+
+      userrole = Admin::UserRole.where(app_type_id: app_type_id)
+                                .reorder(updated_at: :desc)
+                                .limit(1)
+                                .pluck(:updated_at)
+                                &.first.to_i.to_s
+
+      uac = Admin::UserAccessControl.where(app_type_id: app_type_id)
+                                    .reorder(updated_at: :desc)
+                                    .limit(1)
+                                    .pluck(:updated_at)
+                                    &.first.to_i.to_s
+
+      Digest::SHA256.hexdigest("#{userrole}-#{uac}-#{handlebars_cache_key}")[0..12]
+    end
+  end
+
+  # Write a concatenated multi-file combining all requested compiled templates.
+  # Uses a stable filename based on user_id, app_type_id, content digest, and
+  # access_control_version — stable across login sessions for effective browser caching.
+  # Skips all I/O if the output file already exists.
+  # @param requested_handlebars_templates [Array<Hash>] template info hashes with :id, :is_partial keys
+  # @return [Array(String, Array, Array)] URL path, template IDs, partial IDs
   def write_multiple_handlebars_templates(requested_handlebars_templates)
-    template_html = []
     handlebars_partial_ids = []
     handlebars_template_ids = []
     requested_handlebars_templates.each do |template_info|
-      id = template_info[:id]
-      is_partial = template_info[:is_partial]
-      compiled_file_path = template_info[:compiled_file_path]
-      template_html << read_handlebars_template(id, is_partial:)
-      if is_partial
-        handlebars_partial_ids << id
+      if template_info[:is_partial]
+        handlebars_partial_ids << template_info[:id]
       else
-        handlebars_template_ids << id
+        handlebars_template_ids << template_info[:id]
       end
     end
 
     u = current_user || current_admin
     app_type_id = u&.app_type_id if u.respond_to? :app_type_id
     req_digest = Digest::SHA256.hexdigest([handlebars_template_ids, handlebars_partial_ids].join(','))
-    filename = "requested-templates-#{u&.id}-#{u&.current_sign_in_at.to_i}-#{app_type_id}-#{req_digest}.js"
-    dir = HandlebarsPrecompiler::MULTI_PUBLIC_DIR.join(filename)
-
-    # Add initialization header to ensure Handlebars.partials exists before partials register themselves
-    # The CLI-compiled partials assume Handlebars.partials already exists
-    init_header = <<~JS
-      (function() {
-        Handlebars.partials = Handlebars.partials || {};
-        Handlebars.templates = Handlebars.templates || {};
-      })();
-    JS
-    File.write(dir, (init_header + template_html.join("\n")).html_safe)
-
+    filename = "requested-templates-#{u&.id}-#{app_type_id}-#{req_digest}-#{access_control_version}.js"
     url_path = HandlebarsPrecompiler::URL_RELATIVE_PATH
+    multi_file = HandlebarsPrecompiler::MULTI_PUBLIC_DIR.join(filename)
+
+    if File.exist?(multi_file)
+      Rails.logger.info { "Serving existing multi file: #{filename}" }
+    else
+      template_html = requested_handlebars_templates.map do |template_info|
+        read_handlebars_template(template_info[:id], is_partial: template_info[:is_partial])
+      end
+
+      # Add initialization header to ensure Handlebars.partials exists before partials register themselves
+      # The CLI-compiled partials assume Handlebars.partials already exists
+      init_header = <<~JS
+        (function() {
+          Handlebars.partials = Handlebars.partials || {};
+          Handlebars.templates = Handlebars.templates || {};
+        })();
+      JS
+      File.write(multi_file, (init_header + template_html.join("\n")).html_safe)
+      Rails.logger.info { "Generated multi file: #{filename}" }
+    end
+
     ["#{url_path}multi/#{filename}", handlebars_template_ids, handlebars_partial_ids]
   end
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# PagesController Spec
+#
+# Tests for the PagesController actions:
+# - Admin page: renders the admin index page
+# - User page: redirects to search page
+# - Template action (issue #1004 - AC10):
+#   - Returns 304 Not Modified when ETag matches (If-None-Match header)
+#   - Returns 200 with content on cache miss
+#   - Sets appropriate Cache-Control headers for browser caching
+
 require 'rails_helper'
 
 RSpec.describe PagesController, type: :controller do
@@ -21,6 +31,65 @@ RSpec.describe PagesController, type: :controller do
     it 'redirects to search page' do
       get :index, params: {}
       expect(response).to redirect_to '/masters/search'
+    end
+  end
+
+  # AC10: ETag / 304 behavior for the template action (issue #1004)
+  #
+  # The template action should:
+  # - Return 200 with rendered content on first request (cache miss)
+  # - Set Cache-Control max-age and Expires headers for long-lived browser caching
+  # - Return 304 Not Modified when the client sends a matching If-None-Match ETag
+  # - Return 200 with fresh content when the ETag does not match
+  describe '#template (ETag/304 caching - issue #1004)' do
+    include MasterSupport
+    before_each_login_user
+
+    let(:template_version) { Digest::SHA256.hexdigest('test-version') }
+
+    it 'returns 200 on cache miss' do
+      get :template, params: { id: template_version }
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'sets Cache-Control header with max-age for browser caching' do
+      get :template, params: { id: template_version }
+
+      expect(response.headers['Cache-Control']).to include('max-age=')
+    end
+
+    it 'sets Expires header for far-future caching' do
+      get :template, params: { id: template_version }
+
+      expect(response.headers['Expires']).to be_present
+    end
+
+    it 'includes an ETag in the response' do
+      get :template, params: { id: template_version }
+
+      expect(response.headers['ETag']).to be_present
+    end
+
+    it 'returns 304 Not Modified when If-None-Match matches the ETag' do
+      # First request to get the ETag
+      get :template, params: { id: template_version }
+      etag = response.headers['ETag']
+
+      expect(etag).to be_present
+
+      # Second request with matching ETag
+      request.env['HTTP_IF_NONE_MATCH'] = etag
+      get :template, params: { id: template_version }
+
+      expect(response).to have_http_status(:not_modified)
+    end
+
+    it 'returns 200 when If-None-Match does not match (stale ETag)' do
+      request.env['HTTP_IF_NONE_MATCH'] = '"stale-etag-value"'
+      get :template, params: { id: template_version }
+
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/helpers/handlebars_precompiler_helper_spec.rb
+++ b/spec/helpers/handlebars_precompiler_helper_spec.rb
@@ -468,4 +468,190 @@ RSpec.describe HandlebarsPrecompilerHelper, type: :helper do
       expect(url).to include('/multi/')
     end
   end
+
+  # Multi-file caching specs for issue #1004
+  #
+  # Tests that write_multiple_handlebars_templates:
+  # - AC1: Skips I/O when the multi file already exists on disk
+  # - AC2: Does NOT include current_sign_in_at in the filename (stable across logins)
+  # - AC3: Includes user_id in the filename (templates are user-specific)
+  # - AC5: Filename changes when user roles/access controls change
+  # - AC6: Filename changes when handlebars_cache_key changes (template content change)
+  # - AC2: Filename includes an access_control_version derived from userrole, uac, and handlebars_cache_key
+  describe '#write_multiple_handlebars_templates multi-file caching (issue #1004)' do
+    let(:cache_key) { 'cachekey123456' }
+    let(:sign_in_time) { Time.at(1_000_000) }
+    let(:user) { Struct.new(:id, :current_sign_in_at, :app_type_id).new(42, sign_in_time, 7) }
+    let(:templates) { [{ id: 'tpl_alpha', is_partial: false, compiled_file_path: 'irrelevant' }] }
+
+    before do
+      allow(helper).to receive(:handlebars_cache_key).and_return(cache_key)
+      allow(helper).to receive(:current_user).and_return(user)
+      allow(helper).to receive(:current_admin).and_return(nil)
+
+      HandlebarsPrecompiler.setup_directories
+      FileUtils.rm_rf(Dir.glob(HandlebarsPrecompiler::MULTI_PUBLIC_DIR.join('*.js')))
+
+      # Create compiled template files so read_handlebars_template succeeds
+      FileUtils.mkdir_p(HandlebarsPrecompiler::TEMPLATES_PUBLIC_DIR)
+      compiled_file = HandlebarsPrecompiler::TEMPLATES_PUBLIC_DIR.join("tpl_alpha-#{cache_key}.js")
+      File.write(compiled_file, '(function() { var t = Handlebars.template; })();')
+    end
+
+    # AC1: Skip all I/O if the multi file already exists
+    context 'when the multi file already exists on disk' do
+      it 'returns the correct URL path without re-reading individual compiled templates' do
+        # First call creates the file
+        url_first, = helper.write_multiple_handlebars_templates(templates)
+
+        # Spy on File.read to ensure it is not called again for individual templates
+        expect(File).not_to receive(:read).with(a_string_including('tpl_alpha'))
+
+        url_second, = helper.write_multiple_handlebars_templates(templates)
+
+        expect(url_second).to eq(url_first)
+      end
+
+      it 'does not call File.write on the second invocation' do
+        # First call writes the file
+        helper.write_multiple_handlebars_templates(templates)
+
+        # Second call should skip writing entirely
+        expect(File).not_to receive(:write)
+
+        helper.write_multiple_handlebars_templates(templates)
+      end
+    end
+
+    # AC1: Calling twice with same inputs only writes the file once
+    context 'write count' do
+      it 'calls File.write exactly once for two identical invocations' do
+        write_count = 0
+        allow(File).to receive(:write).and_wrap_original do |original, *args|
+          # Only count writes to the MULTI_PUBLIC_DIR
+          write_count += 1 if args.first.to_s.include?('multi/')
+          original.call(*args)
+        end
+
+        helper.write_multiple_handlebars_templates(templates)
+        helper.write_multiple_handlebars_templates(templates)
+
+        expect(write_count).to eq(1)
+      end
+    end
+
+    # AC2: Filename does NOT contain current_sign_in_at
+    context 'filename composition' do
+      it 'does not include current_sign_in_at in the filename' do
+        url, = helper.write_multiple_handlebars_templates(templates)
+        filename = File.basename(url)
+
+        # current_sign_in_at.to_i for Time.at(1_000_000) is "1000000"
+        expect(filename).not_to include(sign_in_time.to_i.to_s)
+      end
+
+      # AC2: Filename does NOT change across different current_sign_in_at values
+      it 'produces the same filename regardless of current_sign_in_at changes' do
+        url_before, = helper.write_multiple_handlebars_templates(templates)
+
+        # Simulate a new login with different sign_in_at
+        new_user = Struct.new(:id, :current_sign_in_at, :app_type_id).new(42, Time.at(9_999_999), 7)
+        allow(helper).to receive(:current_user).and_return(new_user)
+
+        # Clean multi dir to force fresh write
+        FileUtils.rm_rf(Dir.glob(HandlebarsPrecompiler::MULTI_PUBLIC_DIR.join('*.js')))
+
+        url_after, = helper.write_multiple_handlebars_templates(templates)
+
+        expect(File.basename(url_after)).to eq(File.basename(url_before))
+      end
+
+      # AC3: Filename contains user_id
+      it 'includes the user_id in the filename' do
+        url, = helper.write_multiple_handlebars_templates(templates)
+        filename = File.basename(url)
+
+        expect(filename).to include("-#{user.id}-")
+      end
+
+      # AC2: Filename includes access_control_version hash derived from userrole, uac, handlebars_cache_key
+      it 'includes an access_control_version segment in the filename' do
+        url, = helper.write_multiple_handlebars_templates(templates)
+        filename = File.basename(url)
+
+        # The filename should follow the pattern:
+        # requested-templates-{user_id}-{app_type_id}-{req_digest}-{access_control_version}.js
+        # access_control_version is a 13-char hex substring
+        parts = filename.delete_suffix('.js').split('-')
+
+        # Last segment should be a hex hash (access_control_version)
+        last_segment = parts.last
+        expect(last_segment).to match(/\A[a-f0-9]{13}\z/),
+                                     "Expected last filename segment '#{last_segment}' to be a 13-char hex access_control_version"
+      end
+    end
+
+    # AC5: Filename changes when user roles/access controls change
+    context 'when user roles or access controls change' do
+      before do
+        # Stub partial_cache_key related queries for access control version
+        allow(Admin::UserRole).to receive_message_chain(:where, :reorder, :limit, :pluck).and_return([Time.at(2_000_000)])
+        allow(Admin::UserAccessControl).to receive_message_chain(:where, :reorder, :limit, :pluck).and_return([Time.at(3_000_000)])
+      end
+
+      it 'produces a different filename when userrole timestamps change' do
+        url_before, = helper.write_multiple_handlebars_templates(templates)
+
+        # Clean multi dir and change userrole timestamp
+        FileUtils.rm_rf(Dir.glob(HandlebarsPrecompiler::MULTI_PUBLIC_DIR.join('*.js')))
+        allow(Admin::UserRole).to receive_message_chain(:where, :reorder, :limit, :pluck).and_return([Time.at(5_000_000)])
+
+        # Clear any memoization
+        helper.instance_variable_set(:@access_control_version, nil)
+
+        url_after, = helper.write_multiple_handlebars_templates(templates)
+
+        expect(File.basename(url_after)).not_to eq(File.basename(url_before))
+      end
+
+      it 'produces a different filename when user access control timestamps change' do
+        url_before, = helper.write_multiple_handlebars_templates(templates)
+
+        # Clean multi dir and change uac timestamp
+        FileUtils.rm_rf(Dir.glob(HandlebarsPrecompiler::MULTI_PUBLIC_DIR.join('*.js')))
+        allow(Admin::UserAccessControl).to receive_message_chain(:where, :reorder, :limit, :pluck).and_return([Time.at(8_000_000)])
+
+        # Clear any memoization
+        helper.instance_variable_set(:@access_control_version, nil)
+
+        url_after, = helper.write_multiple_handlebars_templates(templates)
+
+        expect(File.basename(url_after)).not_to eq(File.basename(url_before))
+      end
+    end
+
+    # AC6: Filename changes when handlebars_cache_key changes (template content change)
+    context 'when template content changes (handlebars_cache_key changes)' do
+      it 'produces a different filename when handlebars_cache_key changes' do
+        url_before, = helper.write_multiple_handlebars_templates(templates)
+
+        # Simulate template content change: new cache key and new compiled file
+        new_cache_key = 'newcachekey1234'
+        allow(helper).to receive(:handlebars_cache_key).and_return(new_cache_key)
+
+        new_compiled = HandlebarsPrecompiler::TEMPLATES_PUBLIC_DIR.join("tpl_alpha-#{new_cache_key}.js")
+        File.write(new_compiled, '(function() { var t = Handlebars.template; })();')
+
+        # Clean multi dir to force fresh write
+        FileUtils.rm_rf(Dir.glob(HandlebarsPrecompiler::MULTI_PUBLIC_DIR.join('*.js')))
+
+        # Clear any memoization
+        helper.instance_variable_set(:@access_control_version, nil)
+
+        url_after, = helper.write_multiple_handlebars_templates(templates)
+
+        expect(File.basename(url_after)).not_to eq(File.basename(url_before))
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes the `requested-templates-*.js` multi-file caching so browser caching works across login sessions. Previously, every login caused a full cache bust because `current_sign_in_at` was embedded in the filename.

### Changes

**`app/helpers/handlebars_precompiler_helper.rb`**
- Added `access_control_version` method — computes a 13-char hex hash from `Admin::UserRole` timestamps, `Admin::UserAccessControl` timestamps, and `handlebars_cache_key`. Changes only when access controls or template definitions change, not on every login.
- Modified `write_multiple_handlebars_templates`:
  - Replaced `current_sign_in_at` in filename with `access_control_version` (AC2)
  - New filename: `requested-templates-{user_id}-{app_type_id}-{req_digest}-{access_control_version}.js`
  - Added `File.exist?` check — skips all template reads and file writes when the multi file already exists (AC1)
  - Added logging for observability (cache hit vs regeneration)

**`spec/helpers/handlebars_precompiler_helper_spec.rb`** — 10 new tests:
- AC1: Existence check skips I/O on second invocation
- AC2: Filename excludes `current_sign_in_at`, stable across logins
- AC3: Filename includes `user_id`
- AC5: Filename changes when userrole/uac timestamps change
- AC6: Filename changes when `handlebars_cache_key` changes

**`spec/controllers/pages_controller_spec.rb`** — 6 new tests:
- AC10: ETag/304 behavior, Cache-Control headers, Expires headers

### Acceptance Criteria Covered
AC1, AC2, AC3, AC5, AC6, AC9, AC10
