### PR TITLE
Added sort_order option for select_record_from fields - fixes #217

### DIFF
--- a/app/helpers/edit_fields/select_field_handler.rb
+++ b/app/helpers/edit_fields/select_field_handler.rb
@@ -4,7 +4,7 @@ module EditFields
   class SelectFieldHandler
     attr_accessor :form_object_instance, :assoc_or_class_name,
                   :value_attr, :label_attr, :group_split_char,
-                  :no_assoc
+                  :no_assoc, :sort_order
 
     FailedValuesArray = ['failed to get values', 'failed to get values'].freeze
 
@@ -18,7 +18,7 @@ module EditFields
     # @return [Array(String, Array(Array, Array))] a human name string and a list of data from the matched records
     def self.list_record_data_for_select(form_object_instance, assoc_or_class_name,
                                          value_attr: :data, label_attr: :data, group_split_char: nil,
-                                         no_assoc: nil)
+                                         no_assoc: nil, sort_order: nil)
       sf = SelectFieldHandler.new
       sf.form_object_instance = form_object_instance
       sf.assoc_or_class_name = assoc_or_class_name
@@ -26,6 +26,7 @@ module EditFields
       sf.label_attr = label_attr
       sf.group_split_char = group_split_char
       sf.no_assoc = no_assoc
+      sf.sort_order = sort_order
       sf.generate_record_data
     end
 
@@ -187,9 +188,15 @@ module EditFields
       arr_label_attr, pluck_attrs, do_subs_label = pluck_attrs_for(label_attr, model)
       arr_value_attr, val_pluck_attrs, do_subs_value = pluck_attrs_for(value_attr, model)
 
+      sort_target, sort_direction = parsed_sort_order
+      sort_attr = if sort_target == :value
+                    val_pluck_attrs.first || pluck_attrs.first
+                  else
+                    pluck_attrs.first
+                  end
+
       pluck_attrs += val_pluck_attrs
       pluck_attrs.uniq!
-      sort_attr = pluck_attrs.first
       pluck_attrs_strs = pluck_attrs.map(&:to_s)
 
       if pluck_attrs.empty? || sort_attr.blank?
@@ -208,7 +215,7 @@ module EditFields
       end
 
       reslist_data = reslist.reorder('')
-                            .order(sort_attr => :asc)
+                            .order(sort_attr => sort_direction)
                             .pluck(*pluck_attrs)
 
       if pluck_attrs.one?
@@ -253,6 +260,20 @@ module EditFields
     end
 
     #
+    # Parse the sort_order string into target and direction
+    # @return [Array(Symbol, Symbol)] target (:label or :value) and direction (:asc or :desc)
+    def parsed_sort_order
+      return %i[label asc] unless sort_order.present?
+
+      parts = sort_order.to_s.strip.split(/\s+/, 2)
+      target = parts[0]&.to_sym
+      target = :label unless %i[label value].include?(target)
+      direction = parts[1]&.to_sym
+      direction = :asc unless %i[asc desc].include?(direction)
+      [target, direction]
+    end
+
+    #
     # Generate the result list for complex attributes (where the *data* attribute has been selected)
     # since it is likely that we can't retrieve this directly from the database since it is dynamically calculated.
     # The method #list_for_defined_attributes may be much faster than using named methods.
@@ -275,9 +296,12 @@ module EditFields
               "SelectFieldHandler generate_record_data with complex attributes: #{first_res.class} does not respond to #{value_attr}"
       end
 
+      sort_target, sort_direction = parsed_sort_order
+      sort_index = sort_target == :value ? :last : :first
       reslist.all
              .map { |i| [i.send(label_attr), i.send(value_attr)] }
-             .sort { |x, y| x.first <=> y.first }
+             .sort_by { |item| item.send(sort_index) || '' }
+             .then { |sorted| sort_direction == :desc ? sorted.reverse : sorted }
     rescue StandardError, SystemStackError => e
       sql = reslist.to_sql if reslist.respond_to?(:to_sql)
       msg = "list_for_complex_attributes fails with #{label_attr} and #{value_attr}: #{e}\n#{sql}"

