### PR TITLE
Fixed YAML safe_load to permit Date and Time classes during app type import - fixes #4

### DIFF
--- a/app/models/admin/app_type_import.rb
+++ b/app/models/admin/app_type_import.rb
@@ -213,7 +213,7 @@ class Admin
       when :json
         config = JSON.parse(config_text)
       when :yaml
-        config = YAML.safe_load(config_text)
+        config = YAML.safe_load(config_text, permitted_classes: [Date, Time], permitted_symbols: [])
       when :raw
         config = config_text.deep_stringify_keys
       else

--- a/spec/models/admin/app_type_import_spec.rb
+++ b/spec/models/admin/app_type_import_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 # Tests for Admin::AppType import functionality.
-# Verifies that import_config correctly creates app types from exported JSON,
+# Verifies that import_config correctly creates app types from exported JSON and YAML,
 # including app configurations, user access controls, activity logs,
 # config libraries, and item flag names.
+# Also verifies that YAML import handles unquoted dates and YAML round-trip (export/import).
 
 require 'rails_helper'
 
@@ -107,7 +108,6 @@ RSpec.describe 'Import an app configuration', type: :model do
 
     @activity_log = ActivityLog.active.first
 
-    al_orig_name = @activity_log.name
     @activity_log.name = "Changed #{rand}!"
     @activity_log.current_admin = @admin
     @activity_log.disabled = false
@@ -142,7 +142,6 @@ RSpec.describe 'Import an app configuration', type: :model do
     expect(@user.has_access_to?(:read, :table, :sage_assignments)).to be_truthy
 
     @activity_log.reload
-    # expect(@activity_log.name).to eq al_orig_name
   end
 
   it 'imports a test JSON config file' do
@@ -364,5 +363,55 @@ RSpec.describe 'Import an app configuration', type: :model do
 
     # Cleanup
     res.update(disabled: true, current_admin: @admin)
+  end
+
+  it 'imports a YAML configuration exported from an app type' do
+    config_yaml = @app_type.export_config(format: :yaml)
+
+    res, results = Admin::AppTypeImport.import_config(config_yaml, @admin, name: 'yaml_import_test', format: :yaml)
+
+    expect(results).to be_a Hash
+    expect(res).to be_a Admin::AppType
+    expect(res.name).to eq 'yaml_import_test'
+    expect(res.label).to eq 'Test App 12'
+
+    acs = Admin::AppConfiguration.where app_type: res
+    expect(acs.length).to eq 3
+
+    ac = Admin::AppConfiguration.where(app_type: res, name: 'create master with').first
+    expect(ac.value).to eq 'player_info'
+  end
+
+  it 'imports a YAML configuration containing unquoted date values' do
+    yaml_with_dates = <<~YAML
+      app_type:
+        name: yaml_dates_test
+        label: YAML Dates Test
+        default_schema_name: ml_app
+        created_at: 2020-11-11
+        updated_at: 2020-07-27 13:25:11
+        app_configurations:
+        - name: create master with
+          value: player_info
+          created_at: 2020-11-11
+          updated_at: 2020-11-11
+    YAML
+
+    res, results = Admin::AppTypeImport.import_config(yaml_with_dates, @admin, format: :yaml)
+
+    expect(results).to be_a Hash
+    expect(res).to be_a Admin::AppType
+    expect(res.name).to eq 'yaml_dates_test'
+    expect(res.label).to eq 'YAML Dates Test'
+  end
+
+  it 'imports the zeus config YAML file successfully' do
+    config_text = File.read(Rails.root.join('db', 'dumps', 'zeus_config.yaml'))
+
+    res, results = Admin::AppTypeImport.import_config(config_text, @admin, format: :yaml, skip_fail: true)
+
+    expect(results).to be_a Hash
+    expect(res).to be_a Admin::AppType
+    expect(res.name).to eq 'zeus'
   end
 end


### PR DESCRIPTION
## Summary

Fixes the `Psych::DisallowedClass` error when importing app type YAML configurations containing unquoted date/time values (e.g. `created_at: 2020-11-11`). This was reported as a failure when importing `zeus_config.yaml` during initial setup.

### Root Cause

`YAML.safe_load` in `Admin::AppTypeImport#app_type_config` was called without `permitted_classes`, causing it to reject `Date` and `Time` objects that YAML auto-parses from unquoted date strings.

### Changes

- **`app/models/admin/app_type_import.rb`**: Added `permitted_classes: [Date, Time], permitted_symbols: []` to `YAML.safe_load`, matching the pattern used in `OptionsHandler` and `ExtraOptions`
- **`spec/models/admin/app_type_import_spec.rb`**: Added 3 new tests:
  - YAML round-trip (export as YAML then re-import)
  - YAML with unquoted date values (the actual failure case)
  - Import of the real `db/dumps/zeus_config.yaml` file

### Security

- Still uses `YAML.safe_load` (not `YAML.load`/`YAML.unsafe_load`)
- Only safe, non-executable classes (`Date`, `Time`) are permitted
- `permitted_symbols: []` explicitly blocks Symbol deserialization

Fixes #4