### PR TITLE
Added private and immutable Cache-Control headers to cached endpoints - fixes #63

### DIFF
--- a/app/controllers/activity_log/activity_logs_controller.rb
+++ b/app/controllers/activity_log/activity_logs_controller.rb
@@ -18,8 +18,7 @@ class ActivityLog::ActivityLogsController < UserBaseController
     Application.refresh_dynamic_defs
 
     cache_key = Digest::SHA256.hexdigest(helpers.partial_cache_key("activity-log-template-config-#{@item_type}-#{@id_list}"))
-    response.headers['Cache-Control'] = 'max-age=30'
-    response.headers.delete 'Expires'
+    set_browser_cache(max_age: 30)
     return unless stale?(etag: cache_key)
 
     refresh_embedded_item_for @instance_list
@@ -87,7 +86,7 @@ class ActivityLog::ActivityLogsController < UserBaseController
   end
 
   def item_type_id
-    "#{item_type_us}_id".to_sym
+    :"#{item_type_us}_id"
   end
 
   def item_type_us

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -11,8 +11,7 @@ class Admin::ReportsController < AdminController
 
   def search_attr_definer
     cache_key = Digest::SHA256.hexdigest(helpers.partial_cache_key('report_search_attr_definer'))
-    response.headers['Cache-Control'] = "max-age=#{SearchAttrBrowserCacheSeconds}"
-    response.headers.delete 'Expires'
+    set_browser_cache(max_age: SearchAttrBrowserCacheSeconds)
     return unless stale?(etag: cache_key)
 
     render partial: 'admin/reports/form/search_attr_definer'
@@ -68,9 +67,7 @@ class Admin::ReportsController < AdminController
     %i[name item_type category report_type auto searchable admin_id]
   end
 
-  def embedded_report
-    @embedded_report
-  end
+  attr_reader :embedded_report
 
   def search_attrs_params_hash
     @search_attrs_params_hash ||= if params[:search_attrs].blank?

--- a/app/controllers/concerns/controller_utils.rb
+++ b/app/controllers/concerns/controller_utils.rb
@@ -10,6 +10,17 @@ module ControllerUtils
     response.headers['Expires'] = 'Fri, 01 Jan 1990 00:00:00 GMT'
   end
 
+  # Set browser cache headers for user/admin-specific content.
+  # Always includes 'private' to prevent WAFs/proxies from caching sensitive data.
+  # Expires is computed automatically from max_age for HTTP/1.0 client compatibility.
+  # Use immutable: true for responses where the URL changes on content change (cache busting by URL).
+  def set_browser_cache(max_age:, immutable: false)
+    directives = "private, max-age=#{max_age}"
+    directives += ', immutable' if immutable
+    response.headers['Cache-Control'] = directives
+    response.headers['Expires'] = (Time.now + max_age).httpdate
+  end
+
   def params_nil_if_blank(p)
     p1 = p.dup
     p.each do |k, v|

--- a/app/controllers/concerns/master_handler.rb
+++ b/app/controllers/concerns/master_handler.rb
@@ -33,8 +33,7 @@ module MasterHandler
   # so simply add a parameter like :cache_version => current timestamp to force new data
   def index
     index_res = if params[:cache_result].present?
-                  response.headers['Cache-Control'] = 'max-age=30'
-                  response.headers.delete 'Expires'
+                  set_browser_cache(max_age: 30)
                   return unless stale?(etag: index_cache_key)
 
                   Rails.cache.fetch(index_cache_key) do

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -65,8 +65,7 @@ class PagesController < ApplicationController
 
     etag = Digest::SHA256.hexdigest(helpers.partial_cache_key(:master__search_results_template))
     if current_user
