### PR TITLE
Added URL fallback and XSS protection for report column show_as url - fixes #1053

### DIFF
--- a/app/helpers/report_results/reports_common_result_cell.rb
+++ b/app/helpers/report_results/reports_common_result_cell.rb
@@ -165,15 +165,21 @@ module ReportResults
     end
 
     #
-    # Show the result as a link to be opened link to be opened in a new tab.
+    # Show the result as a link to be opened in a new tab.
     # The content should be formatted using Markdown format
     #     [label for link](/url/path)
+    # Falls back to plain text if the content does not match the markdown link format (GitHub #1053)
     def cell_content_for_url
       return cell_content unless cell_content.present?
 
       col_url_parts = cell_content&.scan(/^\[(.+)\]\((.+)\)$/)
+      return html_escape(cell_content) if col_url_parts.blank?
+
+      url = col_url_parts.first.last
+      return html_escape(cell_content) unless safe_url_protocol?(url)
+
       html = <<~END_HTML
-        <a href="#{col_url_parts&.first&.last}" target="_blank">#{html_escape col_url_parts&.first&.first}</a>
+        <a href="#{html_escape url}" target="_blank">#{html_escape col_url_parts.first.first}</a>
       END_HTML
 
       html.html_safe
@@ -211,6 +217,15 @@ module ReportResults
     end
 
     private
+
+    #
+    # Check if a URL uses a safe protocol for rendering as a link.
+    # Rejects javascript: and data: protocols to prevent XSS.
+    def safe_url_protocol?(url)
+      return true if url.start_with?('/', '#')
+
+      !url.match?(/\A\s*(javascript|data|vbscript):/i)
+    end
 
     #
     # Parse the URL from embedded_block content.

--- a/spec/helpers/report_results/reports_common_result_cell_spec.rb
+++ b/spec/helpers/report_results/reports_common_result_cell_spec.rb
@@ -12,6 +12,10 @@
 #   - Handles markdown format links like [Label](/dynamic_model/table_name/123)
 #   - Handles activity log URLs like /activity_log/log_type/456
 #   - Handles edit mode URLs ending with /edit (GitHub #325)
+# - #cell_content_for_url: Renders cell content as a link in a new tab (GitHub #1053)
+#   - Handles markdown format [text](url) correctly
+#   - Falls back to plain text when content doesn't match markdown link format
+#   - Handles nil and blank content gracefully
 
 require 'rails_helper'
 
@@ -114,6 +118,56 @@ RSpec.describe ReportResults::ReportsCommonResultCell do
 
         expect(html).to include('href="/dynamic_model/test/123/edit"')
       end
+    end
+  end
+
+  describe '#cell_content_for_url' do
+    # Override col_show_as to 'url' for these tests
+    let(:col_show_as) { 'url' }
+
+    it 'renders markdown format [text](url) as a link' do
+      html = build_cell('[Click here](https://example.com/page)').cell_content_for_url
+
+      expect(html).to include('href="https://example.com/page"')
+      expect(html).to include('>Click here</a>')
+      expect(html).to include('target="_blank"')
+    end
+
+    it 'falls back to showing plain text when content is not markdown link format' do
+      result = build_cell('just some plain text').cell_content_for_url
+
+      expect(result).to eq('just some plain text')
+    end
+
+    it 'returns nil when content is nil' do
+      result = build_cell(nil).cell_content_for_url
+
+      expect(result).to be_nil
+    end
+
+    it 'returns blank content as-is when content is empty' do
+      result = build_cell('').cell_content_for_url
+
+      expect(result).to eq('')
+    end
+
+    it 'falls back to showing a plain URL as text when not in markdown format' do
+      result = build_cell('https://example.com').cell_content_for_url
+
+      expect(result).to eq('https://example.com')
+    end
+
+    it 'html-escapes the URL in the href attribute' do
+      result = build_cell('[text](https://example.com/path?a=1&b=2)').cell_content_for_url
+
+      expect(result).to include('href="https://example.com/path?a=1&amp;b=2"')
+    end
+
+    it 'falls back to plain text for javascript: protocol URLs' do
+      result = build_cell('[click](javascript:alert(1))').cell_content_for_url
+
+      expect(result).not_to include('<a ')
+      expect(result).to include('javascript:alert(1)')
     end
   end
 end


### PR DESCRIPTION
## Summary

When a report results column has `show_as: url` in column_options, the cell content must match the `[text](url)` markdown format, otherwise an empty broken link is rendered. This PR adds a fallback to display the plain text when the content doesn't match the markdown link format.

Additionally fixes pre-existing XSS vulnerabilities in the URL rendering: the href attribute is now HTML-escaped and unsafe protocols (javascript:, data:, vbscript:) are rejected.

Fixes #1053

### Changes

- **app/helpers/report_results/reports_common_result_cell.rb**
  - `cell_content_for_url`: Falls back to html-escaped plain text when content doesn't match `[text](url)` format
  - `cell_content_for_url`: HTML-escapes the URL in the href attribute to prevent attribute injection
  - Added `safe_url_protocol?` private method to reject javascript:/data:/vbscript: protocol URLs
  - Fixed typo in method comment

- **spec/helpers/report_results/reports_common_result_cell_spec.rb**
  - Added 7 specs for `#cell_content_for_url` covering: markdown link rendering, plain text fallback, nil/blank handling, href escaping, and XSS protocol rejection
