### PR TITLE
Added User Access Overview admin reports with 5 perspectives - fixes #706

### DIFF
--- a/app/assets/stylesheets/app/admin_reports.scss
+++ b/app/assets/stylesheets/app/admin_reports.scss
@@ -1,0 +1,25 @@
+.report-rn--admin_user_access_overview__user_access_overview_by_role,
+.report-rn--admin_user_access_overview__user_access_overview_by_resource,
+.report-rn--admin_user_access_overview__user_access_overview_resolved,
+.report-rn--admin_user_access_overview__user_access_overview_roles_only,
+.report-rn--admin_user_access_overview__user_access_overview_users_with_role {
+
+  th[data-col-name="id0"],
+  th[data-col-name="id1"], 
+  td[data-col-type="id0"],
+  td[data-col-type="id1"] {
+    width: 60px;
+  }
+
+  table.table.report-table tr {
+    td[data-col-type="id1"], th[data-col-name="id1"]{
+      border-right: none;
+    }
+
+    td[data-col-type="blank"], th[data-col-name="blank"] {
+      background: white;
+      border-left: none;
+      visibility: hidden;
+    }
+  }
+}

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -28,9 +28,19 @@ class ReportsController < UserBaseController
   def index
     @no_masters = true
 
-    pm = @all_reports_for_user = Report.enabled.for_user(current_user)
+    pm = @all_reports_for_user = Report.enabled
+
+    # Allow an admin to see reports in a filtered item_type, even if the associated user
+    # does not have access to any reports of that type.
+    if current_admin && params[:filter].present? && params[:filter][:item_type].present?
+      @admin_list_item_type = params[:filter][:item_type]
+    else
+      pm = pm.for_user(current_user)
+    end
+
     pm = filtered_primary_model(pm)
 
+    @simple_view = params[:simple_view] == 'true'
     @reports = pm.order auto: :desc, report_type: :asc, position: :asc
     @reports = @reports.reject { |r| r.report_options.list_options.hide_in_list }
 

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -152,6 +152,14 @@ module ReportsHelper
                      selections.map do |r|
                        [r.send(label), r.send(value)]
                      end
+                   elsif config.group_by
+                     group_field = config.group_by.to_s
+                     unless group_field.in?(valid_attrs)
+                       raise FphsException, "Invalid group_by attribute: #{group_field}"
+                     end
+
+                     raw = selections.pluck(group_field, label, value)
+                     raw.map { |g, l, v| ["#{g}|#{l}", v] }
                    else
                      selections.pluck(label, value)
                    end

--- a/app/models/option_configs/search_attributes_config.rb
+++ b/app/models/option_configs/search_attributes_config.rb
@@ -8,7 +8,7 @@ module OptionConfigs
   class SearchAttributesConfig < BaseConfiguration
     class NamedConfiguration < OptionConfigs::BaseNamedConfiguration
       configure_attributes %i[name label type all item_type multiple default disabled hidden selections conditions
-                              resource_name defined_selector filter_selector options show_if]
+                              resource_name defined_selector filter_selector options show_if group_by]
     end
 
     #

--- a/app/views/pages/_index_admin.html.erb
+++ b/app/views/pages/_index_admin.html.erb
@@ -89,6 +89,7 @@
               <% if current_admin.can_admin?(:user_contact_infos)%><% got_one ||= true %><li class="nav"><%= link_to "User Contact Info", users_contact_infos_path %> </li><%end%>
               <% if current_admin.can_admin?(:user_roles)%><% got_one ||= true %><li class="nav"><%= link_to "User Roles", admin_user_roles_path %> </li><%end%>
               <% if current_admin.can_admin?(:user_access_controls)%><% got_one ||= true %><li class="nav"><%= link_to "User Access Controls", admin_user_access_controls_path %> </li><%end%>
+              <% if current_admin.can_admin?(:user_roles) && current_admin.can_admin?(:user_access_controls) && Report.active.where(item_type: 'admin-user-access-overview').exists? %><% got_one ||= true %><li class="nav"><%= link_to "User Access Overview", reports_path(filter: { item_type: 'admin-user-access-overview' }, simple_view: true), target: '_blank' %> </li><%end%>
               <% if current_admin.can_admin?(:role_descriptions)%><% got_one ||= true %><li class="nav"><%= link_to "Role Descriptions", admin_role_descriptions_path %> </li><%end%>
               <% if current_admin.can_admin?(:filters)%><% got_one ||= true %><li class="nav"><%= link_to "File Filters", admin_nfs_store_filter_filters_path %> </li><%end%>
               <% if current_admin.can_admin?(:manage_admins)%><% got_one ||= true %><li class="nav"><%= link_to "Administrators", admin_manage_admins_path %> </li><%end%>

--- a/app/views/reports/_index.html.erb
+++ b/app/views/reports/_index.html.erb
@@ -1,6 +1,7 @@
 <%
 link_extras = {} unless defined? link_extras
 simple_view = false unless defined? simple_view
+simple_view ||= @simple_view
 
 link_extras ||= {}
 extra_params = {} unless defined? extra_params

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,7 +1,11 @@
 <div class="reports-index" data-admin-type="<%=controller_name.ns_underscore%>">
   <div class="data-results col-md-offset-1 col-md-22 col-lg-offset-2 col-lg-20" data-subscription="admin-list">
     <div data-result="admin-list">
+      <% if @admin_list_item_type %>
+      <h1><%= @admin_list_item_type.gsub('-', ' ').titleize %></h1>
+      <% else %>
       <h1><%= app_config_text :reports_list_title, 'Reports' %></h1>
+      <% end %>
       <% 
     @shown_filter_break = true 
     num_cats = @reports.pluck(:category).uniq.length

--- a/db/migrate/20260409072921_setup_user_access_overview_reports.rb
+++ b/db/migrate/20260409072921_setup_user_access_overview_reports.rb
@@ -1,0 +1,14 @@
+class SetupUserAccessOverviewReports < ActiveRecord::Migration[7.1]
+  def up
+    $dont_seed = true
+
+    begin
+      require "#{::Rails.root}/db/seeds.rb"
+      Seeds::ReportUserAccessOverview.setup
+    rescue StandardError => e
+      puts 'Run "bundle exec rails db:seed" at the end of migrations.'
+      puts e
+      puts e.backtrace.join("\n")
+    end
+  end
+end

