### PR TITLE
Implemented PostgreSQL full text search indexing and docs - fixes #74

### DIFF
--- a/app/models/admin/defs/filestore_nfs_store_defs.yaml
+++ b/app/models/admin/defs/filestore_nfs_store_defs.yaml
@@ -47,6 +47,15 @@
             file_filters:
               - '\.pdf$'
 
+      - full_text_search:
+          target_table: schema.table_name # required: table that stores the tsvector
+          target_column: search_vector # required: tsvector field in target_table
+          target_foreign_key_column: stored_file_id # required: FK referencing stored file id
+          ts_config: english # optional: PostgreSQL text search config (default english)
+          file_filters: # optional: regex filters using the same pattern as scripted job filters
+            - '.*\\.txt$'
+            - '.*\\.pdf$'
+
     # user_file_actions defines custom pipelines to perform if a user selects files 
     # and clicks the action in the drop down
     user_file_actions: 

--- a/app/models/full_text_search/text_extractor.rb
+++ b/app/models/full_text_search/text_extractor.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+module FullTextSearch
+  module TextExtractor
+    PDF_EXTENSIONS = %w[pdf].freeze
+    TEXT_EXTENSIONS = %w[txt csv md html rtf].freeze
+    OFFICE_EXTENSIONS = %w[doc docx xls xlsx ppt pptx odt ods odp odg].freeze
+
+    ALL_EXTENSIONS = (PDF_EXTENSIONS + TEXT_EXTENSIONS + OFFICE_EXTENSIONS).freeze
+
+    module_function
+
+    def extract_text(file_path)
+      raise FphsException, "File does not exist: #{file_path}" unless File.exist?(file_path)
+
+      ext = File.extname(file_path).delete('.').downcase
+
+      if PDF_EXTENSIONS.include?(ext)
+        extract_from_pdf(file_path)
+      elsif TEXT_EXTENSIONS.include?(ext)
+        File.read(file_path)
+      elsif OFFICE_EXTENSIONS.include?(ext)
+        extract_from_office(file_path)
+      end
+    end
+
+    def supported?(file_path)
+      ext = File.extname(file_path).delete('.').downcase
+      ALL_EXTENSIONS.include?(ext)
+    end
+
+    def pdftotext_path
+      SecureView::Config.pdftotext_path || 'pdftotext'
+    end
+
+    def extract_from_pdf(file_path)
+      stdout, _status = Open3.capture2(pdftotext_path, file_path, '-')
+      stdout
+    end
+
+    def extract_from_office(file_path)
+      Dir.mktmpdir do |temp_dir|
+        libreoffice_path = SecureView::Config.libreoffice_path || 'libreoffice'
+        system(libreoffice_path, '--headless', '--norestore', '--convert-to', 'pdf',
+               '--outdir', temp_dir, file_path, out: File::NULL, err: File::NULL)
+
+        pdf_name = "#{File.basename(file_path, File.extname(file_path))}.pdf"
+        pdf_path = File.join(temp_dir, pdf_name)
+
+        return nil unless File.exist?(pdf_path)
+
+        extract_from_pdf(pdf_path)
+      end
+    end
+
+    private_class_method :extract_from_pdf, :extract_from_office
+  end
+end

--- a/app/models/full_text_search/tsvector_writer.rb
+++ b/app/models/full_text_search/tsvector_writer.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module FullTextSearch
+  #
+  # Shared utility for writing tsvector data to PostgreSQL tables.
+  # Used by SaveTriggers::FullTextSearch and NfsStore::Process::FullTextSearchJob.
+  module TsvectorWriter
+    VALID_IDENTIFIER = /\A[\w.]+\z/
+
+    #
+    # Write a tsvector value to a target table, performing an upsert
+    # (insert or update on FK conflict).
+    # @param target_table [String] fully qualified table name (e.g. 'schema.table')
+    # @param target_field [String] tsvector column name
+    # @param text_content [String] text to convert to tsvector
+    # @param fk_column [String] foreign key column name for upsert conflict
+    # @param fk_value [Integer] foreign key value
+    # @param master_id [Integer, nil] optional master_id
+    # @param ts_config [String] PostgreSQL text search configuration (default: 'english')
+    def self.write_tsvector(target_table:, target_field:, text_content:, fk_column:, fk_value:, master_id: nil,
+                            ts_config: 'english')
+      validate_identifier!(target_table, 'target_table')
+      validate_identifier!(target_field, 'target_field')
+      validate_identifier!(fk_column, 'fk_column')
+
+      conn = ActiveRecord::Base.connection
+      quoted_table = target_table.split('.').map { |p| conn.quote_column_name(p) }.join('.')
+      quoted_field = conn.quote_column_name(target_field)
+      quoted_fk = conn.quote_column_name(fk_column)
+
+      sql = <<~SQL
+        INSERT INTO #{quoted_table} (#{quoted_fk}, master_id, #{quoted_field}, created_at, updated_at)
+        VALUES ($1, $2, to_tsvector($4, $3), now(), now())
+        ON CONFLICT (#{quoted_fk})
+        DO UPDATE SET #{quoted_field} = to_tsvector($4, $3), updated_at = now()
+      SQL
+
+      binds = [
+        bind_param('fk_value', fk_value, ActiveModel::Type::Integer.new),
+        bind_param('master_id', master_id, ActiveModel::Type::Integer.new),
+        bind_param('text_content', text_content.to_s, ActiveModel::Type::String.new),
+        bind_param('ts_config', ts_config.to_s, ActiveModel::Type::String.new)
+      ]
+
+      conn.exec_query(sql, 'FullTextSearch::TsvectorWriter', binds)
+    end
+
+    #
+    # Update a tsvector column on an existing record's own table.
+    # @param table_name [String] fully qualified table name (e.g. 'schema.table')
+    # @param target_field [String] tsvector column name
+    # @param text_content [String] text to convert to tsvector
+    # @param record_id [Integer] id of the row to update
+    # @param ts_config [String] PostgreSQL text search configuration (default: 'english')
+    def self.update_tsvector(table_name:, target_field:, text_content:, record_id:, ts_config: 'english')
+      validate_identifier!(table_name, 'table_name')
+      validate_identifier!(target_field, 'target_field')
+
+      conn = ActiveRecord::Base.connection
+      quoted_table = table_name.split('.').map { |p| conn.quote_column_name(p) }.join('.')
+      quoted_field = conn.quote_column_name(target_field)
+
+      sql = <<~SQL
+        UPDATE #{quoted_table}
+        SET #{quoted_field} = to_tsvector($1, $2)
+        WHERE id = $3
+      SQL
+
+      binds = [
+        bind_param('ts_config', ts_config.to_s, ActiveModel::Type::String.new),
+        bind_param('text_content', text_content.to_s, ActiveModel::Type::String.new),
+        bind_param('record_id', record_id, ActiveModel::Type::Integer.new)
+      ]
+
+      conn.exec_query(sql, 'FullTextSearch::TsvectorWriter', binds)
+    end
+
+    #
+    # Build text content by concatenating field values from an item.
+    # @param item [ActiveRecord::Base] record with field values
+    # @param with_fields [Array<Symbol>] field names to extract
+    # @param extra_content [String, nil] additional text to append
+    # @return [String] concatenated text
+    def self.build_text_content(item:, with_fields:, extra_content: nil)
+      parts = with_fields.filter_map do |field|
+        val = item.send(field).to_s
+        val.presence
+      end
+
+      parts << extra_content if extra_content.present?
+      parts.join(' ')
+    end
+
+    def self.validate_identifier!(value, name)
+      raise ArgumentError, "Invalid #{name}: #{value.inspect}" unless value.to_s.match?(VALID_IDENTIFIER)
+    end
+    private_class_method :validate_identifier!
+
+    def self.bind_param(name, value, type)
+      ActiveRecord::Relation::QueryAttribute.new(name, value, type)
+    end
+    private_class_method :bind_param
+  end
+end

--- a/app/models/nfs_store/process/full_text_search_job.rb
+++ b/app/models/nfs_store/process/full_text_search_job.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module NfsStore
+  module Process
+    class FullTextSearchJob < NfsStoreJob
+      queue_as :nfs_store_process
+
+      flow_control :full_text_search,
+                   skip_if: lambda { |container_file|
+                     container_file.is_a?(NfsStore::Manage::ContainerFile) &&
+                       !FullTextSearch::TextExtractor.supported?(container_file.file_name)
+                   }
+
+      def perform(container_files, in_app_type_id, activity_log = nil, call_options = {})
+        log 'Running Full Text Search Job'
+
+        container_files = [container_files] if container_files.is_a? NfsStore::Manage::ContainerFile
+
+        container_files.each do |container_file|
+          container = container_file.container
+          container.parent_item ||= activity_log
+
+          config = NfsStore::Process::ProcessHandler.new(container_file,
+                                                         call_options).pipeline_job_config(:full_text_search)
+          next unless config
+
+          setup_container_file_current_user(container_file, in_app_type_id) do |_c_user|
+            process_file(container_file, config)
+          end
+        end
+      end
+
+      private
+
+      def process_file(container_file, config)
+        filters = config[:file_filters]
+        return unless passes_file_filters?(container_file, filters)
+
+        file_path = container_file.retrieval_path
+        return unless file_path && FullTextSearch::TextExtractor.supported?(file_path)
+
+        text_content = FullTextSearch::TextExtractor.extract_text(file_path)
+        return if text_content.blank?
+
+        target_table = config[:target_table]
+        target_field = config[:target_column]
+        fk_column = config[:target_foreign_key_column]
+        ts_config = config[:ts_config] || 'english'
+
+        return unless target_table && target_field && fk_column
+
+        FullTextSearch::TsvectorWriter.write_tsvector(
+          target_table: target_table,
+          target_field: target_field,
+          text_content: text_content,
+          fk_column: fk_column,
+          fk_value: container_file.id,
+          ts_config: ts_config
+        )
+      end
+
+      def passes_file_filters?(container_file, filters)
+        return true if filters.blank?
+
+        filtered_files = NfsStore::Filter::Filter.evaluate_container_files_as_scopes(
+          container_file.container,
+          filters: filters
+        )
+        return false unless filtered_files
+
+        if container_file.is_a?(NfsStore::Manage::ArchivedFile)
+          filtered_files[:archived_files].where(id: container_file.id).exists?
+        else
+          filtered_files[:stored_files].where(id: container_file.id).exists?
+        end
+      end
+    end
+  end
+end

--- a/app/models/option_configs/extra_option_implementers/save_triggers.rb
+++ b/app/models/option_configs/extra_option_implementers/save_triggers.rb
@@ -26,7 +26,8 @@ module OptionConfigs
                              case
                              set_save_trigger_results
                              set_variables
-                             generate_document].freeze
+                             generate_document
+                             full_text_search].freeze
 
       class_methods do
         #

