### PR TITLE
Added optional expire_datetime field to users and admins - fixes #330

### DIFF
--- a/app/controllers/admin/manage_admins_controller.rb
+++ b/app/controllers/admin/manage_admins_controller.rb
@@ -127,6 +127,6 @@ class Admin::ManageAdminsController < AdminController
   private
 
   def permitted_params
-    %i[email first_name last_name disabled] + [{ capabilities: [] }]
+    %i[email first_name last_name disabled expire_datetime] + [{ capabilities: [] }]
   end
 end

--- a/app/controllers/admin/manage_users_controller.rb
+++ b/app/controllers/admin/manage_users_controller.rb
@@ -120,6 +120,6 @@ class Admin::ManageUsersController < AdminController
   private
 
   def permitted_params
-    %i[email disabled first_name last_name do_not_email]
+    %i[email disabled first_name last_name do_not_email expire_datetime]
   end
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -32,14 +32,20 @@ class Admin < ActiveRecord::Base
     Settings::AdminTimeout
   end
 
-  # Standard Devise callback to allow accounts to be disabled
+  # Standard Devise callback to allow accounts to be disabled or expired
   def active_for_authentication?
-    super && !disabled
+    super && !disabled && !account_expired?
   end
 
-  # Standard Devise callback to tell user that an account has been disabled
+  # Standard Devise callback to tell user that an account has been disabled or expired
   def inactive_message
-    !disabled ? super : :account_has_been_disabled
+    if disabled
+      :account_has_been_disabled
+    elsif account_expired?
+      :account_expired
+    else
+      super
+    end
   end
 
   # Get the user that corresponds to this admin

--- a/app/models/concerns/standard_authentication.rb
+++ b/app/models/concerns/standard_authentication.rb
@@ -40,6 +40,11 @@ module StandardAuthentication
     scope :can_email, -> { where 'do_not_email IS NULL or do_not_email = FALSE' }
   end
 
+  # Check if the account has expired based on the expire_datetime field
+  def account_expired?
+    expire_datetime.present? && expire_datetime <= Time.current
+  end
+
   class_methods do
     def sign_in_after_change_password
       true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -163,14 +163,20 @@ class User < ActiveRecord::Base
                   end
   end
 
-  # Standard Devise callback to allow accounts to be disabled
+  # Standard Devise callback to allow accounts to be disabled or expired
   def active_for_authentication?
-    super && !disabled
+    super && !disabled && !account_expired?
   end
 
-  # Standard Devise callback to tell user that an account has been disabled
+  # Standard Devise callback to tell user that an account has been disabled or expired
   def inactive_message
-    disabled ? :account_has_been_disabled : super
+    if disabled
+      :account_has_been_disabled
+    elsif account_expired?
+      :account_expired
+    else
+      super
+    end
   end
 
   # By default, the user is redirected to the login page after registration.

--- a/app/views/admin/manage_admins/_form.html.erb
+++ b/app/views/admin/manage_admins/_form.html.erb
@@ -14,6 +14,10 @@
     <%= f.label :last_name %>
     <%=f.text_field :last_name, required: true%>
   </div>
+  <div class="form-group">
+    <%= f.label :expire_datetime, 'Account Expiration' %>
+    <%= f.datetime_field :expire_datetime %>
+  </div>
 
   <div class="form-group">
     <%= f.label :capabilities %>

--- a/app/views/admin/manage_admins/_index.html.erb
+++ b/app/views/admin/manage_admins/_index.html.erb
@@ -19,7 +19,8 @@
           <th>First Name</th>
           <th>Last Name</th>
           <th>Matching User?</th>
-          <th>Expires in (days)</th>
+          <th>Password expires in (days)</th>
+          <th>Account Expiration</th>
           <th>Locked</th>
           <th>Capabilities</th>
           <th>Admin</th>
@@ -36,6 +37,7 @@
             <td><%= list_item.last_name %></td>
             <td><%= list_item.matching_user ? 'yes' : 'no' %></td>
             <td><%= list_item.expires_in == 0 ? '<i class="password-expired">expired</i>'.html_safe : list_item.expires_in %></td>
