### PR TITLE
Fixed parallel test failures in specs

### DIFF
--- a/spec/models/option_configs/parsed_options_text_spec.rb
+++ b/spec/models/option_configs/parsed_options_text_spec.rb
@@ -20,6 +20,27 @@ RSpec.describe OptionConfigs::ExtraOptions, '.parsed_options_text', type: :model
 
   before :all do
     change_setting('AllowDynamicMigrations', true)
+    create_admin
+    create_user
+
+    # Create the DynamicModel and its table once to avoid migration timeouts in parallel tests
+    DynamicModel.active.where(table_name: 'test_parsed_opts').reload.each { |d| d.disable!(@admin) }
+    DynamicModel.send(:remove_const, :TestParsedOpt) if DynamicModel.const_defined?(:TestParsedOpt, false)
+
+    @dm_for_parsed_opts = DynamicModel.create!(
+      current_admin: @admin,
+      name: 'test parsed opts',
+      table_name: 'test_parsed_opts',
+      schema_name: 'dynamic_test',
+      primary_key_name: :id,
+      foreign_key_name: :master_id,
+      category: :test,
+      field_list: 'field_1 field_2',
+      options: nil
+    )
+
+    # Disable migrations now that the table exists - subsequent saves only update options
+    change_setting('AllowDynamicMigrations', false)
   end
 
   after :all do
@@ -223,21 +244,16 @@ RSpec.describe OptionConfigs::ExtraOptions, '.parsed_options_text', type: :model
 
   private
 
-  # Create a DynamicModel definition with the given options YAML for testing
+  # Update the existing DynamicModel definition with the given options YAML for testing.
+  # The table was created once in before(:all) to avoid migration timeouts in parallel tests.
+  # Uses update_columns to bypass callbacks (including migration handler) since only
+  # the options text needs to change, not the underlying table structure.
   def generate_dm_with_options(options_yaml)
-    DynamicModel.active.where(table_name: 'test_parsed_opts').reload.each { |d| d.disable!(@admin) }
     DynamicModel.send(:remove_const, :TestParsedOpt) if DynamicModel.const_defined?(:TestParsedOpt, false)
 
-    DynamicModel.create!(
-      current_admin: @admin,
-      name: 'test parsed opts',
-      table_name: 'test_parsed_opts',
-      schema_name: 'dynamic_test',
-      primary_key_name: :id,
-      foreign_key_name: :master_id,
-      category: :test,
-      field_list: 'field_1 field_2',
-      options: options_yaml
-    )
+    dm = @dm_for_parsed_opts
+    dm.update_columns(options: options_yaml, updated_at: Time.now)
+    dm.reload
+    dm
   end
 end

--- a/spec/support/feature_support.rb
+++ b/spec/support/feature_support.rb
@@ -314,15 +314,23 @@ module FeatureSupport
   # Expand a master record tab (such as "details", "external ids", "phone log", etc) by name
   # This avoids the need to explicitly get `a[data-panel-tab="<name>"]` and click it.
   # Expectations are also enforced to ensure the tab shows.
-  def expand_master_record_tab(name)
+  def expand_master_record_tab(name, master_id: nil)
     finish_form_formatting
     tab_selector = "a[data-panel-tab='#{name.id_underscore}']"
-    unless page.has_css?(tab_selector, visible: :all, wait: 15)
+
+    # Scope to a specific master container when master_id is provided
+    scoped_selector = if master_id
+                        "#master-#{master_id}-main-container #{tab_selector}"
+                      else
+                        tab_selector
+                      end
+
+    unless page.has_css?(scoped_selector, visible: :all, wait: 15)
       available_tabs = all('a[data-panel-tab]', visible: :all, wait: 0).map { |tab| tab['data-panel-tab'] }.uniq
       raise "Could not find panel tab #{name.id_underscore.inspect}. Available tabs: #{available_tabs.join(', ')}"
     end
 
-    tab_link = find(tab_selector, visible: :all, wait: 0)
+    tab_link = all(scoped_selector, visible: :all, wait: 0).first
     expect(tab_link).not_to be nil
     scroll_into_view(tab_link)
     tab_link.click if tab_link['aria-expanded'] != 'true'
@@ -338,7 +346,7 @@ module FeatureSupport
   def expand_master_record_and_tab(master_id:, tab_name:)
     expand_master_record(master_id:)
     expect(page).to have_css("#master-#{master_id}-main-container.in", wait: 10)
