### PR TITLE
Added explicit serializer: Marshal to Dalli cache config to suppress security warning - fixes #1038

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,8 +39,9 @@ Rails.application.configure do
 
     # config.cache_store = :null_store
     # The :meta protocol replaces the deprecated :binary protocol (removed in Dalli 5.0)
-    # and requires memcached 1.6+
-    config.cache_store = :mem_cache_store, { protocol: :meta }
+    # and requires memcached 1.6+.
+    # Explicit serializer: Marshal suppresses Dalli's SECURITY WARNING (issue #1038).
+    config.cache_store = :mem_cache_store, { protocol: :meta, serializer: Marshal }
 
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,8 +51,11 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   # The :meta protocol replaces the deprecated :binary protocol (removed in Dalli 5.0)
-  # and requires memcached 1.6+
-  config.cache_store = :mem_cache_store, { protocol: :meta }
+  # and requires memcached 1.6+.
+  # Explicit serializer: Marshal suppresses Dalli's SECURITY WARNING about Marshal
+  # deserialization. A compromised memcached server implies full server compromise,
+  # so Marshal does not amplify the risk (issue #1038).
+  config.cache_store = :mem_cache_store, { protocol: :meta, serializer: Marshal }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -62,8 +62,9 @@ Rails.application.configure do
   config.cache_store = if ENV['TEST_MEM_CACHE_STORE'] == 'true'
                          # Use Dalli memcached store with :meta protocol for cache integration testing.
                          # The :meta protocol replaces the deprecated :binary protocol (removed in Dalli 5.0)
-                         # and requires memcached 1.6+
-                         [:mem_cache_store, { protocol: :meta }]
+                         # and requires memcached 1.6+.
+                         # Explicit serializer: Marshal suppresses Dalli's SECURITY WARNING (issue #1038).
+                         [:mem_cache_store, { protocol: :meta, serializer: Marshal }]
                        else
                          [:memory_store, { namespace: "paralleltests#{ENV.fetch('TEST_ENV_NUMBER', nil)}" }]
                        end

--- a/spec/models/cache_store_spec.rb
+++ b/spec/models/cache_store_spec.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
-# Tests for Dalli memcached cache store configuration (issue #886).
+# Tests for Dalli memcached cache store configuration (issues #886, #1038).
 #
 # These specs verify that when the TEST_MEM_CACHE_STORE environment variable
 # is set, the cache store switches from :memory_store to :mem_cache_store
 # using the :meta protocol. This ensures the Dalli binary protocol deprecation
 # warning is resolved and the app is compatible with Dalli 5.0.
+#
+# Issue #1038: Verify that the Dalli Marshal security warning is suppressed by
+# explicitly configuring `serializer: Marshal` in the cache store options.
 #
 # Run with memcached:
 #   TEST_MEM_CACHE_STORE=true bundle exec rspec spec/models/cache_store_spec.rb
@@ -69,6 +72,54 @@ RSpec.describe 'Cache store configuration', type: :model do
       end
 
       expect(Rails.cache).to be_a(ActiveSupport::Cache::MemoryStore)
+    end
+  end
+
+  describe 'Dalli Marshal security warning suppression (issue #1038)' do
+    it 'configures mem_cache_store with explicit serializer: Marshal in all environments' do
+      %w[production development].each do |env_name|
+        env_file = Rails.root.join('config', 'environments', "#{env_name}.rb")
+        content = File.read(env_file)
+
+        # Verify that every :mem_cache_store config includes serializer: Marshal
+        # to suppress the Dalli SECURITY WARNING about Marshal serialization
+        content.scan(/config\.cache_store\s*=.*:mem_cache_store.*?\n(?:.*\n)*?.*?\}/).each do |match|
+          expect(match).to include('serializer'),
+                           "Expected #{env_name}.rb mem_cache_store config to include serializer option"
+        end
+      end
+    end
+
+    it 'configures test mem_cache_store with explicit serializer: Marshal' do
+      env_file = Rails.root.join('config', 'environments', 'test.rb')
+      content = File.read(env_file)
+
+      mem_cache_section = content[/\[:mem_cache_store.*?\]/m]
+      expect(mem_cache_section).to be_present
+      expect(mem_cache_section).to include('serializer'),
+                                   'Expected test.rb mem_cache_store config to include serializer option'
+    end
+
+    it 'does not emit a Dalli Marshal security warning when creating a new client' do
+      log_output = StringIO.new
+      original_logger = Dalli.logger
+      Dalli.logger = Logger.new(log_output)
+
+      # Reset the class variable so the warning would fire if not suppressed
+      # rubocop:disable Style/ClassVars
+      Dalli::Protocol::ValueSerializer.class_variable_set(:@@marshal_warning_logged, false)
+
+      begin
+        # Create a client with explicit serializer: Marshal (as our config does)
+        Dalli::Client.new(nil, protocol: :meta, serializer: Marshal)
+      ensure
+        Dalli.logger = original_logger
+        # Reset again so other tests aren't affected
+        Dalli::Protocol::ValueSerializer.class_variable_set(:@@marshal_warning_logged, false)
+        # rubocop:enable Style/ClassVars
+      end
+
+      expect(log_output.string).not_to include('SECURITY WARNING')
     end
   end
 end


### PR DESCRIPTION
## Summary

Suppresses the Dalli `SECURITY WARNING` about Marshal serialization that appears during application startup by explicitly declaring `serializer: Marshal` in all `mem_cache_store` configurations.

As noted in #1038, a compromised memcached server implies full server compromise, so Marshal deserialization does not amplify the risk.

### Changes

- **config/environments/production.rb** — Added `serializer: Marshal` to cache store options with security rationale comment
- **config/environments/development.rb** — Added `serializer: Marshal` to cache store options
- **config/environments/test.rb** — Added `serializer: Marshal` to memcached cache store branch
- **spec/models/cache_store_spec.rb** — Added 3 specs verifying all environment configs include explicit serializer and that Dalli emits no warning when configured this way