--- a/db/seeds/report_user_access_overview.rb
+++ b/db/seeds/report_user_access_overview.rb
@@ -1,0 +1,649 @@
+# frozen_string_literal: true
+
+module Seeds
+  module ReportUserAccessOverview
+    def self.do_last
+      true
+    end
+
+    def self.add_report_values(values)
+      values.each do |v|
+        res = Report.find_or_initialize_by(short_name: v[:short_name], item_type: v[:item_type])
+        res.assign_attributes(v)
+        res.current_admin = Seeds.auto_admin
+        res.save!
+      end
+    end
+
+    def self.add_uac_values(values)
+      values.each do |v|
+        res = Admin::UserAccessControl.find_or_initialize_by(v)
+        res.update(current_admin: Seeds.auto_admin) unless res.admin
+      end
+    end
+
+    def self.create_templates
+      # Shared search attributes for all perspectives
+      search_attrs = <<~END_YAML
+        user:
+          user:
+            multiple: single
+            default: current_user
+        role_name:
+          select_from_model:
+            resource_name: admin__user_roles
+            selections:
+              role_name: role_name
+            all: true
+        resource_type:
+          config_selector:
+            label: Resource Type
+            multiple: single
+            all: true
+            filter_selector: resource_name
+            selections:
+              table: table
+              general: general
+              limited_access: limited_access
+              report: report
+              standalone_page: standalone_page
+              activity_log_type: activity_log_type
+        resource_name:
+          select_from_model:
+            resource_name: admin__user_access_controls
+            selections:
+              resource_name: resource_name
+            group_by: resource_type
+            all: true
+        app_type_id:
+          select_from_model:
+            multiple: single
+            resource_name: admin__app_types
+            selections:
+              name: id
+            default: '{{current_user_app_type_id}}'
+      END_YAML
+
+      search_attrs_roles_with_user = <<~END_YAML
+        user:
+          user:
+            multiple: single
+        role_name:
+          select_from_model:
+            resource_name: admin__user_roles
+            selections:
+              role_name: role_name
+            all: true
+        app_type_id:
+          select_from_model:
+            multiple: single
+            resource_name: admin__app_types
+            selections:
+              name: id
+            default: '{{current_user_app_type_id}}'
+      END_YAML
+
+      search_attrs_users_with_role = <<~END_YAML
+        user:
+          user:
+            multiple: single
+        role_name:
+          select_from_model:
+            resource_name: admin__user_roles
+            selections:
+              role_name: role_name
+            all: true
+        app_type_id:
+          select_from_model:
+            multiple: single
+            resource_name: admin__app_types
+            selections:
+              name: id
+            default: '{{current_user_app_type_id}}'
+      END_YAML
+
+      # ── Perspective 1: By Role ──────────────────────────────────────────
+
+      p1_options = <<~END_YAML
+        view_options:
+          view_as: tree
+          report_auto_submit_on_change: false
+          hide_field_names_with_comments: true
+          hide_result_count: false
+          no_results_scroll: true
+
+        tree_view_options:
+          num_levels: 2
+          expand_level: 1
+          column_levels:
+            -
+              - id0
+              - source
+
+        column_options:
+          alt_column_header:
+            id0: '[expand]'
+            source: 'Assigned via (role name)'
+            resource_type: 'Resource Type'
+            resource_name: 'Resource Name'
+            access: 'Access'
+            app_scope: 'App Type Scope'
+            user_email: 'User'
+          show_as:
+            resource_name: url
+            source: url
+            app_scope: url
+            user_email: url
+      END_YAML
+
+      p1_sql = <<~END_SQL
+        -- User Access Overview - Perspective 1: User -> Roles / Direct -> UACs
+        -- Shows all user access controls grouped by the access source (role name or "direct")
+
+        WITH target_user AS (
+          SELECT id, email
+          FROM ml_app.users
+          WHERE id = CAST(NULLIF(:user, '') AS INTEGER)
+            AND disabled IS NOT TRUE
+        ),
+        user_roles AS (
+          SELECT DISTINCT ur.role_name, ur.app_type_id, ur.user_id
+          FROM ml_app.user_roles ur
+          INNER JOIN target_user tu ON ur.user_id = tu.id
+          WHERE ur.disabled IS NOT TRUE
+            AND (ur.app_type_id = CAST(NULLIF(:app_type_id, '') AS INTEGER) OR ur.app_type_id IS NULL)
+            AND (COALESCE(:role_name, '') = '' OR ur.role_name = :role_name)
+        )
+        SELECT
+          CASE
+            WHEN uac.user_id IS NOT NULL THEN '(direct - user-specific)'
+            WHEN uac.role_name IS NOT NULL AND uac.role_name <> '' THEN uac.role_name
+            ELSE '(default - fallback)'
+          END AS id0,
+          uac.id AS id1,
+          ' ' blank,
+          CASE
+            WHEN uac.user_id IS NOT NULL THEN
+              '[(direct - user-specific)](/admin/user_access_controls?filter[user_id]=' || uac.user_id || '&filter[resource_name]=' || uac.resource_name || '&filter[resource_type]=' || uac.resource_type || ')'
+            WHEN uac.role_name IS NOT NULL AND uac.role_name <> '' THEN
+              '[' || uac.role_name || '](/admin/user_roles?filter[role_name]=' || uac.role_name || ')'
+            ELSE '[(default - fallback)](/admin/user_access_controls?filter[resource_name]=' || uac.resource_name || '&filter[resource_type]=' || uac.resource_type || ')'
+          END AS source,
+          uac.resource_type,
+          '[' || uac.resource_name || '](/admin/user_access_controls?filter[resource_name]=' || uac.resource_name || '&filter[resource_type]=' || uac.resource_type || ')' AS resource_name,
+          uac.access,
+          CASE
+            WHEN uac.app_type_id IS NULL THEN '(all)'
+            ELSE '[' || at.name || '](/admin/app_types/' || uac.app_type_id || ')'
+          END AS app_scope,
+          '[' || tu.email || '](/admin/manage_users?filter[email]=' || tu.email || ')' AS user_email
+
+        FROM ml_app.user_access_controls uac
+        LEFT JOIN ml_app.app_types at ON uac.app_type_id = at.id
+        CROSS JOIN target_user tu
+
+        WHERE uac.disabled IS NOT TRUE
+          AND (uac.app_type_id = CAST(NULLIF(:app_type_id, '') AS INTEGER) OR uac.app_type_id IS NULL)
+          AND (COALESCE(:resource_type, '') = '' OR uac.resource_type = :resource_type)
+          AND (COALESCE(:resource_name, '') = '' OR uac.resource_name = :resource_name)
+          AND (COALESCE(:role_name, '') = '' OR uac.role_name = :role_name)
+          AND (
+            uac.user_id = tu.id
+            OR (
+              uac.role_name IN (SELECT ur.role_name FROM user_roles ur WHERE ur.user_id = tu.id)
+              AND uac.user_id IS NULL
+            )
+            OR (
+              uac.user_id IS NULL
+              AND (uac.role_name IS NULL OR uac.role_name = '')
+            )
+          )
+
+        ORDER BY
+          id0,
+          id1,
+          uac.app_type_id ASC NULLS LAST,
+          CASE
+            WHEN uac.user_id IS NOT NULL THEN '0-direct'
+            WHEN uac.role_name IS NOT NULL AND uac.role_name <> '' THEN '1-' || uac.role_name
+            ELSE '2-default'
+          END,
+          uac.resource_type ASC,
+          uac.resource_name ASC
+        ;
+      END_SQL
+
+      # ── Perspective 2: By Resource ──────────────────────────────────────
+
+      p2_options = <<~END_YAML
+        view_options:
+          view_as: tree
+          report_auto_submit_on_change: false
+          hide_field_names_with_comments: true
+          hide_result_count: false
+          no_results_scroll: true
+
+        tree_view_options:
+          num_levels: 2
+          expand_level: 1
+          column_levels:
+            -
+              - id0
+              - resource_type
+              - resource_name
+
+        column_options:
+          alt_column_header:
+            id0: '[expand]'
+            source: 'Assigned via (role name)'
+            resource_type: 'Resource Type'
+            resource_name: 'Resource Name'
+            access: 'Access'
+            app_scope: 'App Type Scope'
+          show_as:
+            resource_name: url
+            source: url
+            app_scope: url
+      END_YAML
+
+      p2_sql = <<~END_SQL
+        -- User Access Overview - Perspective 2: By Resource
+        -- Shows all user access controls grouped by resource
+
+        WITH target_user AS (
+          SELECT id, email
+          FROM ml_app.users
+          WHERE id = CAST(NULLIF(:user, '') AS INTEGER)
+            AND disabled IS NOT TRUE
+        ),
+        user_roles AS (
+          SELECT DISTINCT ur.role_name, ur.app_type_id, ur.user_id
+          FROM ml_app.user_roles ur
+          INNER JOIN target_user tu ON ur.user_id = tu.id
+          WHERE ur.disabled IS NOT TRUE
+            AND (ur.app_type_id = CAST(NULLIF(:app_type_id, '') AS INTEGER) OR ur.app_type_id IS NULL)
+            AND (COALESCE(:role_name, '') = '' OR ur.role_name = :role_name)
+        )
+        SELECT
+          uac.resource_type || ' / ' || uac.resource_name AS id0,
+          uac.resource_type || ' / ' || uac.resource_name || '--' || uac.id AS id1,
+          ' ' blank,
+          CASE
+            WHEN uac.user_id IS NOT NULL THEN
+              '[(direct - user-specific)](/admin/user_access_controls?filter[user_id]=' || uac.user_id || '&filter[resource_name]=' || uac.resource_name || '&filter[resource_type]=' || uac.resource_type || ')'
+            WHEN uac.role_name IS NOT NULL AND uac.role_name <> '' THEN
+              '[' || uac.role_name || '](/admin/user_roles?filter[role_name]=' || uac.role_name || ')'
+            ELSE '[(default - fallback)](/admin/user_access_controls?filter[resource_name]=' || uac.resource_name || '&filter[resource_type]=' || uac.resource_type || ')'
+          END AS source,
+          uac.resource_type,
+          '[' || uac.resource_name || '](/admin/user_access_controls?filter[resource_name]=' || uac.resource_name || '&filter[resource_type]=' || uac.resource_type || ')' AS resource_name,
+          uac.access,
+          CASE
+            WHEN uac.app_type_id IS NULL THEN '(all)'
+            ELSE '[' || at.name || '](/admin/app_types/' || uac.app_type_id || ')'
+          END AS app_scope
+
+        FROM ml_app.user_access_controls uac
+        LEFT JOIN ml_app.app_types at ON uac.app_type_id = at.id
+        CROSS JOIN target_user tu
+
+        WHERE uac.disabled IS NOT TRUE
+          AND (uac.app_type_id = CAST(NULLIF(:app_type_id, '') AS INTEGER) OR uac.app_type_id IS NULL)
+          AND (COALESCE(:resource_type, '') = '' OR uac.resource_type = :resource_type)
+          AND (COALESCE(:resource_name, '') = '' OR uac.resource_name = :resource_name)
+          AND (COALESCE(:role_name, '') = '' OR uac.role_name = :role_name)
+          AND (
+            uac.user_id = tu.id
+            OR (
+              uac.role_name IN (SELECT ur.role_name FROM user_roles ur WHERE ur.user_id = tu.id)
+              AND uac.user_id IS NULL
+            )
+            OR (
+              uac.user_id IS NULL
+              AND (uac.role_name IS NULL OR uac.role_name = '')
+            )
+          )
+
+        ORDER BY
+          id0,
+          id1,
+          uac.resource_type ASC,
+          uac.resource_name ASC,
+          uac.app_type_id ASC NULLS LAST,
+          CASE
+            WHEN uac.user_id IS NOT NULL THEN '0-direct'
+            WHEN uac.role_name IS NOT NULL AND uac.role_name <> '' THEN '1-' || uac.role_name
+            ELSE '2-default'
+          END
+        ;
+      END_SQL
+
+      # ── Perspective 3: Resolved ─────────────────────────────────────────
+
+      p3_options = <<~END_YAML
+        view_options:
+          view_as: tree
+          report_auto_submit_on_change: false
+          hide_field_names_with_comments: true
+          hide_result_count: false
+          no_results_scroll: true
+
+        tree_view_options:
+          num_levels: 2
+          expand_level: 1
+          column_levels:
+            -
+              - id0
+              - resource_type
+              - resource_name
+
+        column_options:
+          alt_column_header:
+            id0: '[expand]'
+            source: 'Resolved via (role name)'
+            resource_type: 'Resource Type'
+            resource_name: 'Resource Name'
+            access: 'Access'
+            app_scope: 'App Type Scope'
+          show_as:
+            resource_name: url
+            source: url
+            app_scope: url
+      END_YAML
+
+      p3_sql = <<~END_SQL
+        -- User Access Overview - Perspective 3: Resolved
+        -- One effective UAC per resource after priority resolution
+
+        WITH target_user AS (
+          SELECT id, email
+          FROM ml_app.users
+          WHERE id = CAST(NULLIF(:user, '') AS INTEGER)
+            AND disabled IS NOT TRUE
+        ),
+        user_roles AS (
+          SELECT DISTINCT ur.role_name, ur.app_type_id, ur.user_id
+          FROM ml_app.user_roles ur
+          INNER JOIN target_user tu ON ur.user_id = tu.id
+          WHERE ur.disabled IS NOT TRUE
+            AND (ur.app_type_id = CAST(NULLIF(:app_type_id, '') AS INTEGER) OR ur.app_type_id IS NULL)
+            AND (COALESCE(:role_name, '') = '' OR ur.role_name = :role_name)
+        )
+        SELECT DISTINCT ON (uac.resource_type, uac.resource_name)
+          uac.resource_type || ' / ' || uac.resource_name AS id0,
+          uac.resource_type || ' / ' || uac.resource_name || '--' || uac.id AS id1,
+          ' ' blank,
+          uac.resource_type,
+          '[' || uac.resource_name || '](/admin/user_access_controls?filter[resource_name]=' || uac.resource_name || '&filter[resource_type]=' || uac.resource_type || ')' AS resource_name,
+          uac.access,
+          CASE
+            WHEN uac.user_id IS NOT NULL THEN
+              '[(direct - user-specific)](/admin/user_access_controls?filter[user_id]=' || uac.user_id || '&filter[resource_name]=' || uac.resource_name || '&filter[resource_type]=' || uac.resource_type || ')'
+            WHEN uac.role_name IS NOT NULL AND uac.role_name <> '' THEN
+              '[' || uac.role_name || '](/admin/user_roles?filter[role_name]=' || uac.role_name || ')'
+            ELSE '[(default - fallback)](/admin/user_access_controls?filter[resource_name]=' || uac.resource_name || '&filter[resource_type]=' || uac.resource_type || ')'
+          END AS source,
+          CASE
+            WHEN uac.app_type_id IS NULL THEN '(all)'
+            ELSE '[' || at.name || '](/admin/app_types/' || uac.app_type_id || ')'
+          END AS app_scope,
+          CASE
+            WHEN uac.user_id IS NOT NULL THEN 0
+            WHEN uac.role_name IS NOT NULL AND uac.role_name <> '' THEN 1
+            ELSE 2
+          END  as reorder
+
+        FROM ml_app.user_access_controls uac
+        LEFT JOIN ml_app.app_types at ON uac.app_type_id = at.id
+        CROSS JOIN target_user tu
+
+        WHERE uac.disabled IS NOT TRUE
+          AND (uac.app_type_id = CAST(NULLIF(:app_type_id, '') AS INTEGER) OR uac.app_type_id IS NULL)
+          AND (COALESCE(:resource_type, '') = '' OR uac.resource_type = :resource_type)
+          AND (COALESCE(:resource_name, '') = '' OR uac.resource_name = :resource_name)
+          AND (COALESCE(:role_name, '') = '' OR uac.role_name = :role_name)
+          AND (
+            uac.user_id = tu.id
+            OR (
+              uac.role_name IN (SELECT ur.role_name FROM user_roles ur WHERE ur.user_id = tu.id)
+              AND uac.user_id IS NULL
+            )
+            OR (
+              uac.user_id IS NULL
+              AND (uac.role_name IS NULL OR uac.role_name = '')
+            )
+          )
+
+        ORDER BY
+          uac.resource_type, uac.resource_name,
+          id0,
+          reorder
+        ;
+      END_SQL
+
+      # ── Perspective 4: Roles Only ───────────────────────────────────────
+
+      p4_options = <<~END_YAML
+        view_options:
+          view_as: tree
+          report_auto_submit_on_change: false
+          hide_field_names_with_comments: true
+          hide_result_count: false
+          no_results_scroll: true
+
+        tree_view_options:
+          num_levels: 2
+          expand_level: 1
+          column_levels:
+            -
+              - id0
+              - user_email
+
+        column_options:
+          alt_column_header:
+            id0: '[expand]'
+            role_name: 'Role Name'
+            app_scope: 'App Type Scope'
+            user_email: 'User'
+          show_as:
+            role_name: url
+            app_scope: url
+            user_email: url
+      END_YAML
+
+      p4_sql = <<~END_SQL
+        -- User Access Overview - Perspective 4: Roles Only
+        -- Lists roles assigned to a user (or all users) in the selected app type
+
+        SELECT
+          u.email AS id0,
+          ur.id AS id1,
+          ' ' blank,
+          '[' || ur.role_name || '](/admin/user_roles?filter[role_name]=' || ur.role_name || ')' AS role_name,
+          CASE
+            WHEN ur.app_type_id IS NULL THEN '(all)'
+            ELSE '[' || at.name || '](/admin/app_types/' || ur.app_type_id || ')'
+          END AS app_scope,
+          '[' || u.email || '](/admin/manage_users?filter[email]=' || u.email || ')' AS user_email
+
+        FROM ml_app.user_roles ur
+        INNER JOIN ml_app.users u ON ur.user_id = u.id
+        LEFT JOIN ml_app.app_types at ON ur.app_type_id = at.id
+
+        WHERE u.disabled IS NOT TRUE
+          AND ur.disabled IS NOT TRUE
+          AND (NULLIF(:user, '') IS NULL OR u.id = CAST(NULLIF(:user, '') AS INTEGER))
+          AND ur.app_type_id = CAST(NULLIF(:app_type_id, '') AS INTEGER)
+          AND (COALESCE(:role_name, '') = '' OR ur.role_name = :role_name)
+
+        ORDER BY u.email ASC, ur.role_name ASC
+        ;
+      END_SQL
+
+      # ── Perspective 5: Users With Role ────────────────────────────────
+
+      p5_options = <<~END_YAML
+        view_options:
+          view_as: tree
+          report_auto_submit_on_change: false
+          hide_field_names_with_comments: true
+          hide_result_count: false
+          no_results_scroll: true
+
+        tree_view_options:
+          num_levels: 2
+          expand_level: 1
+          column_levels:
+            -
+              - id0
+              - role_name
+
+        column_options:
+          alt_column_header:
+            id0: '[expand]'
+            role_name: 'Role Name'
+            app_scope: 'App Type Scope'
+            user_email: 'User'
+          show_as:
+            role_name: url
+            app_scope: url
+            user_email: url
+      END_YAML
+
+      p5_sql = <<~END_SQL
+        -- User Access Overview - Perspective 5: Users With Role
+        -- Lists users who have a role assigned in the selected app type
+
+        SELECT
+          ur.role_name AS id0,
+          ur.id AS id1,
+          ' ' blank,
+          '[' || ur.role_name || '](/admin/user_roles?filter[role_name]=' || ur.role_name || ')' AS role_name,
+          CASE
+            WHEN ur.app_type_id IS NULL THEN '(all)'
+            ELSE '[' || at.name || '](/admin/app_types/' || ur.app_type_id || ')'
+          END AS app_scope,
+          '[' || u.email || '](/admin/manage_users?filter[email]=' || u.email || ')' AS user_email
+
+        FROM ml_app.user_roles ur
+        INNER JOIN ml_app.users u ON ur.user_id = u.id
+        LEFT JOIN ml_app.app_types at ON ur.app_type_id = at.id
+
+        WHERE u.disabled IS NOT TRUE
+          AND ur.disabled IS NOT TRUE
+          AND (NULLIF(:user, '') IS NULL OR u.id = CAST(NULLIF(:user, '') AS INTEGER))
+          AND ur.app_type_id = CAST(NULLIF(:app_type_id, '') AS INTEGER)
+          AND (COALESCE(:role_name, '') = '' OR ur.role_name = :role_name)
+
+        ORDER BY ur.role_name ASC, u.email ASC
+        ;
+      END_SQL
+
+      # ── Build report and UAC arrays ─────────────────────────────────────
+
+      report_values = [
+        {
+          name: 'User Access Overview - By Role',
+          item_type: 'admin-user-access-overview',
+          short_name: 'user_access_overview_by_role',
+          description: 'View all access controls for a user, grouped by role name or direct assignment',
+          report_type: 'regular_report',
+          auto: false,
+          searchable: false,
+          options: p1_options,
+          sql: p1_sql,
+          search_attrs: search_attrs
+        },
+        {
+          name: 'User Access Overview - By Resource',
+          item_type: 'admin-user-access-overview',
+          short_name: 'user_access_overview_by_resource',
+          description: 'View all access controls for a user, grouped by resource',
+          report_type: 'regular_report',
+          auto: false,
+          searchable: false,
+          options: p2_options,
+          sql: p2_sql,
+          search_attrs: search_attrs
+        },
+        {
+          name: 'User Access Overview - Resolved',
+          item_type: 'admin-user-access-overview',
+          short_name: 'user_access_overview_resolved',
+          description: 'View the effective access for each resource after priority resolution',
+          report_type: 'regular_report',
+          auto: false,
+          searchable: false,
+          options: p3_options,
+          sql: p3_sql,
+          search_attrs: search_attrs
+        },
+        {
+          name: 'User Access Overview - Roles Listed by User',
+          item_type: 'admin-user-access-overview',
+          short_name: 'user_access_overview_roles_only',
+          description: 'View the roles assigned to a user in the selected app type',
+          report_type: 'regular_report',
+          auto: false,
+          searchable: false,
+          options: p4_options,
+          sql: p4_sql,
+          search_attrs: search_attrs_roles_with_user
+        },
+        {
+          name: 'User Access Overview - Users Listed by Role',
+          item_type: 'admin-user-access-overview',
+          short_name: 'user_access_overview_users_with_role',
+          description: 'View users who have a role assigned in the selected app type',
+          report_type: 'regular_report',
+          auto: false,
+          searchable: false,
+          options: p5_options,
+          sql: p5_sql,
+          search_attrs: search_attrs_users_with_role
+        }
+      ]
+
+      uac_values = [
+        {
+          resource_type: 'report',
+          access: nil,
+          resource_name: 'admin_user_access_overview__user_access_overview_by_role'
+        },
+        {
+          resource_type: 'report',
+          access: nil,
+          resource_name: 'admin_user_access_overview__user_access_overview_by_resource'
+        },
+        {
+          resource_type: 'report',
+          access: nil,
+          resource_name: 'admin_user_access_overview__user_access_overview_resolved'
+        },
+        {
+          resource_type: 'report',
+          access: nil,
+          resource_name: 'admin_user_access_overview__user_access_overview_roles_only'
+        },
+        {
+          resource_type: 'report',
+          access: nil,
+          resource_name: 'admin_user_access_overview__user_access_overview_users_with_role'
+        }
+      ]
+
+      add_report_values report_values
+      add_uac_values uac_values
+
+      # Disable the old landing page report if it exists
+      old_p0 = Report.find_by(short_name: 'user_access_overview')
+      old_p0&.update(disabled: true, current_admin: Seeds.auto_admin)
+    end
+
+    def self.setup
+      log "In #{self}.setup"
+      create_templates
+      log "Ran #{self}.setup"
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -165960,6 +165960,7 @@ ALTER TABLE ONLY study_info.activity_log_data_variable_package_reviews
 SET search_path TO ml_app,ref_data,redcap,dynamic,organization,pitt_bhi,ipa_ops,study_info;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260409072921'),
 ('20260402110412'),
 ('20260401153819'),
 ('20260331133109'),

