### PR TITLE
Fixed admin Redcap project creation failing in non-ref-data app types - fixes #1043

### DIFF
--- a/app/models/concerns/nfs_store/for_admin_resources.rb
+++ b/app/models/concerns/nfs_store/for_admin_resources.rb
@@ -13,22 +13,31 @@ module NfsStore
 
     #
     # Create a file store container referenced by this project admin record,
-    # with the name of the project admin record as its name
+    # with the name of the project admin record as its name.
+    # Ensures the file store user's app_type is correct for admin container access,
+    # since the admin may be viewing a different app type.
     # @return [NfsStore::Manage::Container]
     def create_file_store
-      master.current_user = file_store_user
+      user = file_store_user
+      orig_app_type_id = user.app_type_id
+      admin_app_type_id = admin_file_store_app_type_id
+      user.app_type_id = admin_app_type_id if admin_app_type_id && admin_app_type_id != orig_app_type_id
+
+      master.current_user = user
 
       safe_name = name.gsub('/', '_')
-      container = NfsStore::Manage::Container.create_in_current_app user: file_store_user,
+      container = NfsStore::Manage::Container.create_in_current_app user:,
                                                                     name: safe_name,
                                                                     extra_params: {
                                                                       master:,
                                                                       create_with_role: nfs_role
                                                                     }
-      container.current_user = file_store_user
+      container.current_user = user
       ModelReference.create_with self, container, force_create: true
 
       @file_store = container
+    ensure
+      user&.app_type_id = orig_app_type_id if admin_app_type_id && admin_app_type_id != orig_app_type_id
     end
 
     #
@@ -104,6 +113,14 @@ module NfsStore
 
     def nfs_role
       Settings.admin_nfs_role
+    end
+
+    #
+    # The app_type_id for admin file store containers,
+    # defined by Settings::FilestoreAdminAppType.
+    # @return [Integer | nil]
+    def admin_file_store_app_type_id
+      Admin::AppType.active.find_by(name: Settings::FilestoreAdminAppType)&.id
     end
   end
 end

--- a/app/models/nfs_store/manage/container.rb
+++ b/app/models/nfs_store/manage/container.rb
@@ -248,6 +248,12 @@ module NfsStore
         false
       end
 
+      def can_create?
+        return true if can_access_if_admin_master?
+
+        super
+      end
+
       def can_edit?
         res = allows_current_user_access_to? :edit
         return unless res

--- a/app/views/redcap/project_admins/_details_block.html.erb
+++ b/app/views/redcap/project_admins/_details_block.html.erb
@@ -10,12 +10,12 @@
   class: 'btn btn-primary btn-sm' %>
   </p>
 <% end %>
-<% if current_admin&.matching_user_app_type&.name != 'ref-data' %>
+<% if current_admin&.matching_user_app_type&.name != Settings::FilestoreAdminAppType %>
   <h4>Important - 
     <%= link_to "switch to the <b>Ref Data</b> app".html_safe, 
               redcap_project_admins_path(
                 no_redirect: true, 
-                use_app_type: 'ref-data',
+                use_app_type: Settings::FilestoreAdminAppType,
                 filter: {id: object_instance.id},
                 perform_action: 'edit'
               ) %> 

--- a/app/views/redcap/project_admins/_files_block.html.erb
+++ b/app/views/redcap/project_admins/_files_block.html.erb
@@ -2,12 +2,12 @@
 <div id="admin-filestore-block-<%= object_instance.id %>">
 </div>
 <%  cuat = current_user&.app_type || current_admin&.matching_user_app_type
-    if cuat&.name != 'ref-data' %>
+    if cuat&.name != Settings::FilestoreAdminAppType %>
 <p>The user must 
   <%= link_to "switch to the <b>Ref Data</b>".html_safe, 
               redcap_project_admins_path(
                 no_redirect: true, 
-                use_app_type: 'ref-data',
+                use_app_type: Settings::FilestoreAdminAppType,
                 filter: {id: object_instance.id},
                 perform_action: 'edit'
               ) %>

