### PR TITLE
Fixed admin forms overriding saved select field values with filter params - fixes #1050

### DIFF
--- a/app/views/admin/app_configurations/_form.html.erb
+++ b/app/views/admin/app_configurations/_form.html.erb
@@ -13,7 +13,7 @@
   <div class="form-group">
     <%= f.label :name %>
     <% select_item_type = {}
-       select_item_type[:selected] = filter_params_hash.first.last if filter_params_hash&.first&.first == 'name'    %>
+       select_item_type[:selected] = filter_params_hash.first.last if filter_params_hash&.first&.first == 'name' && object_instance.name.blank?    %>
 
     <%= big_select_field(f, :name, object_instance.admin_item_type_us, Admin::AppConfiguration.configuation_meanings)%>
   </div>
@@ -21,7 +21,7 @@
     <%= f.label :role_name, 'Role name override' %>
     <%
       select_item_type = {}
-      select_item_type[:selected] = filter_params_hash.first.last if filter_params_permitted && filter_params_hash&.first&.first == 'role_name'
+      select_item_type[:selected] = filter_params_hash.first.last if filter_params_permitted && filter_params_hash&.first&.first == 'role_name' && object_instance.role_name.blank?
       select_item_type[:include_blank] = true
 
       options = role_name_options

--- a/app/views/admin/common_templates/form/_fields.html.erb
+++ b/app/views/admin/common_templates/form/_fields.html.erb
@@ -47,7 +47,7 @@
         <%= form_field_label(f, p) %>
         <%
           select_item_type = {}
-          select_item_type[:selected] = filter_params_hash.first.last if filter_params_hash&.first&.first == p.to_s
+          select_item_type[:selected] = filter_params_hash.first.last if filter_params_hash&.first&.first == p.to_s && object_instance.send(p).blank?
           select_item_type[:include_blank] = true          
 
           options = send("#{p}_options")
@@ -80,7 +80,7 @@
           <%= f.select :app_type_id, app_type_options(default_app_type_id: app_type_select_current_item), ib, add_opts %>
       <% elsif p == :user_id %>
           <%
-            default_user_id = filter_params_hash.first.last if filter_params_hash&.first&.first == 'user_id'
+            default_user_id = filter_params_hash.first.last if filter_params_hash&.first&.first == 'user_id' && object_instance.user_id.blank?
           %>
           <%= form_field_label(f, p) %>
           <%= f.select :user_id, active_user_options(default_user_id: default_user_id), { include_blank: true }, class: 'use-chosen' %>

--- a/app/views/common_templates/edit_fields/_respond_to_options.html.erb
+++ b/app/views/common_templates/edit_fields/_respond_to_options.html.erb
@@ -1,6 +1,6 @@
 <%= edit_field_label(form, field_name_sym, labels) %>
 <%
   select_item_type = {}
-  select_item_type[:selected] = filter_params_hash.first.last if (defined? filter_params_hash) && filter_params_hash&.first&.first == field_name
+  select_item_type[:selected] = filter_params_hash.first.last if (defined? filter_params_hash) && filter_params_hash&.first&.first == field_name && object_instance.send(field_name_sym).blank?
 %>
 <%= form.select field_name_sym, send("#{field_name_sym}_options"), select_item_type %>

--- a/spec/controllers/admin/select_field_filter_override_spec.rb
+++ b/spec/controllers/admin/select_field_filter_override_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Tests for GitHub Issue #1050: Admin forms override saved select field values with filter params
+#
+# Several admin forms unconditionally override select field values with the active
+# filter parameter, causing saved values to revert when re-editing after save.
+# The fix is to add a `.blank?` guard so the filter only pre-selects on new/blank records.
+#
+# Affected templates:
+#   - app/views/admin/common_templates/form/_fields.html.erb (line 50) — tested here
+#     via Admin::ConfigLibrariesController, which renders select fields through _fields.html.erb
+#     for fields that have a matching `*_options` helper (e.g. `format` → `format_options`).
+#
+#   - app/views/common_templates/edit_fields/_respond_to_options.html.erb (line 4) —
+#     same bug pattern as _fields.html.erb line 50.
+#
+#   - app/views/admin/app_configurations/_form.html.erb (lines 16, 24) —
+#     the `name` field bug is dead code (select_item_type not passed to big_select_field),
+#     and the `role_name` field bug is dead code (role_name not in filters_on).
+#     These are code-quality issues to fix but cannot be demonstrated with failing tests.
+#
+# These tests verify that:
+#   - When a record already has a saved value and filter_params_hash matches,
+#     the saved value is preserved (filter does NOT override it).
+#   - When a record is new (field is blank) and filter_params_hash matches,
+#     the filter value IS applied (pre-selection works for new records).
+
+require 'rails_helper'
+
+RSpec.describe Admin::ConfigLibrariesController, type: :controller do
+  render_views
+
+  before(:each) do
+    admin, = ControllerMacros.create_admin
+    @request.env['devise.mapping'] = Devise.mappings[:admin]
+    sign_in admin
+    raise 'Admin not logged in' unless subject.current_admin
+
+    @admin = admin
+  end
+
+  describe 'GET #edit' do
+    it 'does not override saved format with filter value' do
+      library = Admin::ConfigLibrary.create!(
+        name: "test_filter_guard_#{rand(100_000)}",
+        category: 'test',
+        format: 'yaml',
+        options: 'test: true',
+        current_admin: @admin
+      )
+
+      get :edit, params: { id: library.id, filter: { format: 'html' } }
+
+      expect(response).to have_http_status(:ok)
+      # The select should have 'yaml' selected (the saved value), not 'html' (the filter value)
+      expect(response.body).to have_selector(
+        'select#admin_config_library_format option[selected]', text: 'yaml'
+      )
+      expect(response.body).not_to have_selector(
+        'select#admin_config_library_format option[selected]', text: 'html'
+      )
+    end
+  end
+
+  describe 'GET #new' do
+    it 'pre-selects filter value for format on a new record' do
+      get :new, params: { filter: { format: 'html' } }
+
+      expect(response).to have_http_status(:ok)
+      # On a new (blank) record, the filter value should be pre-selected
+      expect(response.body).to have_selector(
+        'select#admin_config_library_format option[selected]', text: 'html'
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `.blank?` guards to admin form templates so filter params only pre-select values on new/blank records, preventing saved values from being overridden when re-editing existing records.

Follow-up from #1049, which fixed the same bug in the message templates form.

### Changes

- **`app/views/admin/common_templates/form/_fields.html.erb`** — added `.blank?` guard on generic `*_options` select fields (line 50) and `user_id` field (line 83)
- **`app/views/common_templates/edit_fields/_respond_to_options.html.erb`** — added `.blank?` guard on dynamic `field_name` select
- **`app/views/admin/app_configurations/_form.html.erb`** — added `.blank?` guards on `name` (line 16) and `role_name` (line 24) fields
- **`spec/controllers/admin/select_field_filter_override_spec.rb`** — new controller spec verifying saved values are preserved on edit while filter pre-selection still works for new records (2 examples)

### Testing

All 229 admin controller specs pass. New spec confirms:
- Editing a record with a saved value preserves that value even when filter params are present
- Creating a new record correctly pre-selects the filter value
