### PR TITLE
Added secure viewer support for Redcap file links and filestore_view show_as option in reports - fixes #1040

### DIFF
--- a/app/assets/javascripts/app/_fpa_ajax_processors_reports.js
+++ b/app/assets/javascripts/app/_fpa_ajax_processors_reports.js
@@ -109,6 +109,7 @@ _fpa.postprocessors_reports = {
   },
   reports_result: function (block, data) {
     block.removeClass('use-secure-view-on-links-setup');
+    _fpa.form_utils.setup_secure_view_links(block);
     if (data) {
       // Update the search form results count bar manually
       var c = block.find('.result-count').html();
@@ -346,7 +347,8 @@ _fpa.postprocessors_reports = {
       'list': 'ul',
       'tags': 'div',
       'choice_label': 'div',
-      'iframe': 'div'
+      'iframe': 'div',
+      'filestore_view': 'span'
     }
 
 
@@ -381,8 +383,12 @@ _fpa.postprocessors_reports = {
         var sa = show_as[ct];
         var orig_cell_content = cell_content;
         if (sa) {
-          sa = mapping[sa] || sa
-          cell_content = `<${sa}>${cell_content}</${sa}>`
+          if (sa === 'filestore_view') {
+            cell_content = `<span class="use-secure-view-on-links">${cell_content}</span>`;
+          } else {
+            sa = mapping[sa] || sa
+            cell_content = `<${sa}>${cell_content}</${sa}>`
+          }
         }
 
         // Format the cell if it is an array or show_as specifies it is tags
@@ -417,6 +423,8 @@ _fpa.postprocessors_reports = {
       row.find('.td-date-formatted').removeClass('td-date-formatted');
       _fpa.postprocessors_reports.report_format_result_cells(row, data);
       row.find('td').removeClass('report-el-was-from-new');
+      row.removeClass('use-secure-view-on-links-setup');
+      _fpa.form_utils.setup_secure_view_links(row);
     }, 50)
 
   },

--- a/app/assets/javascripts/app/_fpa_form_utils.js
+++ b/app/assets/javascripts/app/_fpa_form_utils.js
@@ -842,8 +842,8 @@ _fpa.form_utils = {
   },
 
   // Blocks marked with the class use-secure-view-on-links are checked
-  // to find <a> links for filestore downloads. These are then set to
-  //
+  // to find <a> links for filestore downloads or Redcap file downloads.
+  // These are then set to use the secure viewer.
   setup_secure_view_links: function (block) {
     if (block.hasClass('use-secure-view-on-links-setup')) return;
 
@@ -861,6 +861,13 @@ _fpa.form_utils = {
         $(this).parents('.nfs-store-container-block').length == 0
       ) {
         $(this).addClass('use-secure-view');
+      } else if (
+        href &&
+        href.indexOf('/redcap/project_user_requests/') >= 0 &&
+        href.indexOf('/download_field_file/') >= 0 &&
+        !$(this).hasClass('redcap-file-use-secure-view')
+      ) {
+        $(this).addClass('redcap-file-use-secure-view');
       }
     });
 

--- a/app/helpers/report_results/reports_common_result_cell.rb
+++ b/app/helpers/report_results/reports_common_result_cell.rb
@@ -34,7 +34,8 @@ module ReportResults
         'list' => 'ul',
         'tags' => 'div',
         'choice_label' => 'div',
-        'iframe' => 'div'
+        'iframe' => 'div',
+        'filestore_view' => nil
       }
 
       return col_show_as unless mapping.key? col_show_as
@@ -173,6 +174,23 @@ module ReportResults
       col_url_parts = cell_content&.scan(/^\[(.+)\]\((.+)\)$/)
       html = <<~END_HTML
         <a href="#{col_url_parts&.first&.last}" target="_blank">#{html_escape col_url_parts&.first&.first}</a>
