### PR TITLE
Fixed message template form losing message_type and template_type on save - fixes #1049

### DIFF
--- a/app/views/admin/message_templates/_form.html.erb
+++ b/app/views/admin/message_templates/_form.html.erb
@@ -15,7 +15,7 @@
           <%= f.label :message_type, 'Is a' %>
           <%
           select_item_type = {}
-          select_item_type[:selected] = filter_params_hash.first.last if filter_params_hash&.first&.first == 'message_type'
+          select_item_type[:selected] = filter_params_hash.first.last if filter_params_hash&.first&.first == 'message_type' && object_instance.message_type.blank?
           select_item_type[:include_blank] = true
 
           options = message_type_options
@@ -26,7 +26,7 @@
           <%= f.label :template_type %>
           <%
           select_item_type = {}
-          select_item_type[:selected] = filter_params_hash.first.last if filter_params_hash&.first&.first == 'template_type'
+          select_item_type[:selected] = filter_params_hash.first.last if filter_params_hash&.first&.first == 'template_type' && object_instance.template_type.blank?
           select_item_type[:include_blank] = true
 
           options = template_type_options

--- a/spec/controllers/admin/message_templates_controller_spec.rb
+++ b/spec/controllers/admin/message_templates_controller_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Tests for GitHub Issue #1049: Admin Message Templates loses "Is a" field value
+#
+# The message_templates/_form.html.erb unconditionally overrides the selected value
+# of the message_type and template_type select fields with the filter parameter value.
+# After saving, the edit form re-renders with the filter value instead of the saved model value.
+#
+# These tests verify that:
+# - The edit form shows the saved model value, not the filter value
+# - The new form correctly pre-selects the filter value for blank objects
+
+require 'rails_helper'
+
+RSpec.describe Admin::MessageTemplatesController, type: :controller do
+  render_views
+
+  before(:each) do
+    admin, = ControllerMacros.create_admin
+    @request.env['devise.mapping'] = Devise.mappings[:admin]
+    sign_in admin
+    raise 'Admin not logged in' unless subject.current_admin
+
+    @admin = admin
+  end
+
+  describe 'GET #edit' do
+    it 'does not override saved message_type with filter value' do
+      template = Admin::MessageTemplate.create!(
+        name: 'test_message_type_filter',
+        message_type: 'dialog',
+        template_type: 'content',
+        current_admin: @admin
+      )
+
+      get :edit, params: { id: template.id, filter: { message_type: 'plain' } }
+
+      expect(response).to have_http_status(:ok)
+      # The select should have "dialog" selected (the saved value), not "plain" (the filter value)
+      expect(response.body).to have_selector('select[name="admin_message_template[message_type]"] option[selected]', text: 'dialog')
+      expect(response.body).not_to have_selector('select[name="admin_message_template[message_type]"] option[selected]', text: 'plain')
+    end
+
+    it 'does not override saved template_type with filter value' do
+      template = Admin::MessageTemplate.create!(
+        name: 'test_template_type_filter',
+        message_type: 'email',
+        template_type: 'content',
+        current_admin: @admin
+      )
+
+      get :edit, params: { id: template.id, filter: { template_type: 'layout' } }
+
+      expect(response).to have_http_status(:ok)
+      # The select should have "content" selected (the saved value), not "layout" (the filter value)
+      expect(response.body).to have_selector('select[name="admin_message_template[template_type]"] option[selected]', text: 'content')
+      expect(response.body).not_to have_selector('select[name="admin_message_template[template_type]"] option[selected]', text: 'layout')
+    end
+  end
+
+  describe 'GET #new' do
+    it 'pre-selects filter value for message_type on a new record' do
+      get :new, params: { filter: { message_type: 'dialog' } }
+
+      expect(response).to have_http_status(:ok)
+      # On a new (blank) record, the filter value should be pre-selected
+      expect(response.body).to have_selector('select[name="admin_message_template[message_type]"] option[selected]', text: 'dialog')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the admin message templates form where the "Is a" (message_type) and template_type dropdown fields revert to the active filter value instead of the saved model value after saving.

### Root Cause

The form unconditionally overrode the select field's selected value with the filter parameter. After save, the `admin_result_re_edit` JS preprocessor re-opens the edit form with filter params attached, causing the dropdown to show the filter value instead of the persisted value.

### Changes

- **`app/views/admin/message_templates/_form.html.erb`**: Added `.blank?` guards to both `message_type` and `template_type` select fields so filter params only pre-select on new/blank records
- **`spec/controllers/admin/message_templates_controller_spec.rb`**: New controller spec with 3 examples covering the bug fix and preserved new-record behavior

### Related

- Follow-up issue #1050 filed for the same bug in `_respond_to_options.html.erb` and `app_configurations/_form.html.erb`