--- a/app/models/save_triggers/full_text_search.rb
+++ b/app/models/save_triggers/full_text_search.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class SaveTriggers::FullTextSearch < SaveTriggers::SaveTriggersBase
+  def initialize(config, item)
+    super
+    @model_defs = config
+  end
+
+  def perform
+    @model_defs = [@model_defs] unless @model_defs.is_a? Array
+
+    @model_defs.each do |model_def|
+      model_def.each_value do |config|
+        config = config.symbolize_keys if config.is_a?(Hash)
+
+        with_entry_lifecycle(config) do
+          next unless if_evaluates(config[:if])
+
+          validate_config!(config)
+
+          source_fields = config[:source_fields].map(&:to_sym)
+          target_column = config[:target_column].to_s
+          extra_content = config[:extra_content]
+          ts_config = config[:ts_config] || 'english'
+
+          text_content = ::FullTextSearch::TsvectorWriter.build_text_content(
+            item: @item,
+            with_fields: source_fields,
+            extra_content: extra_content
+          )
+
+          if config[:target_table].present?
+            write_to_separate_table(config, text_content, ts_config)
+          else
+            write_to_same_table(target_column, text_content, ts_config)
+          end
+        end
+      end
+    end
+  end
+
+  private
+
+  def validate_config!(config)
+    raise FphsException, 'full_text_search trigger requires source_fields' if config[:source_fields].blank?
+    raise FphsException, 'full_text_search trigger requires target_column' if config[:target_column].blank?
+  end
+
+  def write_to_separate_table(config, text_content, ts_config)
+    ::FullTextSearch::TsvectorWriter.write_tsvector(
+      target_table: config[:target_table].to_s,
+      target_field: config[:target_column].to_s,
+      fk_column: config[:target_foreign_key_column].to_s,
+      fk_value: @item.id,
+      master_id: @item.respond_to?(:master_id) ? @item.master_id : nil,
+      text_content: text_content,
+      ts_config: ts_config
+    )
+  end
+
+  def write_to_same_table(target_column, text_content, ts_config)
+    ::FullTextSearch::TsvectorWriter.update_tsvector(
+      table_name: @item.class.table_name,
+      target_field: target_column,
+      text_content: text_content,
+      record_id: @item.id,
+      ts_config: ts_config
+    )
+  end
+end

--- a/config/initializers/secure_view.rb
+++ b/config/initializers/secure_view.rb
@@ -7,6 +7,7 @@ SecureView.setup do |config|
   config.dcmj2pnm_path = 'dcmj2pnm'
   config.netpbm_path = 'jpegtopnm'
   config.pdfgrep_path = 'pdfgrep'
