### PR TITLE
Fixed prepend_to_options gsub corrupting YAML with escaped quotes - fixes #1029

### DIFF
--- a/app/models/dynamic_model.rb
+++ b/app/models/dynamic_model.rb
@@ -525,7 +525,9 @@ class DynamicModel < ActiveRecord::Base
     new_options = String.yaml_dump(hash)
     self.options ||= ''
     self.options = if self.options.index(/^#{key}:/)
-                     self.options = self.options.gsub(/^(#{key}:(.+?))(\n[^\s]|\z)/m, "#{new_options}\n\n\\3")
+                     self.options = self.options.gsub(/^(#{key}:(.+?))(\n[^\s]|\z)/m) do
+                       "#{new_options}\n\n#{Regexp.last_match(3)}"
+                     end
                    else
                      "#{new_options}\n\n#{self.options}"
                    end

--- a/spec/models/option_configs/dynamic_model_options_spec.rb
+++ b/spec/models/option_configs/dynamic_model_options_spec.rb
@@ -332,6 +332,117 @@ RSpec.describe 'Dynamic Model Options', type: :model do
     expect(dm.options.strip).to eq exp.strip
   end
 
+  # Test that prepend_to_options correctly handles _comments containing escaped single quotes.
+  # GitHub issue #1029: When a comment value contains a literal backslash-quote (e.g., Alzheimer\'s),
+  # YAML.dump produces text with \' which Ruby's gsub interprets as a postmatch backreference,
+  # corrupting the output.
+  it 'handles comments containing escaped quotes in prepend_to_options' do
+    table_name = 'test_replace_opts'
+    DynamicModel.active.where(table_name:).each { |dm| dm.disable!(@admin) }
+
+    name = 'test replace opts'
+    dm = DynamicModel.create! current_admin: @admin,
+                              name:,
+                              table_name:,
+                              schema_name: 'ml_app',
+                              category: :test,
+                              options: nil
+
+    dm.options = <<~END_OPT
+      _comments:
+        test1: A simple comment
+
+      default:
+        label: Something
+
+    END_OPT
+
+    # Call prepend_to_options with a _comments hash where a field value contains
+    # a literal backslash and single quote, as would appear in a caption like
+    # "Dementia (Alzheimer's Disease)" stored with an escaped quote in YAML
+    comment_with_escaped_quote = "Dementia (Alzheimer\\'s Disease)"
+    hash = {
+      _comments: {
+        test1: comment_with_escaped_quote
+      }
+    }
+
+    dm.prepend_to_options(hash)
+
+    # The resulting options must be valid YAML (not corrupted by postmatch substitution)
+    parsed = nil
+    expect { parsed = YAML.safe_load(dm.options) }.not_to raise_error
+    expect(parsed).to be_a Hash
+
+    # The _comments section should contain the correct value, not corrupted text
+    expect(parsed['_comments']['test1']).to eq "Dementia (Alzheimer\\'s Disease)"
+
+    # The default section should still be present and intact
+    expect(parsed['default']['label']).to eq 'Something'
+  end
+
+  # Test that options with caption_before containing quotes can have _comments regenerated
+  # and re-saved without YAML parse errors.
+  # GitHub issue #1029: Simulates "Update Config from Table" where _comments are regenerated
+  # from captions containing single quotes.
+  it 'handles re-saving comments derived from caption_before with quotes' do
+    table_name = 'test_replace_opts'
+    DynamicModel.active.where(table_name:).each { |dm| dm.disable!(@admin) }
+
+    name = 'test replace opts'
+    dm = DynamicModel.create! current_admin: @admin,
+                              name:,
+                              table_name:,
+                              schema_name: 'ml_app',
+                              category: :test,
+                              options: nil
+
+    # Set up initial options with _comments containing a value with backslash-quote
+    # (as would be generated from a caption_before like "Dementia (Alzheimer's Disease)")
+    dm.options = <<~END_OPT
+      _comments:
+        test1: simple comment
+
+      default:
+        label: Test Label
+
+    END_OPT
+
+    # First prepend: simulate initial _comments generation with escaped quote
+    comment_value = "Dementia (Alzheimer\\'s Disease)"
+    hash = {
+      _comments: {
+        test1: comment_value
+      }
+    }
+    dm.prepend_to_options(hash)
+
+    # Verify first pass produced valid YAML
+    first_pass = nil
+    expect { first_pass = YAML.safe_load(dm.options) }.not_to raise_error
+
+    # Second prepend: simulate "Update Config from Table" re-generating _comments
+    # This is where the bug manifests — the already-corrupted options text
+    # gets further mangled on the second pass
+    hash2 = {
+      _comments: {
+        test1: comment_value
+      }
+    }
+    dm.prepend_to_options(hash2)
+
+    # The resulting options must still be valid YAML after the second pass
+    second_pass = nil
+    expect { second_pass = YAML.safe_load(dm.options) }.not_to raise_error
+    expect(second_pass).to be_a Hash
+
+    # The field comment should be preserved correctly
+    expect(second_pass['_comments']['test1']).to eq "Dementia (Alzheimer\\'s Disease)"
+
+    # The default section should still be intact
+    expect(second_pass['default']['label']).to eq 'Test Label'
+  end
+
   it 'generates show_if from show_if_condition_strings' do
     dmdef = generate_test_dynamic_model
     opt = <<~END_CONFIG


### PR DESCRIPTION
## Summary

Fixes #1029 — Caption with escaped quotes (e.g. `Alzheimer\'s Disease`) in `caption_before` options caused YAML corruption when `_comments` were generated or updated via "Update Config from Table".

### Root Cause

`prepend_to_options` used `gsub` with a string replacement: `gsub(pattern, "#{new_options}\n\n\\3")`. When `String.yaml_dump` produced YAML containing `\'` (escaped single quotes), Ruby's `gsub` interpreted `\'` as a postmatch backreference, corrupting the output.

### Changes

- **app/models/dynamic_model.rb**: Changed `gsub` in `prepend_to_options` from string replacement to block form, which avoids backreference interpretation
- **spec/models/option_configs/dynamic_model_options_spec.rb**: Added 2 specs covering escaped quotes in `prepend_to_options` (single pass and double pass scenarios)

### Testing

- 10/10 specs pass in `dynamic_model_options_spec.rb`
- Rubocop clean on changed files (0 new offenses)