--- a/app/helpers/edit_fields/select_field_helper.rb
+++ b/app/helpers/edit_fields/select_field_helper.rb
@@ -12,13 +12,14 @@ module EditFields
     # @return [Array(String, Array(Array, Array))] a human name string and a list of data from the matched records
     def list_record_data_for_select(form_object_instance, assoc_or_class_name,
                                     value_attr: :data, label_attr: :data, group_split_char: nil,
-                                    no_assoc: nil)
+                                    no_assoc: nil, sort_order: nil)
       EditFields::SelectFieldHandler.list_record_data_for_select(form_object_instance,
                                                                  assoc_or_class_name,
                                                                  value_attr: value_attr,
                                                                  label_attr: label_attr,
                                                                  group_split_char: group_split_char,
-                                                                 no_assoc: no_assoc)
+                                                                 no_assoc: no_assoc,
+                                                                 sort_order: sort_order)
     end
 
     #

--- a/app/models/admin/defs/extra_options_field_options_defs.yaml
+++ b/app/models/admin/defs/extra_options_field_options_defs.yaml
@@ -57,6 +57,10 @@
         value_attr: attribute_name to use for selection value in select_record_* fields
         label_attr: attribute_name to use for selection label in select_record_* fields
         group_split_char: optional character to split on when grouping selections in select_record_* fields
+        sort_order: |
+          optional sort order for select_record_* fields, as "attribute direction"
+          where attribute is "value" or "label" and direction is "asc" or "desc".
+          For example: "value desc" or "label asc". Default is "label asc".
         no_assoc: | 
           false | true - optionally specify that no association should be used in select_record_* data lookup
                          select_record_from_table_* automatically sets this to true

--- a/app/models/classification/selection_options_handler.rb
+++ b/app/models/classification/selection_options_handler.rb
@@ -225,12 +225,14 @@ class Classification::SelectionOptionsHandler
                      end
 
         assoc_or_class_name = alt_fn.sub(/^(tag_)?select_record_(id_)?from_(table_)?/, '').singularize
+        sort_order = edit_as[:sort_order]
 
         got_res, res = EditFields::SelectFieldHandler.list_record_data_for_select(user_base_object,
                                                                                   assoc_or_class_name,
                                                                                   value_attr:,
                                                                                   label_attr:,
-                                                                                  group_split_char:)
+                                                                                  group_split_char:,
+                                                                                  sort_order: sort_order)
 
         if got_res && res
           res = res.to_h if hash_res

--- a/app/views/common_templates/edit_fields/_name_starts_with_select_record_from.html.erb
+++ b/app/views/common_templates/edit_fields/_name_starts_with_select_record_from.html.erb
@@ -8,6 +8,7 @@ label_attr = options.dig(:edit_as, :label_attr) || :data
 big_select = options.dig(:edit_as, :big_select)
 sf_el = options.dig(:edit_as, :select_filtering_target)
 no_assoc = options.dig(:edit_as, :no_assoc)
+sort_order = options.dig(:edit_as, :sort_order)
 options[:include_blank] = true unless options.has_key?(:include_blank)
 assoc_or_class_name = field_name.sub('select_record_from_', '').singularize
 
@@ -16,7 +17,8 @@ human_name, reslist = list_record_data_for_select(form_object_instance,
                                                   value_attr: value_attr, 
                                                   label_attr: label_attr, 
                                                   group_split_char: group_split_char,
-                                                  no_assoc: no_assoc)
+                                                  no_assoc: no_assoc,
+                                                  sort_order: sort_order)
 unless human_name
   logger.warn "Failed to find valid class name for #{field_name}"
 end

