### PR TITLE
Added versioned config library resolution for dynamic definitions - fixes #666

### DIFF
--- a/app/models/admin/config_library.rb
+++ b/app/models/admin/config_library.rb
@@ -18,13 +18,33 @@ class Admin::ConfigLibrary < Admin::AdminBase
   after_commit :refresh_dependencies
 
   def self.content_named(category, name, format: nil)
+    find_active_library!(category, name, format:).options
+  end
+
+  # Get config library content as it was at a specific point in time.
+  # Uses the VersionHandler#versioned method to look up the historical version.
+  # If at: is nil, returns the current content.
+  # @param category [String]
+  # @param name [String]
+  # @param format [Symbol]
+  # @param at [Time | nil] the point in time to get the content for
+  # @return [String] library content
+  def self.content_named_at(category, name, format: nil, at: nil)
+    return content_named(category, name, format:) unless at
+
+    l = find_active_library!(category, name, format:)
+    versioned_lib = l.versioned(at)
+    (versioned_lib || l).options
+  end
+
+  # Find an active config library matching category, name and format.
+  # @raise [FphsException] if no matching library found
+  # @return [Admin::ConfigLibrary]
+  def self.find_active_library!(category, name, format: nil)
     l = where(name:, category:, format:).first
+    return l if l
 
-    unless l
-      raise FphsException, "No config library in category #{category} named #{name} with format #{format || '(nil)'}"
-    end
-
-    l.options
+    raise FphsException, "No config library in category #{category} named #{name} with format #{format || '(nil)'}"
   end
 
   # Directly substitute the library configurations into the supplied text
@@ -164,7 +184,18 @@ class Admin::ConfigLibrary < Admin::AdminBase
       ms << a if cl.include? self
     end
 
-    ms.each(&:force_option_config_parse)
+    ms.each do |m|
+      # Touch the definition to create a new version history entry,
+      # so that instances created before and after this library change
+      # resolve to the correct library content via versioned definitions.
+      # Skip the touch when versioning is disabled globally (DisableVDef)
+      # or when the definition uses use_current_version (always uses latest).
+      unless Settings::DisableVDef || m.use_current_version
+        m.current_admin ||= current_admin
+        m.touch
+      end
+      m.force_option_config_parse
+    end
   end
 
   def valid_options

--- a/app/models/dynamic/version_handler.rb
+++ b/app/models/dynamic/version_handler.rb
@@ -9,6 +9,7 @@ module Dynamic
       attr_accessor :current_definition # latest defined configuration
 
       after_save :reset_all_versions
+      after_touch :reset_all_versions
     end
 
     class_methods do

--- a/app/models/option_configs/extra_options.rb
+++ b/app/models/option_configs/extra_options.rb
@@ -299,7 +299,7 @@ module OptionConfigs
         references.each do |refitem|
           # Make all keys singular, to simplify configurations
           add_refitem = {}
-          refitem.each do |k, _v|
+          refitem.each_key do |k|
             if k.to_s != k.to_s.singularize
               new_k = k.to_s.singularize.to_sym
               add_refitem[new_k] = refitem.delete(k)
@@ -321,11 +321,11 @@ module OptionConfigs
 
         # Make all keys singular, to simplify configurations
         # The changes can't be made directly inside the iteration, so handle it in two steps
-        references.each do |k, _v|
+        references.each_key do |k|
           fix_refs[k] = references[k] if k.to_s != k.to_s.singularize
         end
 
-        fix_refs.each do |k, _v|
+        fix_refs.each_key do |k|
           new_k = k.to_s.singularize.to_sym
           references[new_k] = references.delete(k)
         end
@@ -340,7 +340,7 @@ module OptionConfigs
 
       self.references = new_ref
 
-      references.each do |_k, refitem|
+      references.each_value do |refitem|
         self.bad_ref_items = []
         refitem.each do |mn, conf|
           to_class = ModelReference.to_record_class_for_type(mn)
@@ -362,7 +362,7 @@ module OptionConfigs
               refitem[mn][:no_master_association] = to_class.no_master_association
             end
 
-            refitem[mn][:to_model_name_us] = to_class.to_s&.ns_underscore
+            refitem[mn][:to_model_name_us] = to_class.to_s.ns_underscore
             refitem[mn][:to_model_class_name] = to_class.to_s
             refitem[mn][:to_table_name] = to_class.table_name
             nil