+      END_HTML
+
+      html.html_safe
+    end
+
+    #
+    # Show the result as a link opened in the secure file viewer.
+    # The content should be formatted using Markdown format
+    #     [label for link](/url/path)
+    # The link is wrapped in a span with use-secure-view-on-links class
+    # to enable the secure viewer for filestore and Redcap file downloads.
+    def cell_content_for_filestore_view
+      return cell_content unless cell_content.present?
+
+      col_url_parts = cell_content&.scan(/^\[(.+)\]\((.+)\)$/)
+      html = <<~END_HTML
+        <span class="use-secure-view-on-links"><a href="#{col_url_parts&.first&.last}">#{html_escape col_url_parts&.first&.first}</a></span>
       END_HTML
 
       html.html_safe

--- a/app/helpers/report_results/reports_list_result_cell.rb
+++ b/app/helpers/report_results/reports_list_result_cell.rb
@@ -23,7 +23,8 @@ module ReportResults
         'url' => nil,
         'tags' => nil,
         'choice_label' => nil,
-        'iframe' => 'div'
+        'iframe' => 'div',
+        'filestore_view' => nil
       }
 
       return col_show_as unless mapping.key? col_show_as

--- a/app/helpers/report_results/reports_table_result_cell.rb
+++ b/app/helpers/report_results/reports_table_result_cell.rb
@@ -23,7 +23,8 @@ module ReportResults
         'url' => 'div',
         'tags' => 'div',
         'choice_label' => 'div',
-        'iframe' => 'div'
+        'iframe' => 'div',
+        'filestore_view' => nil
       }
 
       return col_show_as unless mapping.key? col_show_as

--- a/spec/helpers/report_results/reports_filestore_view_cell_spec.rb
+++ b/spec/helpers/report_results/reports_filestore_view_cell_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# ReportsCommonResultCell filestore_view Spec
+#
+# Tests the cell content rendering for report cells with show_as: filestore_view.
+# The filestore_view option wraps file download links in a span with the
+# use-secure-view-on-links class to enable the secure file viewer for
+# NFS filestore and Redcap file downloads in report results.
+#
+# Test Coverage:
+# - #cell_content_for_filestore_view: Generates HTML with secure view wrapper
+#   - Handles markdown format links [label](url)
+#   - Returns blank/nil content unchanged
+#   - Wraps link in span.use-secure-view-on-links
+#   - Does not add target="_blank" (secure viewer handles display)
+# - #html_tag: Returns nil for filestore_view (content includes its own wrapper)
+#   - Tested for table, list, and base cell classes
+
+require 'rails_helper'
+
+RSpec.describe ReportResults::ReportsCommonResultCell do
+  let(:table_name) { 'dynamic_model__test_items' }
+  let(:col_name) { 'file_link' }
+  let(:col_tag) { nil }
+  let(:col_show_as) { 'filestore_view' }
+  let(:selection_options) { double('selection_options') }
+
+  def build_cell(content, klass = described_class)
+    klass.new(table_name, content, col_name, col_tag, col_show_as, selection_options)
+  end
+
+  describe '#cell_content_for_filestore_view' do
+    context 'with NFS filestore download links' do
+      it 'wraps the link in a span with use-secure-view-on-links class' do
+        html = build_cell('[Download File](/nfs_store/downloads/123)').cell_content_for_filestore_view
+
+        expect(html).to include('class="use-secure-view-on-links"')
+        expect(html).to include('<a href="/nfs_store/downloads/123"')
+        expect(html).to include('>Download File</a>')
+        expect(html).to include('<span')
+      end
+
+      it 'does not add target="_blank"' do
+        html = build_cell('[File](/nfs_store/downloads/456)').cell_content_for_filestore_view
+
+        expect(html).not_to include('target="_blank"')
+      end
+    end
+
+    context 'with Redcap file download links' do
+      it 'wraps the link in a span with use-secure-view-on-links class' do
+        url = '/redcap/project_user_requests/dynamic_model__test_rcs/download_field_file/uploaded_file/99'
+        html = build_cell("[View Form](#{url})").cell_content_for_filestore_view
+
+        expect(html).to include('class="use-secure-view-on-links"')
+        expect(html).to include("href=\"#{url}\"")
+        expect(html).to include('>View Form</a>')
+      end
+    end
+
+    context 'with edge cases' do
+      it 'returns blank content unchanged' do
+        expect(build_cell('').cell_content_for_filestore_view).to eq('')
+      end
+
+      it 'returns nil content as nil' do
+        expect(build_cell(nil).cell_content_for_filestore_view).to be_nil
+      end
+    end
+  end
+
+  describe '#view_content' do
+    it 'dispatches to cell_content_for_filestore_view' do
+      cell = build_cell('[File](/nfs_store/downloads/1)')
+      html = cell.view_content
+
+      expect(html).to include('use-secure-view-on-links')
+      expect(html).to include('/nfs_store/downloads/1')
+    end
+  end
+
+  describe '#html_tag' do
+    it 'returns nil for filestore_view in the base class' do
+      cell = build_cell('content')
+      expect(cell.html_tag).to be_nil
+    end
+
+    it 'returns nil for filestore_view in ReportsTableResultCell' do
+      cell = build_cell('content', ReportResults::ReportsTableResultCell)
+      expect(cell.html_tag).to be_nil
+    end
+
+    it 'returns nil for filestore_view in ReportsListResultCell' do
+      cell = build_cell('content', ReportResults::ReportsListResultCell)
+      expect(cell.html_tag).to be_nil
+    end
+  end
+end