--- a/app/views/common_templates/edit_fields/_name_starts_with_select_record_from_table.html.erb
+++ b/app/views/common_templates/edit_fields/_name_starts_with_select_record_from_table.html.erb
@@ -9,6 +9,7 @@ big_select = options.dig(:edit_as, :big_select)
 sf_el = options.dig(:edit_as, :select_filtering_target)
 no_assoc = true
 no_assoc = options.dig(:edit_as, :no_assoc) if options[:edit_as]&.key?(:no_assoc)
+sort_order = options.dig(:edit_as, :sort_order)
 options[:include_blank] = true unless options.has_key?(:include_blank)
 assoc_or_class_name = field_name.sub('select_record_from_table_', '').singularize
 
@@ -17,7 +18,8 @@ human_name, reslist = list_record_data_for_select(form_object_instance,
                                                   value_attr: value_attr, 
                                                   label_attr: label_attr, 
                                                   group_split_char: group_split_char, 
-                                                  no_assoc: true)
+                                                  no_assoc: true,
+                                                  sort_order: sort_order)
 unless human_name
   logger.warn "Failed to find valid class name for #{field_name_sym}"
 end

--- a/app/views/common_templates/edit_fields/_name_starts_with_select_record_id_from.html.erb
+++ b/app/views/common_templates/edit_fields/_name_starts_with_select_record_id_from.html.erb
@@ -7,6 +7,7 @@ label_attr = options.dig(:edit_as, :label_attr) || :data
 big_select = options.dig(:edit_as, :big_select)
 sf_el = options.dig(:edit_as, :select_filtering_target)
 no_assoc = options.dig(:edit_as, :no_assoc)
+sort_order = options.dig(:edit_as, :sort_order)
 options[:include_blank] = true unless options.has_key?(:include_blank)
 assoc_or_class_name = field_name.sub('select_record_id_from_', '').singularize
 human_name, reslist = list_record_data_for_select(form_object_instance, 
@@ -14,7 +15,8 @@ human_name, reslist = list_record_data_for_select(form_object_instance,
                                                   value_attr: :id, 
                                                   label_attr: label_attr, 
                                                   group_split_char: group_split_char,
-                                                  no_assoc: no_assoc)
+                                                  no_assoc: no_assoc,
+                                                  sort_order: sort_order)
 
 unless human_name
   logger.warn "Failed to find valid class name for #{field_name}"

--- a/app/views/common_templates/edit_fields/_name_starts_with_select_record_id_from_table.html.erb
+++ b/app/views/common_templates/edit_fields/_name_starts_with_select_record_id_from_table.html.erb
@@ -8,6 +8,7 @@ big_select = options.dig(:edit_as, :big_select)
 sf_el = options.dig(:edit_as, :select_filtering_target)
 no_assoc = true
 no_assoc = options.dig(:edit_as, :no_assoc) if options[:edit_as]&.key?(:no_assoc)
+sort_order = options.dig(:edit_as, :sort_order)
 options[:include_blank] = true unless options.has_key?(:include_blank)
 assoc_or_class_name = field_name.sub('select_record_id_from_table_', '').singularize
 
@@ -16,7 +17,8 @@ human_name, reslist = list_record_data_for_select(form_object_instance,
                                                   value_attr: :id, 
                                                   label_attr: label_attr, 
                                                   group_split_char: group_split_char,
-                                                  no_assoc: no_assoc)
+                                                  no_assoc: no_assoc,
+                                                  sort_order: sort_order)
 
 unless human_name
   logger.warn "Failed to find valid class name for #{field_name}"

--- a/app/views/common_templates/edit_fields/_name_starts_with_tag_select_record_from.html.erb
+++ b/app/views/common_templates/edit_fields/_name_starts_with_tag_select_record_from.html.erb
@@ -7,8 +7,9 @@ group_split_char = options.dig(:edit_as, :group_split_char)
 value_attr = options.dig(:edit_as, :value_attr) || :data
 label_attr = options.dig(:edit_as, :label_attr) || :data
 no_assoc = options.dig(:edit_as, :no_assoc)
+sort_order = options.dig(:edit_as, :sort_order)
 
