### PR TITLE
Added get_query_count list_option to control report auto-count on reports page - fixes #1011

### DIFF
--- a/app/models/admin/defs/report_options_defs.yaml
+++ b/app/models/admin/defs/report_options_defs.yaml
@@ -102,6 +102,11 @@ list_options:
   # Markdown formatted description to appear in the list of available reports,
   # allowing the main description field to appear just in the search criteria form
 
+  get_query_count: false (default) | true
+  # Automatically fetch the query count when the reports list page loads.
+  # When true, the report will run to retrieve a count and populate search attribute
+  # and result count cells in the reports list.
+
 tree_view_options:
   # A tree view allows for drill down into lower levels.
   # A query must return an "id" field to operate, even if it is random.

--- a/app/models/option_configs/report_options.rb
+++ b/app/models/option_configs/report_options.rb
@@ -22,7 +22,7 @@ module OptionConfigs
                                       force_show_search_button no_sorting result_handlers add_classes
                                       prevent_adding_items use_plain_attribute_names]
 
-    configure :list_options, with: %i[hide_in_list list_description]
+    configure :list_options, with: %i[hide_in_list list_description get_query_count]
     configure :tree_view_options, with: %i[num_levels column_levels expand_level]
     configure :plain_text_options, with: %i[results_column return_content_type
                                             line_join_string column_join_string

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -16,6 +16,7 @@ class Report < ActiveRecord::Base
   before_validation :downcase_item_type
   before_validation :search_attributes_config_valid
   before_validation :gen_short_name
+  after_save :clear_report_options_cache
   validates :report_type, presence: true
   validates :name, presence: true
   validate :valid_short_name?, unless: -> { disabled }
@@ -223,6 +224,12 @@ class Report < ActiveRecord::Base
     report_options.list_options.list_description || description
   end
 
+  # Should this report auto-fetch query counts when the reports list page loads?
+  # Configured via list_options.get_query_count in report options
+  def get_query_count?
+    report_options.list_options.get_query_count == true
+  end
+
   def gen_short_name
     self.short_name = self.class.gen_short_name(name) if short_name.blank?
   end
@@ -240,6 +247,10 @@ class Report < ActiveRecord::Base
   end
 
   private
+
+  def clear_report_options_cache
+    @report_options = nil
+  end
 
   def search_attributes_config_valid
     return true if search_attributes_config.valid?

--- a/app/views/reports/_index.html.erb
+++ b/app/views/reports/_index.html.erb
@@ -32,7 +32,7 @@ extra_params[:embed] = true if link_extras[:data] && link_extras[:data][:remote]
             end
           end    
     %>
-    <tr class="<%=list_item.disabled ? 'disabled-result' : ''%> report-type-<%= list_item.report_type %> <%= list_item.auto ? 'report-auto' : '' %>" data-report-id="<%=list_item.id %>">
+    <tr class="<%=list_item.disabled ? 'disabled-result' : ''%> report-type-<%= list_item.report_type %> <%= list_item.get_query_count? ? 'report-auto' : '' %>" data-report-id="<%=list_item.id %>">
       <td class="report-index__type-cell"><span class="hidden"><%= list_item.report_type %></span><span class="glyphicon <%= list_item.report_type == 'count' ? 'glyphicon-record' : list_item.report_type == 'regular_report' ? 'glyphicon-list-alt' : 'glyphicon-search'  %>" title="<%= list_item.report_type.humanize %>"></span></td>
 
       <td class="report-index__name-cell"><%= link_to  list_item.name, report_path(list_item.alt_resource_name, extra_params), link_extras %></td>

--- a/spec/models/report_options_spec.rb
+++ b/spec/models/report_options_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Tests for the get_query_count option in ReportOptions list_options.
+# Issue #1011: User Reports page shows "loading..." splash for too long.
+#
+# The get_query_count option controls whether a report's record count
+# is automatically fetched when the reports list page loads.
+# Previously, all reports with auto: true would auto-run to get counts,
+# causing delays. This option decouples count fetching from the auto flag.
+
+require 'rails_helper'
+
+RSpec.describe OptionConfigs::ReportOptions, type: :model do
+  include ModelSupport
+  include ReportSupport
+
+  before :example do
+    create_admin
+    create_user
+    create_reports
+  end
+
+  describe 'list_options.get_query_count' do
+    it 'accepts get_query_count as a valid list_options configuration' do
+      report = @report1
+      report.current_admin = @admin
+      report.options = "list_options:\n  get_query_count: true"
+      report.save!
+
+      ro = OptionConfigs::ReportOptions.new report
+      expect(ro.list_options.get_query_count).to eq true
+    end
+
+    it 'returns nil/falsy when get_query_count is not set' do
+      report = @report1
+      report.current_admin = @admin
+      report.options = ''
+      report.save!
+
+      ro = OptionConfigs::ReportOptions.new report
+      expect(ro.list_options.get_query_count).to be_falsy
+    end
+
+    it 'returns false when get_query_count is explicitly set to false' do
+      report = @report1
+      report.current_admin = @admin
+      report.options = "list_options:\n  get_query_count: false"
+      report.save!
+
+      ro = OptionConfigs::ReportOptions.new report
+      expect(ro.list_options.get_query_count).to eq false
+    end
+  end
+end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -41,6 +41,32 @@ RSpec.describe Report, type: :model do
     expect(res.length).to eq 0
   end
 
+  # Issue #1011: get_query_count? decouples count fetching from the auto flag.
+  # A report should only auto-fetch query counts when get_query_count option is true,
+  # regardless of the auto column value.
+  describe '#get_query_count?' do
+    it 'returns false when auto is true but get_query_count is not set' do
+      report = @report1
+      report.current_admin = @admin
+      report.update!(auto: true, options: '')
+      expect(report.get_query_count?).to be false
+    end
+
+    it 'returns true when get_query_count is set to true' do
+      report = @report1
+      report.current_admin = @admin
+      report.update!(auto: true, options: "list_options:\n  get_query_count: true")
+      expect(report.get_query_count?).to be true
+    end
+
+    it 'returns false when get_query_count is explicitly set to false' do
+      report = @report1
+      report.current_admin = @admin
+      report.update!(auto: false, options: "list_options:\n  get_query_count: false")
+      expect(report.get_query_count?).to be false
+    end
+  end
+
   it 'references reports by an item_type__short_name alternative resource name' do
     create_admin
     first_rep = @report1


### PR DESCRIPTION
## Summary

Fixes #1011 — Reports page was slow because every report with `auto: true` triggered an AJAX count request on page load.

Added a new `list_options.get_query_count` option (default: `false`) that explicitly controls whether a report auto-fetches its record count on the reports list page, decoupling this behavior from the `auto` column.

### Changes

- **app/models/option_configs/report_options.rb** — Added `:get_query_count` to `list_options` configuration
- **app/models/report.rb** — Added `get_query_count?` predicate method and `after_save` callback to clear memoized report options
- **app/views/reports/_index.html.erb** — Changed `report-auto` CSS class condition from `list_item.auto` to `list_item.get_query_count?`
- **app/models/admin/defs/report_options_defs.yaml** — Documented the new option
- **spec/models/report_options_spec.rb** — New spec: 3 tests for option parsing (true/false/nil)
- **spec/models/report_spec.rb** — Added 3 tests for `Report#get_query_count?`

### Usage

Admins configure per-report in the options YAML:
```yaml
list_options:
  get_query_count: true
```

Only reports with this set to `true` will auto-run on the reports list page. The `auto` column continues to control criteria panel visibility and auto-submit behavior when viewing a specific report.
