### PR TITLE
Added item flag name import/export support - fixes #3

### DIFF
--- a/spec/models/admin/app_type_export_spec.rb
+++ b/spec/models/admin/app_type_export_spec.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# Tests for Admin::AppType export functionality.
+# Verifies that export_config produces correct JSON including app configurations,
+# user access controls, activity logs, external identifiers, general selections,
+# and item flag names. Ensures exported item flag names are scoped to tables
+# associated with the app type via user access controls.
+
 require 'rails_helper'
 
 RSpec.describe 'Export an app configuration', type: :model do
@@ -142,5 +148,31 @@ RSpec.describe 'Export an app configuration', type: :model do
     config = uac.select { |a| a['item_type'] == 'player_infos_source' }
     expect(config).to be_a Array
     expect(config.map { |a| a['value'] }).to include 'nflpa'
+  end
+
+  it 'exports only item flag names for tables associated with the app type' do
+    # Create an item flag for a table that IS in the app type (player_infos has :create access)
+    associated_flag = Classification::ItemFlagName.create!(
+      name: "Associated Flag #{rand(1_000_000)}",
+      item_type: 'player_info',
+      current_admin: @admin
+    )
+
+    # Create an item flag for a table that is NOT in the app type
+    unassociated_flag = Classification::ItemFlagName.create!(
+      name: "Unassociated Flag #{rand(1_000_000)}",
+      item_type: 'address',
+      current_admin: @admin
+    )
+
+    res = JSON.parse(@app_type.export_config)
+    app = res['app_type']
+    exported_flags = app['associated_item_flag_names']
+
+    expect(exported_flags).to be_a Array
+
+    exported_names = exported_flags.map { |f| f['name'] }
+    expect(exported_names).to include(associated_flag.name)
+    expect(exported_names).not_to include(unassociated_flag.name)
   end
 end


### PR DESCRIPTION
## Summary

Adds import support for item flag names in app type configurations and test coverage for both export filtering and import round-trip.

### Changes

**Import implementation:**
- Added `import_config_sub_items 'associated_item_flag_names', %w[name item_type]` to `import_set` in `app/models/admin/app_type_import.rb`
- Placed after `associated_general_selections` import (item flags depend on table types being available)

**Export test coverage:**
- Added test verifying exported item flag names are scoped to tables associated with the app type
- Flags for non-associated tables are excluded from export

**Import test coverage:**
- Added test verifying item flag names are created during import
- Exports a config with item flags, injects a new flag name, imports to a new app type, and verifies the flag was created

**Spec comments:**
- Added descriptive comment blocks to both export and import spec files

### Files changed

- `app/models/admin/app_type_import.rb` — Added import line for `associated_item_flag_names`
- `spec/models/admin/app_type_export_spec.rb` — Added export filtering test and comment
- `spec/models/admin/app_type_import_spec.rb` — Added import round-trip test and comment
