### PR TITLE
Added URL search formats to admin Master Records and External Identifiers panels - fixes #1041

### DIFF
--- a/app/controllers/masters_controller.rb
+++ b/app/controllers/masters_controller.rb
@@ -68,6 +68,8 @@ class MastersController < UserBaseController
   #
   # An external ID (or master crosswalk ID) may be used to search instead, using the params
   # external_id[id], external_id[field]. The 'field' param names the alternative ID to use.
+  # Alternatively, the #show action handles params[:type] for crosswalk attributes and
+  # external identifier attributes via the URL format /masters/<value>?type=<attr>.
   #
   # params[:external_id] - we have an external_id parameter, use this to search
   # params[:nav_q_id] - if not an external_id instead search by master id
@@ -108,7 +110,7 @@ class MastersController < UserBaseController
 
   def new
     @master = Master.new_master_record current_user
-    
+
     # For admin sample forms, render just the form partial without layout
     if params[:admin_sample] == 'true'
       render partial: 'form', layout: false

--- a/app/views/admin/external_identifiers/_def_details.html.erb
+++ b/app/views/admin/external_identifiers/_def_details.html.erb
@@ -57,6 +57,13 @@
   <%= render partial: 'admin/dynamic_models/est_record_count' %>
   <%= render partial: 'admin/dynamic_models/check_tracker_updates' %>
 
+  <label>URL search format</label>
+  <p class="help-block">
+    Search for a master record by this external identifier using:
+  </p>
+  <p>
+    <code>/masters/&lt;value&gt;?type=<%= object_instance.external_id_attribute %></code>
+  </p>
 
   <label>fields</label>
   <ul class="activity-list">

--- a/app/views/admin/master_records/_def_details_masters.html.erb
+++ b/app/views/admin/master_records/_def_details_masters.html.erb
@@ -30,6 +30,15 @@
                 target: '_blank' %>
   </p>
 
+  <label>estimated record count</label>
+  <p>
+    <% begin %>
+      <%= number_with_delimiter(Master.count) %>
+    <% rescue StandardError => e %>
+      <em>Unable to get count: <%= e.message %></em>
+    <% end %>
+  </p>
+  
   <div>
     <div>
       <label>crosswalk fields</label>
@@ -61,18 +70,24 @@
       <p class="help-block">
         These master IDs are reserved for temporary / anonymous sessions with
         limited user access controls.
-      </p>
-
-      <label>estimated record count</label>
-      <p>
-        <% begin %>
-          <%= number_with_delimiter(Master.count) %>
-        <% rescue StandardError => e %>
-          <em>Unable to get count: <%= e.message %></em>
-        <% end %>
-      </p>
+      </p>      
     </div>
     <div>
+      <label>prevent reload master list</label>
+      <p>
+        <%= link_to link_label_open_in_new('app configuration'),
+                    admin_app_configurations_path(filter: { name: 'prevent reload master list' }),
+                    target: '_blank',
+                    class: 'admin-page-link' %>
+        <code><%= prevent_reload_master_list = app_config_text(:prevent_reload_master_list, alt_user: current_admin.matching_user).presence || 'not set' %></code>
+      </p>
+      <p class="help-block">
+        <% if prevent_reload_master_list == 'not set' %>
+        If the user refreshes a page showing master records from a search, the list of previous master records will be reloaded. This can be prevented, to avoid confusing results, by setting the value to any value.
+        <% else %>
+        If the user refreshes a page showing master records from a search, the list of previous master records won't be reloaded, to avoid confusing results. This can be changed back to allow reloading by setting the value to blank or removing it.
+        <% end %>
+      </p>
       <label>create master with resource</label>
       <p>
         <%= link_to link_label_open_in_new('app configuration'),
@@ -88,6 +103,7 @@
 
   <%# Model field listing %>
   <% fields = object_instance.fields %>
+
   <% if fields.present? %>
     <label>fields (<%= fields.length %>)</label>
     <table class="table table-condensed table-striped master-records-def-details__fields-table">

--- a/app/views/admin/master_records/_form_info.html.erb
+++ b/app/views/admin/master_records/_form_info.html.erb
@@ -5,6 +5,7 @@
     The masters table entry (table_name == 'masters') shows:
       - Details tab (masters-specific)
       - Sample Form tab
+      - URL Search tab (URL formats for searching master records)
       - API tab (masters-specific, no UAC)
     
     Other standard models show:
@@ -31,7 +32,13 @@
            role="tab" data-toggle="tab">Sample Form</a>
       </li>
     <% end %>
-    <% unless is_masters_table %>
+    <% if is_masters_table %>
+      <li role="presentation">
+        <a href="#mr-url-search-<%= object_instance.id %>"
+           aria-controls="mr-url-search-<%= object_instance.id %>"
+           role="tab" data-toggle="tab">URL Search</a>
+      </li>
+    <% else %>
       <li role="presentation">
         <a href="#mr-user-access-controls-<%= object_instance.id %>"
            aria-controls="mr-user-access-controls-<%= object_instance.id %>"