+            <td><%= list_item.expire_datetime&.strftime('%Y-%m-%d %H:%M') %></td>
             <td><%= list_item.access_locked? ? 'locked' : ''%></td>
             <td>
               <ul class="admin-tag-list">

--- a/app/views/admin/manage_users/_form.html.erb
+++ b/app/views/admin/manage_users/_form.html.erb
@@ -15,6 +15,10 @@
     <%=f.text_field :last_name, required: true %>
   </div>
   <div class="form-group">
+    <%= f.label :expire_datetime, 'Account Expiration' %>
+    <%= f.datetime_field :expire_datetime %>
+  </div>
+  <div class="form-group">
     <%= f.check_box :disabled %>
     <%= f.label :disable %>
   </div>

--- a/app/views/admin/manage_users/_index.html.erb
+++ b/app/views/admin/manage_users/_index.html.erb
@@ -21,7 +21,8 @@
           <th>Last Name</th>
           <th>Apps</th>
           <th>Do Not Email</th>
-          <th>Expires in (days)</th>
+          <th>Password expires in (days)</th>
+          <th>Account Expiration</th>
           <th>Signed in at</th>
           <% if @users.first.respond_to? :confirmed_at %><th>Confirmed</th><% end %>
           <th>Locked</th>
@@ -44,6 +45,7 @@
             </td>
             <td><%= list_item.do_not_email ? 'do not email' : ''%></td>
             <td><%= list_item.expires_in == 0 ? '<i class="password-expired">expired</i>'.html_safe : list_item.expires_in %></td>
+            <td><%= list_item.expire_datetime&.strftime('%Y-%m-%d %H:%M') %></td>
             <td><%= list_item.current_sign_in_at %></td>
             <% if list_item.respond_to? :confirmed_at %><td><%= list_item.confirmed_at ? 'confirmed' : ''%></td><% end %>
             <td><%= list_item.access_locked? ? 'locked' : ''%></td>

--- a/config/initializers/warden_expire_hook.rb
+++ b/config/initializers/warden_expire_hook.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Warden hook to check expire_datetime on each request.
+# If the user/admin's expire_datetime has passed during their session,
+# they will be signed out on the next request.
+Warden::Manager.after_set_user do |record, warden, options|
+  scope = options[:scope]
+  if record.respond_to?(:account_expired?) && record.account_expired?
+    warden.logout(scope)
+    throw :warden, scope: scope, message: :account_expired
+  end
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -17,6 +17,7 @@ en:
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
       account_has_been_disabled: "This account has been disabled."
+      account_expired: "Your account has expired. Please contact your administrator."
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"

--- a/db/migrate/20260327120000_add_expire_datetime_to_users_and_admins.rb
+++ b/db/migrate/20260327120000_add_expire_datetime_to_users_and_admins.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddExpireDatetimeToUsersAndAdmins < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :expire_datetime, :datetime, null: true
+    add_column :admins, :expire_datetime, :datetime, null: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2144,7 +2144,8 @@ CREATE TABLE ml_app.users (
     confirmation_sent_at timestamp without time zone,
     country_code character varying,
     terms_of_use_accepted character varying,
-    otp_secret character varying
+    otp_secret character varying,
+    expire_datetime timestamp without time zone
 );
 
 
@@ -8600,7 +8601,8 @@ CREATE TABLE ml_app.admins (
     do_not_email boolean DEFAULT false,
     admin_id bigint,
     capabilities character varying[],
-    otp_secret character varying
+    otp_secret character varying,
+    expire_datetime timestamp without time zone
 );
 
 
@@ -23390,6 +23392,8 @@ ALTER TABLE ONLY ref_data.redcap_data_dictionary_history
 SET search_path TO ml_app,ref_data;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260327153857'),
+('20260327120000'),
 ('20260311180146'),
 ('20260311180013'),
 ('20260311174709'),