@@ -490,7 +490,7 @@ module OptionConfigs
         self.field_configs = self.field_configs.symbolize_keys
         failed = false
         field_configs.each do |fname, fconfig|
-          unless fconfig&.is_a? Hash
+          unless fconfig.is_a? Hash
             failed_config :field_configs, "field '#{fname}' is not a Hash"
             failed = true
             self.field_configs[fname] = {}
@@ -630,7 +630,20 @@ module OptionConfigs
       end
 
       config_text = prepend_standard_definitions(config_text)
-      config_text = include_libraries(config_text)
+
+      # If the config_obj is a versioned definition (from history), pass its timestamp
+      # so that config libraries are resolved at the same point in time.
+      # Skip versioned library resolution when:
+      #   - Settings::DisableVDef is true (versioning disabled globally, e.g. development)
+      #   - use_current_version is set on the definition (always uses latest)
+      version_at = nil
+      if !(Settings::DisableVDef ||
+           (config_obj.respond_to?(:use_current_version) && config_obj.use_current_version)) &&
+         config_obj.respond_to?(:def_version) && config_obj.def_version.present?
+        version_at = config_obj.updated_at || config_obj.created_at
+      end
+
+      config_text = include_libraries(config_text, version_at:)
       config_text.gsub(/^---.*\n/, '')
     end
 
@@ -675,8 +688,8 @@ module OptionConfigs
           Rails.logger.warn e
           Rails.logger.warn errtext
           if Rails.env.test? || Rails.env.development?
-            STDERR.puts e
-            STDERR.puts errtext
+            $stderr.puts e
+            $stderr.puts errtext
           end
 
           bt = ["#{e.class.name} #{e}"] + [errtext]
@@ -1012,10 +1025,12 @@ module OptionConfigs
     end
 
     #
-    # Inject config libraries into the provided content
-    # @param [String] content_to_update (will not be updated)
+    # Inject config libraries into the provided content.
+    # When version_at is provided, resolves library content as it was at that point in time.
+    # @param content_to_update [String] (will not be modified)
+    # @param version_at [Time | nil] optional timestamp for resolving versioned library content
     # @return [String] updated content
-    def self.include_libraries(content_to_update)
+    def self.include_libraries(content_to_update, version_at: nil)
       return unless content_to_update
 
       content_to_update = content_to_update.dup
@@ -1025,7 +1040,11 @@ module OptionConfigs
       while res
         category = res[1].strip
         name = res[2].strip
