### PR TITLE
Refactored spec helper stability and layout cleanup - fixes #1020

### DIFF
--- a/app/controllers/admin/dynamic_models_controller.rb
+++ b/app/controllers/admin/dynamic_models_controller.rb
@@ -58,7 +58,7 @@ class Admin::DynamicModelsController < AdminController
   rescue StandardError => e
     Rails.logger.error "Batch processing failed for #{object_instance}: #{e.message}"
     Rails.logger.error e.short_string_backtrace
-    @error_message = e.message
+    @error_message = "Batch processing failed: #{e.message}"
     render partial: 'admin/dynamic_models/run_batch_now_error'
   end
 

--- a/spec/models/option_configs/dynamic_model_options_spec.rb
+++ b/spec/models/option_configs/dynamic_model_options_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe 'Dynamic Model Options', type: :model do
   end
 
   before :all do
+    # Use a unique table name to avoid conflicts with generate_test_dynamic_model
+    # which creates test_created_by_recs with additional columns (use_def_version_time, text_array)
+    table_name = 'test_replace_opts'
+    unless Admin::MigrationGenerator.table_exists? table_name
+      TableGenerators.dynamic_models_table(table_name, :create_do, 'test1', 'test2', 'created_by_user_id')
+    end
+
     DynamicModel.active.where(table_name: 'test_created_by_recs').each { |dm| dm.disable!(@admin) }
     DynamicModel.reset_active_model_configurations!
   end
@@ -149,12 +156,7 @@ RSpec.describe 'Dynamic Model Options', type: :model do
   end
 
   it 'replaces option configurations' do
-    # Use a unique table name to avoid conflicts with generate_test_dynamic_model
-    # which creates test_created_by_recs with additional columns (use_def_version_time, text_array)
     table_name = 'test_replace_opts'
-    unless Admin::MigrationGenerator.table_exists? table_name
-      TableGenerators.dynamic_models_table(table_name, :create_do, 'test1', 'test2', 'created_by_user_id')
-    end
     DynamicModel.active.where(table_name:).each { |dm| dm.disable!(@admin) }
 
     name = 'test replace opts'

--- a/spec/support/feature_support.rb
+++ b/spec/support/feature_support.rb
@@ -316,8 +316,15 @@ module FeatureSupport
   # Expectations are also enforced to ensure the tab shows.
   def expand_master_record_tab(name)
     finish_form_formatting
-    tab_link = all("ul.details-tabs li a[data-panel-tab='#{name.id_underscore}']").first
+    tab_selector = "a[data-panel-tab='#{name.id_underscore}']"
+    unless page.has_css?(tab_selector, visible: :all, wait: 15)
+      available_tabs = all('a[data-panel-tab]', visible: :all, wait: 0).map { |tab| tab['data-panel-tab'] }.uniq
+      raise "Could not find panel tab #{name.id_underscore.inspect}. Available tabs: #{available_tabs.join(', ')}"
+    end
+
+    tab_link = find(tab_selector, visible: :all, wait: 0)
     expect(tab_link).not_to be nil
+    scroll_into_view(tab_link)
     tab_link.click if tab_link['aria-expanded'] != 'true'
 
     # Wait for the target panel to fully expand (Bootstrap collapse animation)
@@ -447,8 +454,8 @@ module FeatureSupport
 
     list_of_items = []
     list_of_texts = []
-    got_item_key = nil
-    all_items.each_with_index do |item, _i|
+    chosen_item = nil
+    all_items.each do |item|
       item_text = item.text.strip
       item_key = item['data-bsi-key']
       list_of_items << item_key
@@ -457,9 +464,24 @@ module FeatureSupport
       # Match by key OR by text
       next unless item_key == value || item_text.include?(value) || value.nil?
 
-      item.click
-      got_item_key = item_key
+      chosen_item = { key: item_key, text: item_text }
       break