--- a/spec/models/expire_datetime_spec.rb
+++ b/spec/models/expire_datetime_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+# Expire Datetime Spec - Issue #330
+#
+# Tests for the optional expire_datetime field on User and Admin models.
+#
+# Test Coverage:
+# - User model:
+#   - expire_datetime field exists and can be set/read
+#   - authentication blocked when expire_datetime is in the past
+#   - authentication allowed when expire_datetime is nil (not set)
+#   - authentication allowed when expire_datetime is in the future
+#   - inactive_message returns :account_expired when expired
+#   - account_expired? helper method returns correct boolean
+#   - disabled takes precedence over expired for inactive_message
+#
+# - Admin model:
+#   - expire_datetime field exists and can be set/read
+#   - authentication blocked when expire_datetime is in the past
+#   - authentication allowed when expire_datetime is nil (not set)
+#   - authentication allowed when expire_datetime is in the future
+#   - inactive_message returns :account_expired when expired
+#   - account_expired? helper method returns correct boolean
+#   - disabled takes precedence over expired for inactive_message
+
+require 'rails_helper'
+
+describe 'expire_datetime for User and Admin - Issue #330' do
+  include ModelSupport
+  include SetupHelper
+
+  describe User do
+    before(:each) do
+      @user, @good_password = create_user
+    end
+
+    describe 'expire_datetime field' do
+      it 'responds to expire_datetime' do
+        expect(@user).to respond_to(:expire_datetime)
+      end
+
+      it 'can set and read expire_datetime' do
+        future_time = 1.week.from_now
+        @user.expire_datetime = future_time
+        @user.current_admin = @admin
+        @user.save!
+        @user.reload
+        expect(@user.expire_datetime).to be_within(1.second).of(future_time)
+      end
+
+      it 'defaults to nil when not set' do
+        expect(@user.expire_datetime).to be_nil
+      end
+    end
+
+    describe '#account_expired?' do
+      it 'returns true when expire_datetime is in the past' do
+        @user.expire_datetime = 1.hour.ago
+        expect(@user.account_expired?).to be true
+      end
+
+      it 'returns false when expire_datetime is nil' do
+        @user.expire_datetime = nil
+        expect(@user.account_expired?).to be false
+      end
+
+      it 'returns false when expire_datetime is in the future' do
+        @user.expire_datetime = 1.week.from_now
+        expect(@user.account_expired?).to be false
+      end
+    end
+
+    describe '#active_for_authentication?' do
+      it 'returns false when expire_datetime is in the past' do
+        @user.expire_datetime = 1.hour.ago
+        expect(@user.active_for_authentication?).to be false
+      end
+
+      it 'returns true when expire_datetime is nil' do
+        expect(@user.expire_datetime).to be_nil
+        expect(@user.active_for_authentication?).to be true
+      end
+
+      it 'returns true when expire_datetime is in the future' do
+        @user.expire_datetime = 1.week.from_now
+        expect(@user.active_for_authentication?).to be true
+      end
+
+      it 'returns false when user is disabled regardless of expire_datetime' do
+        create_admin
+        @user.disabled = true
+        @user.current_admin = @admin
+        @user.expire_datetime = 1.week.from_now
+        @user.save!
+        expect(@user.active_for_authentication?).to be false
+      end
+    end
+
+    describe '#inactive_message' do
+      it 'returns :account_expired when expire_datetime is in the past' do
+        @user.expire_datetime = 1.hour.ago
+        expect(@user.inactive_message).to eq(:account_expired)
+      end
+
+      it 'returns :account_has_been_disabled when disabled, even if also expired' do
+        create_admin
+        @user.disabled = true
+        @user.current_admin = @admin
+        @user.expire_datetime = 1.hour.ago
+        @user.save!
+        expect(@user.inactive_message).to eq(:account_has_been_disabled)
+      end
+    end
+  end
+
+  describe Admin do
+    before(:each) do
+      ENV['FPHS_ADMIN_SETUP'] = 'yes'
+      @admin, @good_password = create_admin 'test-admin-expire'
+    end
+
+    describe 'expire_datetime field' do
+      it 'responds to expire_datetime' do
+        expect(@admin).to respond_to(:expire_datetime)
+      end
+
+      it 'can set and read expire_datetime' do
+        future_time = 1.week.from_now
+        @admin.expire_datetime = future_time
+        @admin.save!
+        @admin.reload
+        expect(@admin.expire_datetime).to be_within(1.second).of(future_time)
+      end
+
+      it 'defaults to nil when not set' do
+        expect(@admin.expire_datetime).to be_nil
+      end
+    end
+
+    describe '#account_expired?' do
+      it 'returns true when expire_datetime is in the past' do
+        @admin.expire_datetime = 1.hour.ago
+        expect(@admin.account_expired?).to be true
+      end
+
+      it 'returns false when expire_datetime is nil' do
+        @admin.expire_datetime = nil
+        expect(@admin.account_expired?).to be false
+      end
+
+      it 'returns false when expire_datetime is in the future' do
+        @admin.expire_datetime = 1.week.from_now
+        expect(@admin.account_expired?).to be false
+      end
+    end
+
+    describe '#active_for_authentication?' do
+      it 'returns false when expire_datetime is in the past' do
+        @admin.expire_datetime = 1.hour.ago
+        expect(@admin.active_for_authentication?).to be false
+      end
+
+      it 'returns true when expire_datetime is nil' do
+        expect(@admin.expire_datetime).to be_nil
+        expect(@admin.active_for_authentication?).to be true
+      end
+
+      it 'returns true when expire_datetime is in the future' do
+        @admin.expire_datetime = 1.week.from_now
+        expect(@admin.active_for_authentication?).to be true
+      end
+
+      it 'returns false when admin is disabled regardless of expire_datetime' do
+        @admin.current_admin = @admin
+        @admin.expire_datetime = 1.week.from_now
+        @admin.disable!
+        expect(@admin.active_for_authentication?).to be false
+      end
+    end
+
+    describe '#inactive_message' do
+      it 'returns :account_expired when expire_datetime is in the past' do
+        @admin.expire_datetime = 1.hour.ago
+        expect(@admin.inactive_message).to eq(:account_expired)
+      end
+
+      it 'returns :account_has_been_disabled when disabled, even if also expired' do
+        @admin.current_admin = @admin
+        @admin.expire_datetime = 1.hour.ago
+        @admin.disable!
+        expect(@admin.inactive_message).to eq(:account_has_been_disabled)
+      end
+    end
+  end
+end