--- a/spec/javascripts/_fpa_secure_view_links_spec.js
+++ b/spec/javascripts/_fpa_secure_view_links_spec.js
@@ -1,0 +1,139 @@
+/**
+ * Tests for _fpa.form_utils.setup_secure_view_links
+ *
+ * Issue: #1040 - Reports don't handle secure viewer with Redcap files
+ *
+ * The secure viewer should recognize both NFS store download links
+ * (URLs containing /nfs_store/downloads) and Redcap file download links
+ * (URLs containing /redcap/project_user_requests/ with /download_field_file/).
+ *
+ * Links matching either pattern should receive the appropriate class
+ * so the secure viewer can handle them.
+ */
+describe('setup_secure_view_links', function () {
+
+  var $block;
+
+  beforeEach(function () {
+    // Set up _fpa.state.user_can to simulate a user with file viewing permissions
+    _fpa.state = _fpa.state || {};
+    _fpa.state.user_can = { view_files_as_image: true };
+
+    // Mock _fpa.secure_view.setup_links to avoid full secure viewer initialization
+    _fpa.secure_view = _fpa.secure_view || {};
+    _fpa.secure_view.setup_links = function () {};
+  });
+
+  afterEach(function () {
+    if ($block) {
+      $block.remove();
+      $block = null;
+    }
+  });
+
+  it('adds use-secure-view class to NFS store download links', function () {
+    $block = $('<div>' +
+      '<a href="/nfs_store/downloads/123?retrieve=abc">file.pdf</a>' +
+      '</div>');
+    $('body').append($block);
+
+    _fpa.form_utils.setup_secure_view_links($block);
+
+    expect($block.find('a').hasClass('use-secure-view')).toBe(true);
+  });
+
+  it('does not add use-secure-view class to NFS links inside nfs-store-container-block', function () {
+    $block = $('<div>' +
+      '<div class="nfs-store-container-block">' +
+      '<a href="/nfs_store/downloads/123">file.pdf</a>' +
+      '</div>' +
+      '</div>');
+    $('body').append($block);
+
+    _fpa.form_utils.setup_secure_view_links($block);
+
+    expect($block.find('a').hasClass('use-secure-view')).toBe(false);
+  });
+
+  it('adds redcap-file-use-secure-view class to Redcap download_field_file links', function () {
+    $block = $('<div>' +
+      '<a href="/redcap/project_user_requests/dynamic_model__press_bp_measurement_rcs/download_field_file/uploaded_bp_form/33">bp_form.pdf</a>' +
+      '</div>');
+    $('body').append($block);
+
+    _fpa.form_utils.setup_secure_view_links($block);
+
+    expect($block.find('a').hasClass('redcap-file-use-secure-view')).toBe(true);
+  });
+
+  it('adds redcap-file-use-secure-view class to various Redcap file URL patterns', function () {
+    $block = $('<div>' +
+      '<a id="link1" href="/redcap/project_user_requests/dynamic_model__some_model/download_field_file/some_field/1">file1.pdf</a>' +
+      '<a id="link2" href="/redcap/project_user_requests/dynamic_model__another_model_rcs/download_field_file/another_field/999">file2.png</a>' +
+      '</div>');
+    $('body').append($block);
+
+    _fpa.form_utils.setup_secure_view_links($block);
+
+    expect($block.find('#link1').hasClass('redcap-file-use-secure-view')).toBe(true);
+    expect($block.find('#link2').hasClass('redcap-file-use-secure-view')).toBe(true);
+  });
+
+  it('does not add secure view classes to unrelated links', function () {
+    $block = $('<div>' +
+      '<a href="/masters/123">Master Record</a>' +
+      '<a href="https://example.com/file.pdf">External Link</a>' +
+      '</div>');
+    $('body').append($block);
+
+    _fpa.form_utils.setup_secure_view_links($block);
+
+    var links = $block.find('a');
+    links.each(function () {
+      expect($(this).hasClass('use-secure-view')).toBe(false);
+      expect($(this).hasClass('redcap-file-use-secure-view')).toBe(false);
+    });
+  });
+
+  it('handles a block with both NFS and Redcap links', function () {
+    $block = $('<div>' +
+      '<a id="nfs-link" href="/nfs_store/downloads/456?retrieve=def">nfs_file.pdf</a>' +
+      '<a id="rc-link" href="/redcap/project_user_requests/dynamic_model__test_rcs/download_field_file/doc_field/77">rc_file.pdf</a>' +
+      '<a id="plain-link" href="/masters/1">Master</a>' +
+      '</div>');
+    $('body').append($block);
+
+    _fpa.form_utils.setup_secure_view_links($block);
+
+    expect($block.find('#nfs-link').hasClass('use-secure-view')).toBe(true);
+    expect($block.find('#rc-link').hasClass('redcap-file-use-secure-view')).toBe(true);
+    expect($block.find('#plain-link').hasClass('use-secure-view')).toBe(false);
+    expect($block.find('#plain-link').hasClass('redcap-file-use-secure-view')).toBe(false);
+  });
+
+  it('does not re-process a block already marked as setup', function () {
+    $block = $('<div class="use-secure-view-on-links-setup">' +
+      '<a href="/redcap/project_user_requests/dynamic_model__test/download_field_file/field/1">file.pdf</a>' +
+      '</div>');
+    $('body').append($block);
+
+    _fpa.form_utils.setup_secure_view_links($block);
+
+    // Should not add class since block is already setup
+    expect($block.find('a').hasClass('redcap-file-use-secure-view')).toBe(false);
+  });
+
+  it('does not add duplicate class to links that already have redcap-file-use-secure-view', function () {
+    $block = $('<div>' +
+      '<a class="redcap-file-use-secure-view" href="/redcap/project_user_requests/dynamic_model__test/download_field_file/field/1">file.pdf</a>' +
+      '</div>');
+    $('body').append($block);
+
+    _fpa.form_utils.setup_secure_view_links($block);
+
+    // The class should still be there (not doubled)
+    var classes = $block.find('a').attr('class').split(/\s+/);
+    var count = classes.filter(function (c) { return c === 'redcap-file-use-secure-view'; }).length;
+    expect(count).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds support for the secure viewer to handle Redcap file download URLs in reports, and introduces a new `filestore_view` show_as column option for report configurations.

Fixes #1040

### Changes

**JavaScript (client-side secure viewer)**
- Updated `setup_secure_view_links` in `_fpa_form_utils.js` to detect Redcap file download URLs (`/redcap/project_user_requests/` + `/download_field_file/`)
- Added `filestore_view` handling in `_fpa_ajax_processors_reports.js` for both initial report rendering and inline row editing
- Calls `setup_secure_view_links()` on report result blocks to activate secure viewer on Redcap links

**Ruby (server-side report cell rendering)**
- Added `cell_content_for_filestore_view` method in `ReportsCommonResultCell` to wrap markdown-format links in `<span class="use-secure-view-on-links">`
- Registered `filestore_view` in tag mappings for both table and list result cell helpers

**Tests**
- 8 Jasmine specs validating Redcap URL detection in `setup_secure_view_links`
- 8 RSpec examples for the `filestore_view` show_as cell rendering