-        lib = Admin::ConfigLibrary.content_named category, name, format: :yaml
+        lib = if version_at
+                Admin::ConfigLibrary.content_named_at(category, name, format: :yaml, at: version_at)
+              else
+                Admin::ConfigLibrary.content_named(category, name, format: :yaml)
+              end
         lib = (lib || '').dup
         LibraryKeyRenamePatterns.each do |key|
           lib.gsub!(/^#{key}:.*/, "#{key}__#{category}_#{name}:")

--- a/spec/models/admin/config_library_versioned_spec.rb
+++ b/spec/models/admin/config_library_versioned_spec.rb
@@ -1,0 +1,357 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/db/table_generators/dynamic_models_table"
+
+# Tests for GitHub Issue #666:
+# "Config libraries and dynamic definition versions"
+#
+# Config library versions should also be applied when using a dynamic definition
+# that is versioned. The `_configurations.use_current_version` option config set
+# for the dynamic definition referencing the config library should control whether
+# the current version or the history dated version of the config library should be used.
+#
+# Strategy:
+# 1. Create a config library with v1 content
+# 2. Create a dynamic model definition that references the library
+# 3. Create an instance under v1
+# 4. Update the config library to v2 content
+# 5. Update the dynamic model definition to trigger a new version
+# 6. Verify the v1 instance still uses the v1 library content
+# 7. Verify a v2 instance uses the v2 library content
+# 8. Verify use_current_version overrides this behavior
+
+RSpec.describe 'Config library versioning with dynamic definitions', type: :model do
+  include MasterSupport
+  include ModelSupport
+  include PlayerContactSupport
+  include BulkMsgSupport
+  include DynamicModelSupport
+  include OptionsSupport
+
+  before :all do
+    change_setting('AllowDynamicMigrations', true)
+  end
+
+  after :all do
+    change_setting('AllowDynamicMigrations', false)
+  end
+
+  before :example do
+    @user0, = create_user
+    create_admin
+    create_user
+    setup_access :trackers
+    setup_access :tracker_histories
+  end
+
+  def create_test_config_library(label_value:)
+    @lib_category = "test_ver_cat_#{rand(1_000_000_000)}"
+    @lib_name = "test_ver_lib_#{rand(1_000_000_000)}"
+
+    Admin::ConfigLibrary.create!(
+      current_admin: @admin,
+      name: @lib_name,
+      category: @lib_category,
+      format: 'yaml',
+      options: <<~YAML
+        _definitions_lib:
+          label_from_lib: &label_from_lib #{label_value}
+      YAML
+    )
+  end
+
+  def generate_dm_with_library_ref(_config_library, use_current_version: false)
+    unless Admin::MigrationGenerator.table_exists? 'test_created_by_recs'
+      TableGenerators.dynamic_models_table('test_created_by_recs', :create_do,
+                                           'test1', 'test2', 'created_by_user_id',
+                                           'use_def_version_time', 'text_array')
+    end
+
+    @master = Master.create! current_user: @user
+    @master.current_user = @user
+
+    DynamicModel.active.where(table_name: 'test_created_by_recs').reload.each { |dm| dm.disable!(@admin) }
+    begin
+      DynamicModel.send(:remove_const, :TestCreatedByRec) if DynamicModel.const_defined?(:TestCreatedByRec, false)
+    rescue NameError
+      # ignored
+    end
+
+    ucv_config = if use_current_version
+                   "_configurations:\n  use_current_version: true\n"
+                 else
+                   ''
+                 end
+
+    options_yaml = <<~YAML
+      # @library #{@lib_category} #{@lib_name}
+      #{ucv_config}default:
+        label: *label_from_lib
+        fields:
+          - test1
+          - test2
+    YAML
+
+    dm = DynamicModel.create!(
+      current_admin: @admin,
+      name: 'test created by',
+      table_name: 'test_created_by_recs',
+      primary_key_name: :id,
+      foreign_key_name: :master_id,
+      field_list: 'test1 test2',
+      category: :test,
+      options: options_yaml
+    )
+    dm.current_admin = @admin
+    dm.update_tracker_events
+
+    setup_access :dynamic_model__test_created_by_recs, user: @user
+    setup_access :dynamic_model__test_created_by_recs, user: @user0
+    dm
+  end
+
+  describe 'Admin::ConfigLibrary.content_named_at' do
+    it 'returns the current library content when no timestamp is provided' do
+      create_test_config_library(label_value: 'v1_label')
+
+      result = Admin::ConfigLibrary.content_named_at(@lib_category, @lib_name, format: :yaml, at: nil)
+      expect(result).to include('v1_label')
+    end
+
+    it 'returns historical library content at a specific timestamp' do
+      lib = create_test_config_library(label_value: 'v1_label')
+
+      sleep 2
+      after_v1_time = Time.current
+
+      sleep 2
+      lib.current_admin = @admin
+      lib.update!(options: <<~YAML)
+        _definitions_lib:
+          label_from_lib: &label_from_lib v2_label
+      YAML
+
+      # Requesting content at the time after v1 but before v2 should return v1 content
+      result = Admin::ConfigLibrary.content_named_at(@lib_category, @lib_name, format: :yaml, at: after_v1_time)
+      expect(result).to include('v1_label')
+      expect(result).not_to include('v2_label')
+    end
+
+    it 'returns current content when requested timestamp is after the latest version' do
+      lib = create_test_config_library(label_value: 'v1_label')
+
+      sleep 2
+      lib.current_admin = @admin
+      lib.update!(options: <<~YAML)
+        _definitions_lib:
+          label_from_lib: &label_from_lib v2_label
+      YAML
+
+      sleep 2
+      after_v2_time = Time.current
+
+      result = Admin::ConfigLibrary.content_named_at(@lib_category, @lib_name, format: :yaml, at: after_v2_time)
+      expect(result).to include('v2_label')
+    end
+  end
+
+  describe 'versioned dynamic definition uses versioned config library' do
+    it 'uses the v1 library content for instances created under v1 definition' do
+      # Create library v1 and dynamic model referencing it
+      lib = create_test_config_library(label_value: 'v1_label')
+      dmdef = generate_dm_with_library_ref(lib)
+
+      # Verify v1 definition has the v1 label
+      v1_otc = dmdef.option_type_config_for(:default)
+      expect(v1_otc).not_to be_nil
+      expect(v1_otc.label).to eq('v1_label')
+
+      sleep 2
+
+      # Create an instance under v1
+      instance_v1 = @master.dynamic_model__test_created_by_recs.create!(test1: 'v1_record')
+
+      sleep 2
+
+      # Update the library to v2
+      # refresh_dependencies callback should touch the dependent DM definition,
+      # creating a new version boundary in history
+      lib.current_admin = @admin
+      lib.update!(options: <<~YAML)
+        _definitions_lib:
+          label_from_lib: &label_from_lib v2_label
+      YAML
+
+      # Reload and re-parse the definition to simulate what refresh_outdated does
+      # on the next web request. This is needed because refresh_dependencies
+      # parses a throwaway object, not the cached definition (see issue #1033).
+      dmdef.reload
+      dmdef.force_option_config_parse
+
+      # The current definition should now use v2 library content
+      current_otc = dmdef.option_type_config_for(:default)
+      expect(current_otc.label).to eq('v2_label')
+
+      # Reload the v1 instance to clear any memoization
+      instance_v1 = DynamicModel::TestCreatedByRec.find(instance_v1.id)
+
+      # The v1 instance's versioned definition should still use v1 library content
+      versioned_otc = instance_v1.versioned_definition.option_type_config_for(:default)
+      expect(versioned_otc).not_to be_nil
+      expect(versioned_otc.label).to eq('v1_label'),
+                                     "Expected v1 instance to use v1 library content with label 'v1_label', " \
+                                     "but got: #{versioned_otc.label}"
+    end
+
+    it 'uses the v2 library content for instances created after v2' do
+      # Create library v1 and dynamic model referencing it
+      lib = create_test_config_library(label_value: 'v1_label')
+      dmdef = generate_dm_with_library_ref(lib)
+
+      sleep 2
+
+      # Update the library to v2
+      # refresh_dependencies callback should touch the dependent DM definition
+      lib.current_admin = @admin
+      lib.update!(options: <<~YAML)
+        _definitions_lib:
+          label_from_lib: &label_from_lib v2_label
+      YAML
+
+      # Reload and re-parse the definition to simulate what refresh_outdated does
+      # on the next web request. This is needed because refresh_dependencies
+      # parses a throwaway object, not the cached definition (see issue #1033).
+      dmdef.reload
+      dmdef.force_option_config_parse
+
+      sleep 2
+
+      # Create an instance under v2
+      instance_v2 = @master.dynamic_model__test_created_by_recs.create!(test1: 'v2_record')
+
+      # Reload to clear memoization
+      instance_v2 = DynamicModel::TestCreatedByRec.find(instance_v2.id)
+
+      # The v2 instance should use v2 library content
+      versioned_otc = instance_v2.versioned_definition.option_type_config_for(:default)
+      expect(versioned_otc).not_to be_nil
+      expect(versioned_otc.label).to eq('v2_label'),
+                                     "Expected v2 instance to use v2 library content with label 'v2_label', " \
+                                     "but got: #{versioned_otc.label}"
+    end
+  end
+
+  describe 'use_current_version controls library versioning' do
+    it 'uses current library for all instances when use_current_version is true' do
+      # Create library v1 and dynamic model with use_current_version: true
+      lib = create_test_config_library(label_value: 'v1_label')
+
+      unless Admin::MigrationGenerator.table_exists? 'test_created_by_recs'
+        TableGenerators.dynamic_models_table('test_created_by_recs', :create_do,
+                                             'test1', 'test2', 'created_by_user_id',
+                                             'use_def_version_time', 'text_array')
+      end
+
+      @master = Master.create! current_user: @user
+      @master.current_user = @user
+
+      DynamicModel.active.where(table_name: 'test_created_by_recs').reload.each { |dm| dm.disable!(@admin) }
+      begin
+        DynamicModel.send(:remove_const, :TestCreatedByRec) if DynamicModel.const_defined?(:TestCreatedByRec, false)
+      rescue NameError
+        # ignored
+      end
+
+      options_yaml = <<~YAML
+        # @library #{@lib_category} #{@lib_name}
+        _configurations:
+          use_current_version: true
+        default:
+          label: *label_from_lib
+          fields:
+            - test1
+            - test2
+      YAML
+
+      dmdef = DynamicModel.create!(
+        current_admin: @admin,
+        name: 'test created by',
+        table_name: 'test_created_by_recs',
+        primary_key_name: :id,
+        foreign_key_name: :master_id,
+        field_list: 'test1 test2',
+        category: :test,
+        options: options_yaml
+      )
+      dmdef.current_admin = @admin
+      dmdef.update_tracker_events
+
+      setup_access :dynamic_model__test_created_by_recs, user: @user
+      setup_access :dynamic_model__test_created_by_recs, user: @user0
+
+      sleep 2
+
+      # Create an instance under v1
+      instance_v1 = @master.dynamic_model__test_created_by_recs.create!(test1: 'v1_record')
+
+      sleep 2
+
+      # Update the library to v2
+      lib.current_admin = @admin
+      lib.update!(options: <<~YAML)
+        _definitions_lib:
+          label_from_lib: &label_from_lib v2_label
+      YAML
+
+      sleep 2
+
+      # Force re-parse of current definition
+      dmdef.force_option_config_parse
+
+      # Reload the v1 instance to clear memoization
+      instance_v1 = DynamicModel::TestCreatedByRec.find(instance_v1.id)
+
+      # With use_current_version: true, the v1 instance should use CURRENT (v2) library
+      versioned_def = instance_v1.versioned_definition
+      expect(versioned_def).to eq(instance_v1.current_definition),
+                               'Expected versioned_definition to return current_definition when use_current_version is true'
+
+      versioned_otc = versioned_def.option_type_config_for(:default)
+      expect(versioned_otc).not_to be_nil
+      expect(versioned_otc.label).to eq('v2_label'),
+                                     'Expected v1 instance to use current (v2) library when use_current_version is true, ' \
+                                     "but got: #{versioned_otc.label}"
+    end
+
+    it 'does not pass version_at to include_libraries when use_current_version is true' do
+      lib = create_test_config_library(label_value: 'v1_label')
+      dmdef = generate_dm_with_library_ref(lib, use_current_version: true)
+
+      sleep 2
+
+      # Update the library to v2
+      lib.current_admin = @admin
+      lib.update!(options: <<~YAML)
+        _definitions_lib:
+          label_from_lib: &label_from_lib v2_label
+      YAML
+
+      sleep 2
+
+      # With use_current_version, the library update should NOT have touched the definition,
+      # so no new version boundary exists. Verify versioned() returns nil.
+      versioned_def = dmdef.versioned(dmdef.created_at)
+      expect(versioned_def).to be_nil,
+                               'Expected no version boundary when use_current_version is true (touch should be skipped)'
+
+      # Verify prepare_options_text on the current definition uses latest library (v2)
+      config_text = OptionConfigs::ExtraOptions.prepare_options_text(dmdef)
+      expect(config_text).to include('v2_label'),
+                             'Expected prepare_options_text to use current library content when use_current_version is true, ' \
+                             "Got:\n#{config_text}"
+      expect(config_text).not_to include('v1_label'),
+                                 'Expected versioned library content (v1_label) to NOT be used when use_current_version is true'
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements versioned config library resolution for dynamic definitions (issue #666). When a dynamic definition is versioned, config libraries referenced via `# @library` directives are now resolved at the same point in time as the definition version, ensuring historical instances see the library content that was active when they were created.

The `_configurations.use_current_version` option controls this behavior: when set to `true`, the current (latest) library content is always used regardless of version boundaries.

### Changes

- **`OptionConfigs::ExtraOptions`**: `prepare_options_text` now passes `version_at` timestamp to `include_libraries` for versioned definitions; `include_libraries` uses `content_named_at` when `version_at` is present
- **`Dynamic::VersionHandler`**: Added `after_touch :reset_all_versions` callback so version caches are cleared when definitions are touched
- **New spec**: 7 tests covering `content_named_at`, versioned instance resolution (v1/v2), `use_current_version` override, and version boundary verification

### Related

- Fixes #666
- References #1033 (pre-existing definition cache issue documented in spec comments)
- Complements PR #1024 (config library cache check)