+    end
+
+    got_item_key = chosen_item&.dig(:key)
+    if chosen_item
+      # Re-find the item before clicking because the modal content can re-render while opening.
+      item_selector = if chosen_item[:key].present?
+                        %(#primary-modal .big-select-item[data-bsi-key="#{chosen_item[:key]}"])
+                      else
+                        [:xpath, %{//div[@id="primary-modal"]//*[contains(@class, "big-select-item")][contains(normalize-space(.), #{chosen_item[:text].inspect})]}]
+                      end
+
+      if item_selector.is_a?(Array)
+        find(*item_selector, wait: 5).click
+      else
+        find(item_selector, wait: 5).click
+      end
     end
 
     page.has_css?('#primary-modal.fade', class: '!in')

--- a/spec/support/feature_support.rb
+++ b/spec/support/feature_support.rb
@@ -335,6 +335,22 @@ module FeatureSupport
     expect(page).to have_css(target_selector, wait: 15)
   end
 
+  def expand_master_record_and_tab(master_id:, tab_name:)
+    expand_master_record(master_id:)
+    expect(page).to have_css("#master-#{master_id}-main-container.in", wait: 10)
+    expand_master_record_tab(tab_name)
+  end
+
+  def disable_active_panel_layout(panel_name, app_type: @app_type, admin: @admin, reload_routes: false)
+    return unless app_type&.id && admin
+
+    Admin::PageLayout.active.where(app_type_id: app_type.id, panel_name:).each do |panel_layout|
+      panel_layout.disable!(admin)
+    end
+
+    Rails.application.routes_reloader.reload! if reload_routes
+  end
+
   #
   # Expand a search tab by the name that appears on the button
   # Expectations are also enforced to ensure the search form shows.
@@ -477,10 +493,17 @@ module FeatureSupport
                         [:xpath, %{//div[@id="primary-modal"]//*[contains(@class, "big-select-item")][contains(normalize-space(.), #{chosen_item[:text].inspect})]}]
                       end
 
-      if item_selector.is_a?(Array)
-        find(*item_selector, wait: 5).click
-      else
-        find(item_selector, wait: 5).click
+      3.times do |attempt|
+        begin
+          if item_selector.is_a?(Array)
+            find(*item_selector, wait: 5).click
+          else
+            find(item_selector, wait: 5).click
+          end
+          break
+        rescue Selenium::WebDriver::Error::StaleElementReferenceError
+          raise if attempt == 2
+        end
       end
     end
 

--- a/spec/support/user_support.rb
+++ b/spec/support/user_support.rb
@@ -195,7 +195,11 @@ module UserSupport
     app_type ||= @user.app_type
 
     uac = Admin::UserAccessControl.where(app_type:, resource_type:, resource_name:, role_name: [nil, ''])
-    uac = uac.where(user:) if user
+    uac = if user
+            uac.where(user:)
+          else
+            uac.where(user_id: nil)
+          end
 
     uac.active.update_all(disabled: true) if uac.active.length > 1
     uac = uac.active.first || uac.first

--- a/spec/system/big_select_field_spec.rb
+++ b/spec/system/big_select_field_spec.rb
@@ -57,9 +57,7 @@ describe 'big-select field component', js: true, driver: $browser_driver do
     @app_type = @user.app_type
     expect(@app_type).not_to be nil
     expect(@user.two_factor_setup_required?).to be_falsey
-    Admin::PageLayout.active.where(app_type_id: @app_type.id, panel_name: 'test-columns-panel').each do |panel_layout|
-      panel_layout.disable!(@admin)
-    end
+    disable_active_panel_layout('test-columns-panel')
   end
 
   # Create a source table with test data for selections
@@ -236,18 +234,19 @@ describe 'big-select field component', js: true, driver: $browser_driver do
 
     expect(page).to have_css("#master-#{@master.id}")
 
-    expand_master_record(master_id: @master.id)
-    expect(page).to have_css("#master-#{@master.id}-main-container.in", wait: 10)
-
-    expand_master_record_tab('details')
+    expand_master_record_and_tab(master_id: @master.id, tab_name: 'details')
     finish_page_loading
 
     new_button_selector = '.details-item-type-dynamic-model--test-big-select-fields .new-button-container a.btn'
     expect(page).to have_css(new_button_selector, wait: 10)
-    new_button = find(new_button_selector, wait: 10)
-    scroll_into_view(new_button)
-    new_button.click
-    finish_page_loading
+    5.times do
+      new_button = find(new_button_selector, wait: 10)
+      scroll_into_view(new_button)
+      new_button.click
+      finish_page_loading
+
+      break if page.has_css?('form.new_dynamic_model_test_big_select_field', wait: 2)
+    end
 
     unless page.has_css?('form.new_dynamic_model_test_big_select_field', wait: 2)
       new_button = find(new_button_selector, wait: 10)
@@ -487,7 +486,7 @@ describe 'big-select field component', js: true, driver: $browser_driver do
 
       expect(page).to have_css("#master-#{@master.id}")
 
-      expand_master_record_tab('details')
+      expand_master_record_and_tab(master_id: @master.id, tab_name: 'details')
       finish_page_loading
 
       # Find the details section for our dynamic model
@@ -499,6 +498,15 @@ describe 'big-select field component', js: true, driver: $browser_driver do
         edit_button = find('.edit-entity', match: :first, visible: :all)
         scroll_into_view(edit_button)
         edit_button.click
+      end
+
+      unless page.has_css?('form.edit_dynamic_model_test_big_select_field', wait: 2)
+        details_section = find('.details-item-type-dynamic-model--test-big-select-fields', wait: 5)
+        within(details_section) do
+          edit_button = find('.edit-entity', match: :first, visible: :all)
+          scroll_into_view(edit_button)
+          edit_button.click
+        end
       end
 
       expect(page).to have_css('form.edit_dynamic_model_test_big_select_field', wait: 10)

--- a/spec/system/big_select_field_spec.rb
+++ b/spec/system/big_select_field_spec.rb
@@ -57,6 +57,9 @@ describe 'big-select field component', js: true, driver: $browser_driver do
     @app_type = @user.app_type
     expect(@app_type).not_to be nil
     expect(@user.two_factor_setup_required?).to be_falsey
+    Admin::PageLayout.active.where(app_type_id: @app_type.id, panel_name: 'test-columns-panel').each do |panel_layout|
+      panel_layout.disable!(@admin)
+    end
   end
 
   # Create a source table with test data for selections
@@ -233,14 +236,25 @@ describe 'big-select field component', js: true, driver: $browser_driver do
 
     expect(page).to have_css("#master-#{@master.id}")
 
-    details_tab = all('a[data-panel-tab="details"]').first
-    details_tab.click
+    expand_master_record(master_id: @master.id)
+    expect(page).to have_css("#master-#{@master.id}-main-container.in", wait: 10)
+
+    expand_master_record_tab('details')
     finish_page_loading
 
     new_button_selector = '.details-item-type-dynamic-model--test-big-select-fields .new-button-container a.btn'
     expect(page).to have_css(new_button_selector, wait: 10)
-    find(new_button_selector).click
+    new_button = find(new_button_selector, wait: 10)
+    scroll_into_view(new_button)
+    new_button.click
     finish_page_loading
+
+    unless page.has_css?('form.new_dynamic_model_test_big_select_field', wait: 2)
+      new_button = find(new_button_selector, wait: 10)
+      scroll_into_view(new_button)
+      new_button.click
+      finish_page_loading
+    end
 
     expect(page).to have_css('form.new_dynamic_model_test_big_select_field', wait: 10)
     finish_form_formatting
@@ -473,8 +487,7 @@ describe 'big-select field component', js: true, driver: $browser_driver do
 
       expect(page).to have_css("#master-#{@master.id}")
 
-      details_tab = all('a[data-panel-tab="details"]').first
-      details_tab.click
+      expand_master_record_tab('details')
       finish_page_loading
 
       # Find the details section for our dynamic model

--- a/spec/system/dynamic_model/dynamic_model_alt_width_classes_spec.rb
+++ b/spec/system/dynamic_model/dynamic_model_alt_width_classes_spec.rb
@@ -105,11 +105,7 @@ describe 'Dynamic Model alt_width_classes', js: true, driver: $browser_driver do
       expect(page).to have_css("#master-#{@master.id}")
       expect(page).not_to have_css('.alert')
 
-      expand_master_record(master_id: @master.id)
-      expect(page).to have_css("#master-#{@master.id}-main-container.in", wait: 10)
-
-      # Find the details tab
-      expand_master_record_tab('details')
+      expand_master_record_and_tab(master_id: @master.id, tab_name: 'details')
 
       expect(page).to have_css("#details-#{@master_id}")
 
@@ -168,11 +164,7 @@ describe 'Dynamic Model alt_width_classes', js: true, driver: $browser_driver do
       expect(page).to have_css("#master-#{@master.id}")
       expect(page).not_to have_css('.alert')
 
-      expand_master_record(master_id: @master.id)
-      expect(page).to have_css("#master-#{@master.id}-main-container.in", wait: 10)
-
-      # Find the details tab
-      expand_master_record_tab('details')
+      expand_master_record_and_tab(master_id: @master.id, tab_name: 'details')
 
       expect(page).to have_css("#details-#{@master_id}")
 
@@ -290,9 +282,7 @@ describe 'Dynamic Model alt_width_classes', js: true, driver: $browser_driver do
       )
 
       # Create a panel layout with 'columns' orientation for this category
-      Admin::PageLayout.active.where(app_type_id: @app_type.id, panel_name: 'test-columns-panel').each do |p|
-        p.disable!(@admin)
-      end
+      disable_active_panel_layout('test-columns-panel')
 
       @panel_layout = Admin::PageLayout.create!(
         current_admin: @admin,
@@ -315,10 +305,7 @@ describe 'Dynamic Model alt_width_classes', js: true, driver: $browser_driver do
     end
 
     after(:all) do
-      Admin::PageLayout.active.where(app_type_id: @app_type.id, panel_name: 'test-columns-panel').each do |panel_layout|
-        panel_layout.disable!(@admin)
-      end
-      Rails.application.routes_reloader.reload!
+      disable_active_panel_layout('test-columns-panel', reload_routes: true)
     end
 
     before :each do

--- a/spec/system/dynamic_model/dynamic_model_alt_width_classes_spec.rb
+++ b/spec/system/dynamic_model/dynamic_model_alt_width_classes_spec.rb
@@ -105,10 +105,11 @@ describe 'Dynamic Model alt_width_classes', js: true, driver: $browser_driver do
       expect(page).to have_css("#master-#{@master.id}")
       expect(page).not_to have_css('.alert')
 
+      expand_master_record(master_id: @master.id)
+      expect(page).to have_css("#master-#{@master.id}-main-container.in", wait: 10)
+
       # Find the details tab
-      l = all('a[data-panel-tab="details"]').first
-      expect(l).not_to be nil
-      l.click
+      expand_master_record_tab('details')
 
       expect(page).to have_css("#details-#{@master_id}")
 
@@ -167,10 +168,11 @@ describe 'Dynamic Model alt_width_classes', js: true, driver: $browser_driver do
       expect(page).to have_css("#master-#{@master.id}")
       expect(page).not_to have_css('.alert')
 
+      expand_master_record(master_id: @master.id)
+      expect(page).to have_css("#master-#{@master.id}-main-container.in", wait: 10)
+
       # Find the details tab
-      l = all('a[data-panel-tab="details"]').first
-      expect(l).not_to be nil
-      l.click
+      expand_master_record_tab('details')
 
       expect(page).to have_css("#details-#{@master_id}")
 
@@ -236,10 +238,8 @@ describe 'Dynamic Model alt_width_classes', js: true, driver: $browser_driver do
 
       # Find the history tab (if it exists as a separate tab)
       # or it may be under a general tab depending on app configuration
-      history_tab = all('a[data-panel-tab="history"]').first
-
-      if history_tab
-        history_tab.click
+      if page.has_css?('a[data-panel-tab="history"]', wait: 5)
+        expand_master_record_tab('history')
         expect(page).to have_css("#history-#{@master_id}")
 
         # Find the dynamic model container with horizontal orientation
@@ -314,6 +314,13 @@ describe 'Dynamic Model alt_width_classes', js: true, driver: $browser_driver do
       Rails.application.routes_reloader.reload!
     end
 
+    after(:all) do
+      Admin::PageLayout.active.where(app_type_id: @app_type.id, panel_name: 'test-columns-panel').each do |panel_layout|
+        panel_layout.disable!(@admin)
+      end
+      Rails.application.routes_reloader.reload!
+    end
+
     before :each do
       validate_setup
       login
@@ -327,10 +334,8 @@ describe 'Dynamic Model alt_width_classes', js: true, driver: $browser_driver do
       expect(page).not_to have_css('.alert')
 
       # Find the test-columns-panel tab
-      columns_tab = all('a[data-panel-tab="test-columns-panel"]').first
-
-      if columns_tab
-        columns_tab.click
+      if page.has_css?('a[data-panel-tab="test-columns-panel"]', wait: 5)
+        expand_master_record_tab('test-columns-panel')
         expect(page).to have_css("#test-columns-panel-#{@master_id}")
 
         # Find the dynamic model container with columns orientation
@@ -401,12 +406,12 @@ describe 'Dynamic Model alt_width_classes', js: true, driver: $browser_driver do
       expect(page).not_to have_css('.alert')
 
       # Find the external IDs tab
-      l = all('a[data-panel-tab="external_ids"]').first
-
       # Skip if external IDs tab is not available in this app type
-      skip 'External IDs tab not available in this app type' if l.nil?
+      unless page.has_css?('a[data-panel-tab="external_ids"]', wait: 5)
+        skip 'External IDs tab not available in this app type'
+      end
 
-      l.click
+      expand_master_record_tab('external ids')
 
       expect(page).to have_css("#external-ids-#{@master_id}")
 

--- a/spec/system/dynamic_model/dynamic_model_show_if_spec.rb
+++ b/spec/system/dynamic_model/dynamic_model_show_if_spec.rb
@@ -62,9 +62,7 @@ describe 'dynamic model show_if with embedded_item', js: true, driver: $browser_
       expect(page).not_to have_css('.alert')
 
       # Find and click the details tab
-      l = all('a[data-panel-tab="details"]').first
-      expect(l).not_to be nil
-      l.click
+      expand_master_record_tab('details')
       finish_page_loading
       finish_form_formatting
 
@@ -140,9 +138,7 @@ describe 'dynamic model show_if with embedded_item', js: true, driver: $browser_
       expect(page).not_to have_css('.alert')
 
       # Find and click the details tab
-      l = all('a[data-panel-tab="details"]').first
-      expect(l).not_to be nil
-      l.click
+      expand_master_record_tab('details')
       finish_page_loading
       finish_form_formatting
       expect(page).to have_css("#details-#{@master_id}")
@@ -218,9 +214,7 @@ describe 'dynamic model show_if with embedded_item', js: true, driver: $browser_
       expect(page).not_to have_css('.alert')
 
       # Find and click the details tab
-      l = all('a[data-panel-tab="details"]').first
-      expect(l).not_to be nil
-      l.click
+      expand_master_record_tab('details')
       finish_page_loading
       finish_form_formatting
 

--- a/spec/system/dynamic_model/dynamic_model_show_if_spec.rb
+++ b/spec/system/dynamic_model/dynamic_model_show_if_spec.rb
@@ -61,8 +61,7 @@ describe 'dynamic model show_if with embedded_item', js: true, driver: $browser_
       expect(page).to have_css("#master-#{@master_id}")
       expect(page).not_to have_css('.alert')
 
-      # Find and click the details tab
-      expand_master_record_tab('details')
+      expand_master_record_and_tab(master_id: @master_id, tab_name: 'details')
       finish_page_loading
       finish_form_formatting
 
@@ -137,8 +136,7 @@ describe 'dynamic model show_if with embedded_item', js: true, driver: $browser_
       expect(page).to have_css("#master-#{@master_id}")
       expect(page).not_to have_css('.alert')
 
-      # Find and click the details tab
-      expand_master_record_tab('details')
+      expand_master_record_and_tab(master_id: @master_id, tab_name: 'details')
       finish_page_loading
       finish_form_formatting
       expect(page).to have_css("#details-#{@master_id}")
@@ -213,8 +211,7 @@ describe 'dynamic model show_if with embedded_item', js: true, driver: $browser_
       expect(page).to have_css("#master-#{@master_id}")
       expect(page).not_to have_css('.alert')
 
-      # Find and click the details tab
-      expand_master_record_tab('details')
+      expand_master_record_and_tab(master_id: @master_id, tab_name: 'details')
       finish_page_loading
       finish_form_formatting
 

--- a/spec/system/external_identifier/external_id_spec.rb
+++ b/spec/system/external_identifier/external_id_spec.rb
@@ -63,11 +63,7 @@ describe 'external id (bhs_assignments)', js: true, driver: $browser_driver do
     expect(page).to have_css("#master-#{@master.id}")
     expect(page).not_to have_css('.alert')
 
-    expand_master_record(master_id: @master.id)
-    expect(page).to have_css("#master-#{@master.id}-main-container.in", wait: 10)
-
-    # Find the external ID tab
-    expand_master_record_tab('external ids')
+    expand_master_record_and_tab(master_id: @master.id, tab_name: 'external ids')
     finish_page_loading
 
     expect(page).to have_css("#external-ids-#{@master_id}")

--- a/spec/system/external_identifier/external_id_spec.rb
+++ b/spec/system/external_identifier/external_id_spec.rb
@@ -58,20 +58,17 @@ describe 'external id (bhs_assignments)', js: true, driver: $browser_driver do
   it 'creates external IDs' do
     visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@master.id}"
     dismiss_modal
+    finish_page_loading
 
     expect(page).to have_css("#master-#{@master.id}")
     expect(page).not_to have_css('.alert')
 
+    expand_master_record(master_id: @master.id)
+    expect(page).to have_css("#master-#{@master.id}-main-container.in", wait: 10)
+
     # Find the external ID tab
-    l = all('a[data-panel-tab="external_ids"]').first
-
-    unless l
-      ls = all('a[data-panel-tab]').map { |a| a['data-panel-tab'] }
-      puts "About to fail a[data-panel-tab=\"external_ids\"] - available tabs: #{ls.join(',')}"
-    end
-    expect(l).not_to be nil
-
-    l.click
+    expand_master_record_tab('external ids')
+    finish_page_loading
 
     expect(page).to have_css("#external-ids-#{@master_id}")
     c = "#bhs-assignments-#{@master_id}- .new-button-container a.btn"

--- a/spec/system/nfs_store/secure_viewer_enhancements_spec.rb
+++ b/spec/system/nfs_store/secure_viewer_enhancements_spec.rb
@@ -166,6 +166,8 @@ describe 'Secure viewer enhancements (Issue #590)', js: true, driver: $browser_d
   end
 
   def expand_phone_log_tab
+    expand_master_record(master_id: @master.id)
+    expect(page).to have_css("#master-#{@master.id}-main-container.in", wait: 10)
     expand_master_record_tab('activity_log__player_contact_phones')
   end
 
@@ -192,6 +194,9 @@ describe 'Secure viewer enhancements (Issue #590)', js: true, driver: $browser_d
     create_admin unless @admin
 
     @app_type = @user.app_type
+    Admin::PageLayout.active.where(app_type_id: @app_type.id, panel_name: 'test-columns-panel').each do |panel_layout|
+      panel_layout.disable!(@admin)
+    end
 
     # Setup filestore directories
     test_dir = File.join(
@@ -305,6 +310,9 @@ describe 'Secure viewer enhancements (Issue #590)', js: true, driver: $browser_d
   end
 
   after :all do
+    Admin::PageLayout.active.where(app_type_id: @app_type.id, panel_name: 'test-columns-panel').each do |panel_layout|
+      panel_layout.disable!(@admin)
+    end
     temp_dir = Rails.root.join('tmp', 'test_files')
     FileUtils.rm_rf(temp_dir)
   end

--- a/spec/system/nfs_store/secure_viewer_enhancements_spec.rb
+++ b/spec/system/nfs_store/secure_viewer_enhancements_spec.rb
@@ -166,9 +166,7 @@ describe 'Secure viewer enhancements (Issue #590)', js: true, driver: $browser_d
   end
 
   def expand_phone_log_tab
-    expand_master_record(master_id: @master.id)
-    expect(page).to have_css("#master-#{@master.id}-main-container.in", wait: 10)
-    expand_master_record_tab('activity_log__player_contact_phones')
+    expand_master_record_and_tab(master_id: @master.id, tab_name: 'activity_log__player_contact_phones')
   end
 
   # Open the secure viewer by clicking a file link in the filestore browser
@@ -194,9 +192,7 @@ describe 'Secure viewer enhancements (Issue #590)', js: true, driver: $browser_d
     create_admin unless @admin
 
     @app_type = @user.app_type
-    Admin::PageLayout.active.where(app_type_id: @app_type.id, panel_name: 'test-columns-panel').each do |panel_layout|
-      panel_layout.disable!(@admin)
-    end
+    disable_active_panel_layout('test-columns-panel')
 
     # Setup filestore directories
     test_dir = File.join(
@@ -310,9 +306,7 @@ describe 'Secure viewer enhancements (Issue #590)', js: true, driver: $browser_d
   end
 
   after :all do
-    Admin::PageLayout.active.where(app_type_id: @app_type.id, panel_name: 'test-columns-panel').each do |panel_layout|
-      panel_layout.disable!(@admin)
-    end
+    disable_active_panel_layout('test-columns-panel')
     temp_dir = Rails.root.join('tmp', 'test_files')
     FileUtils.rm_rf(temp_dir)
   end

--- a/spec/system/switch_id_display_spec.rb
+++ b/spec/system/switch_id_display_spec.rb
@@ -216,30 +216,30 @@ describe 'switch ID display in search results', js: true, driver: $browser_drive
         switch_button = find('a.switch_id')
 
         # Initially master_id should be visible
-        expect(find('.alt-id-item.master_id', visible: :all)).to be_visible
+        expect(page).to have_css('.alt-id-item.master_id', visible: true)
 
         # First click: switch to msid
         switch_button.click
-        expect(find('.alt-id-item.master_id', visible: :all)).not_to be_visible
-        expect(find('.alt-id-item.msid', visible: :all)).to be_visible
+        expect(page).to have_no_css('.alt-id-item.master_id', visible: true)
+        expect(page).to have_css('.alt-id-item.msid', visible: true)
         expect(switch_button['title']).to eq('switch to Scantron ID')
 
         # Second click: switch to scantron_id
         switch_button.click
-        expect(find('.alt-id-item.msid', visible: :all)).not_to be_visible
-        expect(find('.alt-id-item.scantron_id', visible: :all)).to be_visible
+        expect(page).to have_no_css('.alt-id-item.msid', visible: true)
+        expect(page).to have_css('.alt-id-item.scantron_id', visible: true)
         expect(switch_button['title']).to eq('switch to Sage ID')
 
         # Third click: switch to sage_id
         switch_button.click
-        expect(find('.alt-id-item.scantron_id', visible: :all)).not_to be_visible
-        expect(find('.alt-id-item.sage_id', visible: :all)).to be_visible
+        expect(page).to have_no_css('.alt-id-item.scantron_id', visible: true)
+        expect(page).to have_css('.alt-id-item.sage_id', visible: true)
         expect(switch_button['title']).to eq('switch to Master')
 
         # Fourth click: back to master_id
         switch_button.click
-        expect(find('.alt-id-item.sage_id', visible: :all)).not_to be_visible
-        expect(find('.alt-id-item.master_id', visible: :all)).to be_visible
+        expect(page).to have_no_css('.alt-id-item.sage_id', visible: true)
+        expect(page).to have_css('.alt-id-item.master_id', visible: true)
         expect(switch_button['title']).to eq('switch to MSID')
       end
     end
@@ -256,21 +256,21 @@ describe 'switch ID display in search results', js: true, driver: $browser_drive
 
         # Switch to msid - should show actual value
         switch_button.click
-        msid_span = find('.alt-id-item.msid', visible: true)
-        expect(msid_span).to have_css('[title="MSID"]')
-        expect(msid_span).to have_content(@master_msid_only.msid.to_s)
+        expect(page).to have_css('.alt-id-item.msid', visible: true)
+        expect(page).to have_css('.alt-id-item.msid [title="MSID"]', visible: true)
+        expect(page).to have_css('.alt-id-item.msid', text: @master_msid_only.msid.to_s, visible: true)
 
         # Switch to scantron_id - should show (none)
         switch_button.click
-        scantron_span = find('.alt-id-item.scantron_id', visible: true)
-        expect(scantron_span).to have_css('[title="No Scantron ID"]')
-        expect(scantron_span).to have_content('(none)')
+        expect(page).to have_css('.alt-id-item.scantron_id', visible: true)
+        expect(page).to have_css('.alt-id-item.scantron_id [title="No Scantron ID"]', visible: true)
+        expect(page).to have_css('.alt-id-item.scantron_id', text: '(none)', visible: true)
 
         # Switch to sage_id - should show (none)
         switch_button.click
-        sage_span = find('.alt-id-item.sage_id', visible: true)
-        expect(sage_span).to have_css('[title="No Sage ID"]')
-        expect(sage_span).to have_content('(none)')
+        expect(page).to have_css('.alt-id-item.sage_id', visible: true)
+        expect(page).to have_css('.alt-id-item.sage_id [title="No Sage ID"]', visible: true)
+        expect(page).to have_css('.alt-id-item.sage_id', text: '(none)', visible: true)
       end
     end
   end
@@ -287,19 +287,19 @@ describe 'switch ID display in search results', js: true, driver: $browser_drive
         switch_button = find('a.switch_id')
 
         # First should be msid
-        expect(find('.alt-id-item.msid', visible: :all)).to be_visible
+        expect(page).to have_css('.alt-id-item.msid', visible: true)
         expect(switch_button['title']).to eq('switch to Scantron ID')
 
         # Click to switch to scantron_id
         switch_button.click
-        expect(find('.alt-id-item.msid', visible: :all)).not_to be_visible
-        expect(find('.alt-id-item.scantron_id', visible: :all)).to be_visible
+        expect(page).to have_no_css('.alt-id-item.msid', visible: true)
+        expect(page).to have_css('.alt-id-item.scantron_id', visible: true)
         expect(switch_button['title']).to eq('switch to MSID')
 
         # Click again to return to msid
         switch_button.click
-        expect(find('.alt-id-item.scantron_id', visible: :all)).not_to be_visible
-        expect(find('.alt-id-item.msid', visible: :all)).to be_visible
+        expect(page).to have_no_css('.alt-id-item.scantron_id', visible: true)
+        expect(page).to have_css('.alt-id-item.msid', visible: true)
       end
     end
 
@@ -310,15 +310,16 @@ describe 'switch ID display in search results', js: true, driver: $browser_drive
         switch_button = find('a.switch_id')
 
         # First (msid) should show (none)
-        msid_span = find('.alt-id-item.msid', visible: true)
-        expect(msid_span).to have_css('[title="No MSID"]')
-        expect(msid_span).to have_content('(none)')
+        expect(page).to have_css('.alt-id-item.msid', visible: true)
+        expect(page).to have_css('.alt-id-item.msid [title="No MSID"]', visible: true)
+        expect(page).to have_css('.alt-id-item.msid', text: '(none)', visible: true)
 
         # Switch to scantron_id - should also show (none)
         switch_button.click
-        scantron_span = find('.alt-id-item.scantron_id', visible: true)
-        expect(scantron_span).to have_css('[title="No Scantron ID"]')
-        expect(scantron_span).to have_content('(none)')
+        expect(page).to have_no_css('.alt-id-item.msid', visible: true)
+        expect(page).to have_css('.alt-id-item.scantron_id', visible: true)
+        expect(page).to have_css('.alt-id-item.scantron_id [title="No Scantron ID"]', visible: true)
+        expect(page).to have_css('.alt-id-item.scantron_id', text: '(none)', visible: true)
       end
     end
   end
@@ -335,16 +336,14 @@ describe 'switch ID display in search results', js: true, driver: $browser_drive
         switch_button = find('a.switch_id')
 
         # First should be sage_id
-        sage_span = find('.alt-id-item.sage_id', visible: :all)
-        expect(sage_span).to be_visible
-        expect(sage_span).to have_content(@sage_base.to_s)
+        expect(page).to have_css('.alt-id-item.sage_id', visible: true)
+        expect(page).to have_css('.alt-id-item.sage_id', text: @sage_base.to_s, visible: true)
 
         # Switch to scantron_id
         switch_button.click
-        expect(sage_span).not_to be_visible
-        scantron_span = find('.alt-id-item.scantron_id', visible: :all)
-        expect(scantron_span).to be_visible
-        expect(scantron_span).to have_content(@scantron_base.to_s)
+        expect(page).to have_no_css('.alt-id-item.sage_id', visible: true)
+        expect(page).to have_css('.alt-id-item.scantron_id', visible: true)
+        expect(page).to have_css('.alt-id-item.scantron_id', text: @scantron_base.to_s, visible: true)
       end
     end
 
@@ -356,14 +355,14 @@ describe 'switch ID display in search results', js: true, driver: $browser_drive
         switch_button = find('a.switch_id')
 
         # First should be sage_id with value
-        sage_span = find('.alt-id-item.sage_id', visible: true)
-        expect(sage_span).to have_content((@sage_base + 3).to_s)
+        expect(page).to have_css('.alt-id-item.sage_id', text: (@sage_base + 3).to_s, visible: true)
 
         # Switch to scantron_id - should show (none)
         switch_button.click
-        scantron_span = find('.alt-id-item.scantron_id', visible: true)
-        expect(scantron_span).to have_css('[title="No Scantron ID"]')
-        expect(scantron_span).to have_content('(none)')
+        expect(page).to have_no_css('.alt-id-item.sage_id', visible: true)
+        expect(page).to have_css('.alt-id-item.scantron_id', visible: true)
+        expect(page).to have_css('.alt-id-item.scantron_id [title="No Scantron ID"]', visible: true)
+        expect(page).to have_css('.alt-id-item.scantron_id', text: '(none)', visible: true)
       end
     end
   end


### PR DESCRIPTION
## Summary
Stabilizes the failing spec cluster by fixing shared helper behavior, preventing page layout state leakage across system specs, and moving expensive one-time test setup out of example scope.

### Changes
- scoped default `setup_access` lookups to `user_id: nil` so overlapping UACs do not block create access
- made big-select interactions resilient to modal re-renders and explicit master/tab expansion
- cleaned up leaked `test-columns-panel` page layouts so later specs keep their expected tabs
- replaced brittle cached visibility assertions in switch ID display specs with Capybara waiting assertions
- aligned external ID and dynamic model tab navigation with the shared helper
- moved `test_replace_opts` table setup into `before :all` in dynamic model options specs to avoid timeouts
- prefixed dynamic model batch error messages with the expected failure context

### Validation
- `bundle exec rspec spec/system/nfs_store/secure_viewer_enhancements_spec.rb`
- `bundle exec rspec spec/system/big_select_field_spec.rb`
- `bundle exec rspec spec/system/dynamic_model/dynamic_model_alt_width_classes_spec.rb spec/system/external_identifier/external_id_spec.rb`
- `bundle exec rspec spec/system/nfs_store/secure_viewer_enhancements_spec.rb spec/system/big_select_field_spec.rb spec/system/dynamic_model/dynamic_model_alt_width_classes_spec.rb spec/system/external_identifier/external_id_spec.rb spec/system/switch_id_display_spec.rb`
- `bundle exec rspec spec/models/option_configs/dynamic_model_options_spec.rb`

Closes #1020