@@ -64,7 +71,11 @@
       </div>
     <% end %>
 
-    <% unless is_masters_table %>
+    <% if is_masters_table %>
+      <div role="tabpanel" class="tab-pane" id="mr-url-search-<%= object_instance.id %>">
+        <%= render partial: 'admin/master_records/url_search_formats' %>
+      </div>
+    <% else %>
       <div role="tabpanel" class="tab-pane on-open-click" id="mr-user-access-controls-<%= object_instance.id %>">
         <% if current_admin.can_admin?(:user_access_controls) %>
           <%= render partial: 'admin/master_records/uac_panel', locals: { object_instance: object_instance } %>

--- a/app/views/admin/master_records/_url_search_formats.html.erb
+++ b/app/views/admin/master_records/_url_search_formats.html.erb
@@ -1,0 +1,126 @@
+<%# URL Search tab for the masters table entry (issue #1041).
+    Shows URL formats for searching master records by various identifiers. %>
+
+<h4>URL Search</h4>
+
+<div class="master-records-url-search-formats">
+
+  <% begin %>
+    <% crosswalk_attrs = Master.crosswalk_attrs %>
+  <% rescue StandardError => e %>
+    <p class="text-danger">Error loading masters metadata: <%= e.message %></p>
+    <% crosswalk_attrs = [] %>
+  <% end %>
+
+  <label>URL search formats</label>
+  <p class="help-block">
+    The following URL formats can be used to search for master records.
+  </p>
+  <table class="table table-condensed table-striped master-records-url-formats">
+    <thead>
+      <tr>
+        <th>Format</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>/masters/&lt;master_id&gt;</code></td>
+        <td>Direct lookup by primary master ID</td>
+      </tr>
+      <tr>
+        <td><code>/masters/&lt;value&gt;?type=&lt;crosswalk_attr&gt;</code></td>
+        <td>Search by crosswalk field on masters table (see below)</td>
+      </tr>
+      <tr>
+        <td><code>/masters/&lt;value&gt;?type=&lt;external_id_attr&gt;</code></td>
+        <td>Search by external identifier attribute (see below)</td>
+      </tr>
+      <tr>
+        <td><code>/masters/search?external_id[field]=&lt;attr&gt;&amp;external_id[id]=&lt;value&gt;</code></td>
+        <td>Search by external identifier using query params</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <label>result format parameter</label>
+  <p class="help-block">
+    Append <code>&amp;req_format=&lt;format&gt;</code> to any search URL to control the result format.
+  </p>
+  <table class="table table-condensed table-striped">
+    <thead>
+      <tr>
+        <th>Value</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>reg</code></td>
+        <td>UI search result (default)</td>
+      </tr>
+      <tr>
+        <td><code>csv</code></td>
+        <td>CSV download</td>
+      </tr>
+      <tr>
+        <td><code>json</code></td>
+        <td>JSON response</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <label>crosswalk attributes for URL search</label>
+  <p class="help-block">
+    These crosswalk fields on the masters table can be used as
+    <code>type</code> parameter values.
+  </p>
+  <table class="table table-condensed table-striped">
+    <thead>
+      <tr>
+        <th>Attribute</th>
+        <th>URL</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% crosswalk_attrs.each do |attr| %>
+        <tr>
+          <td><code><%= attr %></code></td>
+          <td><code>/masters/&lt;value&gt;?type=<%= attr %></code></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <% ext_defs = Master.external_id_definitions %>
+  <% if ext_defs.present? %>
+    <label>external identifiers for URL search</label>
+    <p class="help-block">
+      These external identifier attributes can be used as
+      <code>type</code> parameter values.
+    </p>
+    <table class="table table-condensed table-striped">
+      <thead>
+        <tr>
+          <th>Attribute</th>
+          <th>Label</th>
+          <th>URL</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% ext_defs.each do |attr_name, ext_id| %>
+          <tr>
+            <td>
+              <%= link_to link_label_open_in_new(attr_name),
+                          admin_external_identifiers_path(filter: { name: ext_id.name, disabled: :enabled }, perform_action: 'edit'),
+                          target: '_blank' %>
+            </td>
+            <td><%= ext_id.label %></td>
+            <td><code>/masters/&lt;value&gt;?type=<%= attr_name %></code></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
+</div>