--- a/spec/models/reports/user_access_overview_spec.rb
+++ b/spec/models/reports/user_access_overview_spec.rb
@@ -1,0 +1,945 @@
+# frozen_string_literal: true
+
+# Purpose: Tests for the User Access Overview seeded admin reports (GitHub Issue #706).
+#
+# These reports provide five complementary perspectives on a user's effective access controls
+# within an app type:
+#   Perspective 1 (by_role): UACs grouped by role name or "direct" assignment
+#   Perspective 2 (by_resource): UACs grouped by resource, showing which roles granted each
+#   Perspective 3 (resolved): One effective UAC per resource after priority_order resolution
+#   Perspective 4 (roles_only): User's assigned roles in the selected app type (user optional)
+#   Perspective 5 (users_with_role): Users who have a role assigned (user optional)
+#
+# The tests verify:
+#   - All four reports are seeded with correct attributes
+#   - Default UAC records are created to gate access to the reports
+#   - Each perspective returns expected results given a known set of roles and UACs
+#   - Results are correctly scoped by app_type and user
+#   - Priority resolution (user-specific > role-based > default) works in Perspective 3
+#   - Correct alt_resource_names are set for access gating
+#   - The admin index page links to the filtered report list
+#   - search_attrs uses select_from_model for app_type_id with default current_user_app_type_id (AC7)
+#   - search_attrs uses user type dropdown (label=email, value=user_id) for user selection (AC7)
+#   - search_attrs uses select_from_model with group_by for resource_name (AC7)
+#   - search_attrs includes role_name filter with select_from_model pointing to admin__user_roles
+#   - resource_type config_selector includes filter_selector pointing to resource_name (AC7)
+#   - SQL supports optional resource_type, resource_name, and role_name filtering (AC7)
+#   - SQL requires user and app_type_id parameters (mandatory criteria)
+#   - Result columns contain inline admin links (resource_name, source, role_name, app_scope)
+#   - P1 includes user_email column
+#   - P4 uses tree view with user email as top level
+#   - Column headers include "(role name)" suffix for source columns
+#   - Runner nil parameter handling: the report runner converts blank form values to nil,
+#     which causes SQL patterns like (:param = '' OR ...) to fail because NULL = '' is NULL (falsy).
+#     The NULLIF(:param, '') IS NULL pattern used for :user and :app_type_id handles nil correctly,
+#     but :resource_type, :resource_name, and :role_name use the broken (:param = '' OR ...) pattern.
+
+require 'rails_helper'
+
+RSpec.describe 'User Access Overview Reports', type: :model do
+  include ModelSupport
+  include ReportSupport
+
+  let(:report_short_names) do
+    %w[
+      user_access_overview_by_role
+      user_access_overview_by_resource
+      user_access_overview_resolved
+      user_access_overview_roles_only
+      user_access_overview_users_with_role
+    ]
+  end
+
+  before :example do
+    create_admin
+    create_user
+
+    # Run the seed to create/update the reports
+    Seeds::ReportUserAccessOverview.setup
+
+    # Create a dedicated app type to avoid collisions with existing seed UACs
+    @test_app_type = create_app_type(
+      name: "uao_test_#{SecureRandom.hex(4)}",
+      label: 'UAO Test App'
+    )
+
+    # Grant the user access to the test app type
+    Admin::UserAccessControl.create!(
+      app_type: @test_app_type,
+      user: @user,
+      access: :read,
+      resource_type: :general,
+      resource_name: :app_type,
+      current_admin: @admin
+    )
+
+    # Assign roles to the user
+    create_user_role 'editor', user: @user, app_type: @test_app_type
+    create_user_role 'viewer', user: @user, app_type: @test_app_type
+
+    # Direct (user-specific) UACs
+    Admin::UserAccessControl.create!(
+      app_type: @test_app_type,
+      user: @user,
+      access: :create,
+      resource_type: :table,
+      resource_name: :player_infos,
+      current_admin: @admin
+    )
+    Admin::UserAccessControl.create!(
+      app_type: @test_app_type,
+      user: @user,
+      access: :read,
+      resource_type: :table,
+      resource_name: :trackers,
+      current_admin: @admin
+    )
+
+    # Role-based UACs for 'editor'
+    Admin::UserAccessControl.create!(
+      app_type: @test_app_type,
+      access: :update,
+      resource_type: :table,
+      resource_name: :player_infos,
+      role_name: 'editor',
+      current_admin: @admin
+    )
+    Admin::UserAccessControl.create!(
+      app_type: @test_app_type,
+      access: :update,
+      resource_type: :table,
+      resource_name: :trackers,
+      role_name: 'editor',
+      current_admin: @admin
+    )
+
+    # Role-based UACs for 'viewer'
+    Admin::UserAccessControl.create!(
+      app_type: @test_app_type,
+      access: :read,
+      resource_type: :table,
+      resource_name: :player_infos,
+      role_name: 'viewer',
+      current_admin: @admin
+    )
+    Admin::UserAccessControl.create!(
+      app_type: @test_app_type,
+      access: :read,
+      resource_type: :general,
+      resource_name: :app_type,
+      role_name: 'viewer',
+      current_admin: @admin
+    )
+
+    # Role-based UAC for 'viewer' on addresses (no direct UAC exists for addresses)
+    Admin::UserAccessControl.create!(
+      app_type: @test_app_type,
+      access: :read,
+      resource_type: :table,
+      resource_name: :addresses,
+      role_name: 'viewer',
+      current_admin: @admin
+    )
+
+    # Default (fallback) UACs — no user, no role
+    Admin::UserAccessControl.create!(
+      app_type: @test_app_type,
+      access: :read,
+      resource_type: :table,
+      resource_name: :trackers,
+      current_admin: @admin
+    )
+    Admin::UserAccessControl.create!(
+      app_type: @test_app_type,
+      access: :read,
+      resource_type: :table,
+      resource_name: :addresses,
+      current_admin: @admin
+    )
+  end
+
+  describe 'seed creation' do
+    it 'creates all four reports with correct attributes' do
+      report_short_names.each do |short_name|
+        report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
+        expect(report).to be_present, "Expected report with short_name '#{short_name}' to exist"
+        expect(report.disabled).not_to eq true
+        expect(report.report_type).to eq 'regular_report'
+        expect(report.sql).to be_present
+        expect(report.search_attrs).to be_present
+      end
+    end
+
+    it 'sets correct names for each perspective' do
+      expect(Report.find_by(short_name: 'user_access_overview_by_role', item_type: 'admin-user-access-overview').name)
+        .to include('By Role')
+      expect(Report.find_by(short_name: 'user_access_overview_by_resource', item_type: 'admin-user-access-overview').name)
+        .to include('By Resource')
+      expect(Report.find_by(short_name: 'user_access_overview_resolved', item_type: 'admin-user-access-overview').name)
+        .to include('Resolved')
+      expect(Report.find_by(short_name: 'user_access_overview_roles_only', item_type: 'admin-user-access-overview').name)
+        .to include('Roles')
+    end
+
+    it 'includes search_attrs with app_type_id and user for all reports' do
+      report_short_names.each do |short_name|
+        report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
+        expect(report.search_attrs).to include('app_type_id')
+        expect(report.search_attrs).to include('user'),
+                                       "Expected search_attrs to include 'user' key in '#{short_name}'"
+      end
+    end
+
+    it 'uses user type for user search attribute' do
+      report_short_names.each do |short_name|
+        report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
+        attrs = YAML.safe_load(report.search_attrs)
+
+        expect(attrs).to have_key('user'),
+                         "Expected search_attrs to have 'user' key in '#{short_name}'"
+        expect(attrs['user']).to have_key('user'),
+                                 "Expected 'user' attr to have type 'user' in '#{short_name}'"
+
+        user_config = attrs['user']['user']
+        expect(user_config['multiple']).to eq('single'),
+                                           "Expected user multiple to be 'single' in '#{short_name}'"
+      end
+    end
+
+    it 'uses select_from_model for app_type_id with default current_user_app_type_id' do
+      report_short_names.each do |short_name|
+        report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
+        attrs = YAML.safe_load(report.search_attrs)
+
+        expect(attrs['app_type_id']).to have_key('select_from_model'),
+                                        "Expected app_type_id to use select_from_model in '#{short_name}'"
+        expect(attrs['app_type_id']).not_to have_key('config_selector'),
+                                            "Expected app_type_id NOT to use config_selector in '#{short_name}'"
+
+        sfm = attrs['app_type_id']['select_from_model']
+        expect(sfm['resource_name']).to eq('admin__app_types')
+        expect(sfm['multiple']).to eq('single')
+        expect(sfm['default']).to eq('{{current_user_app_type_id}}'),
+                                  "Expected app_type_id to default to current_user_app_type_id in '#{short_name}'"
+      end
+    end
+
+    it 'includes optional resource_type (config_selector) and resource_name (select_from_model with group_by) filter fields' do
+      # Only P1-P3 have resource_type and resource_name filters; P4/P5 use simplified search_attrs
+      reports_with_resource_filters = %w[
+        user_access_overview_by_role
+        user_access_overview_by_resource
+        user_access_overview_resolved
+      ]
+
+      reports_with_resource_filters.each do |short_name|
+        report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
+        attrs = YAML.safe_load(report.search_attrs)
+
+        # resource_type should be a config_selector with all: true
+        expect(attrs).to have_key('resource_type'),
+                         "Expected search_attrs to include resource_type in '#{short_name}'"
+        rt = attrs['resource_type']
+        expect(rt).to have_key('config_selector'),
+                      "Expected resource_type to use config_selector in '#{short_name}'"
+        expect(rt['config_selector']['all']).to eq(true),
+                                                "Expected resource_type config_selector to have all: true in '#{short_name}'"
+
+        # Verify the expected selection values are present
+        selections = rt['config_selector']['selections']
+        %w[table general limited_access report standalone_page activity_log_type].each do |val|
+          expect(selections.values).to include(val),
+                                       "Expected resource_type selections to include '#{val}' in '#{short_name}'"
+        end
+
+        # resource_type config_selector should include filter_selector pointing to resource_name
+        expect(rt['config_selector']['filter_selector']).to eq('resource_name'),
+                                                            "Expected resource_type config_selector to have filter_selector: resource_name in '#{short_name}'"
+
+        # resource_name should be select_from_model with group_by
+        expect(attrs).to have_key('resource_name'),
+                         "Expected search_attrs to include resource_name in '#{short_name}'"
+        rn = attrs['resource_name']
+        expect(rn).to have_key('select_from_model'),
+                      "Expected resource_name to use select_from_model in '#{short_name}'"
+
+        sfm = rn['select_from_model']
+        expect(sfm['resource_name']).to eq('admin__user_access_controls'),
+                                        "Expected resource_name select_from_model resource_name to be 'admin__user_access_controls' in '#{short_name}'"
+        expect(sfm['selections']).to eq({ 'resource_name' => 'resource_name' }),
+                                     "Expected resource_name selections to map resource_name in '#{short_name}'"
+        expect(sfm['group_by']).to eq('resource_type'),
+                                   "Expected resource_name select_from_model to have group_by: resource_type in '#{short_name}'"
+        expect(sfm['all']).to eq(true),
+                              "Expected resource_name select_from_model to have all: true in '#{short_name}'"
+      end
+    end
+
+    it 'includes role_name filter in search_attrs with select_from_model' do
+      report_short_names.each do |short_name|
+        report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
+        attrs = YAML.safe_load(report.search_attrs)
+
+        expect(attrs).to have_key('role_name'),
+                         "Expected search_attrs to include role_name in '#{short_name}'"
+
+        rn = attrs['role_name']
+        expect(rn).to have_key('select_from_model'),
+                      "Expected role_name to use select_from_model in '#{short_name}'"
+
+        sfm = rn['select_from_model']
+        expect(sfm['resource_name']).to eq('admin__user_roles'),
+                                        "Expected role_name select_from_model resource_name to be 'admin__user_roles' in '#{short_name}'"
+        expect(sfm['all']).to eq(true),
+                              "Expected role_name select_from_model to have all: true in '#{short_name}'"
+      end
+    end
+
+    it 'includes column headers with role name suffix for source columns' do
+      %w[user_access_overview_by_role user_access_overview_by_resource].each do |short_name|
+        report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
+        options = YAML.safe_load(report.options)
+        col_opts = options['column_options']
+        alt_headers = col_opts&.dig('alt_column_header') || {}
+
+        expect(alt_headers['source']).to include('(role name)'),
+                                         "Expected source alt_column_header to include '(role name)' in '#{short_name}'"
+      end
+
+      resolved_report = Report.find_by(short_name: 'user_access_overview_resolved', item_type: 'admin-user-access-overview')
+      options = YAML.safe_load(resolved_report.options)
+      col_opts = options['column_options']
+      alt_headers = col_opts&.dig('alt_column_header') || {}
+
+      expect(alt_headers['source']).to include('(role name)'),
+                                       "Expected source alt_column_header to include '(role name)' in resolved report"
+    end
+  end
+
+  describe 'UAC seed records' do
+    it 'creates default UAC records for each report' do
+      report_short_names.each do |short_name|
+        alt_name = "admin_user_access_overview__#{short_name}"
+        uac = Admin::UserAccessControl.active.find_by(
+          resource_type: 'report',
+          resource_name: alt_name
+        )
+        expect(uac).to be_present,
+                       "Expected a UAC with resource_name '#{alt_name}' for report '#{short_name}'"
+      end
+    end
+  end
+
+  describe 'alt_resource_names' do
+    it 'follows the <item_type_underscored>__<short_name> pattern for all reports' do
+      report_short_names.each do |short_name|
+        report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
+        expect(report.alt_resource_name).to eq("admin_user_access_overview__#{short_name}")
+      end
+    end
+  end
+
+  describe 'Perspective 1 — by role' do
+    let(:report) { Report.find_by(short_name: 'user_access_overview_by_role', item_type: 'admin-user-access-overview') }
+
+    it 'returns results for the given user and app type' do
+      results = run_report_sql(report)
+      expect(results.count).to be > 0
+    end
+
+    it 'groups UACs under role names and direct assignments' do
+      results = run_report_sql(report)
+      sources = results.map { |r| r['source'] || r['id0'] }.uniq
+
+      # Should contain direct, editor, viewer, and default groupings
+      expect(sources).to include(a_string_matching(/direct/i))
+      expect(sources).to include(a_string_matching(/editor/))
+      expect(sources).to include(a_string_matching(/viewer/))
+    end
+
+    it 'includes default fallback UACs' do
+      results = run_report_sql(report)
+      sources = results.map { |r| r['source'] || r['id0'] }.uniq
+
+      expect(sources).to include(a_string_matching(/default/i))
+    end
+
+    it 'includes the correct resource details in each row' do
+      results = run_report_sql(report)
+      fields = results.first.keys
+
+      expect(fields).to include('resource_type')
+      expect(fields).to include('resource_name')
+      expect(fields).to include('access')
+    end
+
+    it 'includes resource_name cells with admin UAC link format' do
+      results = run_report_sql(report)
+
+      results.each do |row|
+        expect(row['resource_name']).to match(%r{\[.+\]\(/admin/user_access_controls\?filter}),
+                                        "Expected resource_name to contain admin UAC link, got: #{row['resource_name']}"
+      end
+    end
+
+    it 'includes user_email column' do
+      results = run_report_sql(report)
+      fields = results.first.keys
+
+      expect(fields).to include('user_email'),
+                        'Expected P1 results to include a user_email column'
+    end
+
+    it 'includes source cells with admin user_roles links for role-based entries' do
+      results = run_report_sql(report)
+
+      role_rows = results.select { |r| r['source']&.match?(/editor|viewer/) }
+      expect(role_rows).not_to be_empty, 'Expected some role-based rows'
+
+      role_rows.each do |row|
+        expect(row['source']).to match(%r{\[.+\]\(/admin/user_roles\?filter\[role_name\]=}),
+                                 "Expected source to contain user_roles link, got: #{row['source']}"
+      end
+    end
+  end
+
+  describe 'Perspective 2 — by resource' do
+    let(:report) { Report.find_by(short_name: 'user_access_overview_by_resource', item_type: 'admin-user-access-overview') }
+
+    it 'returns results for the given user and app type' do
+      results = run_report_sql(report)
+      expect(results.count).to be > 0
+    end
+
+    it 'groups by resource showing which roles granted each' do
+      results = run_report_sql(report)
+
+      # player_infos should appear with multiple sources (direct, editor, viewer, default)
+      pi_rows = results.select { |r| r['resource_name']&.include?('player_infos') }
+      sources = pi_rows.map { |r| r['source'] }.compact
+      expect(sources.length).to be >= 2
+    end
+
+    it 'includes resource_type, resource_name, and access in grouping' do
+      results = run_report_sql(report)
+      fields = results.first.keys
+
+      expect(fields).to include('resource_type')
+      expect(fields).to include('resource_name')
+      expect(fields).to include('access')
+      expect(fields).to include('source')
+    end
+  end
+
+  describe 'Perspective 3 — resolved' do
+    let(:report) { Report.find_by(short_name: 'user_access_overview_resolved', item_type: 'admin-user-access-overview') }
+
+    it 'returns results for the given user and app type' do
+      results = run_report_sql(report)
+      expect(results.count).to be > 0
+    end
+
+    it 'returns exactly one row per resource_type + resource_name combination' do
+      results = run_report_sql(report)
+
+      resource_keys = results.map { |r| [r['resource_type'], r['resource_name']] }
+      expect(resource_keys).to eq(resource_keys.uniq),
+                               'Expected one resolved row per resource but found duplicates'
+    end
+
+    it 'resolves user-specific UAC over role-based for player_infos' do
+      results = run_report_sql(report)
+
+      pi_row = results.find { |r| r['resource_type'] == 'table' && r['resource_name']&.include?('player_infos') }
+      expect(pi_row).to be_present
+
+      # The direct (user-specific) UAC with access=create should win over role-based and default
+      expect(pi_row['access']).to eq('create')
+      expect(pi_row['source']).to match(/direct/i)
+    end
+
+    it 'resolves direct UAC for general/app_type' do
+      results = run_report_sql(report)
+
+      # general/app_type has a direct UAC (from create_user setup) — it should win
+      app_type_row = results.find { |r| r['resource_type'] == 'general' && r['resource_name']&.include?('app_type') }
+      expect(app_type_row).to be_present
+      expect(app_type_row['source']).to match(/direct/i)
+    end
+
+    it 'resolves role-based UAC over default for resources with no direct UAC' do
+      results = run_report_sql(report)
+
+      # addresses has role-based (viewer) + default, but no direct UAC
+      addresses_row = results.find { |r| r['resource_type'] == 'table' && r['resource_name']&.include?('addresses') }
+      expect(addresses_row).to be_present
+      expect(addresses_row['source']).to include('viewer')
+    end
+
+    it 'includes resource_name cells with admin UAC link format' do
+      results = run_report_sql(report)
+
+      results.each do |row|
+        expect(row['resource_name']).to match(%r{\[.+\]\(/admin/user_access_controls\?filter}),
+                                        "Expected resource_name to contain admin UAC link, got: #{row['resource_name']}"
+      end
+    end
+
+    it 'uses tree view grouped by resource_type' do
+      report_record = Report.find_by(short_name: 'user_access_overview_resolved', item_type: 'admin-user-access-overview')
+      options = YAML.safe_load(report_record.options)
+      view_options = options['view_options']
+
+      expect(view_options['view_as']).to eq('tree'),
+                                         'Expected P3 to use tree view'
+      expect(options).to have_key('tree_view_options'),
+                         'Expected P3 to have tree_view_options'
+    end
+
+    it 'includes id0 and id1 columns for tree grouping' do
+      results = run_report_sql(report)
+      fields = results.first.keys
+
+      expect(fields).to include('id0'),
+                        'Expected P3 results to include id0 for tree grouping'
+      expect(fields).to include('id1'),
+                        'Expected P3 results to include id1 for tree row identity'
+    end
+  end
+
+  describe 'Perspective 4 — roles only' do
+    let(:report) { Report.find_by(short_name: 'user_access_overview_roles_only', item_type: 'admin-user-access-overview') }
+
+    it 'returns results for the given user and app type' do
+      results = run_report_sql(report)
+      expect(results.count).to be > 0
+    end
+
+    it 'lists the assigned roles for the user' do
+      results = run_report_sql(report)
+      role_names = results.map { |r| r['role_name'] }
+
+      expect(role_names).to include(a_string_matching(/editor/))
+      expect(role_names).to include(a_string_matching(/viewer/))
+    end
+
+    it 'does not include roles from other users' do
+      original_user = @user
+      other_user, = create_user('other')
+      create_user_role 'other_role', user: other_user, app_type: @test_app_type
+
+      # Restore original user for the report query
+      @user = original_user
+
+      # Re-run with original user
+      results = run_report_sql(report)
+      role_names = results.map { |r| r['role_name'] }
+
+      expect(role_names).not_to include(a_string_matching(/other_role/))
+    end
+
+    it 'includes role_name cells with admin user_roles link format' do
+      results = run_report_sql(report)
+
+      results.each do |row|
+        expect(row['role_name']).to match(%r{\[.+\]\(/admin/user_roles\?filter\[role_name\]=}),
+                                    "Expected role_name to contain user_roles link, got: #{row['role_name']}"
+      end
+    end
+
+    it 'uses tree view with user email as top level' do
+      report_record = Report.find_by(short_name: 'user_access_overview_roles_only', item_type: 'admin-user-access-overview')
+      options = YAML.safe_load(report_record.options)
+      view_options = options['view_options']
+
+      expect(view_options['view_as']).to eq('tree'),
+                                         'Expected P4 to use tree view'
+      expect(options).to have_key('tree_view_options'),
+                         'Expected P4 to have tree_view_options'
+    end
+
+    it 'includes user_email and id0 columns for tree grouping' do
+      results = run_report_sql(report)
+      fields = results.first.keys
+
+      expect(fields).to include('id0'),
+                        'Expected P4 results to include id0 for tree grouping'
+      expect(fields).to include('user_email'),
+                        'Expected P4 results to include user_email column'
+    end
+
+    it 'returns results when user is blank (user is optional)' do
+      results = run_report_sql(report, user: '')
+      expect(results).not_to be_empty,
+                             'Expected P4 to return results when user is blank (optional)'
+    end
+
+    it 'returns no results when app_type_id is blank (app_type_id is mandatory)' do
+      results = run_report_sql(report, app_type_id: '')
+      expect(results).to be_empty,
+                         'Expected P4 to return no results when app_type_id is blank (mandatory)'
+    end
+  end
+
+  describe 'Perspective 5 — users with role' do
+    let(:report) { Report.find_by(short_name: 'user_access_overview_users_with_role', item_type: 'admin-user-access-overview') }
+
+    it 'exists and has correct attributes' do
+      expect(report).to be_present, "Expected report with short_name 'user_access_overview_users_with_role' to exist"
+      expect(report.disabled).not_to eq true
+      expect(report.report_type).to eq 'regular_report'
+    end
+
+    it 'returns results for the given app type' do
+      results = run_report_sql(report, user: '')
+      expect(results.count).to be > 0
+    end
+
+    it 'lists users and their assigned roles in the app type' do
+      results = run_report_sql(report, user: '')
+
+      # Should include our test user's roles
+      user_emails = results.map { |r| r['user_email'] }
+      expect(user_emails).to include(a_string_matching(/@/)),
+                             'Expected users_with_role results to include user emails'
+
+      role_names = results.map { |r| r['role_name'] }
+      expect(role_names).to include(a_string_matching(/editor/))
+      expect(role_names).to include(a_string_matching(/viewer/))
+    end
+
+    it 'groups by role_name with user details in child rows' do
+      report_record = Report.find_by(short_name: 'user_access_overview_users_with_role', item_type: 'admin-user-access-overview')
+      options = YAML.safe_load(report_record.options)
+      view_options = options['view_options']
+
+      expect(view_options['view_as']).to eq('tree'),
+                                         'Expected P5 to use tree view'
+      expect(options).to have_key('tree_view_options'),
+                         'Expected P5 to have tree_view_options'
+    end
+
+    it 'returns results when user is blank (user is optional)' do
+      results = run_report_sql(report, user: '')
+      expect(results).not_to be_empty,
+                             'Expected P5 to return results when user is blank'
+    end
+
+    it 'returns no results when app_type_id is blank (app_type_id is mandatory)' do
+      results = run_report_sql(report, app_type_id: '')
+      expect(results).to be_empty,
+                         'Expected P5 to return no results when app_type_id is blank'
+    end
+
+    it 'filters by user when provided' do
+      original_user = @user
+      other_user, = create_user('p5other')
+      create_user_role 'p5only_role', user: other_user, app_type: @test_app_type
+
+      # Restore original user for the report query
+      @user = original_user
+
+      # With our test user, should not see p5only_role
+      results = run_report_sql(report)
+      role_names = results.map { |r| r['role_name'] }
+      expect(role_names).not_to include(a_string_matching(/p5only_role/))
+    end
+
+    it 'filters by role_name when provided' do
+      results = run_report_sql(report, user: '', role_name: 'editor')
+
+      results.each do |row|
+        expect(row['role_name']).to include('editor'),
+                                    "Expected role_name to include 'editor', got: #{row['role_name']}"
+      end
+    end
+
+    it 'includes role_name and user_email cells with admin links' do
+      results = run_report_sql(report, user: '')
+
+      results.each do |row|
+        expect(row['role_name']).to match(%r{\[.+\]\(/admin/user_roles\?filter\[role_name\]=}),
+                                    "Expected role_name link, got: #{row['role_name']}"
+        expect(row['user_email']).to match(%r{\[.+\]\(/admin/manage_users\?filter\[email\]=}),
+                                     "Expected user_email link, got: #{row['user_email']}"
+      end
+    end
+  end
+
+  describe 'filtering' do
+    let(:report) { Report.find_by(short_name: 'user_access_overview_by_role', item_type: 'admin-user-access-overview') }
+
+    it 'scopes results to the specified app_type' do
+      other_app_type = create_app_type(name: "other_app_#{SecureRandom.hex(4)}", label: 'Other App')
+
+      # Create a UAC in the other app type
+      Admin::UserAccessControl.create!(
+        app_type: other_app_type,
+        user: @user,
+        access: :read,
+        resource_type: :table,
+        resource_name: :addresses,
+        current_admin: @admin
+      )
+
+      # Results for the test app_type should not include UACs from other_app_type
+      # (the user-specific address UAC is in other_app_type, not test_app_type)
+      results = run_report_sql(report)
+      direct_address_rows = results.select do |r|
+        r['resource_name']&.include?('addresses') && r['source']&.match?(/direct/i)
+      end
+      expect(direct_address_rows).to be_empty
+    end
+
+    it 'scopes results to the specified user' do
+      original_user = @user
+      other_user, = create_user('filtered')
+      create_user_role 'editor', user: other_user, app_type: @test_app_type
+
+      Admin::UserAccessControl.create!(
+        app_type: @test_app_type,
+        user: other_user,
+        access: :read,
+        resource_type: :table,
+        resource_name: :pro_infos,
+        current_admin: @admin
+      )
+
+      # Restore original user for the report query
+      @user = original_user
+
+      # Results for original user should not include UACs specific to other_user
+      results = run_report_sql(report)
+      direct_pro_info_rows = results.select do |r|
+        r['resource_name']&.include?('pro_infos') && r['source']&.match?(/direct/i)
+      end
+      expect(direct_pro_info_rows).to be_empty
+    end
+  end
+
+  describe 'optional resource filters' do
+    let(:report) { Report.find_by(short_name: 'user_access_overview_by_role', item_type: 'admin-user-access-overview') }
+
+    it 'filters results by resource_type when provided' do
+      # Without filter, we should get multiple resource_types (table and general)
+      all_results = run_report_sql(report)
+      all_types = all_results.map { |r| r['resource_type'] }.uniq
+      expect(all_types.length).to be > 1,
+                                  'Precondition: expected multiple resource_types without filter'
+
+      # With resource_type = 'table', only table resources should appear
+      filtered_results = run_report_sql(report, resource_type: 'table')
+      filtered_types = filtered_results.map { |r| r['resource_type'] }.uniq
+
+      expect(filtered_types).to eq(['table']),
+                                "Expected only 'table' resources, got: #{filtered_types}"
+      expect(filtered_results.count).to be < all_results.count,
+                                        'Expected fewer results when filtering by resource_type'
+    end
+
+    it 'filters results by resource_name when provided' do
+      # Without filter, we should get multiple resource_names
+      all_results = run_report_sql(report)
+      all_names = all_results.map { |r| r['resource_name'] }.uniq
+      expect(all_names.length).to be > 1,
+                                  'Precondition: expected multiple resource_names without filter'
+
+      # With resource_name = 'player_infos', only matching resources should appear
+      filtered_results = run_report_sql(report, resource_name: 'player_infos')
+
+      filtered_results.each do |r|
+        expect(r['resource_name']).to include('player_infos'),
+                                      "Expected resource_name to include 'player_infos', got: #{r['resource_name']}"
+      end
+      expect(filtered_results.count).to be < all_results.count,
+                                        'Expected fewer results when filtering by resource_name'
+    end
+
+    it 'returns all results when resource_type and resource_name are blank' do
+      all_results = run_report_sql(report)
+      blank_filter_results = run_report_sql(report, resource_type: '', resource_name: '')
+
+      expect(blank_filter_results.count).to eq(all_results.count),
+                                            'Expected blank filters to return same results as no filters'
+    end
+
+    it 'combines resource_type and resource_name filters' do
+      filtered_results = run_report_sql(report, resource_type: 'table', resource_name: 'player_infos')
+
+      filtered_results.each do |row|
+        expect(row['resource_type']).to eq('table')
+        expect(row['resource_name']).to include('player_infos')
+      end
+
+      expect(filtered_results.count).to be > 0,
+                                        'Expected at least one result for table/player_infos'
+    end
+
+    it 'returns no results when user and app_type_id are blank (mandatory)' do
+      # user and app_type_id are now mandatory — blank values should return empty results
+      results = run_report_sql(report, user: '', app_type_id: '')
+      expect(results).to be_empty,
+                         'Expected no results when mandatory user and app_type_id are blank'
+    end
+
+    it 'filters results by role_name when provided' do
+      all_results = run_report_sql(report)
+
+      # With role_name = 'editor', only role-based UACs for 'editor' should appear
+      filtered_results = run_report_sql(report, role_name: 'editor')
+
+      expect(filtered_results.count).to be > 0,
+                                        'Expected at least one result when filtering by role_name=editor'
+      expect(filtered_results.count).to be < all_results.count,
+                                        'Expected fewer results when filtering by role_name'
+
+      filtered_results.each do |row|
+        expect(row['source']).to include('editor'),
+                                 "Expected source to reference 'editor' when filtering by role_name, got: #{row['source']}"
+      end
+    end
+  end
+
+  describe 'runner nil parameter handling' do
+    # The report runner's search_attrs_prep converts blank form values to nil.
+    # sanitize_sql_for_conditions then renders nil as NULL in the SQL.
+    # user and app_type_id are now mandatory — nil/blank values return empty results.
+    # resource_type, resource_name, and role_name remain optional and use COALESCE.
+
+    it 'P1 (by_role): returns empty when user and app_type_id are nil' do
+      report = Report.find_by(short_name: 'user_access_overview_by_role', item_type: 'admin-user-access-overview')
+      results = run_report_sql(report, user: nil, app_type_id: nil,
+                                       resource_type: nil, resource_name: nil, role_name: nil)
+      expect(results).to be_empty,
+                         'Expected P1 to return no results when mandatory user/app_type_id are nil'
+    end
+
+    it 'P2 (by_resource): returns empty when user and app_type_id are nil' do
+      report = Report.find_by(short_name: 'user_access_overview_by_resource', item_type: 'admin-user-access-overview')
+      results = run_report_sql(report, user: nil, app_type_id: nil,
+                                       resource_type: nil, resource_name: nil, role_name: nil)
+      expect(results).to be_empty,
+                         'Expected P2 to return no results when mandatory user/app_type_id are nil'
+    end
+
+    it 'P3 (resolved): returns empty when user and app_type_id are nil' do
+      report = Report.find_by(short_name: 'user_access_overview_resolved', item_type: 'admin-user-access-overview')
+      results = run_report_sql(report, user: nil, app_type_id: nil,
+                                       resource_type: nil, resource_name: nil, role_name: nil)
+      expect(results).to be_empty,
+                         'Expected P3 to return no results when mandatory user/app_type_id are nil'
+    end
+
+    it 'P4 (roles_only): returns results when user is nil but app_type_id is valid' do
+      report = Report.find_by(short_name: 'user_access_overview_roles_only', item_type: 'admin-user-access-overview')
+      results = run_report_sql(report, user: nil,
+                                       resource_type: nil, resource_name: nil, role_name: nil)
+      expect(results).not_to be_empty,
+                             'Expected P4 to return results when app_type_id is valid but user is nil'
+    end
+
+    it 'P4 (roles_only): returns empty when app_type_id is nil' do
+      report = Report.find_by(short_name: 'user_access_overview_roles_only', item_type: 'admin-user-access-overview')
+      results = run_report_sql(report, user: nil, app_type_id: nil,
+                                       resource_type: nil, resource_name: nil, role_name: nil)
+      expect(results).to be_empty,
+                         'Expected P4 to return no results when mandatory app_type_id is nil'
+    end
+
+    it 'P5 (users_with_role): returns results when user is nil but app_type_id is valid' do
+      report = Report.find_by(short_name: 'user_access_overview_users_with_role', item_type: 'admin-user-access-overview')
+      results = run_report_sql(report, user: nil,
+                                       resource_type: nil, resource_name: nil, role_name: nil)
+      expect(results).not_to be_empty,
+                             'Expected P5 to return results when app_type_id is valid but user is nil'
+    end
+
+    it 'P5 (users_with_role): returns empty when app_type_id is nil' do
+      report = Report.find_by(short_name: 'user_access_overview_users_with_role', item_type: 'admin-user-access-overview')
+      results = run_report_sql(report, user: nil, app_type_id: nil,
+                                       resource_type: nil, resource_name: nil, role_name: nil)
+      expect(results).to be_empty,
+                         'Expected P5 to return no results when mandatory app_type_id is nil'
+    end
+
+    it 'P1: returns results when only resource filters are nil' do
+      report = Report.find_by(short_name: 'user_access_overview_by_role', item_type: 'admin-user-access-overview')
+      results = run_report_sql(report, user: @user.id.to_s, app_type_id: @test_app_type.id.to_s,
+                                       resource_type: nil, resource_name: nil, role_name: nil)
+      expect(results).not_to be_empty,
+                             'Expected P1 to return results with valid user/app_type but nil resource filters'
+    end
+  end
+
+  describe 'ordering' do
+    let(:report) { Report.find_by(short_name: 'user_access_overview_by_role', item_type: 'admin-user-access-overview') }
+
+    it 'groups results by id0 (source category)' do
+      results = run_report_sql(report)
+      id0_values = results.map { |r| r['id0'] }
+
+      # id0 values should be grouped (consecutive identical values)
+      # Each category should appear in a contiguous block
+      categories = id0_values.chunk { |v| v }.map(&:first)
+      expect(categories.length).to be >= 2,
+                                   'Expected at least two distinct source categories'
+
+      # Should contain direct, role, and default categories
+      expect(id0_values).to include(a_string_matching(/direct/i))
+      expect(id0_values).to include(a_string_matching(/default/i))
+    end
+  end
+
+  describe 'P0 landing page report removal' do
+    it 'disables the old landing page report if it exists' do
+      # The seed should disable any existing P0 report
+      report = Report.find_by(short_name: 'user_access_overview')
+      if report
+        expect(report.disabled).to eq(true),
+                                   'Expected old P0 landing page report to be disabled'
+      end
+    end
+  end
+
+  describe 'admin index page link' do
+    it 'links to the filtered report list for user access overview' do
+      template_path = Rails.root.join('app/views/pages/_index_admin.html.erb')
+      template_content = File.read(template_path)
+
+      # Find the line(s) that contain the User Access Overview link
+      overview_lines = template_content.lines.select { |line| line.include?('User Access Overview') }
+      expect(overview_lines).not_to be_empty, 'Expected a User Access Overview link in the admin index'
+
+      overview_line = overview_lines.first
+
+      # Should link to filtered report list, not a specific report
+      expect(overview_line).to include('admin-user-access-overview'),
+                               'Expected the admin index link to filter by item_type admin-user-access-overview'
+
+      # The link line must still be gated by both :user_roles AND :user_access_controls
+      expect(overview_line).to include('can_admin?(:user_roles)'),
+                               'Expected the overview link to require :user_roles capability'
+      expect(overview_line).to include('can_admin?(:user_access_controls)'),
+                               'Expected the overview link to require :user_access_controls capability'
+    end
+  end
+
+  private
+
+  # Execute a report's SQL directly against the database with test parameters.
+  # Accepts optional extra_params (e.g. resource_type, resource_name) to test filter clauses.
+  def run_report_sql(report, **extra_params)
+    raise 'Report not found' unless report
+
+    sql = report.sql
+    params = {
+      app_type_id: @test_app_type.id.to_s,
+      user: @user.id.to_s,
+      resource_type: '',
+      resource_name: '',
+      role_name: ''
+    }.merge(extra_params)
+    sanitized = ActiveRecord::Base.sanitize_sql_for_conditions([sql, params])
+    ActiveRecord::Base.connection.execute(sanitized).to_a
+  end
+end

--- a/spec/system/admin_user_access_overview_spec.rb
+++ b/spec/system/admin_user_access_overview_spec.rb
@@ -1,0 +1,328 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Purpose: System spec for the User Access Overview admin reports (GitHub Issue #706).
+#
+# These reports provide administrators with comprehensive views of user access controls
+# from multiple perspectives, accessible from the admin index page:
+#
+#   P1 (by_role): Tree view of UACs grouped by role name or direct assignment
+#   P2 (by_resource): Tree view of UACs grouped by resource type/name
+#   P3 (resolved): Tree view showing effective UAC per resource after priority resolution
+#   P4 (roles_only): Tree view of roles assigned to the user, with user email as top level
+#   P5 (users_with_role): Tree view of users grouped by role name
+#
+# The tests verify end-to-end functionality through the admin UI:
+#   - Admin index page shows "User Access Overview" link under Users & Access
+#   - Each perspective report loads with correct search criteria fields
+#   - Reports return results when submitted with specific criteria
+#   - Reports return results when all criteria are left empty (optional criteria)
+#   - filter_selector on resource_type updates resource_name dropdown
+#   - Inline cell links render as clickable links in report results
+#   - Tree view reports display expandable tree structure
+#   - Report column headers use custom labels (e.g. "Assigned via (role name)")
+#
+# Authentication:
+#   - Admin index page tests sign in as admin via admin_sign_in_with_2fa
+#   - Report tests sign in as a regular user (since ReportsController inherits from
+#     UserBaseController which requires authenticate_user!). The admin reports allow
+#     access to admin users via current_admin OR to users via UAC gating. For system
+#     specs we sign in as a user to access the report pages normally.
+describe 'admin User Access Overview reports', js: true, driver: $browser_driver do
+  include ModelSupport
+  include MasterDataSupport
+  include AdminActionsSetup
+  include FeatureSupport
+  include ReportSupport
+
+  before(:all) do
+    SetupHelper.feature_setup
+
+    @admin, = create_admin
+    seed_database
+    create_data_set_outside_tx
+  end
+
+  before(:example) do
+    change_setting('TwoFactorAuthDisabledForUser', true)
+  end
+
+  def setup_report_user_with_roles
+    @user, @good_password = create_user
+    @good_email = @user.email
+
+    # Grant permission to view and access reports
+    Admin::UserAccessControl.create!(
+      app_type_id: @user.app_type_id,
+      access: :read,
+      resource_type: :general,
+      resource_name: :view_reports,
+      current_admin: @admin,
+      user: @user
+    )
+    Admin::UserAccessControl.create!(
+      user: @user,
+      app_type: @user.app_type,
+      access: :read,
+      resource_type: :report,
+      resource_name: :_all_reports_,
+      current_admin: @admin
+    )
+
+    # Grant the user roles and UACs to produce test data in the reports
+    create_user_role 'editor', user: @user, app_type: @user.app_type
+    create_user_role 'viewer', user: @user, app_type: @user.app_type
+
+    # Direct (user-specific) UAC
+    Admin::UserAccessControl.create!(
+      app_type: @user.app_type,
+      user: @user,
+      access: :create,
+      resource_type: :table,
+      resource_name: :player_infos,
+      current_admin: @admin
+    )
+
+    # Role-based UAC
+    Admin::UserAccessControl.create!(
+      app_type: @user.app_type,
+      access: :update,
+      resource_type: :table,
+      resource_name: :player_infos,
+      role_name: 'editor',
+      current_admin: @admin
+    )
+
+    # Another role-based UAC
+    Admin::UserAccessControl.create!(
+      app_type: @user.app_type,
+      access: :read,
+      resource_type: :table,
+      resource_name: :addresses,
+      role_name: 'viewer',
+      current_admin: @admin
+    )
+  end
+
+  def navigate_to_report(short_name)
+    report = Report.active.find_by(item_type: 'admin-user-access-overview', short_name: short_name)
+    expect(report).to be_present, "Report '#{short_name}' not found"
+    visit report_path(report)
+    finish_page_loading
+    report
+  end
+
+  def submit_report
+    within '#report_query_form' do
+      click_button 'table'
+    end
+    expect(page).to have_css('.search-status-done', wait: 15)
+    finish_page_loading
+  end
+
+  describe 'admin index page' do
+    before(:example) do
+      make_an_admin
+      admin_sign_in_with_2fa
+    end
+
+    it 'shows User Access Overview link under Users & Access' do
+      visit '/'
+      finish_page_loading
+
+      expect(page).to have_link('User Access Overview')
+    end
+  end
+
+  describe 'report pages' do
+    before(:example) do
+      setup_report_user_with_roles
+      login
+    end
+
+    describe 'By Role report (P1)' do
+      it 'has correct search criteria fields' do
+        navigate_to_report('user_access_overview_by_role')
+
+        expect(page).to have_css('.report-criteria')
+
+        # Verify all search criteria fields are present
+        expect(page).to have_css('[name="search_attrs[app_type_id]"]', visible: :all)
+        expect(page).to have_css('[name="search_attrs[user]"]', visible: :all)
+        expect(page).to have_css('[name="search_attrs[resource_type]"]', visible: :all)
+        expect(page).to have_css('[name="search_attrs[resource_name]"]', visible: :all)
+        expect(page).to have_css('[name="search_attrs[role_name]"]', visible: :all)
+      end
+
+      it 'returns results with specific user criteria' do
+        navigate_to_report('user_access_overview_by_role')
+
+        # Select the test user from the user dropdown
+        select_from_dropdown_field('user', @user.email, is_report: true)
+
+        submit_report
+
+        expect(page).to have_css('.report-results-block')
+        # Tree view should have a table with tree-table class
+        expect(page).to have_css('table.tree-table')
+
+        # Should have data rows
+        expect(page).to have_css('table.tree-table tbody tr')
+      end
+
+      it 'returns no results when user is not selected (mandatory)' do
+        navigate_to_report('user_access_overview_by_role')
+
+        # Clear the user field and submit with just the default app_type
+        # P1 requires user, so should show no results
+        submit_report
+
+        expect(page).to have_css('.report-results-block')
+        expect(page).not_to have_css('table.tree-table tbody tr')
+      end
+
+      it 'renders inline links in result cells' do
+        navigate_to_report('user_access_overview_by_role')
+
+        select_from_dropdown_field('user', @user.email, is_report: true)
+
+        submit_report
+
+        # Resource name cells should contain clickable admin links
+        within '.report-results-block' do
+          links = all('a[href*="/admin/"]')
+          expect(links.length).to be > 0,
+                                  'Expected inline admin links in report results'
+        end
+      end
+
+      it 'displays custom column headers' do
+        navigate_to_report('user_access_overview_by_role')
+
+        select_from_dropdown_field('user', @user.email, is_report: true)
+
+        submit_report
+
+        within '.report-results-block' do
+          # Check for custom column headers
+          expect(page).to have_content('Assigned via (role name)')
+          expect(page).to have_content('Resource Type')
+          expect(page).to have_content('Resource Name')
+          expect(page).to have_content('Access')
+        end
+      end
+    end
+
+    describe 'By Resource report (P2)' do
+      it 'returns results as a tree view' do
+        navigate_to_report('user_access_overview_by_resource')
+
+        select_from_dropdown_field('user', @user.email, is_report: true)
+
+        submit_report
+
+        expect(page).to have_css('table.tree-table')
+        expect(page).to have_css('table.tree-table tbody tr')
+      end
+    end
+
+    describe 'Resolved report (P3)' do
+      it 'returns results as a tree view' do
+        navigate_to_report('user_access_overview_resolved')
+
+        select_from_dropdown_field('user', @user.email, is_report: true)
+
+        submit_report
+
+        expect(page).to have_css('.report-results-block')
+        expect(page).to have_css('table.tree-table')
+        expect(page).to have_css('table.tree-table tbody tr')
+      end
+
+      it 'displays Resolved via (role name) header' do
+        navigate_to_report('user_access_overview_resolved')
+
+        select_from_dropdown_field('user', @user.email, is_report: true)
+
+        submit_report
+
+        within '.report-results-block' do
+          expect(page).to have_content('Resolved via (role name)')
+        end
+      end
+    end
+
+    describe 'Roles Only report (P4)' do
+      it 'returns results as a tree view grouped by user email' do
+        navigate_to_report('user_access_overview_roles_only')
+
+        select_from_dropdown_field('user', @user.email, is_report: true)
+
+        submit_report
+
+        expect(page).to have_css('table.tree-table')
+        expect(page).to have_css('table.tree-table tbody tr')
+
+        # The tree should contain the test user's email
+        within '.report-results-block' do
+          expect(page).to have_content(@user.email)
+        end
+      end
+
+      it 'returns results with default app_type and no user selected (user is optional)' do
+        navigate_to_report('user_access_overview_roles_only')
+
+        # P4 has app_type_id defaulted to current user's app type; user is optional
+        submit_report
+
+        expect(page).to have_css('table.tree-table tbody tr')
+      end
+    end
+
+    describe 'Users With Role report (P5)' do
+      it 'returns results as a tree view grouped by role name' do
+        navigate_to_report('user_access_overview_users_with_role')
+
+        submit_report
+
+        expect(page).to have_css('table.tree-table')
+        expect(page).to have_css('table.tree-table tbody tr')
+      end
+
+      it 'filters by user when provided' do
+        navigate_to_report('user_access_overview_users_with_role')
+
+        select_from_dropdown_field('user', @user.email, is_report: true)
+
+        submit_report
+
+        expect(page).to have_css('table.tree-table')
+        within '.report-results-block' do
+          expect(page).to have_content(@user.email)
+        end
+      end
+    end
+
+    describe 'filter_selector interaction' do
+      it 'updates resource_name options when resource_type is selected' do
+        navigate_to_report('user_access_overview_by_role')
+
+        # Verify the filter_selector attribute is set on the resource_type field
+        resource_type_select = find('[name="search_attrs[resource_type]"]', visible: :all)
+        expect(resource_type_select['data-filter-selector']).to eq('resource_name')
+
+        # Select a resource_type value
+        select_from_dropdown_field('resource_type', 'table', is_report: true)
+        sleep 0.5
+
+        # After selecting resource_type, resource_name should have its
+        # data-big-select-subtype attribute updated
+        resource_name_select = find('[name="search_attrs[resource_name]"]', visible: :all)
+        updated_subtype = resource_name_select['data-big-select-subtype']
+        expect(updated_subtype).to eq('table'),
+                                   "Expected resource_name subtype to be 'table', got '#{updated_subtype}'"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements GitHub issue #706: Provides admin reports showing all access controls for a user within an app type, from five complementary perspectives. Uses Option A (seeded SQL reports with tree views).

### Changes

- **5 seeded SQL reports** in `db/seeds/report_user_access_overview.rb`:
  - **P1 (By Role)**: UACs grouped by role name or direct assignment
  - **P2 (By Resource)**: UACs grouped by resource type/name
  - **P3 (Resolved)**: One effective UAC per resource after priority resolution (`DISTINCT ON`)
  - **P4 (Roles Listed by User)**: User's assigned roles (user optional, app_type mandatory)
  - **P5 (Users Listed by Role)**: Users with a role assigned (user optional, app_type mandatory)
- **Migration** to seed reports on deploy
- **Admin index link** gated by `can_admin?(:user_roles) && can_admin?(:user_access_controls)`
- **Reports controller** enhanced to allow admin-filtered item_type bypass
- **Reports helper** added `group_by` support for `select_from_model` search attributes
- **SearchAttributesConfig** added `group_by` attribute
- **SCSS** for tree column styling
- **64 model specs** covering all perspectives, filtering, ordering, nil params, access control
- **System specs** covering admin index link, all 5 perspectives, filter_selector interaction

### Acceptance Criteria Coverage

| AC | Status |
|---|---|
| AC1: Admin index link | Done |
| AC2: Requires app_type + user | Done (P1-P3 mandatory; P4-P5 user optional) |
| AC3-AC6: All 4+ perspectives | Done (5 perspectives) |
| AC7: Optional resource/role filters | Done |
| AC8: Inline admin links | Done |
| AC9: Priority ordering | Done |
| AC10: Admin-only access | Done |
| AC11: RSpec specs | Done (64 model + 13 system) |