-      response.headers['Cache-Control'] = 'max-age=604800'
-      response.headers['Expires'] = 'Fri, 01 Jan 2090 00:00:00 GMT'
+      set_browser_cache(max_age: 604_800, immutable: true)
       return unless stale?(etag: etag)
 
       render partial: 'masters/cache_search_results_template'

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Admin::ReportsController Spec (issue #63)
+#
+# Tests the search_attr_definer action cache headers.
+# The action should set private Cache-Control headers to prevent WAFs
+# from caching admin-specific content.
+
+require 'rails_helper'
+
+RSpec.describe Admin::ReportsController, type: :controller do
+  include MasterSupport
+
+  before_each_login_admin
+
+  describe '#search_attr_definer (issue #63)' do
+    it 'sets Cache-Control with private and max-age' do
+      get :search_attr_definer
+
+      cache_control = response.headers['Cache-Control']
+      expect(cache_control).to include('private')
+      expect(cache_control).to include("max-age=#{48.hours.to_i}")
+      expect(cache_control).not_to include('immutable')
+    end
+  end
+end

--- a/spec/controllers/concerns/controller_utils_spec.rb
+++ b/spec/controllers/concerns/controller_utils_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# ControllerUtils Concern Spec (issue #63)
+#
+# Tests the set_browser_cache method added to support private cache headers
+# for user/admin-specific content, preventing WAFs from caching sensitive data.
+#
+# Test Coverage:
+# - set_browser_cache sets Cache-Control with private and max-age directives
+# - set_browser_cache sets Expires header computed from max_age
+# - set_browser_cache adds immutable directive when requested
+# - set_browser_cache does not add immutable by default
+
+require 'rails_helper'
+
+RSpec.describe ControllerUtils, type: :controller do
+  include ModelSupport
+
+  # Use MastersController as a concrete controller that includes ControllerUtils
+  controller(MastersController) do
+    # Inherits all behavior from MastersController
+  end
+
+  before_each_login_user
+
+  describe '#set_browser_cache' do
+    it 'sets Cache-Control with private and max-age directives' do
+      get :index
+      subject.send(:set_browser_cache, max_age: 300)
+
+      cache_control = response.headers['Cache-Control']
+      expect(cache_control).to include('private')
+      expect(cache_control).to include('max-age=300')
+    end
+
+    it 'sets Expires header computed from max_age' do
+      get :index
+      freeze_time = Time.now
+      allow(Time).to receive(:now).and_return(freeze_time)
+      subject.send(:set_browser_cache, max_age: 300)
+
+      expect(response.headers['Expires']).to eq((freeze_time + 300).httpdate)
+    end
+
+    it 'adds immutable directive when requested' do
+      get :index
+      subject.send(:set_browser_cache, max_age: 604_800, immutable: true)
+
+      cache_control = response.headers['Cache-Control']
+      expect(cache_control).to include('private')
+      expect(cache_control).to include('max-age=604800')
+      expect(cache_control).to include('immutable')
+    end
+
+    it 'does not add immutable by default' do
+      get :index
+      subject.send(:set_browser_cache, max_age: 30)
+
+      expect(response.headers['Cache-Control']).not_to include('immutable')
+    end
+  end
+end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -5,16 +5,18 @@
 # Tests for the PagesController actions:
 # - Admin page: renders the admin index page
 # - User page: redirects to search page
-# - Template action (issue #1004 - AC10):
+# - Template action (issue #1004 - AC10, issue #63):
 #   - Returns 304 Not Modified when ETag matches (If-None-Match header)
 #   - Returns 200 with content on cache miss
-#   - Sets appropriate Cache-Control headers for browser caching
+#   - Sets Cache-Control with private, max-age, and immutable directives
+#   - Sets Expires header computed from max-age
 
 require 'rails_helper'
 
 RSpec.describe PagesController, type: :controller do
   describe 'admin page' do
     include MasterSupport
+
     before_each_login_admin
 
     it 'shows the admin menu page' do
@@ -26,6 +28,7 @@ RSpec.describe PagesController, type: :controller do
 
   describe 'user page' do
     include MasterSupport
+
     before_each_login_user
 
     it 'redirects to search page' do
@@ -35,14 +38,16 @@ RSpec.describe PagesController, type: :controller do
   end
 
   # AC10: ETag / 304 behavior for the template action (issue #1004)
+  # Issue #63: Add Cache-Control: private and immutable directives
   #
   # The template action should:
   # - Return 200 with rendered content on first request (cache miss)
-  # - Set Cache-Control max-age and Expires headers for long-lived browser caching
+  # - Set Cache-Control with private, max-age, and immutable for browser caching
   # - Return 304 Not Modified when the client sends a matching If-None-Match ETag
   # - Return 200 with fresh content when the ETag does not match
-  describe '#template (ETag/304 caching - issue #1004)' do
+  describe '#template (ETag/304 caching - issue #1004, #63)' do
     include MasterSupport
+
     before_each_login_user
 
     let(:template_version) { Digest::SHA256.hexdigest('test-version') }
@@ -53,16 +58,20 @@ RSpec.describe PagesController, type: :controller do
       expect(response).to have_http_status(:ok)
     end
 
-    it 'sets Cache-Control header with max-age for browser caching' do
+    it 'sets Cache-Control header with private, max-age, and immutable for browser caching' do
       get :template, params: { id: template_version }
 
-      expect(response.headers['Cache-Control']).to include('max-age=')
+      cache_control = response.headers['Cache-Control']
+      expect(cache_control).to include('private')
+      expect(cache_control).to include('max-age=')
+      expect(cache_control).to include('immutable')
     end
 
-    it 'sets Expires header for far-future caching' do
+    it 'sets Expires header computed from max-age' do
       get :template, params: { id: template_version }
 
-      expect(response.headers['Expires']).to be_present
+      expires = Time.httpdate(response.headers['Expires'])
+      expect(expires).to be > Time.now
     end
 
     it 'includes an ETag in the response' do

--- a/spec/controllers/player_infos_controller_spec.rb
+++ b/spec/controllers/player_infos_controller_spec.rb
@@ -1,19 +1,47 @@
-require 'rails_helper'
-RSpec.describe PlayerInfosController, type: :controller do
+# frozen_string_literal: true
 
+# PlayerInfosController Spec
+#
+# Tests for the PlayerInfosController, which includes MasterHandler.
+# - Standard user controller behavior (shared examples)
+# - MasterHandler cached index sets private Cache-Control header (issue #63)
+
+require 'rails_helper'
+
+RSpec.describe PlayerInfosController, type: :controller do
   include PlayerInfoSupport
+
   def object_class
     PlayerInfo
   end
-  
+
   def item
     @player_info
   end
 
   def edit_form_prefix
-    @edit_form_prefix = "common_templates"
+    @edit_form_prefix = 'common_templates'
   end
-  
+
   it_behaves_like 'a standard user controller'
-  
+
+  # Issue #63: MasterHandler cached index should set private Cache-Control header
+  describe 'GET #index with cache_result (issue #63)' do
+    before_each_login_user
+
+    before :each do
+      create_admin
+      setup_access :player_infos
+      create_items
+    end
+
+    it 'sets Cache-Control with private and max-age when cache_result is present' do
+      get :index, params: { master_id: @master_id, cache_result: true, format: :json }
+
+      cache_control = response.headers['Cache-Control']
+      expect(cache_control).to include('private')
+      expect(cache_control).to include('max-age=30')
+      expect(cache_control).not_to include('immutable')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds `Cache-Control: private` to all user/admin-specific cached endpoints to prevent WAFs (e.g. Imperva) from caching sensitive per-user data. Adds `immutable` to the template endpoint which uses URL-based cache busting. Computes `Expires` header automatically from `max-age`.

Resolves #63.

### Changes

- **New `set_browser_cache` helper** in `ControllerUtils` — centralizes cache header logic, always includes `private`, computes `Expires` from `max_age`, optionally adds `immutable`
- **`PagesController#template`** — `private, max-age=604800, immutable` (URL-based cache busting via template_version)
- **`MasterHandler#index`** — `private, max-age=30` (user-specific JSON)
- **`ActivityLogsController#template_config`** — `private, max-age=30` (user-specific templates)
- **`Admin::ReportsController#search_attr_definer`** — `private, max-age=172800` (admin-specific)

### Tests

- New `ControllerUtils` concern spec — 4 unit tests for `set_browser_cache` (private, expires, immutable, no-immutable-default)
- Updated `PagesController` spec — verifies `private`, `immutable`, computed `Expires`
- New `PlayerInfosController` spec — verifies MasterHandler cached index has `private, max-age=30`
- New `Admin::ReportsController` spec — verifies `private, max-age=172800`
- 30 examples, 0 failures"