-human_name, reslist = list_record_data_for_select(form_object_instance, rl, value_attr: value_attr, label_attr: label_attr, group_split_char: group_split_char, no_assoc: no_assoc)
+human_name, reslist = list_record_data_for_select(form_object_instance, rl, value_attr: value_attr, label_attr: label_attr, group_split_char: group_split_char, no_assoc: no_assoc, sort_order: sort_order)
 
 unless human_name
   logger.warn "Failed to find valid class name for #{field_name}"

--- a/app/views/common_templates/edit_fields/_name_starts_with_tag_select_record_from_table.html.erb
+++ b/app/views/common_templates/edit_fields/_name_starts_with_tag_select_record_from_table.html.erb
@@ -6,8 +6,9 @@ options = field_options_for(form_object_instance, field_name_sym)
 group_split_char = options.dig(:edit_as, :group_split_char)
 value_attr = options.dig(:edit_as, :value_attr) || :data
 label_attr = options.dig(:edit_as, :label_attr) || :data
+sort_order = options.dig(:edit_as, :sort_order)
 
-human_name, reslist = list_record_data_for_select(form_object_instance, rl, value_attr: value_attr, label_attr: label_attr, group_split_char: group_split_char)
+human_name, reslist = list_record_data_for_select(form_object_instance, rl, value_attr: value_attr, label_attr: label_attr, group_split_char: group_split_char, sort_order: sort_order)
 
 unless human_name
   logger.warn "Failed to find valid class name for #{field_name}"

--- a/app/views/common_templates/edit_fields/_name_starts_with_tag_select_record_id_from.html.erb
+++ b/app/views/common_templates/edit_fields/_name_starts_with_tag_select_record_id_from.html.erb
@@ -6,8 +6,9 @@ options = field_options_for(form_object_instance, field_name_sym)
 group_split_char = options.dig(:edit_as, :group_split_char)
 label_attr = options.dig(:edit_as, :label_attr) || :data
 no_assoc = options.dig(:edit_as, :no_assoc)
+sort_order = options.dig(:edit_as, :sort_order)
 
-human_name, reslist = list_record_data_for_select(form_object_instance, rl, value_attr: :id, group_split_char: group_split_char, label_attr: label_attr, no_assoc: no_assoc)
+human_name, reslist = list_record_data_for_select(form_object_instance, rl, value_attr: :id, group_split_char: group_split_char, label_attr: label_attr, no_assoc: no_assoc, sort_order: sort_order)
 
 unless human_name
   logger.warn "Failed to find valid class name for #{field_name}"