--- a/config/initializers/app_settings.rb
+++ b/config/initializers/app_settings.rb
@@ -190,8 +190,11 @@ class Settings
     (ENV['NFS_STORE_DEFAULT_APP_TYPE_ID'].presence || OnlyLoadAppTypes&.first || Admin::AppType.active.first&.id || 1).to_i
   end
 
-  # A list of resource names for admin classes that us filestore for file storage
+  # A list of resource names for admin classes that use filestore for file storage
   FilestoreAdminResourceNames = %w[redcap__project_admin].freeze
+
+  # App type used for admin filestore containers (e.g. REDCap project files)
+  FilestoreAdminAppType = 'ref-data'
 
   #
   # Short links are generated and can be used by text substitutions

--- a/spec/models/redcap/project_admin_spec.rb
+++ b/spec/models/redcap/project_admin_spec.rb
@@ -322,4 +322,56 @@ RSpec.describe Redcap::ProjectAdmin, type: :model do
       expect(rc.frequency).to be_nil
     end
   end
+
+  # Tests for issue #1043: Admin Redcap projects - fails to create new project
+  # when admin's matching user is in a non-ref-data app type.
+  # The file store container creation should succeed regardless of the admin's
+  # current app type, because admin containers use admin_master and the admin NFS role.
+  describe 'creating project admin in non-ref-data app type' do
+    it 'creates a project and file store container when user is in a different app type' do
+      # Ensure all existing projects are disabled so we can create duplicates
+      Redcap::ProjectAdmin.update_all(disabled: true)
+
+      # Create a brand new app type with no container access configured
+      other_app_type = Admin::AppType.create!(name: "test-no-containers-#{rand(1000)}",
+                                              label: 'Test No Containers',
+                                              current_admin: @admin)
+
+      # Switch user to the new app type
+      enable_user_app_access(other_app_type, @user)
+      @user.app_type = other_app_type
+      @user.save!
+      expect(@user.app_type_id).to eq other_app_type.id
+
+      # Add the admin NFS role for this app type (roles are per-app-type)
+      add_user_to_role Settings.admin_nfs_role, for_user: @user
+      @user.clear_role_names!
+      expect(@user.role_names).to include(Settings.admin_nfs_role)
+
+      # Verify user does NOT have container create access in the new app type
+      @user.clear_has_access_to!
+      has_container_access = @user.has_access_to?(:create, :table, 'nfs_store__manage__containers',
+                                                  force_reset: true)
+      expect(has_container_access).to be_falsey
+
+      # Reset admin's memoized matching_user so it picks up the user's current
+      # app type (simulates production where the admin's user is freshly loaded)
+      @admin.instance_variable_set(:@matching_user, nil)
+      expect(@admin.matching_user.app_type_id).to eq other_app_type.id
+
+      p = @projects.first
+
+      # This should NOT raise "This item can not be created" error
+      pa = Redcap::ProjectAdmin.create!(
+        current_admin: @admin,
+        study: Redcap::RedcapSupport::DefaultStudy,
+        name: p[:name],
+        api_key: p[:api_key],
+        server_url: p[:server_url]
+      )
+
+      expect(pa).to be_persisted
+      expect(pa.file_store).to be_a(NfsStore::Manage::Container)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes admin Redcap project creation failing with "This item can not be created" when the admin's matching user is in any app type other than ref-data.

### Changes

- **`NfsStore::ForAdminResources#create_file_store`** — temporarily switches the file store user's `app_type_id` to the admin filestore app type during container creation, restoring it in an `ensure` block
- **`NfsStore::Manage::Container#can_create?`** — overrides to allow creation when the container belongs to the admin master and the user has the admin NFS role
- **`Settings::FilestoreAdminAppType`** — new constant (`'ref-data'`) providing a single source of truth for the admin filestore app type
- **View partials** — replaced hardcoded `'ref-data'` strings in `_details_block.html.erb` and `_files_block.html.erb` with `Settings::FilestoreAdminAppType`
- **Spec** — added test verifying project creation succeeds when admin's user is in a non-ref-data app type with no container access configured

### Testing

25 examples, 0 failures (project_admin_spec.rb)
33 examples, 0 failures (broader redcap specs)
