### PR TITLE
Added UAC summary to reports admin Definition tab - fixes #1014

### DIFF
--- a/app/views/admin/common_templates/_def_uac_summary.html.erb
+++ b/app/views/admin/common_templates/_def_uac_summary.html.erb
@@ -1,10 +1,15 @@
 <%#
-  Partial to display User Access Control summary for a dynamic definition (dynamic model, external identifier, etc.)
+  Partial to display User Access Control summary for a resource definition
+  (dynamic model, external identifier, report, etc.)
   
   Required local variables:
-  - object_instance: The dynamic definition instance (DynamicModel, ExternalIdentifier, etc.)
+  - object_instance: The definition instance (DynamicModel, ExternalIdentifier, Report, etc.)
   - current_app_type_id: The current admin user's app type ID (via current_admin.matching_user.app_type_id)
   - current_user: The current admin user's matching user (for access check)
+  
+  Optional local variables:
+  - resource_name: Override the resource name (defaults to object_instance.resource_name.pluralize)
+  - resource_type: Override the resource type (defaults to 'table')
   
   This partial:
   1. Shows a summary of UAC roles and access levels for this resource
@@ -12,7 +17,8 @@
   3. Warns if the current user/admin has no access to this resource
 %>
 <%
-  resource_name = object_instance.resource_name&.pluralize
+  resource_name = local_assigns[:resource_name] || object_instance.resource_name&.pluralize
+  resource_type = local_assigns[:resource_type] || 'table'
   return unless resource_name.present?
 
   uacs = Admin::UserAccessControl.active_for(resource_name:).not_template_role
@@ -24,7 +30,7 @@
     current_user_has_access = Admin::UserAccessControl.access_for?(
       current_user,
       :access,
-      :table,
+      resource_type.to_sym,
       resource_name,
       alt_app_type_id: current_app_type_id
     ).present?
@@ -38,7 +44,7 @@
 
 <label>user access controls</label>
 <%= link_to link_label_open_in_new("view all"), 
-            admin_user_access_controls_path(filter: { resource_name:, resource_type: "table", app_type_id: '' }), 
+            admin_user_access_controls_path(filter: { resource_name:, resource_type:, app_type_id: '' }), 
             target: '_blank' %>
 
 <% if no_non_template_uacs %>

--- a/app/views/admin/reports/_def_block.html.erb
+++ b/app/views/admin/reports/_def_block.html.erb
@@ -20,6 +20,14 @@
   <span class="info-danger">invalid</span>
   <% end %>
   </p>
+  <%= render partial: 'admin/common_templates/def_uac_summary',
+             locals: {
+               object_instance: @report,
+               resource_name: @report.alt_resource_name,
+               resource_type: 'report',
+               current_app_type_id: current_admin.matching_user&.app_type_id,
+               current_user: current_admin.matching_user
+             } %>
   <label>preview</label>
   <div class="well row force-form-block">
   <%= render partial: 'admin/reports/form/admin_criteria_view' %>  

--- a/spec/system/admin/admin_report_uac_summary_spec.rb
+++ b/spec/system/admin/admin_report_uac_summary_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+# Admin Report UAC Summary Spec - Issue #1014
+#
+# Tests that the Reports admin page Definition tab displays a user access controls
+# summary section, similar to the dynamic models admin page.
+#
+# The _def_uac_summary partial should be rendered within the Definition tab
+# (id="report-def") of the reports admin panel, showing:
+# - A "user access controls" label with a "view all" link
+# - A list of UAC entries with role names and access levels
+# - A warning when no UACs are defined for the resource
+#
+# The reports _def_block.html.erb renders the _def_uac_summary partial with
+# explicit resource_name and resource_type locals for reports.
+
+require 'rails_helper'
+
+describe 'admin report UAC summary - Issue #1014', js: true, driver: $browser_driver do
+  include ModelSupport
+  include AdminActionsSetup
+  include FeatureSupport
+
+  before(:all) do
+    SetupHelper.feature_setup
+    ENV['FPHS_ADMIN_SETUP'] = 'yes'
+    make_an_admin
+    # Save admin credentials before create_user overwrites @good_email / @good_password
+    @admin_email = @good_email
+    @admin_password = @good_password
+    create_user
+
+    # Restore admin credentials for admin_sign_in_with_2fa
+    @good_email = @admin_email
+    @good_password = @admin_password
+
+    # Report WITH a UAC entry
+    @report_with_uac = Report.create!(
+      current_admin: @admin,
+      name: "UAC Summary Test #{SecureRandom.hex(4)}",
+      description: 'Test report for UAC summary display',
+      sql: 'select id from admins limit 1',
+      search_attrs: '',
+      disabled: false,
+      report_type: 'regular_report',
+      auto: false,
+      searchable: false,
+      position: nil
+    )
+
+    Admin::UserAccessControl.create!(
+      app_type: @user.app_type,
+      access: :read,
+      resource_type: :report,
+      resource_name: @report_with_uac.alt_resource_name,
+      current_admin: @admin
+    )
+
+    # Report WITHOUT any UAC entries
+    @report_without_uac = Report.create!(
+      current_admin: @admin,
+      name: "No UAC Test #{SecureRandom.hex(4)}",
+      description: 'Test report with no UACs defined',
+      sql: 'select id from admins limit 1',
+      search_attrs: '',
+      disabled: false,
+      report_type: 'regular_report',
+      auto: false,
+      searchable: false,
+      position: nil
+    )
+  end
+
+  after(:all) do
+    @report_with_uac&.update(disabled: true, current_admin: @admin) if @report_with_uac&.persisted?
+    @report_without_uac&.update(disabled: true, current_admin: @admin) if @report_without_uac&.persisted?
+  end
+
+  it 'shows UAC summary with entries in the Definition tab for a report with UACs' do
+    admin_sign_in_with_2fa
+
+    visit '/admin/reports'
+    finish_page_loading
+
+    within "#admin-item-#{@report_with_uac.id}" do
+      find('a.edit-entity.glyphicon-pencil').click
+    end
+
+    # The Definition tab (report-def) is active by default
+    expect(page).to have_css('#report-def', wait: 10)
+    finish_page_loading
+
+    within '#report-def' do
+      expect(page).to have_content('user access controls')
+      expect(page).to have_link('view all')
+      expect(page).to have_css('.common-def-panel--uacs')
+      expect(page).to have_css('.common-def-panel--uacs li', minimum: 1)
+    end
+  end
+
+  it 'shows a warning when no UACs are defined for the report' do
+    admin_sign_in_with_2fa
+
+    visit '/admin/reports'
+    finish_page_loading
+
+    within "#admin-item-#{@report_without_uac.id}" do
+      find('a.edit-entity.glyphicon-pencil').click
+    end
+
+    expect(page).to have_css('#report-def', wait: 10)
+    finish_page_loading
+
+    within '#report-def' do
+      expect(page).to have_content('user access controls')
+      expect(page).to have_content('No user access controls defined for this resource')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Show user access controls summary in the Reports admin page Definition tab, matching the existing behavior on dynamic models, activity logs, and external identifiers admin pages.

Fixes #1014

### Changes

- **app/views/admin/reports/_def_block.html.erb** — Render the `_def_uac_summary` partial in the Definition tab, above the preview section
- **app/views/admin/common_templates/_def_uac_summary.html.erb** — Accept optional `resource_name` and `resource_type` locals to support reports (which use `alt_resource_name` and `resource_type: 'report'`), with backward-compatible defaults for existing callers
- **spec/system/admin/admin_report_uac_summary_spec.rb** — New system spec verifying UAC summary appears with entries and shows a warning when none are defined
