### PR TITLE
Fixed duplicate admin panel server alerts - fixes #1035

### DIFF
--- a/config/initializers/z_check_app_settings.rb
+++ b/config/initializers/z_check_app_settings.rb
@@ -28,6 +28,7 @@ class Settings
     configuration_failed_reason << 'EncryptionSecretKeyBase is not set' if EncryptionSecretKeyBase.blank?
     configuration_failed_reason << 'EncryptionSalt is not set' if EncryptionSalt.blank?
 
+    configuration_failed_reason.uniq!
     configuration_failed_reason.blank?
   end
 end

--- a/spec/models/admin/server_info_spec.rb
+++ b/spec/models/admin/server_info_spec.rb
@@ -92,6 +92,50 @@ RSpec.describe Admin::ServerInfo, type: :model do
     expect(stats[:error]).to include('Memcached unavailable')
   end
 
+  # Tests for issue #1035 - Admin panel server alerts duplicated
+  # Settings.configuration_successful? appends to a persistent class-level array,
+  # so multiple calls produce duplicate alert messages.
+  describe '#configuration_failed_reason - Issue1035' do
+    before :each do
+      # Reset Settings state so alerts will be freshly generated
+      Settings.instance_variable_set(:@configuration_failed_reason, nil)
+      # Stub a blank encryption setting to ensure at least one alert is generated
+      stub_const('Settings::EncryptionSecretKeyBase', '')
+    end
+
+    after :each do
+      # Clean up Settings state
+      Settings.instance_variable_set(:@configuration_failed_reason, nil)
+    end
+
+    it 'does not produce duplicate Settings alerts when called multiple times' do
+      # First call should generate alerts
+      Settings.configuration_successful?
+      first_call_reasons = Settings.configuration_failed_reason.dup
+      expect(first_call_reasons).to include('EncryptionSecretKeyBase is not set')
+
+      # Second call should NOT add duplicate alerts
+      Settings.configuration_successful?
+      second_call_reasons = Settings.configuration_failed_reason.dup
+
+      expect(second_call_reasons).to eq(first_call_reasons)
+      expect(second_call_reasons.length).to eq(first_call_reasons.length)
+    end
+
+    it 'does not produce duplicate alerts in ServerInfo when instantiated multiple times' do
+      si1 = Admin::ServerInfo.new(@admin)
+      reasons1 = si1.configuration_failed_reason.dup
+      expect(reasons1).to include('EncryptionSecretKeyBase is not set')
+
+      # A second ServerInfo instance should report the same alerts without duplication
+      si2 = Admin::ServerInfo.new(@admin)
+      reasons2 = si2.configuration_failed_reason.dup
+
+      expect(reasons2).to eq(reasons1)
+      expect(reasons2.length).to eq(reasons1.length)
+    end
+  end
+
   # Tests for issue #896 - NFS mountpoint info
   describe '#nfs_store_mount_dirs' do
     it 'returns structured data with mountpoint status for all group IDs - Issue896' do


### PR DESCRIPTION
## Summary

Fixes #1035 — Admin panel server alerts were displayed with duplicate entries.

### Root Cause

`Settings.configuration_successful?` appends alert messages to a persistent class-level array (`@configuration_failed_reason`) without deduplication. Each call to the method re-appends the same alerts, so multiple `Admin::ServerInfo` instances or page loads within the same server process accumulate duplicate entries.

### Changes

- **spec/models/admin/server_info_spec.rb**: Added 2 tests (tagged `Issue1035`) verifying that repeated calls to `Settings.configuration_successful?` and multiple `Admin::ServerInfo` instances do not produce duplicate alerts

### Testing

- 34 model spec examples pass, 0 failures
- 4 admin alerts panel system spec examples pass, 0 failures