-    expand_master_record_tab(tab_name)
+    expand_master_record_tab(tab_name, master_id:)
   end
 
   def disable_active_panel_layout(panel_name, app_type: @app_type, admin: @admin, reload_routes: false)

--- a/spec/system/admin/admin_parsed_config_spec.rb
+++ b/spec/system/admin/admin_parsed_config_spec.rb
@@ -15,11 +15,21 @@ describe 'admin parsed config display', js: true, driver: $browser_driver do
 
   describe 'dynamic models' do
     it 'displays parsed config tab with line numbers' do
-      # Find any existing dynamic model to test with
+      # Find a dynamic model and ensure it has option types that produce parsed config output
       dm = DynamicModel.active.first
+      expect(dm).not_to be nil
 
-      # Skip test if no dynamic models exist
-      skip 'No active dynamic models found' unless dm
+      # Set up options with actual config so parsed_options_text produces output
+      dm.current_admin = @admin
+      dm.options = <<~YAML
+        default:
+          labels:
+            field_1: Test Field
+          view_options:
+            data_attribute: field_1
+      YAML
+      dm.updated_at = Time.now
+      dm.save!
 
       admin_sign_in_with_2fa
 
@@ -38,8 +48,15 @@ describe 'admin parsed config display', js: true, driver: $browser_driver do
       click_link 'Parsed Config'
       expect(page).to have_css('#parsed-config', visible: true)
 
-      # Wait for CodeMirror to render
-      expect(page).to have_css('#parsed-config .CodeMirror', wait: 5)
+      # Wait for CodeMirror to render (may need time for JS initialization after tab switch)
+      expect(page).to have_css('#parsed-config .CodeMirror', wait: 10)
+
+      # Verify merged YAML content is displayed with CodeMirror
+      within '#parsed-config .CodeMirror' do
+        content = page.text
+        expect(content.length).to be > 10
+        expect(content).to match(/:\s/)
+      end
 
       # Verify merged YAML content is displayed with CodeMirror
       within '#parsed-config .CodeMirror' do
@@ -56,7 +73,7 @@ describe 'admin parsed config display', js: true, driver: $browser_driver do
       # Find or use a dynamic model (all should have at least some config after parsing)
       dm = DynamicModel.active.first
 
-      skip 'No active dynamic models found' unless dm
+      expect(dm).not_to be nil
 
       admin_sign_in_with_2fa
 
@@ -207,7 +224,7 @@ describe 'admin parsed config display', js: true, driver: $browser_driver do
       # Use any existing dynamic model (they all should work)
       dm = DynamicModel.active.first
 
-      skip 'No active dynamic models found' unless dm
+      expect(dm).not_to be nil
 
       admin_sign_in_with_2fa
 

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -161,13 +161,18 @@ describe 'advanced search', js: true, driver: $browser_driver do
 
     expect(sprot.length).to be > 0
 
-    protocol = pick_one_from(sprot)
-    sp = pick_one_from(protocol.sub_processes.active)
+    # Use a protocol and sub_process that have existing tracker records to avoid flaky empty results
+    selectable_ids = sprot.pluck(:id)
+    tracker_with_data = Tracker.where(protocol_id: selectable_ids).where.not(sub_process_id: nil).first
+    expect(tracker_with_data).to be_present, 'Expected at least one tracker record with a selectable protocol and sub_process'
+    protocol = tracker_with_data.protocol
+    sp = tracker_with_data.sub_process
     has_css? '#master_trackers_attributes_0_sub_process_id'
 
     within '#advanced_search_master' do
       select protocol.name, from: 'master_trackers_attributes_0_protocol_id'
-      select sp.name, from: 'master_trackers_attributes_0_sub_process_id'
+      # Use option value (id) to avoid ambiguity when multiple sub_processes share the same name
+      find('#master_trackers_attributes_0_sub_process_id').find("option[value='#{sp.id}']").select_option
     end
 
     # wait a while, maybe

--- a/spec/system/external_identifier/external_ids_panel_on_open_click_spec.rb
+++ b/spec/system/external_identifier/external_ids_panel_on_open_click_spec.rb
@@ -121,7 +121,7 @@ describe 'external ids panel on-open-click mechanism', js: true, driver: $browse
     expect(page).to have_css("#master-#{master3.id}-main-container.in", wait: 10)
     finish_form_formatting
 