--- a/spec/system/user/user_account_expiration_spec.rb
+++ b/spec/system/user/user_account_expiration_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+# Tests for User account expiration via expire_datetime - Issue #330
+#
+# This spec verifies the Warden after_set_user hook that checks expire_datetime
+# on each request. When a user's expire_datetime has passed, they are logged out
+# and shown the "account has expired" message.
+#
+# Test Coverage:
+# - User can login normally when expire_datetime is nil (no expiration set)
+# - User can login normally when expire_datetime is in the future
+# - User cannot login when expire_datetime is in the past (sees expiration message)
+# - Active session is terminated when expire_datetime passes mid-session
+# - User can login again after expire_datetime is cleared (set back to nil)
+#
+# The Warden hook is defined in config/initializers/warden_expire_hook.rb.
+# The account_expired? method is defined in app/models/concerns/standard_authentication.rb.
+# The flash message is defined in config/locales/devise.en.yml.
+
+require 'rails_helper'
+
+describe 'user account expiration via expire_datetime', js: true, driver: $browser_driver do
+  include ModelSupport
+  include FeatureSupport
+
+  before(:all) do
+    change_setting('TwoFactorAuthDisabledForUser', true)
+    change_setting('AllowUsersToRegister', false)
+    Rails.application.reload_routes!
+    Rails.application.routes_reloader.reload!
+
+    SetupHelper.feature_setup
+
+    @user, @good_password = create_user
+    @good_email = @user.email
+
+    # Ensure clean state
+    User.where(id: @user.id).update_all(expire_datetime: nil)
+  end
+
+  after(:each) do
+    # Reset expire_datetime after each test to avoid leaking state
+    User.where(id: @user.id).update_all(expire_datetime: nil)
+  end
+
+  it 'allows login when expire_datetime is nil' do
+    User.where(id: @user.id).update_all(expire_datetime: nil)
+
+    login
+    finish_page_loading
+
+    expect(user_logged_in?).to be(true),
+                               'User should be logged in when expire_datetime is nil'
+  end
+
+  it 'allows login when expire_datetime is in the future' do
+    User.where(id: @user.id).update_all(expire_datetime: 1.week.from_now)
+
+    login
+    finish_page_loading
+
+    expect(user_logged_in?).to be(true),
+                               'User should be logged in when expire_datetime is in the future'
+  end
+
+  it 'prevents login when expire_datetime is in the past' do
+    User.where(id: @user.id).update_all(expire_datetime: 1.hour.ago)
+
+    visit '/users/sign_in'
+    fill_in 'user_email', with: @good_email
+    fill_in 'user_password', with: @good_password
+    click_button 'Log in'
+
+    expect(page).to have_css('#new_user', wait: 10),
+                    'Expected to remain on the login page when account is expired'
+    expect(page).to have_content('Your account has expired'),
+                    'Expected the account expired flash message'
+  end
+
+  it 'terminates an active session when expire_datetime passes' do
+    # Ensure no expiration so we can log in
+    User.where(id: @user.id).update_all(expire_datetime: nil)
+
+    login
+    finish_page_loading
+
+    expect(user_logged_in?).to be(true),
+                               'User should be logged in before expiration is set'
+
+    # Set expire_datetime to a few seconds from now
+    User.where(id: @user.id).update_all(expire_datetime: 3.seconds.from_now)
+
+    # Wait for the expiration to pass
+    sleep 5
+
+    # Navigate to a protected page — the Warden hook should detect expiration
+    visit '/masters/search'
+
+    expect(page).to have_css('#new_user', wait: 10),
+                    'Expected redirect to login page after expire_datetime passed'
+    expect(current_path).to eq('/users/sign_in')
+    expect(page).to have_content('Your account has expired'),
+                    'Expected the account expired flash message after mid-session expiration'
+  end
+
+  it 'allows login again after expire_datetime is cleared' do
+    # First, set the account as expired
+    User.where(id: @user.id).update_all(expire_datetime: 1.hour.ago)
+
+    visit '/users/sign_in'
+    fill_in 'user_email', with: @good_email
+    fill_in 'user_password', with: @good_password
+    click_button 'Log in'
+
+    expect(page).to have_css('#new_user', wait: 10),
+                    'Expected login to be blocked while account is expired'
+
+    # Clear the expiration
+    User.where(id: @user.id).update_all(expire_datetime: nil)
+
+    # Now login should succeed
+    login
+    finish_page_loading
+
+    expect(user_logged_in?).to be(true),
+                               'User should be able to login after expire_datetime is cleared'
+  end
+end


### PR DESCRIPTION
## Summary

Adds an optional `expire_datetime` field to both User and Admin models, allowing administrators to set an account expiration date/time. When set and past, authentication is blocked and active sessions are terminated.

Fixes #330

### Changes

**Migration**
- Added nullable `expire_datetime` column to `users` and `admins` tables

**Authentication**
- `account_expired?` method in `StandardAuthentication` concern checks if expiration has passed
- `active_for_authentication?` and `inactive_message` updated on both User and Admin models to block expired accounts (disabled status takes precedence)
- Warden `after_set_user` hook forces logout on every request if expiration has passed mid-session
- Devise locale message: "Your account has expired. Please contact your administrator."

**Admin Panel**
- Account Expiration datetime field added to user and admin edit forms (after Last Name)
- Account Expiration column added to user and admin list views
- "Expires in (days)" column renamed to "Password expires in (days)" for clarity
- `expire_datetime` added to permitted params in both controllers

**Tests**
- 24 model specs: field existence, `account_expired?`, `active_for_authentication?`, `inactive_message` for both User and Admin
- 5 system specs: login with nil/future/past expiration, mid-session termination, re-login after clearing expiration