+  config.pdftotext_path = 'pdftotext'
 
   config.resolution = {
     pdf: 150

--- a/docs/admin_reference/general/0_introduction.md
+++ b/docs/admin_reference/general/0_introduction.md
@@ -1,3 +1,4 @@
 # General Administration Concepts
 
 - [Substitutions](substitutions.md) provide insertion of data into calculated conditions, captions, [message templates and dialogs](../message_templates/0_introduction.md).
+- [Full Text Search](full_text_search.md) provides end-to-end setup for indexing record and file content and querying in reports.

--- a/docs/admin_reference/general/filestore_nfs_store.md
+++ b/docs/admin_reference/general/filestore_nfs_store.md
@@ -1,4 +1,5 @@
 # `nfs_store`
+
 ## NFS Filestore Configuration
 
 Configure how an NFS filestore container responds to uploads, file actions, and access control within this activity log. Includes pipeline jobs, user file actions, and conditional access.
@@ -6,3 +7,34 @@ Configure how an NFS filestore container responds to uploads, file actions, and 
 ```yaml
 !defs(filestore_nfs_store_defs.yaml)
 ```
+
+## Full Text Search Pipeline Step
+
+Use the `full_text_search` pipeline step to extract text from supported uploaded files and write searchable `tsvector` data to a target table.
+
+```yaml
+nfs_store:
+  pipeline:
+    - mount_archive:
+    - index_files:
+    - full_text_search:
+        target_table: dynamic_test.file_search_indexes
+        target_column: search_vector
+        target_foreign_key_column: stored_file_id
+        ts_config: english
+        file_filters:
+          - '.*\\.txt$'
+          - '.*\\.pdf$'
+```
+
+### Configuration fields
+
+- `target_table`: schema-qualified table storing search vectors
+- `target_column`: `tsvector` column to update
+- `target_foreign_key_column`: FK column that identifies the source stored file
+- `ts_config`: PostgreSQL text search configuration, such as `english` or `simple`
+- `file_filters`: optional list of regex filters. If set, only matching files are indexed.
+
+`file_filters` follows the same regex list pattern used by `scripted` and `dicom_deidentify` pipeline jobs.
+
+See also: [Full Text Search](full_text_search.md)

--- a/docs/admin_reference/general/full_text_search.md
+++ b/docs/admin_reference/general/full_text_search.md
@@ -1,0 +1,115 @@
+# Full Text Search
+
+## Overview
+
+Full text search combines extracted raw text with PostgreSQL full text indexing and SQL querying.
+
+Typical flow:
+
+1. Raw text is collected from dynamic definition instances (save trigger source fields) and/or files uploaded to Filestore.
+2. The text is written into `tsvector` indexes, usually in a dedicated target table with a foreign key back to the source record or stored file.
+3. Reports join to indexed tables and use PostgreSQL full text SQL operators to include text search results in broader queries.
+
+## End-to-End Configuration
+
+Full text search in ReStructure is configured across three layers:
+
+1. Define `tsvector` storage in the database
+2. Populate indexed text using save triggers and/or filestore pipeline jobs
+3. Query indexed content from reports using PostgreSQL full text search operators
+
+## Define Search Vector Storage
+
+Use `_db_columns` definitions to create `tsvector` columns and `gin` indexes where needed.
+
+```yaml
+_db_columns:
+  search_index:
+    type: tsvector
+    index: gin
+```
+
+You may index directly on the source table, or store vectors in a separate target table with an FK to the source record or stored file.
+
+See also: [db_columns](db_columns.md)
+
+## Populate Index Data
+
+### Save trigger indexing (record fields)
+
+Use the `full_text_search` save trigger to build text from record fields and write to a target `tsvector` column.
+
+```yaml
+save_trigger:
+  on_save:
+    full_text_search:
+      - index_this:
+          target_column: search_index
+          source_fields:
+            - title
+            - body
+          ts_config: english
+```
+
+For writing to a separate target table:
+
+```yaml
+save_trigger:
+  on_save:
+    full_text_search:
+      - index_to_target:
+          target_table: dynamic_test.item_search_indexes
+          target_column: search_vector
+          target_foreign_key_column: source_record_id
+          source_fields:
+            - title
+            - body
+            - notes
+          ts_config: english
+```
+
+See also: [Save Trigger: full_text_search](save_trigger_full_text_search.md)
+
+### Filestore pipeline indexing (uploaded file text)
+
+Use `nfs_store.pipeline.full_text_search` to extract text from supported files and write search vectors.
+
+```yaml
+nfs_store:
+  pipeline:
+    - mount_archive:
+    - index_files:
+    - full_text_search:
+        target_table: dynamic_test.file_search_indexes
+        target_column: search_vector
+        target_foreign_key_column: stored_file_id
+        ts_config: english
+        file_filters:
+          - '.*\\.txt$'
+          - '.*\\.pdf$'
+```
+
+`file_filters` is optional. If set, only files matching one of the regex filters are indexed.
+
+See also: [Filestore nfs_store configuration](filestore_nfs_store.md)
+
+## Query in Reports
+
+Reports can search indexed data by joining to the target table and applying full-text operators.
+
+```sql
+select dm.id, dm.title
+from dynamic_test.my_items dm
+join dynamic_test.item_search_indexes idx
+  on idx.source_record_id = dm.id
+where :search_text is null
+   or idx.search_vector @@ plainto_tsquery('english', :search_text)
+```
+
+See also: [Reports: Full Text Search](../reports/full_text_search.md)
+
+## Operational Notes
+
+- Use `simple` when stemming should be disabled.
+- Keep source text concise and relevant; avoid indexing large low-signal fields.
+- Ensure a `gin` index exists on `tsvector` columns used in report queries.

--- a/docs/admin_reference/general/save_trigger.md
+++ b/docs/admin_reference/general/save_trigger.md
@@ -26,6 +26,7 @@ Each trigger task listed under an event key corresponds to one of the following 
 | [set_item_flags](save_trigger_set_item_flags.md) | Set item flags |
 | [update_reference](save_trigger_update_reference.md) | Update a referenced record |
 | [update_this](save_trigger_update_this.md) | Update fields on the current record |
+| [full_text_search](save_trigger_full_text_search.md) | Build and persist PostgreSQL `tsvector` search indexes |
 | [run_batch_trigger](save_trigger_run_batch_trigger.md) | Run a batch trigger |
 | [log](save_trigger_log.md) | Log a message |
 | [transaction](save_trigger_transaction.md) | Wrap triggers in a transaction |

--- a/docs/admin_reference/general/save_trigger_full_text_search.md
+++ b/docs/admin_reference/general/save_trigger_full_text_search.md
@@ -1,0 +1,61 @@
+# `full_text_search`
+
+## Build and Persist Full Text Search Indexes
+
+Use this save trigger to build text from model fields and persist PostgreSQL `tsvector` data for search.
+
+This trigger supports two write modes:
+
+- Same-table mode: writes to a `tsvector` column on the current record table
+- Separate-table mode: upserts into a target table using a foreign key reference
+
+## Configuration
+
+### Same-table mode
+
+```yaml
+save_trigger:
+  on_save:
+    full_text_search:
+      - index_this:
+          target_column: search_index
+          source_fields:
+            - title
+            - description
+          ts_config: english
+```
+
+### Separate-table mode
+
+```yaml
+save_trigger:
+  on_save:
+    full_text_search:
+      - index_target:
+          target_table: dynamic_test.record_search_indexes
+          target_column: search_vector
+          target_foreign_key_column: source_record_id
+          source_fields:
+            - title
+            - description
+            - notes
+          extra_content: '{{external_identifiers.reference_text}}'
+          ts_config: english
+```
+
+## Options
+
+- `source_fields`: required array of field names used to build text content
+- `target_column`: required tsvector field to update
+- `target_table`: optional; if omitted, writes to current record table
+- `target_foreign_key_column`: required when `target_table` is set
+- `extra_content`: optional additional text appended to indexed content
+- `ts_config`: optional PostgreSQL text search configuration (defaults to `english`)
+
+## Requirements
+
+- Target `tsvector` columns must exist before trigger execution.
+- Use a `gin` index on `tsvector` fields for report performance.
+- Ensure the trigger runs on events where source text is finalized (`on_save` is typical).
+
+See also: [Full Text Search](full_text_search.md)

--- a/docs/admin_reference/main/README.md
+++ b/docs/admin_reference/main/README.md
@@ -56,3 +56,4 @@ A separate developer's reference, including API samples, is available in the [De
 ### General Concepts
 
 - [Substitutions](../general/substitutions.md) provide insertion of data into calculated conditions, captions, message templates and dialogs
+- [Full Text Search](../general/full_text_search.md) outlines end-to-end configuration for indexing and searching file and record content

--- a/docs/admin_reference/reports/0_introduction.md
+++ b/docs/admin_reference/reports/0_introduction.md
@@ -8,6 +8,12 @@ the risk of SQL injection.
 
 Administration is provided in [Admin: Reports](/admin/reports)
 
+## Full Text Search in Reports
+
+Reports can query full-text indexed data by joining to `tsvector` target tables and using PostgreSQL search operators such as `@@`, `to_tsquery`, and `plainto_tsquery`.
+
+See [Full Text Search](full_text_search.md) for a concise guide and query patterns.
+
 ## Field Definitions
 
 !defs(report_field_defs.yaml)
@@ -18,3 +24,4 @@ Administration is provided in [Admin: Reports](/admin/reports)
 - [URL Search Attributes](url_search_attributes.md)
 - [Detailed Options](detailed_options.md)
 - [File Filtering](file_filtering.md)
+- [Full Text Search](full_text_search.md)

--- a/docs/admin_reference/reports/full_text_search.md
+++ b/docs/admin_reference/reports/full_text_search.md
@@ -1,0 +1,48 @@
+# Full Text Search
+
+## Summary
+
+Reports can perform full text search against indexed `tsvector` columns produced by save triggers or filestore pipeline jobs.
+
+Use PostgreSQL search operators and functions:
+
+- `@@` to test if a vector matches a query
+- `to_tsquery(config, text)` for explicit query syntax
+- `plainto_tsquery(config, text)` for plain user-entered terms
+
+## Typical Pattern
+
+1. Join report source data to the table that stores the `tsvector` index.
+2. Add a report search attribute (for example `search_text`).
+3. Apply a conditional where clause using `@@` when the search input is present.
+
+```sql
+select dm.id,
+       dm.title,
+       dm.updated_at
+from dynamic_test.my_items dm
+join dynamic_test.item_search_indexes idx
+  on idx.source_record_id = dm.id
+where :search_text is null
+   or idx.search_vector @@ plainto_tsquery('english', :search_text)
+order by dm.updated_at desc;
+```
+
+## When to Use `to_tsquery` vs `plainto_tsquery`
+
+- Use `plainto_tsquery` for free-text user input.
+- Use `to_tsquery` when you need operators such as `&`, `|`, or `!`.
+
+Example using `to_tsquery`:
+
+```sql
+where idx.search_vector @@ to_tsquery('english', 'heart & disease')
+```
+
+## Performance Guidance
+
+- Ensure indexed columns use a `gin` index.
+- Keep indexed text focused to avoid bloated vectors.
+- Prefer filtering by app context and date ranges before full-text predicates where possible.
+
+See also: [General Concepts: Full Text Search](../general/full_text_search.md)

--- a/lib/active_record/migration/app_generator.rb
+++ b/lib/active_record/migration/app_generator.rb
@@ -903,7 +903,13 @@ module ActiveRecord
             f = field_config[:type]
             fopts = {}
             fopts[:default] = field_config[:default] if field_config[:default]
-            fopts[:index] = field_config[:index] if field_config[:index]
+            if field_config[:index].is_a?(Symbol) || field_config[:index].is_a?(String)
+              # Support custom index types like :gin, :gist (YAML parses as String)
+              idx_type = field_config[:index].to_sym
+              fopts[:index] = { using: idx_type, name: "#{rand_id}_#{idx_type}_idx" }
+            elsif field_config[:index]
+              fopts[:index] = field_config[:index]
+            end
           elsif a == 'created_by_user_id'
             f = :references
             fopts = { index: { name: "#{rand_id}_ref_cb_user_idx" }, foreign_key: { to_table: :users }, attr_name: :created_by_user }

--- a/lib/secure_view/config.rb
+++ b/lib/secure_view/config.rb
@@ -5,7 +5,7 @@ module SecureView
   # Configuration options for SecureView
   module Config
     mattr_accessor :pdftoppm_path, :pdfinfo_path, :libreoffice_path, :dcmj2pnm_path, :netpbm_path, :pdfgrep_path,
-                   :tempdir, :resolution
+                   :pdftotext_path, :tempdir, :resolution
 
     def self.setup(block)
       block.call self

--- a/spec/fixtures/files/text_extraction/sample.pdf
+++ b/spec/fixtures/files/text_extraction/sample.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/MediaBox[0 0 612 792]/Parent 2 0 R/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 155>>stream
+BT /F1 12 Tf 72 720 Td (Full text search PDF document. Cardiovascular research findings.) Tj 0 -20 Td (Neuroplasticity experiments demonstrate brain adaptation.) Tj ET
+endstream
+endobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000266 00000 n 
+0000000473 00000 n 
+trailer<</Size 6/Root 1 0 R>>
+startxref
+547
+%%EOF

--- a/spec/fixtures/files/text_extraction/sample.txt
+++ b/spec/fixtures/files/text_extraction/sample.txt
@@ -1,0 +1,1 @@
+This is a test document for full text search extraction. It contains important keywords like cardiovascular research and neuroplasticity experiments.

--- a/spec/models/dynamic_model_tsvector_column_spec.rb
+++ b/spec/models/dynamic_model_tsvector_column_spec.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Tests for tsvector column and GIN index support in dynamic model definitions (issue #74).
+# Verifies that specifying `type: tsvector` and `index: gin` in _db_columns configuration
+# causes the dynamic migration system to:
+# - Create a tsvector column in the database (not string)
+# - Create a GIN index on that column (not B-tree)
+# - Allow storing tsvector data via SQL
+# - Allow querying tsvector data with full text search operators
+RSpec.describe 'Dynamic Model Tsvector Column and GIN Index', type: :model do
+  include MasterSupport
+  include ModelSupport
+  include PlayerContactSupport
+  include DynamicModelSupport
+
+  before :all do
+    create_admin
+    create_user
+
+    @original_allow_migrations = Settings::AllowDynamicMigrations
+    change_setting('AllowDynamicMigrations', true)
+
+    @schema_name = 'dynamic_test'
+    @table_name = 'test_tsvector_fields'
+    @full_table_name = "#{@schema_name}.#{@table_name}"
+
+    # Clean up any existing test tables and model
+    DynamicModel.active.where(table_name: @table_name).each { |dm| dm.disable!(@admin) }
+    begin
+      DynamicModel.send(:remove_const, :TestTsvectorField) if DynamicModel.const_defined?(:TestTsvectorField, false)
+    rescue NameError
+      # Constant may have been removed by another parallel test
+    end
+
+    # Drop existing tables if they exist
+    @conn = ActiveRecord::Base.connection
+    history_table = "#{@table_name.singularize}_history"
+    @conn.execute("DROP TABLE IF EXISTS #{@schema_name}.#{history_table} CASCADE")
+    @conn.execute("DROP TABLE IF EXISTS #{@full_table_name} CASCADE")
+
+    # Create the dynamic model definition with tsvector column and GIN index
+    @dm = DynamicModel.create!(
+      current_admin: @admin,
+      name: 'Test Tsvector Fields',
+      table_name: @table_name,
+      schema_name: @schema_name,
+      primary_key_name: :id,
+      foreign_key_name: :master_id,
+      category: :test,
+      field_list: 'title body search_index',
+      options: <<~YAML
+        _db_columns:
+          title:
+            type: string
+          body:
+            type: string
+          search_index:
+            type: tsvector
+            index: gin
+      YAML
+    )
+
+    @dm.update_tracker_events
+    setup_access :dynamic_model__test_tsvector_fields
+  end
+
+  after :all do
+    @dm&.disable!(@admin)
+    change_setting('AllowDynamicMigrations', @original_allow_migrations)
+  end
+
+  before :each do
+    @master = Master.create! current_user: @user
+    @master.current_user = @user
+  end
+
+  describe 'tsvector column creation' do
+    it 'creates a tsvector column in the database' do
+      @conn.schema_cache.clear!
+      columns = @conn.columns(@full_table_name)
+
+      search_col = columns.find { |c| c.name == 'search_index' }
+      expect(search_col).not_to be_nil
+      expect(search_col.sql_type).to eq('tsvector')
+    end
+
+    it 'creates string columns for non-tsvector fields' do
+      @conn.schema_cache.clear!
+      columns = @conn.columns(@full_table_name)
+
+      title_col = columns.find { |c| c.name == 'title' }
+      body_col = columns.find { |c| c.name == 'body' }
+
+      expect(title_col).not_to be_nil
+      expect(body_col).not_to be_nil
+      expect(title_col.type).to eq(:string)
+      expect(body_col.type).to eq(:string)
+    end
+  end
+
+  describe 'GIN index creation' do
+    it 'creates a GIN index on the tsvector column' do
+      @conn.schema_cache.clear!
+      indexes = @conn.indexes(@full_table_name)
+
+      gin_index = indexes.find { |idx| idx.columns.include?('search_index') }
+      expect(gin_index).not_to be_nil
+      expect(gin_index.using).to eq(:gin)
+    end
+
+    it 'does not create GIN indexes on regular string columns' do
+      @conn.schema_cache.clear!
+      indexes = @conn.indexes(@full_table_name)
+
+      title_index = indexes.find { |idx| idx.columns.include?('title') }
+      body_index = indexes.find { |idx| idx.columns.include?('body') }
+
+      # String columns without index config should have no index
+      expect(title_index).to be_nil
+      expect(body_index).to be_nil
+    end
+  end
+
+  describe 'tsvector data storage' do
+    it 'can store tsvector data via raw SQL' do
+      # Insert a record first to get a master association
+      record = @master.dynamic_model__test_tsvector_fields.create!(
+        current_user: @user,
+        title: 'test document',
+        body: 'this is the body text'
+      )
+
+      # Write tsvector data directly via SQL
+      @conn.execute(<<~SQL)
+        UPDATE #{@full_table_name}
+        SET search_index = to_tsvector('english', 'test document this is the body text')
+        WHERE id = #{record.id}
+      SQL
+
+      # Verify the tsvector data was stored
+      result = @conn.execute(<<~SQL)
+        SELECT search_index::text FROM #{@full_table_name} WHERE id = #{record.id}
+      SQL
+
+      tsvector_value = result.first['search_index']
+      expect(tsvector_value).to be_present
+    end
+  end
+
+  describe 'tsvector querying' do
+    it 'can query tsvector data with full text search operators' do
+      record = @master.dynamic_model__test_tsvector_fields.create!(
+        current_user: @user,
+        title: 'important report',
+        body: 'this contains critical findings about research'
+      )
+
+      @conn.execute(<<~SQL)
+        UPDATE #{@full_table_name}
+        SET search_index = to_tsvector('english', 'important report this contains critical findings about research')
+        WHERE id = #{record.id}
+      SQL
+
+      # Query using tsquery - should find the record
+      matching = @conn.execute(<<~SQL)
+        SELECT id FROM #{@full_table_name}
+        WHERE search_index @@ to_tsquery('english', 'critical & findings')
+      SQL
+
+      expect(matching.map { |r| r['id'] }).to include(record.id)
+
+      # Query using tsquery - should NOT find with unrelated terms
+      non_matching = @conn.execute(<<~SQL)
+        SELECT id FROM #{@full_table_name}
+        WHERE search_index @@ to_tsquery('english', 'banana & smoothie')
+      SQL
+
+      expect(non_matching.map { |r| r['id'] }).not_to include(record.id)
+    end
+  end
+
+  describe 'db_columns configuration parsing' do
+    it 'includes tsvector type in parsed db_columns' do
+      @dm.option_configs(force: true)
+      db_cols = @dm.db_columns
+
+      # YAML parses unquoted values as strings
+      expect(db_cols[:search_index][:type].to_s).to eq('tsvector')
+    end
+
+    it 'includes gin index in parsed db_columns' do
+      @dm.option_configs(force: true)
+      db_cols = @dm.db_columns
+
+      # YAML parses unquoted values as strings
+      expect(db_cols[:search_index][:index].to_s).to eq('gin')
+    end
+  end
+end

--- a/spec/models/full_text_search/text_extractor_spec.rb
+++ b/spec/models/full_text_search/text_extractor_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Tests for FullTextSearch::TextExtractor module (Issue #74 - Add full text search to Postgres)
+#
+# This module extracts text content from files for full-text search indexing.
+# It supports:
+#   - PDF files via pdftotext (poppler-utils)
+#   - Office documents (doc, docx, xls, xlsx, ppt, pptx, odt, ods, odp) via LibreOffice + pdftotext
+#   - Plain text files (txt, csv, md, rtf, html) read directly
+#
+# These specs verify extraction from real fixture files and correct handling
+# of supported/unsupported file types, missing files, and configuration.
+
+RSpec.describe 'FullTextSearch::TextExtractor', type: :model do
+  let(:fixtures_path) { Rails.root.join('spec', 'fixtures', 'files') }
+  let(:pdf_path) { fixtures_path.join('text_extraction', 'sample.pdf').to_s }
+  let(:txt_path) { fixtures_path.join('text_extraction', 'sample.txt').to_s }
+  let(:pptx_path) { fixtures_path.join('secure_view', 'sample.pptx').to_s }
+  let(:nonexistent_path) { fixtures_path.join('text_extraction', 'does_not_exist.pdf').to_s }
+
+  describe '.extract_text' do
+    context 'with a PDF file' do
+      it 'extracts text content from the PDF' do
+        result = FullTextSearch::TextExtractor.extract_text(pdf_path)
+
+        expect(result).to be_a(String)
+        expect(result).not_to be_empty
+        expect(result).to include('Cardiovascular research')
+        expect(result).to include('Neuroplasticity')
+      end
+    end
+
+    context 'with a plain text file' do
+      it 'reads text content directly from the file' do
+        result = FullTextSearch::TextExtractor.extract_text(txt_path)
+
+        expect(result).to be_a(String)
+        expect(result).not_to be_empty
+        expect(result).to include('cardiovascular research')
+        expect(result).to include('neuroplasticity experiments')
+      end
+    end
+
+    context 'with an office document (pptx)' do
+      it 'extracts text content from the office document' do
+        result = FullTextSearch::TextExtractor.extract_text(pptx_path)
+
+        expect(result).to be_a(String)
+        # The pptx fixture may have limited text content;
+        # primarily verifying extraction completes without error
+      end
+    end
+
+    context 'with a non-existent file' do
+      it 'raises FphsException' do
+        expect do
+          FullTextSearch::TextExtractor.extract_text(nonexistent_path)
+        end.to raise_error(FphsException)
+      end
+    end
+
+    context 'with an unsupported file type' do
+      let(:unsupported_path) { fixtures_path.join('text_extraction', 'sample.dcm').to_s }
+
+      it 'returns nil for unsupported file types' do
+        # Create a dummy file so the "missing file" check doesn't trigger
+        FileUtils.mkdir_p(File.dirname(unsupported_path))
+        File.write(unsupported_path, 'binary content')
+
+        result = FullTextSearch::TextExtractor.extract_text(unsupported_path)
+
+        expect(result).to be_nil
+      ensure
+        FileUtils.rm_f(unsupported_path)
+      end
+    end
+  end
+
+  describe '.supported?' do
+    context 'with PDF files' do
+      it 'returns true for .pdf extension' do
+        expect(FullTextSearch::TextExtractor.supported?('document.pdf')).to be true
+      end
+    end
+
+    context 'with plain text files' do
+      it 'returns true for .txt extension' do
+        expect(FullTextSearch::TextExtractor.supported?('notes.txt')).to be true
+      end
+
+      it 'returns true for .csv extension' do
+        expect(FullTextSearch::TextExtractor.supported?('data.csv')).to be true
+      end
+
+      it 'returns true for .md extension' do
+        expect(FullTextSearch::TextExtractor.supported?('readme.md')).to be true
+      end
+
+      it 'returns true for .html extension' do
+        expect(FullTextSearch::TextExtractor.supported?('page.html')).to be true
+      end
+
+      it 'returns true for .rtf extension' do
+        expect(FullTextSearch::TextExtractor.supported?('document.rtf')).to be true
+      end
+    end
+
+    context 'with office document files' do
+      it 'returns true for .docx extension' do
+        expect(FullTextSearch::TextExtractor.supported?('report.docx')).to be true
+      end
+
+      it 'returns true for .doc extension' do
+        expect(FullTextSearch::TextExtractor.supported?('report.doc')).to be true
+      end
+
+      it 'returns true for .xlsx extension' do
+        expect(FullTextSearch::TextExtractor.supported?('spreadsheet.xlsx')).to be true
+      end
+
+      it 'returns true for .xls extension' do
+        expect(FullTextSearch::TextExtractor.supported?('spreadsheet.xls')).to be true
+      end
+
+      it 'returns true for .pptx extension' do
+        expect(FullTextSearch::TextExtractor.supported?('slides.pptx')).to be true
+      end
+
+      it 'returns true for .ppt extension' do
+        expect(FullTextSearch::TextExtractor.supported?('slides.ppt')).to be true
+      end
+
+      it 'returns true for .odt extension' do
+        expect(FullTextSearch::TextExtractor.supported?('document.odt')).to be true
+      end
+
+      it 'returns true for .ods extension' do
+        expect(FullTextSearch::TextExtractor.supported?('spreadsheet.ods')).to be true
+      end
+
+      it 'returns true for .odp extension' do
+        expect(FullTextSearch::TextExtractor.supported?('slides.odp')).to be true
+      end
+    end
+
+    context 'with unsupported file types' do
+      it 'returns false for .dcm extension' do
+        expect(FullTextSearch::TextExtractor.supported?('image.dcm')).to be false
+      end
+
+      it 'returns false for .zip extension' do
+        expect(FullTextSearch::TextExtractor.supported?('archive.zip')).to be false
+      end
+
+      it 'returns false for .jpg extension' do
+        expect(FullTextSearch::TextExtractor.supported?('photo.jpg')).to be false
+      end
+
+      it 'returns false for .exe extension' do
+        expect(FullTextSearch::TextExtractor.supported?('program.exe')).to be false
+      end
+    end
+  end
+
+  describe '.pdftotext_path' do
+    context 'when SecureView::Config.pdftotext_path is set' do
+      it 'returns the configured path' do
+        original = SecureView::Config.pdftotext_path
+        SecureView::Config.pdftotext_path = '/custom/path/pdftotext'
+
+        expect(FullTextSearch::TextExtractor.pdftotext_path).to eq('/custom/path/pdftotext')
+      ensure
+        SecureView::Config.pdftotext_path = original
+      end
+    end
+
+    context 'when SecureView::Config.pdftotext_path is not set' do
+      it 'defaults to pdftotext' do
+        original = SecureView::Config.pdftotext_path
+        SecureView::Config.pdftotext_path = nil
+
+        expect(FullTextSearch::TextExtractor.pdftotext_path).to eq('pdftotext')
+      ensure
+        SecureView::Config.pdftotext_path = original
+      end
+    end
+  end
+end

--- a/spec/models/full_text_search/tsvector_writer_spec.rb
+++ b/spec/models/full_text_search/tsvector_writer_spec.rb
@@ -1,0 +1,494 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Tests for FullTextSearch::TsvectorWriter (issue #74).
+# Verifies the shared utility module that writes tsvector data to database tables:
+# - write_tsvector inserts tsvector data using parameterized SQL (Mode 1: separate target table)
+# - write_tsvector performs upsert (update if FK row already exists)
+# - update_tsvector updates a tsvector column on the record's own table (Mode 2: same table)
+# - build_text_content concatenates field values with nil-safe handling
+# - build_text_content supports extra_content parameter for file text
+# - Table and column names are properly quoted to prevent SQL injection
+RSpec.describe 'FullTextSearch::TsvectorWriter', type: :model do
+  include MasterSupport
+  include ModelSupport
+  include PlayerContactSupport
+  include DynamicModelSupport
+
+  before :all do
+    create_admin
+    create_user
+
+    @original_allow_migrations = Settings::AllowDynamicMigrations
+    change_setting('AllowDynamicMigrations', true)
+
+    @schema_name = 'dynamic_test'
+    @source_table_name = 'test_fts_sources'
+    @target_table_name = 'test_fts_targets'
+    @same_table_name = 'test_fts_same_tables'
+    @full_target_table = "#{@schema_name}.#{@target_table_name}"
+    @full_source_table = "#{@schema_name}.#{@source_table_name}"
+    @full_same_table = "#{@schema_name}.#{@same_table_name}"
+
+    @conn = ActiveRecord::Base.connection
+
+    # Create the schema if it doesn't exist
+    @conn.execute("CREATE SCHEMA IF NOT EXISTS #{@schema_name}")
+
+    # Clean up any existing test tables
+    [@source_table_name, @same_table_name].each do |tname|
+      DynamicModel.active.where(table_name: tname).each { |dm| dm.disable!(@admin) }
+
+      const_name = tname.singularize.camelize.to_sym
+      begin
+        DynamicModel.send(:remove_const, const_name) if DynamicModel.const_defined?(const_name, false)
+      rescue NameError
+        # Constant may have been removed by another parallel test
+      end
+
+      history_name = "#{tname.singularize}_history"
+      @conn.execute("DROP TABLE IF EXISTS #{@schema_name}.#{history_name} CASCADE")
+      @conn.execute("DROP TABLE IF EXISTS #{@schema_name}.#{tname} CASCADE")
+    end
+    @conn.execute("DROP TABLE IF EXISTS #{@full_target_table} CASCADE")
+
+    # Create a source dynamic model with fields to index
+    @source_dm = DynamicModel.create!(
+      current_admin: @admin,
+      name: 'Test FTS Source',
+      table_name: @source_table_name,
+      schema_name: @schema_name,
+      primary_key_name: :id,
+      foreign_key_name: :master_id,
+      category: :test,
+      field_list: 'title description notes',
+      options: <<~YAML
+        _db_columns:
+          title:
+            type: string
+          description:
+            type: string
+          notes:
+            type: string
+      YAML
+    )
+
+    @source_dm.update_tracker_events
+    setup_access :dynamic_model__test_fts_sources, resource_type: :table, access: :create
+
+    # Create a target table for tsvector storage with raw SQL
+    # This simulates the FTS target table that TsvectorWriter writes to
+    @conn.execute(<<~SQL)
+      CREATE TABLE IF NOT EXISTS #{@full_target_table} (
+        id bigserial PRIMARY KEY,
+        master_id bigint,
+        source_id bigint NOT NULL,
+        search_content tsvector,
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now(),
+        UNIQUE (source_id)
+      )
+    SQL
+
+    # Create a GIN index on the tsvector column
+    @conn.execute(<<~SQL)
+      CREATE INDEX IF NOT EXISTS idx_test_fts_target_search_content
+      ON #{@full_target_table}
+      USING gin (search_content)
+    SQL
+
+    # ---- Same-table dynamic model for Mode 2 (has its own tsvector column) ----
+    @same_dm = DynamicModel.create!(
+      current_admin: @admin,
+      name: 'Test FTS Same Table',
+      table_name: @same_table_name,
+      schema_name: @schema_name,
+      primary_key_name: :id,
+      foreign_key_name: :master_id,
+      category: :test,
+      field_list: 'title body search_index',
+      options: <<~YAML
+        _db_columns:
+          title:
+            type: string
+          body:
+            type: string
+          search_index:
+            type: tsvector
+      YAML
+    )
+    @same_dm.update_tracker_events
+    setup_access :dynamic_model__test_fts_same_tables, resource_type: :table, access: :create
+  end
+
+  after :all do
+    @source_dm&.disable!(@admin)
+    @same_dm&.disable!(@admin)
+    @conn&.execute("DROP TABLE IF EXISTS #{@full_target_table} CASCADE")
+    change_setting('AllowDynamicMigrations', @original_allow_migrations)
+  end
+
+  before :each do
+    @master = Master.create! current_user: @user
+    @master.current_user = @user
+
+    # Clean target table rows between tests
+    @conn.execute("DELETE FROM #{@full_target_table}")
+  end
+
+  describe '.write_tsvector' do
+    it 'writes a tsvector value to the target table' do
+      source_record = @master.dynamic_model__test_fts_sources.create!(
+        current_user: @user,
+        title: 'test document',
+        description: 'a sample description',
+        notes: 'some notes here'
+      )
+
+      FullTextSearch::TsvectorWriter.write_tsvector(
+        target_table: @full_target_table,
+        target_field: 'search_content',
+        text_content: 'test document a sample description some notes here',
+        fk_column: 'source_id',
+        fk_value: source_record.id,
+        master_id: @master.id
+      )
+
+      result = @conn.execute(<<~SQL)
+        SELECT search_content::text, master_id, source_id
+        FROM #{@full_target_table}
+        WHERE source_id = #{source_record.id}
+      SQL
+
+      row = result.first
+      expect(row).not_to be_nil
+      expect(row['search_content']).to be_present
+      expect(row['master_id']).to eq(@master.id)
+      expect(row['source_id']).to eq(source_record.id)
+    end
+
+    it 'performs upsert - updates existing row when FK matches' do
+      source_record = @master.dynamic_model__test_fts_sources.create!(
+        current_user: @user,
+        title: 'original title',
+        description: 'original description',
+        notes: 'original notes'
+      )
+
+      # First write
+      FullTextSearch::TsvectorWriter.write_tsvector(
+        target_table: @full_target_table,
+        target_field: 'search_content',
+        text_content: 'original title original description original notes',
+        fk_column: 'source_id',
+        fk_value: source_record.id,
+        master_id: @master.id
+      )
+
+      # Second write with updated content - should update, not insert
+      FullTextSearch::TsvectorWriter.write_tsvector(
+        target_table: @full_target_table,
+        target_field: 'search_content',
+        text_content: 'updated title with new keywords and findings',
+        fk_column: 'source_id',
+        fk_value: source_record.id,
+        master_id: @master.id
+      )
+
+      # Should only have one row
+      count_result = @conn.execute(<<~SQL)
+        SELECT count(*) AS cnt FROM #{@full_target_table} WHERE source_id = #{source_record.id}
+      SQL
+      expect(count_result.first['cnt']).to eq(1)
+
+      # Content should be the updated version
+      search_result = @conn.execute(<<~SQL)
+        SELECT id FROM #{@full_target_table}
+        WHERE source_id = #{source_record.id}
+        AND search_content @@ to_tsquery('english', 'updated & keywords')
+      SQL
+      expect(search_result.count).to eq(1)
+    end
+
+    it 'writes data that is queryable with full text search' do
+      source_record = @master.dynamic_model__test_fts_sources.create!(
+        current_user: @user,
+        title: 'cardiovascular research',
+        description: 'a study on heart disease prevention',
+        notes: 'preliminary findings are promising'
+      )
+
+      FullTextSearch::TsvectorWriter.write_tsvector(
+        target_table: @full_target_table,
+        target_field: 'search_content',
+        text_content: 'cardiovascular research a study on heart disease prevention preliminary findings are promising',
+        fk_column: 'source_id',
+        fk_value: source_record.id,
+        master_id: @master.id
+      )
+
+      # Should match relevant query
+      matching = @conn.execute(<<~SQL)
+        SELECT source_id FROM #{@full_target_table}
+        WHERE search_content @@ to_tsquery('english', 'cardiovascular & research')
+      SQL
+      expect(matching.map { |r| r['source_id'] }).to include(source_record.id)
+
+      # Should not match unrelated query
+      non_matching = @conn.execute(<<~SQL)
+        SELECT source_id FROM #{@full_target_table}
+        WHERE search_content @@ to_tsquery('english', 'banana & smoothie')
+      SQL
+      expect(non_matching.map { |r| r['source_id'] }).not_to include(source_record.id)
+    end
+
+    it 'uses the specified ts_config for separate-table writes' do
+      source_record = @master.dynamic_model__test_fts_sources.create!(
+        current_user: @user,
+        title: 'running quickly',
+        description: '',
+        notes: ''
+      )
+
+      FullTextSearch::TsvectorWriter.write_tsvector(
+        target_table: @full_target_table,
+        target_field: 'search_content',
+        text_content: 'running quickly',
+        fk_column: 'source_id',
+        fk_value: source_record.id,
+        master_id: @master.id,
+        ts_config: 'simple'
+      )
+
+      simple_match = @conn.execute(<<~SQL)
+        SELECT id FROM #{@full_target_table}
+        WHERE source_id = #{source_record.id}
+        AND search_content @@ to_tsquery('simple', 'running')
+      SQL
+      expect(simple_match.count).to eq(1)
+
+      english_stem_match = @conn.execute(<<~SQL)
+        SELECT id FROM #{@full_target_table}
+        WHERE source_id = #{source_record.id}
+        AND search_content @@ to_tsquery('english', 'run')
+      SQL
+      expect(english_stem_match.count).to eq(0)
+    end
+  end
+
+  describe '.build_text_content' do
+    it 'concatenates field values from an item' do
+      source_record = @master.dynamic_model__test_fts_sources.create!(
+        current_user: @user,
+        title: 'my title',
+        description: 'my description',
+        notes: 'my notes'
+      )
+
+      text = FullTextSearch::TsvectorWriter.build_text_content(
+        item: source_record,
+        with_fields: %i[title description notes]
+      )
+
+      expect(text).to include('my title')
+      expect(text).to include('my description')
+      expect(text).to include('my notes')
+    end
+
+    it 'skips nil and blank field values' do
+      source_record = @master.dynamic_model__test_fts_sources.create!(
+        current_user: @user,
+        title: 'only title set',
+        description: '',
+        notes: nil
+      )
+
+      text = FullTextSearch::TsvectorWriter.build_text_content(
+        item: source_record,
+        with_fields: %i[title description notes]
+      )
+
+      expect(text).to include('only title set')
+      # Should not contain empty separators or garbage from nil/blank values
+      expect(text).not_to match(/\s{2,}/)
+    end
+
+    it 'appends extra_content when provided' do
+      source_record = @master.dynamic_model__test_fts_sources.create!(
+        current_user: @user,
+        title: 'document title',
+        description: 'document description',
+        notes: ''
+      )
+
+      text = FullTextSearch::TsvectorWriter.build_text_content(
+        item: source_record,
+        with_fields: %i[title description],
+        extra_content: 'extracted file text content from a PDF attachment'
+      )
+
+      expect(text).to include('document title')
+      expect(text).to include('document description')
+      expect(text).to include('extracted file text content from a PDF attachment')
+    end
+
+    it 'handles extra_content when all fields are blank' do
+      source_record = @master.dynamic_model__test_fts_sources.create!(
+        current_user: @user,
+        title: '',
+        description: nil,
+        notes: nil
+      )
+
+      text = FullTextSearch::TsvectorWriter.build_text_content(
+        item: source_record,
+        with_fields: %i[title description notes],
+        extra_content: 'only file content available'
+      )
+
+      expect(text).to include('only file content available')
+      expect(text.strip).not_to be_empty
+    end
+  end
+
+  describe '.update_tsvector' do
+    it 'updates a tsvector column on the record own table' do
+      record = @master.dynamic_model__test_fts_same_tables.create!(
+        current_user: @user,
+        title: 'neuroscience developments',
+        body: 'recent advances in brain imaging technology'
+      )
+
+      FullTextSearch::TsvectorWriter.update_tsvector(
+        table_name: @full_same_table,
+        target_field: 'search_index',
+        text_content: 'neuroscience developments recent advances in brain imaging technology',
+        record_id: record.id
+      )
+
+      result = @conn.execute(<<~SQL)
+        SELECT search_index::text
+        FROM #{@full_same_table}
+        WHERE id = #{record.id}
+      SQL
+
+      row = result.first
+      expect(row).not_to be_nil
+      expect(row['search_index']).to be_present
+    end
+
+    it 'data is queryable with full text search' do
+      record = @master.dynamic_model__test_fts_same_tables.create!(
+        current_user: @user,
+        title: 'cardiovascular research',
+        body: 'a study on heart disease prevention'
+      )
+
+      FullTextSearch::TsvectorWriter.update_tsvector(
+        table_name: @full_same_table,
+        target_field: 'search_index',
+        text_content: 'cardiovascular research a study on heart disease prevention',
+        record_id: record.id
+      )
+
+      matching = @conn.execute(<<~SQL)
+        SELECT id FROM #{@full_same_table}
+        WHERE search_index @@ to_tsquery('english', 'cardiovascular & research')
+      SQL
+      expect(matching.map { |r| r['id'] }).to include(record.id)
+
+      non_matching = @conn.execute(<<~SQL)
+        SELECT id FROM #{@full_same_table}
+        WHERE search_index @@ to_tsquery('english', 'banana & smoothie')
+      SQL
+      expect(non_matching.map { |r| r['id'] }).not_to include(record.id)
+    end
+
+    it 'uses the specified ts_config' do
+      record = @master.dynamic_model__test_fts_same_tables.create!(
+        current_user: @user,
+        title: 'running jumping',
+        body: 'the dogs are running and jumping'
+      )
+
+      FullTextSearch::TsvectorWriter.update_tsvector(
+        table_name: @full_same_table,
+        target_field: 'search_index',
+        text_content: 'running jumping the dogs are running and jumping',
+        record_id: record.id,
+        ts_config: 'simple'
+      )
+
+      # With 'simple' config, words are not stemmed — exact match on 'running' should work
+      matching = @conn.execute(<<~SQL)
+        SELECT id FROM #{@full_same_table}
+        WHERE search_index @@ to_tsquery('simple', 'running')
+      SQL
+      expect(matching.map { |r| r['id'] }).to include(record.id)
+    end
+
+    it 'rejects invalid table_name' do
+      expect do
+        FullTextSearch::TsvectorWriter.update_tsvector(
+          table_name: 'dynamic_test.test_fts_same_table; DROP TABLE users; --',
+          target_field: 'search_index',
+          text_content: 'test content',
+          record_id: 1
+        )
+      end.to raise_error(ArgumentError)
+    end
+
+    it 'rejects invalid target_field' do
+      expect do
+        FullTextSearch::TsvectorWriter.update_tsvector(
+          table_name: @full_same_table,
+          target_field: 'search_index; DROP TABLE users; --',
+          text_content: 'test content',
+          record_id: 1
+        )
+      end.to raise_error(ArgumentError)
+    end
+  end
+
+  describe 'SQL injection prevention' do
+    it 'safely handles table and column names' do
+      # Attempting to use a malicious table name should raise an ArgumentError
+      # (not NameError from missing constant — the module must exist to validate input)
+      expect do
+        FullTextSearch::TsvectorWriter.write_tsvector(
+          target_table: "#{@schema_name}.test_fts_targets; DROP TABLE users; --",
+          target_field: 'search_content',
+          text_content: 'test content',
+          fk_column: 'source_id',
+          fk_value: 1
+        )
+      end.to raise_error(ArgumentError)
+    end
+
+    it 'safely handles malicious text content without SQL injection' do
+      source_record = @master.dynamic_model__test_fts_sources.create!(
+        current_user: @user,
+        title: 'safe title',
+        description: 'safe description',
+        notes: ''
+      )
+
+      # Malicious text content should be parameterized and safe
+      expect do
+        FullTextSearch::TsvectorWriter.write_tsvector(
+          target_table: @full_target_table,
+          target_field: 'search_content',
+          text_content: "'; DROP TABLE users; --",
+          fk_column: 'source_id',
+          fk_value: source_record.id,
+          master_id: @master.id
+        )
+      end.not_to raise_error
+
+      # Verify the target table still exists and data was written
+      result = @conn.execute("SELECT count(*) AS cnt FROM #{@full_target_table}")
+      expect(result.first['cnt']).to be >= 1
+    end
+  end
+end

--- a/spec/models/nfs_store/process/full_text_search_job_spec.rb
+++ b/spec/models/nfs_store/process/full_text_search_job_spec.rb
@@ -1,0 +1,288 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Tests for NfsStore::Process::FullTextSearchJob (issue #74).
+# Verifies the NFS Store pipeline job that extracts text from uploaded files
+# and writes tsvector data to a target table for full-text searching:
+# - Reads pipeline configuration for :full_text_search from extra_log_types
+# - Extracts text from supported files (text, PDF, office) via FullTextSearch::TextExtractor
+# - Writes extracted text to a target table's tsvector column via FullTextSearch::TsvectorWriter
+# - Applies file_filters using the scripted pipeline pattern (regex filters)
+# - Skips unsupported file types (e.g. DICOM files)
+# - Handles multiple files independently, creating one tsvector row per file
+RSpec.describe 'NfsStore::Process::FullTextSearchJob', type: :model do
+  include PlayerContactSupport
+  include ModelSupport
+  include MasterSupport
+  include NfsStoreSupport
+  include DynamicModelSupport
+
+  def default_role
+    'file1'
+  end
+
+  before :all do
+    create_admin
+    create_user
+
+    @original_allow_migrations = Settings::AllowDynamicMigrations
+    change_setting('AllowDynamicMigrations', true)
+
+    @schema_name = 'dynamic_test'
+    @target_table_name = 'test_fts_job_targets'
+    @full_target_table = "#{@schema_name}.#{@target_table_name}"
+
+    @conn = ActiveRecord::Base.connection
+    @conn.execute("CREATE SCHEMA IF NOT EXISTS #{@schema_name}")
+
+    # Drop existing target table if it exists
+    @conn.execute("DROP TABLE IF EXISTS #{@full_target_table} CASCADE")
+
+    # Create the target table for tsvector storage
+    # This simulates the FTS target table that the pipeline job writes to
+    @conn.execute(<<~SQL)
+      CREATE TABLE #{@full_target_table} (
+        id bigserial PRIMARY KEY,
+        master_id bigint,
+        stored_file_id bigint NOT NULL,
+        search_vector tsvector,
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now(),
+        UNIQUE (stored_file_id)
+      )
+    SQL
+
+    # Create a GIN index on the tsvector column
+    @conn.execute(<<~SQL)
+      CREATE INDEX idx_test_fts_job_targets_search_vector
+      ON #{@full_target_table}
+      USING gin (search_vector)
+    SQL
+  end
+
+  after :all do
+    @conn&.execute("DROP TABLE IF EXISTS #{@full_target_table} CASCADE")
+    change_setting('AllowDynamicMigrations', @original_allow_migrations)
+  end
+
+  before :each do
+    seed_database && ActivityLog.define_models
+    setup_nfs_store
+    setup_fts_pipeline
+    setup_container_and_al activity: :fts_test
+    setup_default_filters activity: :fts_test
+
+    # Clean target table rows between tests
+    @conn.execute("DELETE FROM #{@full_target_table}")
+  end
+
+  # Configure the activity log definition with a full_text_search pipeline step
+  def setup_fts_pipeline(file_filters: ['.*'], ts_config: 'english')
+    @al_name = NfsStoreSupport::AlFilterTestName
+
+    @aldef = ActivityLog.active.where(name: @al_name).first
+    unless @aldef
+      @aldef = ActivityLog.where(name: @al_name).first
+      @aldef.update(disabled: false, current_admin: @admin)
+      @aldef = ActivityLog.active.where(name: @al_name).first
+    end
+    expect(@aldef).not_to be nil
+
+    @aldef.extra_log_types = <<~ENDDEF
+      fts_test:
+        label: FTS Test
+        fields:
+          - select_call_direction
+          - select_who
+
+        save_trigger:
+          on_create:
+            create_filestore_container:
+              name:
+                - session files
+                - select_scanner
+              label: Session Files
+              create_with_role: nfs_store group 600
+
+        references:
+          nfs_store__manage__container:
+            label: Files
+            from: this
+            add: one_to_this
+            view_as:
+              edit: hide
+              show: filestore
+              new: not_embedded
+
+        nfs_store:
+          pipeline:
+            - mount_archive:
+            - index_files:
+            - full_text_search:
+                target_table: #{@full_target_table}
+                target_column: search_vector
+                target_foreign_key_column: stored_file_id
+                ts_config: #{ts_config}
+                file_filters:
+                  - #{file_filters.join("\n                  - ")}
+    ENDDEF
+
+    @aldef.current_admin = @admin
+    @aldef.save!
+    @aldef.option_configs(force: true)
+    ActivityLog::PlayerContactPhone.definition.option_configs(force: true)
+
+    finalize_al_setup activity: :fts_test
+  end
+
+  describe 'pipeline config reading' do
+    it 'reads the full_text_search config from the pipeline' do
+      text_content = 'This is searchable text content for full text search testing'
+      ul = upload_file('test-document.txt', text_content)
+      sf = ul.stored_file
+
+      ph = NfsStore::Process::ProcessHandler.new(sf)
+      config = ph.pipeline_job_config(:full_text_search)
+
+      expect(config).not_to be_nil
+      expect(config[:target_table]).to eq @full_target_table
+      expect(config[:target_column]).to eq 'search_vector'
+      expect(config[:target_foreign_key_column]).to eq 'stored_file_id'
+      expect(config[:ts_config]).to eq 'english'
+      expect(config[:file_filters]).to eq(['.*'])
+    end
+  end
+
+  describe 'file_filters' do
+    it 'indexes a supported file when it matches file_filters' do
+      setup_fts_pipeline(file_filters: ['.*\\.txt$'])
+
+      ul = upload_file('filter-match.txt', 'text content to include')
+      sf = ul.stored_file
+
+      job = NfsStore::Process::FullTextSearchJob.new
+      curr_app = sf.current_user.app_type_id
+      job.perform(sf, curr_app)
+
+      result = @conn.execute(
+        "SELECT count(*) AS cnt FROM #{@full_target_table} WHERE stored_file_id = #{sf.id}"
+      )
+      expect(result.first['cnt']).to eq 1
+    end
+
+    it 'skips a supported file when it does not match file_filters' do
+      setup_fts_pipeline(file_filters: ['.*\\.txt$'])
+
+      ul = upload_file('filter-miss.csv', 'text content that should be skipped by filters')
+      sf = ul.stored_file
+
+      job = NfsStore::Process::FullTextSearchJob.new
+      curr_app = sf.current_user.app_type_id
+      job.perform(sf, curr_app)
+
+      result = @conn.execute(
+        "SELECT count(*) AS cnt FROM #{@full_target_table} WHERE stored_file_id = #{sf.id}"
+      )
+      expect(result.first['cnt']).to eq 0
+    end
+  end
+
+  describe 'basic text extraction and indexing' do
+    it 'extracts text from a text file and writes tsvector to the target table' do
+      text_content = 'This is searchable text content for full text search testing'
+      ul = upload_file('test-document.txt', text_content)
+      sf = ul.stored_file
+
+      job = NfsStore::Process::FullTextSearchJob.new
+      curr_app = sf.current_user.app_type_id
+      job.perform(sf, curr_app)
+
+      # Verify a row was written to the target table
+      result = @conn.execute(
+        "SELECT stored_file_id, search_vector FROM #{@full_target_table} WHERE stored_file_id = #{sf.id}"
+      )
+      expect(result.count).to eq 1
+
+      row = result.first
+      expect(row['stored_file_id']).to eq sf.id
+      expect(row['search_vector']).not_to be_nil
+      expect(row['search_vector']).not_to be_empty
+    end
+
+    it 'uses the configured ts_config when writing to the target table' do
+      setup_fts_pipeline(ts_config: 'simple')
+
+      ul = upload_file('config-simple.txt', 'running data')
+      sf = ul.stored_file
+
+      job = NfsStore::Process::FullTextSearchJob.new
+      curr_app = sf.current_user.app_type_id
+      job.perform(sf, curr_app)
+
+      simple_match = @conn.execute(<<~SQL)
+        SELECT id FROM #{@full_target_table}
+        WHERE stored_file_id = #{sf.id}
+        AND search_vector @@ to_tsquery('simple', 'running')
+      SQL
+      expect(simple_match.count).to eq(1)
+
+      english_stem_match = @conn.execute(<<~SQL)
+        SELECT id FROM #{@full_target_table}
+        WHERE stored_file_id = #{sf.id}
+        AND search_vector @@ to_tsquery('english', 'run')
+      SQL
+      expect(english_stem_match.count).to eq(0)
+    end
+  end
+
+  describe 'skipping unsupported files' do
+    it 'does not write tsvector data for unsupported file types' do
+      # Upload a DICOM file (unsupported for text extraction)
+      ul = upload_file('test-image.dcm', 'binary dicom data')
+      sf = ul.stored_file
+
+      job = NfsStore::Process::FullTextSearchJob.new
+      curr_app = sf.current_user.app_type_id
+      job.perform(sf, curr_app)
+
+      # Verify no row was written to the target table
+      result = @conn.execute(
+        "SELECT count(*) AS cnt FROM #{@full_target_table} WHERE stored_file_id = #{sf.id}"
+      )
+      expect(result.first['cnt']).to eq 0
+    end
+  end
+
+  describe 'multiple files' do
+    it 'creates a separate tsvector entry for each uploaded text file' do
+      stored_file_ids = []
+
+      3.times do |i|
+        content = "Document number #{i} with unique searchable content about topic #{i}"
+        ul = upload_file("test-doc-#{i}.txt", content)
+        sf = ul.stored_file
+        stored_file_ids << sf.id
+
+        job = NfsStore::Process::FullTextSearchJob.new
+        curr_app = sf.current_user.app_type_id
+        job.perform(sf, curr_app)
+      end
+
+      # Verify each file has its own tsvector row
+      result = @conn.execute(
+        "SELECT count(*) AS cnt FROM #{@full_target_table}"
+      )
+      expect(result.first['cnt']).to eq 3
+
+      # Verify each stored_file_id has a row
+      stored_file_ids.each do |sf_id|
+        row = @conn.execute(
+          "SELECT search_vector FROM #{@full_target_table} WHERE stored_file_id = #{sf_id}"
+        ).first
+        expect(row).not_to be_nil
+        expect(row['search_vector']).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/save_triggers/full_text_search_spec.rb
+++ b/spec/models/save_triggers/full_text_search_spec.rb
@@ -1,0 +1,479 @@
+# frozen_string_literal: true
+
+# Tests for SaveTriggers::FullTextSearch (issue #74)
+#
+# Verifies the full_text_search save trigger, which writes tsvector data
+# for full-text search indexing when a dynamic model record is saved.
+#
+# Two modes are supported:
+#
+# Mode 1 - Separate target table:
+#   Reads specified source fields from the item and writes tsvector data
+#   to a separate target table via FullTextSearch::TsvectorWriter (upsert).
+#
+# Mode 2 - Same table column:
+#   Reads specified source fields and updates the tsvector column on the
+#   item's own table row using a direct SQL UPDATE.
+#
+# Covers:
+# - Registration in ValidSaveTriggers
+# - Resolution via trigger_class(:full_text_search)
+# - Mode 1: writing tsvector to a separate target table
+# - Mode 2: writing tsvector to the same table's column
+# - Upsert behaviour (update, not duplicate)
+# - Conditional execution with if:
+# - Extra content appended to text
+# - Error on missing required config (source_fields, target_column)
+# - Default ts_config when omitted
+
+require 'rails_helper'
+
+RSpec.describe 'SaveTriggers::FullTextSearch', type: :model do
+  include MasterSupport
+  include ModelSupport
+  include PlayerContactSupport
+  include DynamicModelSupport
+
+  before :all do
+    create_admin
+    create_user
+
+    @original_allow_migrations = Settings::AllowDynamicMigrations
+    change_setting('AllowDynamicMigrations', true)
+
+    @schema_name = 'dynamic_test'
+    @source_table_name = 'test_fts_trigger_sources'
+    @target_table_name = 'test_fts_trigger_targets'
+    @same_table_name = 'test_fts_trigger_sames'
+
+    @conn = ActiveRecord::Base.connection
+    @conn.execute("CREATE SCHEMA IF NOT EXISTS #{@schema_name}")
+
+    # ---- Clean up any existing test dynamic models and tables ----
+
+    [@source_table_name, @target_table_name, @same_table_name].each do |tname|
+      DynamicModel.active.where(table_name: tname).each { |dm| dm.disable!(@admin) }
+
+      const_name = tname.singularize.camelize.to_sym
+      begin
+        DynamicModel.send(:remove_const, const_name) if DynamicModel.const_defined?(const_name, false)
+      rescue NameError
+        # already removed
+      end
+
+      history_name = "#{tname.singularize}_history"
+      @conn.execute("DROP TABLE IF EXISTS #{@schema_name}.#{history_name} CASCADE")
+      @conn.execute("DROP TABLE IF EXISTS #{@schema_name}.#{tname} CASCADE")
+    end
+
+    # ---- Source dynamic model (title, body, notes) ----
+
+    @source_dm = DynamicModel.create!(
+      current_admin: @admin,
+      name: 'Test FTS Trigger Source',
+      table_name: @source_table_name,
+      schema_name: @schema_name,
+      primary_key_name: :id,
+      foreign_key_name: :master_id,
+      category: :test,
+      field_list: 'title body notes'
+    )
+    @source_dm.update_tracker_events
+    setup_access :dynamic_model__test_fts_trigger_sources, resource_type: :table, access: :create
+
+    # ---- Target table for Mode 1 (separate tsvector storage) ----
+
+    @conn.execute(<<~SQL)
+      CREATE TABLE #{@schema_name}.#{@target_table_name} (
+        id bigserial PRIMARY KEY,
+        master_id bigint,
+        source_record_id bigint NOT NULL,
+        search_vector tsvector,
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now(),
+        UNIQUE (source_record_id)
+      )
+    SQL
+
+    @conn.execute(<<~SQL)
+      CREATE INDEX idx_fts_trigger_targets_search_vector
+      ON #{@schema_name}.#{@target_table_name}
+      USING gin (search_vector)
+    SQL
+
+    # ---- Same-table dynamic model for Mode 2 (has its own tsvector column) ----
+
+    @same_dm = DynamicModel.create!(
+      current_admin: @admin,
+      name: 'Test FTS Trigger Same',
+      table_name: @same_table_name,
+      schema_name: @schema_name,
+      primary_key_name: :id,
+      foreign_key_name: :master_id,
+      category: :test,
+      field_list: 'title body search_index',
+      options: <<~YAML
+        _db_columns:
+          title:
+            type: string
+          body:
+            type: string
+          search_index:
+            type: tsvector
+      YAML
+    )
+    @same_dm.update_tracker_events
+    setup_access :dynamic_model__test_fts_trigger_sames, resource_type: :table, access: :create
+  end
+
+  after :all do
+    @source_dm&.disable!(@admin)
+    @same_dm&.disable!(@admin)
+    @conn&.execute("DROP TABLE IF EXISTS #{@schema_name}.#{@target_table_name} CASCADE")
+    change_setting('AllowDynamicMigrations', @original_allow_migrations)
+  end
+
+  before :each do
+    @master = Master.create!(current_user: @user)
+    @master.current_user = @user
+
+    # Clean target table rows between tests
+    @conn.execute("DELETE FROM #{@schema_name}.#{@target_table_name}")
+  end
+
+  describe 'registration' do
+    it 'is listed in ValidSaveTriggers' do
+      expect(
+        OptionConfigs::ExtraOptionImplementers::SaveTriggers::ValidSaveTriggers
+      ).to include(:full_text_search)
+    end
+
+    it 'resolves via trigger_class' do
+      klass = OptionConfigs::ExtraOptions.trigger_class(:full_text_search)
+      expect(klass).to eq(SaveTriggers::FullTextSearch)
+    end
+  end
+
+  describe 'Mode 1 - separate target table' do
+    it 'writes tsvector data to the target table from source fields' do
+      source_record = @master.dynamic_model__test_fts_trigger_sources.create!(
+        current_user: @user,
+        title: 'cardiovascular research',
+        body: 'a study on heart disease prevention',
+        notes: 'preliminary findings are promising'
+      )
+
+      config = {
+        fts_1: {
+          target_table: "#{@schema_name}.#{@target_table_name}",
+          target_column: 'search_vector',
+          target_foreign_key_column: 'source_record_id',
+          source_fields: %w[title body notes],
+          ts_config: 'english'
+        }
+      }
+
+      trigger = SaveTriggers::FullTextSearch.new(config, source_record)
+      trigger.perform
+
+      result = @conn.execute(<<~SQL)
+        SELECT search_vector::text, source_record_id
+        FROM #{@schema_name}.#{@target_table_name}
+        WHERE source_record_id = #{source_record.id}
+      SQL
+
+      row = result.first
+      expect(row).not_to be_nil
+      expect(row['search_vector']).to be_present
+      expect(row['source_record_id']).to eq(source_record.id)
+    end
+
+    it 'writes data that is queryable with @@ to_tsquery()' do
+      source_record = @master.dynamic_model__test_fts_trigger_sources.create!(
+        current_user: @user,
+        title: 'neuroplasticity experiments',
+        body: 'brain adaptation under stress conditions',
+        notes: 'control group showed minimal change'
+      )
+
+      config = {
+        fts_1: {
+          target_table: "#{@schema_name}.#{@target_table_name}",
+          target_column: 'search_vector',
+          target_foreign_key_column: 'source_record_id',
+          source_fields: %w[title body],
+          ts_config: 'english'
+        }
+      }
+
+      trigger = SaveTriggers::FullTextSearch.new(config, source_record)
+      trigger.perform
+
+      search_result = @conn.execute(<<~SQL)
+        SELECT id FROM #{@schema_name}.#{@target_table_name}
+        WHERE source_record_id = #{source_record.id}
+        AND search_vector @@ to_tsquery('english', 'neuroplasticity & brain')
+      SQL
+
+      expect(search_result.count).to eq(1)
+    end
+
+    it 'uses the specified ts_config for separate-table writes' do
+      source_record = @master.dynamic_model__test_fts_trigger_sources.create!(
+        current_user: @user,
+        title: 'running studies',
+        body: '',
+        notes: ''
+      )
+
+      config = {
+        fts_1: {
+          target_table: "#{@schema_name}.#{@target_table_name}",
+          target_column: 'search_vector',
+          target_foreign_key_column: 'source_record_id',
+          source_fields: %w[title],
+          ts_config: 'simple'
+        }
+      }
+
+      trigger = SaveTriggers::FullTextSearch.new(config, source_record)
+      trigger.perform
+
+      simple_match = @conn.execute(<<~SQL)
+        SELECT id FROM #{@schema_name}.#{@target_table_name}
+        WHERE source_record_id = #{source_record.id}
+        AND search_vector @@ to_tsquery('simple', 'running')
+      SQL
+      expect(simple_match.count).to eq(1)
+
+      english_stem_match = @conn.execute(<<~SQL)
+        SELECT id FROM #{@schema_name}.#{@target_table_name}
+        WHERE source_record_id = #{source_record.id}
+        AND search_vector @@ to_tsquery('english', 'run')
+      SQL
+      expect(english_stem_match.count).to eq(0)
+    end
+  end
+
+  describe 'Mode 2 - same table column' do
+    it 'writes tsvector data to the same record column' do
+      same_record = @master.dynamic_model__test_fts_trigger_sames.create!(
+        current_user: @user,
+        title: 'machine learning overview',
+        body: 'neural networks and deep learning algorithms'
+      )
+
+      config = {
+        fts_1: {
+          target_column: 'search_index',
+          source_fields: %w[title body],
+          ts_config: 'english'
+        }
+      }
+
+      trigger = SaveTriggers::FullTextSearch.new(config, same_record)
+      trigger.perform
+
+      # Re-read the record from the database to verify tsvector was written
+      row = @conn.execute(<<~SQL).first
+        SELECT search_index::text
+        FROM #{@schema_name}.#{@same_table_name}
+        WHERE id = #{same_record.id}
+      SQL
+
+      expect(row).not_to be_nil
+      expect(row['search_index']).to be_present
+    end
+  end
+
+  describe 'upsert behaviour' do
+    it 'updates existing tsvector row rather than duplicating on re-save' do
+      source_record = @master.dynamic_model__test_fts_trigger_sources.create!(
+        current_user: @user,
+        title: 'original title',
+        body: 'original body',
+        notes: 'original notes'
+      )
+
+      config = {
+        fts_1: {
+          target_table: "#{@schema_name}.#{@target_table_name}",
+          target_column: 'search_vector',
+          target_foreign_key_column: 'source_record_id',
+          source_fields: %w[title body notes],
+          ts_config: 'english'
+        }
+      }
+
+      # First trigger execution
+      trigger = SaveTriggers::FullTextSearch.new(config, source_record)
+      trigger.perform
+
+      # Simulate update by changing the source record and re-triggering
+      source_record.update!(title: 'updated title with new keywords', current_user: @user)
+      trigger2 = SaveTriggers::FullTextSearch.new(config, source_record)
+      trigger2.perform
+
+      # Should still be exactly one row for this source record
+      count_result = @conn.execute(<<~SQL)
+        SELECT count(*) AS cnt
+        FROM #{@schema_name}.#{@target_table_name}
+        WHERE source_record_id = #{source_record.id}
+      SQL
+      expect(count_result.first['cnt']).to eq(1)
+
+      # And the content should reflect the updated text
+      search_result = @conn.execute(<<~SQL)
+        SELECT id FROM #{@schema_name}.#{@target_table_name}
+        WHERE source_record_id = #{source_record.id}
+        AND search_vector @@ to_tsquery('english', 'updated & keywords')
+      SQL
+      expect(search_result.count).to eq(1)
+    end
+  end
+
+  describe 'conditional execution' do
+    it 'skips trigger when if: condition evaluates false' do
+      source_record = @master.dynamic_model__test_fts_trigger_sources.create!(
+        current_user: @user,
+        title: 'should not be indexed',
+        body: 'this should be skipped',
+        notes: ''
+      )
+
+      config = {
+        fts_1: {
+          target_table: "#{@schema_name}.#{@target_table_name}",
+          target_column: 'search_vector',
+          target_foreign_key_column: 'source_record_id',
+          source_fields: %w[title body],
+          ts_config: 'english',
+          if: {
+            all: {
+              this: {
+                notes: 'non_empty_value_that_wont_match'
+              }
+            }
+          }
+        }
+      }
+
+      trigger = SaveTriggers::FullTextSearch.new(config, source_record)
+      trigger.perform
+
+      count_result = @conn.execute(<<~SQL)
+        SELECT count(*) AS cnt
+        FROM #{@schema_name}.#{@target_table_name}
+        WHERE source_record_id = #{source_record.id}
+      SQL
+      expect(count_result.first['cnt']).to eq(0)
+    end
+  end
+
+  describe 'extra content' do
+    it 'appends extra_content to the indexed text' do
+      source_record = @master.dynamic_model__test_fts_trigger_sources.create!(
+        current_user: @user,
+        title: 'document title',
+        body: 'document body text',
+        notes: ''
+      )
+
+      config = {
+        fts_1: {
+          target_table: "#{@schema_name}.#{@target_table_name}",
+          target_column: 'search_vector',
+          target_foreign_key_column: 'source_record_id',
+          source_fields: %w[title body],
+          extra_content: 'supplementary keywords appended',
+          ts_config: 'english'
+        }
+      }
+
+      trigger = SaveTriggers::FullTextSearch.new(config, source_record)
+      trigger.perform
+
+      search_result = @conn.execute(<<~SQL)
+        SELECT id FROM #{@schema_name}.#{@target_table_name}
+        WHERE source_record_id = #{source_record.id}
+        AND search_vector @@ to_tsquery('english', 'supplementary & keywords')
+      SQL
+      expect(search_result.count).to eq(1)
+    end
+  end
+
+  describe 'missing required config' do
+    it 'raises an error when source_fields is missing' do
+      source_record = @master.dynamic_model__test_fts_trigger_sources.create!(
+        current_user: @user,
+        title: 'test',
+        body: 'test',
+        notes: ''
+      )
+
+      config = {
+        fts_1: {
+          target_table: "#{@schema_name}.#{@target_table_name}",
+          target_column: 'search_vector',
+          target_foreign_key_column: 'source_record_id',
+          ts_config: 'english'
+        }
+      }
+
+      trigger = SaveTriggers::FullTextSearch.new(config, source_record)
+      expect { trigger.perform }.to raise_error(FphsException, /source_fields/)
+    end
+
+    it 'raises an error when target_column is missing' do
+      source_record = @master.dynamic_model__test_fts_trigger_sources.create!(
+        current_user: @user,
+        title: 'test',
+        body: 'test',
+        notes: ''
+      )
+
+      config = {
+        fts_1: {
+          target_table: "#{@schema_name}.#{@target_table_name}",
+          target_foreign_key_column: 'source_record_id',
+          source_fields: %w[title body],
+          ts_config: 'english'
+        }
+      }
+
+      trigger = SaveTriggers::FullTextSearch.new(config, source_record)
+      expect { trigger.perform }.to raise_error(FphsException, /target_column/)
+    end
+  end
+
+  describe 'default ts_config' do
+    it 'defaults to english when ts_config is omitted' do
+      source_record = @master.dynamic_model__test_fts_trigger_sources.create!(
+        current_user: @user,
+        title: 'default config test',
+        body: 'should use english text search configuration',
+        notes: ''
+      )
+
+      config = {
+        fts_1: {
+          target_table: "#{@schema_name}.#{@target_table_name}",
+          target_column: 'search_vector',
+          target_foreign_key_column: 'source_record_id',
+          source_fields: %w[title body]
+          # ts_config intentionally omitted
+        }
+      }
+
+      trigger = SaveTriggers::FullTextSearch.new(config, source_record)
+      trigger.perform
+
+      search_result = @conn.execute(<<~SQL)
+        SELECT id FROM #{@schema_name}.#{@target_table_name}
+        WHERE source_record_id = #{source_record.id}
+        AND search_vector @@ to_tsquery('english', 'default & english')
+      SQL
+      expect(search_result.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Implemented end-to-end PostgreSQL full text search support for dynamic model records and filestore uploads, including trigger/pipeline indexing and admin documentation.

### Changes
- Added dynamic model support for `tsvector` columns and `gin` index generation from `_db_columns`
- Added `SaveTriggers::FullTextSearch` for same-table and separate-table indexing modes
- Added `FullTextSearch::TsvectorWriter` with safe identifier validation and parameterized SQL
- Added `FullTextSearch::TextExtractor` for text, PDF, and office document extraction
- Added `NfsStore::Process::FullTextSearchJob` with `file_filters` support and `ts_config` propagation
- Added/updated model specs covering tsvector generation, save trigger behavior, text extraction, and nfs pipeline indexing
- Added admin documentation for general concepts, save trigger config, nfs_store pipeline config, and report query patterns
- Linked documentation sections with reciprocal See also references