-    expand_master_record_tab('external ids')
+    expand_master_record_tab('external ids', master_id: master3.id)
     finish_page_loading
 
     # Verify master 3 external IDs are loaded
@@ -137,7 +137,7 @@ describe 'external ids panel on-open-click mechanism', js: true, driver: $browse
     expect(page).to have_css("#master-#{master1.id}-main-container.in", wait: 10)
     finish_form_formatting
 
-    expand_master_record_tab('external ids')
+    expand_master_record_tab('external ids', master_id: master1.id)
     finish_page_loading
 
     # Verify master 1 external IDs are loaded
@@ -153,7 +153,7 @@ describe 'external ids panel on-open-click mechanism', js: true, driver: $browse
     expect(page).to have_css("#master-#{master3.id}-main-container.in", wait: 10)
     finish_form_formatting
 
-    expand_master_record_tab('external ids')
+    expand_master_record_tab('external ids', master_id: master3.id)
     finish_page_loading
 
     # THIS IS THE CRITICAL CHECK - the panel should have content when returning
@@ -169,7 +169,7 @@ describe 'external ids panel on-open-click mechanism', js: true, driver: $browse
     expect(page).to have_css("#master-#{master2.id}-main-container.in", wait: 10)
     finish_form_formatting
 
-    expand_master_record_tab('external ids')
+    expand_master_record_tab('external ids', master_id: master2.id)
     finish_page_loading
 
     ext_panel_2 = find("#external-ids-#{master2.id}", visible: :all)
@@ -184,7 +184,7 @@ describe 'external ids panel on-open-click mechanism', js: true, driver: $browse
     expect(page).to have_css("#master-#{master1.id}-main-container.in", wait: 10)
     finish_form_formatting
 
-    expand_master_record_tab('external ids')
+    expand_master_record_tab('external ids', master_id: master1.id)
     finish_page_loading
 
     ext_panel_1_revisit = find("#external-ids-#{master1.id}", visible: :all)
@@ -211,7 +211,7 @@ describe 'external ids panel on-open-click mechanism', js: true, driver: $browse
     finish_form_formatting
 
     # Click the external IDs tab to expand the panel
-    expand_master_record_tab('external ids')
+    expand_master_record_tab('external ids', master_id: master1.id)
     finish_page_loading
 
     # The panel should now be expanded - wait for it

--- a/spec/system/external_identifier/external_ids_panel_switch_spec.rb
+++ b/spec/system/external_identifier/external_ids_panel_switch_spec.rb
@@ -101,7 +101,7 @@ describe 'external ids panel switching between participants', js: true, driver: 
       finish_form_formatting
 
       # Expand the external ids tab using helper
-      expand_master_record_tab('external ids')
+      expand_master_record_tab('external ids', master_id: master.id)
       finish_page_loading
 
       # Verify the external ids panel is shown and has content
@@ -124,7 +124,7 @@ describe 'external ids panel switching between participants', js: true, driver: 
         expect(page).to have_css("#master-#{master.id}-main-container.in", wait: 10)
 
         # Expand external ids tab using helper
-        expand_master_record_tab('external ids')
+        expand_master_record_tab('external ids', master_id: master.id)
         finish_page_loading
 
         # Verify panel has content


### PR DESCRIPTION
## Summary

Fixed 12 parallel test failures across 6 spec files. All 21 previously failing specs now pass with 0 failures when run together.

### Changes

- **spec/support/feature_support.rb**: `expand_master_record_tab` now accepts optional `master_id:` parameter to scope CSS selectors to `#master-{id}-main-container`, avoiding ambiguous matches when multiple master records are displayed
- **spec/models/option_configs/parsed_options_text_spec.rb**: Creates DM table once in `before(:all)`, uses `update_columns` to update options without triggering migration callbacks, preventing migration timeouts under parallel load
- **spec/system/admin/admin_parsed_config_spec.rb**: Sets up DM with real option types before testing parsed config tab so `parsed_options_text` returns valid YAML
- **spec/system/advanced_search_spec.rb**: Selects dropdown option by value instead of text to avoid ambiguity; picks protocol/sub_process with known tracker data instead of random selection via `pick_one_from`
- **spec/system/external_identifier/external_ids_panel_on_open_click_spec.rb**: Updated `expand_master_record_tab` calls to pass `master_id:` parameter
- **spec/system/external_identifier/external_ids_panel_switch_spec.rb**: Updated `expand_master_record_tab` calls to pass `master_id:` parameter