--- a/spec/models/edit_fields/select_field_handler_spec.rb
+++ b/spec/models/edit_fields/select_field_handler_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+# Tests for EditFields::SelectFieldHandler sort_order option (Issue #217)
+#
+# The sort_order option allows configuring how select_record_from_table_*
+# and related field types sort their results. By default, results are sorted
+# by the first label attribute ascending. The new sort_order option supports:
+#   - "label asc" (default behavior)
+#   - "label desc" (label descending)
+#   - "value asc" (value ascending)
+#   - "value desc" (value descending)
+#
+# Two code paths are tested:
+#   1. list_for_defined_attributes - when label_attr and value_attr are named
+#      database columns (not :data)
+#   2. list_for_complex_attributes - when label_attr or value_attr is :data,
+#      requiring in-memory sorting of dynamically computed attributes
+
+require 'rails_helper'
+
+RSpec.describe EditFields::SelectFieldHandler, type: :model do
+  include ModelSupport
+  include PlayerContactSupport
+  include TestFieldsDmSupport
+
+  before(:all) do
+    change_setting('AllowDynamicMigrations', true)
+    create_admin
+    create_user
+    create_master
+    setup_fields_dm
+  end
+
+  after(:all) do
+    change_setting('AllowDynamicMigrations', false)
+  end
+
+  let(:form_object_instance) do
+    DynamicModel::TestWithIdRec.new(master: @master, current_user: @user)
+  end
+
+  describe '.list_record_data_for_select with defined attributes (list_for_defined_attributes path)' do
+    let(:common_args) do
+      {
+        value_attr: :value,
+        label_attr: :name,
+        no_assoc: true
+      }
+    end
+
+    it 'sorts by label ascending by default when no sort_order is provided' do
+      _human_name, results = described_class.list_record_data_for_select(
+        form_object_instance, 'test_with_id_recs',
+        **common_args
+      )
+
+      labels = results.map(&:first)
+      expect(labels).to eq(['test name 1', 'test name 2', 'test name 3'])
+    end
+
+    it 'sorts by value ascending when sort_order is "value asc"' do
+      _human_name, results = described_class.list_record_data_for_select(
+        form_object_instance, 'test_with_id_recs',
+        **common_args,
+        sort_order: 'value asc'
+      )
+
+      values = results.map(&:last)
+      expect(values).to eq(['test value 1', 'test value 2', 'test value 3'])
+    end
+
+    it 'sorts by value descending when sort_order is "value desc"' do
+      _human_name, results = described_class.list_record_data_for_select(
+        form_object_instance, 'test_with_id_recs',
+        **common_args,
+        sort_order: 'value desc'
+      )
+
+      values = results.map(&:last)
+      expect(values).to eq(['test value 3', 'test value 2', 'test value 1'])
+    end
+
+    it 'sorts by label descending when sort_order is "label desc"' do
+      _human_name, results = described_class.list_record_data_for_select(
+        form_object_instance, 'test_with_id_recs',
+        **common_args,
+        sort_order: 'label desc'
+      )
+
+      labels = results.map(&:first)
+      expect(labels).to eq(['test name 3', 'test name 2', 'test name 1'])
+    end
+
+    it 'sorts by label ascending when sort_order is "label asc" (explicit default)' do
+      _human_name, results = described_class.list_record_data_for_select(
+        form_object_instance, 'test_with_id_recs',
+        **common_args,
+        sort_order: 'label asc'
+      )
+
+      labels = results.map(&:first)
+      expect(labels).to eq(['test name 1', 'test name 2', 'test name 3'])
+    end
+  end
+
+  describe '.list_record_data_for_select with complex attributes (list_for_complex_attributes path)' do
+    let(:common_args) do
+      {
+        value_attr: :data,
+        label_attr: :data,
+        no_assoc: true
+      }
+    end
+
+    it 'sorts by label ascending by default when no sort_order is provided' do
+      _human_name, results = described_class.list_record_data_for_select(
+        form_object_instance, 'test_with_id_recs',
+        **common_args
+      )
+
+      labels = results.map(&:first)
+      expect(labels).to eq(labels.sort)
+    end
+
+    it 'sorts by label descending when sort_order is "label desc"' do
+      _human_name, results = described_class.list_record_data_for_select(
+        form_object_instance, 'test_with_id_recs',
+        **common_args,
+        sort_order: 'label desc'
+      )
+
+      labels = results.map(&:first)
+      expect(labels).to eq(labels.sort.reverse)
+    end
+
+    it 'sorts by value descending when sort_order is "value desc"' do
+      _human_name, results = described_class.list_record_data_for_select(
+        form_object_instance, 'test_with_id_recs',
+        **common_args,
+        sort_order: 'value desc'
+      )
+
+      values = results.map(&:last)
+      expect(values).to eq(values.sort.reverse)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Adds support for configuring sort order on select_record_from-style dynamic definition fields.

### Changes
- added sort_order handling to SelectFieldHandler for defined and complex attribute paths
- threaded sort_order through select_record_from, select_record_from_table, select_record_id_from, and tag_select variants
- updated SelectionOptionsHandler to pass sort_order from edit_as config
- documented sort_order in extra field option definitions
- added specs covering label/value sorting in ascending and descending directions

### Verification
- bundle exec rspec spec/models/edit_fields/select_field_handler_spec.rb spec/models/classification/selection_options_handler_spec.rb
- 13 examples, 0 failures