--- a/spec/system/admin/admin_master_search_urls_spec.rb
+++ b/spec/system/admin/admin_master_search_urls_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+# System tests for Master Records admin page showing URL search formats (issue #1041)
+#
+# Tests that verify the Master Records admin page displays URL formats for
+# various search methods in the URL Search tab, and that each external
+# identifier's details panel shows the URL search format for that external identifier.
+
+require 'rails_helper'
+
+describe 'Master Records admin URL search formats', js: true, driver: $browser_driver do
+  include ModelSupport
+  include FeatureSupport
+  include UserSupport
+
+  before(:all) do
+    SetupHelper.feature_setup
+
+    change_setting('TwoFactorAuthDisabledForAdmin', true)
+
+    create_admin
+    @admin.update!(capabilities: %w[master_records external_identifiers])
+
+    @user, = create_user
+    @master = Master.create!(current_user: @user)
+    change_setting('AdminMaster', @master.id)
+  end
+
+  before(:each) do
+    login_as(@admin, scope: :admin)
+  end
+
+  after(:all) do
+    change_setting('TwoFactorAuthDisabledForAdmin', false)
+  end
+
+  def open_masters_url_search_tab
+    visit '/admin/master_records'
+
+    within('.master-records-index__models-table tbody') do
+      first('a.glyphicon-eye-open').click
+    end
+
+    expect(page).to have_css('.master-records-show-panel', wait: 10)
+    click_link 'URL Search'
+    expect(page).to have_css('.master-records-url-search-formats', wait: 10)
+  end
+
+  describe 'URL Search tab' do
+    it 'shows URL search formats section' do
+      open_masters_url_search_tab
+
+      expect(page).to have_content('URL search formats')
+    end
+
+    it 'shows the direct master ID URL format' do
+      open_masters_url_search_tab
+
+      expect(page).to have_content('/masters/<master_id>')
+    end
+
+    it 'shows crosswalk attribute URL format' do
+      open_masters_url_search_tab
+
+      expect(page).to have_content('/masters/<value>?type=<crosswalk_attr>')
+    end
+
+    it 'shows external ID URL format' do
+      open_masters_url_search_tab
+
+      expect(page).to have_content('/masters/<value>?type=<external_id_attr>')
+    end
+
+    it 'shows search with external_id params URL format' do
+      open_masters_url_search_tab
+
+      expect(page).to have_content('external_id[field]')
+      expect(page).to have_content('external_id[id]')
+    end
+
+    it 'lists the available crosswalk attributes in a table' do
+      open_masters_url_search_tab
+
+      crosswalk_attrs = Master.crosswalk_attrs
+      expect(crosswalk_attrs).not_to be_empty
+
+      crosswalk_attrs.each do |attr|
+        expect(page).to have_content(attr.to_s)
+      end
+    end
+
+    it 'lists available external identifiers with links' do
+      open_masters_url_search_tab
+
+      ext_defs = Master.external_id_definitions
+      next if ext_defs.empty?
+
+      ext_defs.each do |attr_name, ext_id|
+        expect(page).to have_content(attr_name.to_s)
+        expect(page).to have_content(ext_id.label)
+        expected_path = admin_external_identifiers_path(filter: { name: ext_id.name, disabled: :enabled }, perform_action: 'edit')
+        expect(page).to have_link(attr_name.to_s, href: expected_path)
+      end
+    end
+  end
+
+  describe 'External identifier details panel' do
+    it 'shows the URL search format for the external identifier' do
+      visit '/admin/external_identifiers'
+
+      first('.admin-list-item:not(.disabled-result) .simple-admin-edit').click
+
+      expect(page).to have_css('.dynamic-details-section', wait: 10)
+
+      expect(page).to have_content('URL search format')
+    end
+
+    it 'shows the correct URL with the external id attribute name' do
+      visit '/admin/external_identifiers'
+
+      first('.admin-list-item:not(.disabled-result) .simple-admin-edit').click
+
+      expect(page).to have_css('.dynamic-details-section', wait: 10)
+
+      attr_name = find('.dynamic-details-section').text[%r{/masters/<value>\?type=(\w+)}, 1]
+      expect(attr_name).to be_present
+      expect(page).to have_content("/masters/<value>?type=#{attr_name}")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Show URL search formats in the admin Master Records and External Identifiers panels, so admins can see and reference the available URL formats for searching master records.

### Changes

- **New URL Search tab** on the Masters entry in Master Records admin, showing:
  - Table of all URL search formats (`/masters/<master_id>`, `?type=<attr>`, `external_id[field]`/`external_id[id]`)
  - Result format parameter table (`req_format`: reg, csv, json)
  - Crosswalk attributes table with example URLs
  - External identifiers table with admin page links (using filter/perform_action pattern) and example URLs

- **URL search format** added to each External Identifier details panel showing `/masters/<value>?type=<attr>`

- **Details tab** additions on Masters entry:
  - Moved estimated record count to top level
  - Added prevent reload master list setting display with contextual help text
  - Restructured layout for clarity

- **Controller comment** updated to document `params[:type]` URL search support in `#show` action

- **9 system specs** covering URL Search tab content, crosswalk/external ID listings, admin links, and external identifier panel
