### PR TITLE
Added support for arbitrary-length else-if and else-is conditional blocks - fixes #1061

### DIFF
--- a/app/assets/javascripts/app/_fpa_substitution.js
+++ b/app/assets/javascripts/app/_fpa_substitution.js
@@ -116,19 +116,21 @@ _fpa.substitution = class {
     text = text.replaceAll('{^{', '{{').replaceAll('}^}', '}}')
 
     const TagnameRegExString = '[0-9a-zA-Z_.:\-]+';
-    const IfBlockRegExString = `({{#if +(${TagnameRegExString})}}([^]+?)({{else if +(${TagnameRegExString})}}(.+?))?({{else}}([^]+?))?{{/if}})`;
+    const IfBlockRegExString = `({{#if +(${TagnameRegExString})}}([^]+?){{/if}})`;
     const StartQuote = `["'‘“]`
     const EndQuote = `["'’”]`
     const IsOperator = '(.+?)'
     const IsConditions = `([0-9a-zA-Z_.:-]+) ${StartQuote}${IsOperator}${EndQuote} (${StartQuote}?.+?${EndQuote}?)`
-    const IsBlockRegExString = `({{#is ${IsConditions}}}(.+?)({{else is ${IsConditions}}}(.+?))?({{else is ${IsConditions}}}(.+?))?({{else}}(.+?))?{{/is}})`;
+    const IsBlockRegExString = `({{#is ${IsConditions}}}(.+?){{/is}})`;
 
     // [^]+? if the Javascript way to get everything across multiple lines (non-greedy)
     const IfBlocksRegEx = new RegExp(IfBlockRegExString, 'gms');
     const IfBlockRegEx = new RegExp(IfBlockRegExString, 'ms');
     const IsBlocksRegEx = new RegExp(IsBlockRegExString, 'gms');
     const IsBlockRegEx = new RegExp(IsBlockRegExString, 'ms');
-    const MaxElseIfs = 2;
+    const ElseIfBoundaryRegEx = new RegExp(`{{else if +(${TagnameRegExString})}}`, 'ms');
+    const ElseRegEx = /{{else}}/ms;
+    const ElseIsBoundaryRegEx = new RegExp(`{{else is +${IsConditions}}}`, 'ms');
     const TagRegEx = new RegExp(`{{${TagnameRegExString}}}`, 'g');
 
     var ifres = text.match(IfBlocksRegEx);
@@ -139,28 +141,28 @@ _fpa.substitution = class {
 
       ifres.forEach(function (if_blocks) {
         const if_block = if_blocks.match(IfBlockRegEx);
+        if (!if_block) return;
+
         let block_container = if_block[0];
-        let tag = if_block[2]
-        let vpair = _this.value_for_tag(tag, new_data)
-        let tag_value = vpair[0];
-        let else_if_block = if_block[4];
-        let else_if_tag = if_block[5];
+        let initial_tag = if_block[2];
+        let inner_content = if_block[3] || '';
+        let parsed = _this.parse_if_clauses(initial_tag, inner_content, ElseIfBoundaryRegEx, ElseRegEx);
+        let clauses = parsed[0];
+        let else_content = parsed[1];
         let sub_text = null;
 
-        if (tag_value && tag_value.toString().length) {
-          sub_text = if_block[3] || ''
-        }
+        clauses.forEach(function (clause) {
+          if (sub_text != null) return;
+          let tag = clause[0];
+          let clause_content = clause[1];
+          let vpair = _this.value_for_tag(tag, new_data)
+          let tag_value = vpair[0];
+          if (tag_value && tag_value.toString().length) {
+            sub_text = clause_content || '';
+          }
+        });
 
-        if (sub_text == null && else_if_block) {
-          vpair = _this.value_for_tag(else_if_tag, new_data)
-          tag_value = vpair[0];
-          if (tag_value && tag_value.toString().length) sub_text = if_block[6] || '';
-        }
-
-        //  Handle {{else}}
-        if (sub_text == null)
-          sub_text = if_block[8] || ''
-
+        if (sub_text == null) sub_text = else_content || '';
         text = text.replace(block_container, sub_text || '');
       });
     }
@@ -172,45 +174,34 @@ _fpa.substitution = class {
 
       isres.forEach(function (is_blocks) {
         const is_block = is_blocks.match(IsBlockRegEx);
+        if (!is_block) return;
+
         let block_container = is_block[0];
-        let tag = is_block[2]
-        let vpair = _this.value_for_tag(tag, new_data)
-        let tag_value = vpair[0];
-        let op = is_block[3]
-        let exp = is_block[4]
-        let comp = _this.eval_is_comp(op, tag_value, exp, new_data)
+        let initial_tag = is_block[2]
+        let initial_op = is_block[3]
+        let initial_exp = is_block[4]
+        let inner_content = is_block[5] || '';
+        let parsed = _this.parse_is_clauses(initial_tag, initial_op, initial_exp, inner_content, ElseIsBoundaryRegEx, ElseRegEx);
+        let clauses = parsed[0];
+        let else_content = parsed[1];
         let sub_text = null;
 
-        if (comp) {
-          sub_text = is_block[5] || '';
-        }
-
-        let iters = 1
-        let start_pos = iters * 5 + 1
-        let else_is_block = is_block[start_pos]
-        while (!sub_text && else_is_block) {
-          let else_is_tag = is_block[start_pos + 1]
-          let else_is_op = is_block[start_pos + 2]
-          let else_is_exp = is_block[start_pos + 3]
-
-          vpair = _this.value_for_tag(else_is_tag, new_data)
-          let else_is_tag_value = vpair[0];
-          comp = _this.eval_is_comp(else_is_op, else_is_tag_value, else_is_exp, new_data)
+        clauses.forEach(function (clause) {
+          if (sub_text != null) return;
+          let tag = clause[0];
+          let op = clause[1];
+          let exp = clause[2];
+          let clause_content = clause[3];
+          let vpair = _this.value_for_tag(tag, new_data)
+          let tag_value = vpair[0];
+          let comp = _this.eval_is_comp(op, tag_value, exp, new_data)
           if (comp) {
-            sub_text = is_block[start_pos + 4] || ''
-            break;
+            sub_text = clause_content || '';
           }
-          iters++;
-          if (iters > MaxElseIfs) break;
+        });
 
-          start_pos = iters * 5 + 1;
-          else_is_block = is_block[start_pos];
-        }
-        // Handle {{else}}
-        if (sub_text == null) sub_text = is_block[17] || ''
-
+        if (sub_text == null) sub_text = else_content || '';
         text = text.replace(block_container, sub_text || '');
-
       });
     }
 
@@ -254,6 +245,82 @@ _fpa.substitution = class {
 
     return text;
   };
+
+  parse_if_clauses(initial_tag, inner_content, elseIfBoundaryRegEx, elseRegEx) {
+    let clauses = [];
+    let else_content = null;
+    let remaining = inner_content;
+    let current_tag = initial_tag;
+
+    while (remaining != null) {
+      let else_if_match = remaining.match(elseIfBoundaryRegEx);
+      let else_match = remaining.match(elseRegEx);
+      let next_boundary = null;
+
+      if (else_if_match && else_match) {
+        next_boundary = else_if_match.index < else_match.index ? 'else_if' : 'else';
+      } else if (else_if_match) {
+        next_boundary = 'else_if';
+      } else if (else_match) {
+        next_boundary = 'else';
+      }
+
+      if (next_boundary === 'else_if') {
+        clauses.push([current_tag, remaining.slice(0, else_if_match.index)]);
+        current_tag = else_if_match[1];
+        remaining = remaining.slice(else_if_match.index + else_if_match[0].length);
+      } else if (next_boundary === 'else') {
+        clauses.push([current_tag, remaining.slice(0, else_match.index)]);
+        else_content = remaining.slice(else_match.index + else_match[0].length);
+        break;
+      } else {
+        clauses.push([current_tag, remaining]);
+        break;
+      }
+    }
+
+    return [clauses, else_content];
+  }
+
+  parse_is_clauses(initial_tag, initial_op, initial_exp, inner_content, elseIsBoundaryRegEx, elseRegEx) {
+    let clauses = [];
+    let else_content = null;
+    let remaining = inner_content;
+    let current_tag = initial_tag;
+    let current_op = initial_op;
+    let current_exp = initial_exp;
+
+    while (remaining != null) {
+      let else_is_match = remaining.match(elseIsBoundaryRegEx);
+      let else_match = remaining.match(elseRegEx);
+      let next_boundary = null;
+
+      if (else_is_match && else_match) {
+        next_boundary = else_is_match.index < else_match.index ? 'else_is' : 'else';
+      } else if (else_is_match) {
+        next_boundary = 'else_is';
+      } else if (else_match) {
+        next_boundary = 'else';
+      }
+
+      if (next_boundary === 'else_is') {
+        clauses.push([current_tag, current_op, current_exp, remaining.slice(0, else_is_match.index)]);
+        current_tag = else_is_match[1];
+        current_op = else_is_match[2];
+        current_exp = else_is_match[3];
+        remaining = remaining.slice(else_is_match.index + else_is_match[0].length);
+      } else if (next_boundary === 'else') {
+        clauses.push([current_tag, current_op, current_exp, remaining.slice(0, else_match.index)]);
+        else_content = remaining.slice(else_match.index + else_match[0].length);
+        break;
+      } else {
+        clauses.push([current_tag, current_op, current_exp, remaining]);
+        break;
+      }
+    }
+
+    return [clauses, else_content];
+  }
 
   eval_is_comp(op, tag_value, exp, new_data) {
     const _this = this;

--- a/app/models/formatter/substitution.rb
+++ b/app/models/formatter/substitution.rb
@@ -5,21 +5,27 @@ module Formatter
     HtmlRegEx = /<(p|br|div|ul|hr|p .+=.+|br |div .+=.+|ul .+=.+|hr .+=.+)>/
     TagnameRegExString = '[0-9a-zA-Z_.:\-]+'
 
-    # Gets an array of 5 element arrays for each {(#if <tagname>}}true text{{else}}else text{{/if}}
-    # - the full matched block
-    # - tagname
-    # - true text
-    # - truthy if there is an {{else}}
-    # - else text
-    IfBlockRegEx = %r{({{#if +(#{TagnameRegExString})}}(.+?)({{else if +(#{TagnameRegExString})}}(.+?))?({{else}}(.+?))?{{/if}})}m
+    # Matches an if block: {{#if tagname}}content{{/if}}
+    # Content may include {{else if tagname}} and {{else}} clauses which are parsed iteratively
+    # Capture groups: [0] full match, [1] initial tag, [2] full inner content
+    IfBlockRegEx = %r{({{#if +(#{TagnameRegExString})}}(.+?){{/if}})}m
+
+    # Boundary regex for splitting {{else if tagname}} clauses within an if block
+    ElseIfBoundaryRegEx = /{{else if +(#{TagnameRegExString})}}/
 
     StartQuote = '["\'‘“]'
     EndQuote = '["\'’”]'
     NotEndQuote = '[^"\'’”]'
     IsOperator = '(.+?)'
-    MaxElseIfs = 2
     IsConditions = "([0-9a-zA-Z_.:-]+) +#{StartQuote}#{IsOperator}#{EndQuote} +(#{StartQuote}?.+?#{EndQuote}?)"
-    IsBlockRegEx = %r{({{#is +#{IsConditions}}}(.+?)?({{else is +#{IsConditions}}}(.+?))?({{else is +#{IsConditions}}}(.+?))?({{else}}(.+?))?{{/is}})}m
+
+    # Matches an is block: {{#is condition}}content{{/is}}
+    # Content may include {{else is condition}} and {{else}} clauses which are parsed iteratively
+    # Capture groups: [0] full match, [1] tag, [2] operator, [3] expression, [4] full inner content
+    IsBlockRegEx = %r{({{#is +#{IsConditions}}}(.+?){{/is}})}m
+
+    # Boundary regex for splitting {{else is condition}} clauses within an is block
+    ElseIsBoundaryRegEx = /{{else is +#{IsConditions}}}/
     OverrideTags = /^(embedded_report_|add_item_button_|glyphicon_|template_block_)/
 
     FunctionalDirectives = %w[shortlink].freeze
@@ -67,68 +73,47 @@ module Formatter
       # Only setup data if there are double curly brackets
       sub_data = setup_data(data) if all_content.index('{{')
 
-      # Replace each if block {{#if ...}}...(optional {{else}}...){{/if}}
+      # Replace each if block {{#if ...}}...(optional {{else if ...}}...)...(optional {{else}}...){{/if}}
       if_blocks = all_content.scan(IfBlockRegEx)
       if_blocks.each do |if_block|
         block_container = if_block[0]
-        tag = if_block[1]
-        tag_value = value_for_tag(tag, sub_data, tag_subs: nil, ignore_missing: true)
-        else_if_block = if_block[3]
-        else_if_tag = if_block[4]
+        initial_tag = if_block[1]
+        inner_content = if_block[2]
 
-        # Handle {{if}}
-        sub_text = if_block[2] || '' if tag_value.present?
+        clauses, else_content = parse_if_clauses(initial_tag, inner_content)
 
-        if !sub_text && else_if_block
-          else_if_tag_value = value_for_tag(else_if_tag, sub_data, tag_subs: nil, ignore_missing: true)
-          sub_text = if_block[5] || '' if else_if_tag_value.present?
+        sub_text = nil
+        clauses.each do |tag, clause_content|
+          tag_value = value_for_tag(tag, sub_data, tag_subs: nil, ignore_missing: true)
+          if tag_value.present?
+            sub_text = clause_content || ''
+            break
+          end
         end
 
-        # Handle {{else}}
-        sub_text ||= if_block[7] || ''
-
+        sub_text ||= else_content || ''
         all_content.sub!(block_container, sub_text)
       end
 
-      # Replace each if block {{#is ...}}...(optional {{else}}...){{/is}}
+      # Replace each is block {{#is ...}}...(optional {{else is ...}}...)...(optional {{else}}...){{/is}}
       is_blocks = all_content.scan(IsBlockRegEx)
       is_blocks.each do |is_block|
         block_container = is_block[0]
-        tag = is_block[1]
-        tag_value = value_for_tag(tag, sub_data, tag_subs: nil, ignore_missing: true, original_type: true)
-        op = is_block[2]
-        exp = is_block[3]
-        comp = eval_is_comp(op, tag_value, exp, sub_data, is_block:)
+        inner_content = is_block[4]
 
-        # Handle {{is}}
-        sub_text = is_block[4] || '' if comp
+        clauses, else_content = parse_is_clauses(is_block[1], is_block[2], is_block[3], inner_content)
 
-        iters = 1
-        start_pos = iters * 5
-        else_is_block = is_block[start_pos]
-        while !sub_text && else_is_block
-          else_is_tag = is_block[start_pos + 1]
-          else_is_op = is_block[start_pos + 2]
-          else_is_exp = is_block[start_pos + 3]
-          else_is_tag_value = value_for_tag(else_is_tag, sub_data, tag_subs: nil, ignore_missing: true,
-                                                                   original_type: true)
-          comp = eval_is_comp(else_is_op, else_is_tag_value, else_is_exp, sub_data, is_block:)
-
+        sub_text = nil
+        clauses.each do |tag, op, exp, clause_content|
+          tag_value = value_for_tag(tag, sub_data, tag_subs: nil, ignore_missing: true, original_type: true)
+          comp = eval_is_comp(op, tag_value, exp, sub_data, is_block: [block_container])
           if comp
-            sub_text = is_block[start_pos + 4] || ''
+            sub_text = clause_content || ''
             break
           end
-
-          iters += 1
-          break if iters > MaxElseIfs
-
-          start_pos = iters * 5
-          else_is_block = is_block[start_pos]
         end
 
-        # Handle {{else}}
-        sub_text ||= is_block[16] || ''
-
+        sub_text ||= else_content || ''
         all_content.sub!(block_container, sub_text)
       end
 
@@ -371,6 +356,98 @@ module Formatter
     end
 
     ##### The following methods are not intended for use outside this class ######
+
+    # Parse the inner content of an if block into an array of [tag, content] clauses
+    # and an optional else content string.
+    # @param initial_tag [String] the tag from the {{#if tag}} opener
+    # @param inner_content [String] everything between {{#if tag}} and {{/if}}
+    # @return [Array<Array(String, String)>, String|nil] clauses and else_content
+    def self.parse_if_clauses(initial_tag, inner_content)
+      clauses = []
+      else_content = nil
+      remaining = inner_content
+      current_tag = initial_tag
+
+      while remaining
+        # Look for the next {{else if tag}} or {{else}} boundary
+        else_if_match = remaining.match(ElseIfBoundaryRegEx)
+        else_match = remaining.match(/{{else}}/)
+
+        # Determine which boundary comes first
+        next_boundary = nil
+        if else_if_match && else_match
+          next_boundary = else_if_match.begin(0) < else_match.begin(0) ? :else_if : :else
+        elsif else_if_match
+          next_boundary = :else_if
+        elsif else_match
+          next_boundary = :else
+        end
+
+        case next_boundary
+        when :else_if
+          clauses << [current_tag, remaining[0...else_if_match.begin(0)]]
+          current_tag = else_if_match[1]
+          remaining = remaining[else_if_match.end(0)..]
+        when :else
+          clauses << [current_tag, remaining[0...else_match.begin(0)]]
+          else_content = remaining[else_match.end(0)..]
+          break
+        else
+          clauses << [current_tag, remaining]
+          break
+        end
+      end
+
+      [clauses, else_content]
+    end
+
+    # Parse the inner content of an is block into an array of [tag, op, exp, content] clauses
+    # and an optional else content string.
+    # @param initial_tag [String] the tag from the {{#is}} opener
+    # @param initial_op [String] the operator from the {{#is}} opener
+    # @param initial_exp [String] the expression from the {{#is}} opener
+    # @param inner_content [String] everything between {{#is ...}} and {{/is}}
+    # @return [Array<Array(String, String, String, String)>, String|nil] clauses and else_content
+    def self.parse_is_clauses(initial_tag, initial_op, initial_exp, inner_content)
+      clauses = []
+      else_content = nil
+      remaining = inner_content
+      current_tag = initial_tag
+      current_op = initial_op
+      current_exp = initial_exp
+
+      while remaining
+        else_is_match = remaining.match(ElseIsBoundaryRegEx)
+        else_match = remaining.match(/{{else}}/)
+
+        next_boundary = nil
+        if else_is_match && else_match
+          next_boundary = else_is_match.begin(0) < else_match.begin(0) ? :else_is : :else
+        elsif else_is_match
+          next_boundary = :else_is
+        elsif else_match
+          next_boundary = :else
+        end
+
+        case next_boundary
+        when :else_is
+          clauses << [current_tag, current_op, current_exp, remaining[0...else_is_match.begin(0)]]
+          current_tag = else_is_match[1]
+          current_op = else_is_match[2]
+          current_exp = else_is_match[3]
+          remaining = remaining[else_is_match.end(0)..]
+        when :else
+          clauses << [current_tag, current_op, current_exp, remaining[0...else_match.begin(0)]]
+          else_content = remaining[else_match.end(0)..]
+          break
+        else
+          clauses << [current_tag, current_op, current_exp, remaining]
+          break
+        end
+      end
+
+      [clauses, else_content]
+    end
 
     # if the item has its own referenced item (much like an activity log might), then get it
     def self.setup_data_for_referenced_item(data, item)

--- a/spec/javascripts/_fpa_substitution_spec.js
+++ b/spec/javascripts/_fpa_substitution_spec.js
@@ -96,4 +96,43 @@ describe('substitutions', function () {
     var res = $t[0].outerHTML;
     expect(res).toEqual(expected_text)
   });
+
+  it("supports arbitrary else-if conditions", function () {
+    const text = '{{#if v1}}one{{else if v2}}two{{else if v3}}three{{else if v4}}four{{else if v5}}five{{else}}none{{/if}}';
+
+    let res = _fpa.substitution.substitute(text, { v1: false, v2: false, v3: true, v4: true, v5: true });
+    expect(res).toEqual('three');
+
+    res = _fpa.substitution.substitute(text, { v1: false, v2: false, v3: false, v4: false, v5: true });
+    expect(res).toEqual('five');
+
+    res = _fpa.substitution.substitute(text, { v1: false, v2: false, v3: false, v4: false, v5: false });
+    expect(res).toEqual('none');
+  });
+
+  it("handles a single if string with at least five else-if clauses", function () {
+    const text = '{{#if a}}A{{else if b}}B{{else if c}}C{{else if d}}D{{else if e}}E{{else if f}}F{{else}}none{{/if}}';
+
+    let res = _fpa.substitution.substitute(text, { a: true, b: false, c: false, d: false, e: false, f: true });
+    expect(res).toEqual('A');
+
+    res = _fpa.substitution.substitute(text, { a: false, b: false, c: false, d: false, e: false, f: true });
+    expect(res).toEqual('F');
+
+    res = _fpa.substitution.substitute(text, { a: false, b: false, c: false, d: false, e: false, f: false });
+    expect(res).toEqual('none');
+  });
+
+  it("supports arbitrary else-is conditions", function () {
+    const text = '{{#is score \'==\' 1}}one{{else is score \'==\' 2}}two{{else is score \'==\' 3}}three{{else is score \'==\' 4}}four{{else is score \'==\' 5}}five{{else}}none{{/is}}';
+
+    let res = _fpa.substitution.substitute(text, { score: 4 });
+    expect(res).toEqual('four');
+
+    res = _fpa.substitution.substitute(text, { score: 5 });
+    expect(res).toEqual('five');
+
+    res = _fpa.substitution.substitute(text, { score: 99 });
+    expect(res).toEqual('none');
+  });
 });

--- a/spec/models/formatter/substitution_spec.rb
+++ b/spec/models/formatter/substitution_spec.rb
@@ -221,26 +221,20 @@ RSpec.describe Formatter::Substitution, type: :model do
 
     if_blocks = txt.scan Formatter::Substitution::IfBlockRegEx
 
-    # 13 blocks each of 7 elements
+    # 13 blocks each of 3 capture groups (full match, tag, inner content)
     expect(if_blocks.length).to eq 13
-    expect(if_blocks[0].length).to eq 8
+    expect(if_blocks[0].length).to eq 3
     expect(if_blocks[0][0]).to eq '{{#if some_text}}shows {{some_text}}{{/if}}'
     expect(if_blocks[0][1]).to eq 'some_text'
     expect(if_blocks[0][2]).to eq 'shows {{some_text}}'
-    expect(if_blocks[0][3]).to be nil
-    expect(if_blocks[0][4]).to be nil
 
     expect(if_blocks[1][0]).to eq '{{#if truthy_val}}some other text{{/if}}'
     expect(if_blocks[1][1]).to eq 'truthy_val'
     expect(if_blocks[1][2]).to eq 'some other text'
-    expect(if_blocks[1][3]).to be nil
-    expect(if_blocks[1][4]).to be nil
 
     expect(if_blocks[3][0]).to eq '{{#if false_val}}does not show false{{else}}but does show {{int_val}} else{{/if}}'
     expect(if_blocks[3][1]).to eq 'false_val'
-    expect(if_blocks[3][2]).to eq 'does not show false'
-    expect(if_blocks[3][6]).to be_truthy
-    expect(if_blocks[3][7]).to eq 'but does show {{int_val}} else'
+    expect(if_blocks[3][2]).to eq 'does not show false{{else}}but does show {{int_val}} else'
 
     expect(if_blocks[6][0]).to eq %({{#if true_val}}
 It can also handle multiple
@@ -255,41 +249,24 @@ lines in the results.
 OK?
 )
 
-    expect(if_blocks[6][3]).to be nil
-    expect(if_blocks[6][4]).to eq nil
-
     expect(if_blocks[7][0]).to eq %({{#if false_val}}Not shown{{else}}It can also handle multiple
 lines in the else results.
 Good?{{/if}})
     expect(if_blocks[7][1]).to eq 'false_val'
-    expect(if_blocks[7][2]).to eq 'Not shown'
-    expect(if_blocks[7][6]).to be_truthy
-
-    expect(if_blocks[7][7]).to eq %(It can also handle multiple
+    expect(if_blocks[7][2]).to eq %(Not shown{{else}}It can also handle multiple
 lines in the else results.
 Good?)
 
-    # Now test else if
-    expect(if_blocks[10].length).to eq 8
+    # Now test else if - inner content includes the else if and else clauses
+    expect(if_blocks[10].length).to eq 3
     expect(if_blocks[10][0]).to eq '{{#if false_val}}Not shown{{else if true_val}}Else If shown{{else}}Not else{{/if}}'
     expect(if_blocks[10][1]).to eq 'false_val'
-    expect(if_blocks[10][2]).to eq 'Not shown'
-    expect(if_blocks[10][3]).to eq '{{else if true_val}}Else If shown'
-    expect(if_blocks[10][4]).to eq 'true_val'
-    expect(if_blocks[10][5]).to eq 'Else If shown'
-    expect(if_blocks[10][6]).to be_truthy
-    expect(if_blocks[10][7]).to eq 'Not else'
+    expect(if_blocks[10][2]).to eq 'Not shown{{else if true_val}}Else If shown{{else}}Not else'
 
-    # Now test else if
-    expect(if_blocks[12].length).to eq 8
+    expect(if_blocks[12].length).to eq 3
     expect(if_blocks[12][0]).to eq '{{#if false_val}}Not shown{{else if false_val}}Else If shown{{else}}Show else{{/if}}'
     expect(if_blocks[12][1]).to eq 'false_val'
-    expect(if_blocks[12][2]).to eq 'Not shown'
-    expect(if_blocks[12][3]).to eq '{{else if false_val}}Else If shown'
-    expect(if_blocks[12][4]).to eq 'false_val'
-    expect(if_blocks[12][5]).to eq 'Else If shown'
-    expect(if_blocks[12][6]).to be_truthy
-    expect(if_blocks[12][7]).to eq 'Show else'
+    expect(if_blocks[12][2]).to eq 'Not shown{{else if false_val}}Else If shown{{else}}Show else'
 
     data = {
       int_val: 12_345,
@@ -354,47 +331,26 @@ Good?)
 
     if_blocks = txt.scan Formatter::Substitution::IsBlockRegEx
 
-    # 5 blocks each of 10 elements
+    # 10 blocks each of 5 capture groups (full match, tag, op, exp, inner content)
     expect(if_blocks.length).to eq 10
-    expect(if_blocks[0].length).to eq 17
+    expect(if_blocks[0].length).to eq 5
     expect(if_blocks[0][0]).to eq '{{#is some_text "==" \'this is optional\'}}shows {{some_text}}{{/is}}'
     expect(if_blocks[0][1]).to eq 'some_text'
     expect(if_blocks[0][2]).to eq '=='
     expect(if_blocks[0][3]).to eq "'this is optional'"
     expect(if_blocks[0][4]).to eq 'shows {{some_text}}'
-    expect(if_blocks[0][5]).to be nil
-    expect(if_blocks[0][6]).to be nil
-    expect(if_blocks[0][7]).to be nil
-    expect(if_blocks[0][8]).to be nil
-    expect(if_blocks[0][9]).to be nil
-    expect(if_blocks[0][15]).to be nil
-    expect(if_blocks[0][16]).to be nil
 
     expect(if_blocks[1][0]).to eq '{{#is some_text \'!=\' "this is optional"}}shows {{some_text}}{{else}}no show {{some_text}}{{/is}}'
     expect(if_blocks[1][1]).to eq 'some_text'
     expect(if_blocks[1][2]).to eq '!='
     expect(if_blocks[1][3]).to eq '"this is optional"'
-    expect(if_blocks[1][4]).to eq 'shows {{some_text}}'
-    expect(if_blocks[1][5]).to be nil
-    expect(if_blocks[1][6]).to be nil
-    expect(if_blocks[1][7]).to be nil
-    expect(if_blocks[1][8]).to be nil
-    expect(if_blocks[1][9]).to be nil
-    expect(if_blocks[1][15]).to eq '{{else}}no show {{some_text}}'
-    expect(if_blocks[1][16]).to eq 'no show {{some_text}}'
+    expect(if_blocks[1][4]).to eq 'shows {{some_text}}{{else}}no show {{some_text}}'
 
     expect(if_blocks[2][0]).to eq "{{#is int_val '<' 50}}too large {{int_val}}{{else}}so show {{int_val}} >= 50{{/is}}"
     expect(if_blocks[2][1]).to eq 'int_val'
     expect(if_blocks[2][2]).to eq '<'
     expect(if_blocks[2][3]).to eq '50'
-    expect(if_blocks[2][4]).to eq 'too large {{int_val}}'
-    expect(if_blocks[2][5]).to be nil
-    expect(if_blocks[2][6]).to be nil
-    expect(if_blocks[2][7]).to be nil
-    expect(if_blocks[2][8]).to be nil
-    expect(if_blocks[2][9]).to be nil
-    expect(if_blocks[2][15]).to eq '{{else}}so show {{int_val}} >= 50'
-    expect(if_blocks[2][16]).to eq 'so show {{int_val}} >= 50'
+    expect(if_blocks[2][4]).to eq 'too large {{int_val}}{{else}}so show {{int_val}} >= 50'
 
     data = {
       int_val: 12_345,
@@ -426,5 +382,144 @@ Good?)
 
       All done!
     END_TEXT
+  end
+
+  it 'handles arbitrary number of else if conditions in if blocks' do
+    txt = <<~END_TEXT
+      {{#if val_a}}A{{else if val_b}}B{{else if val_c}}C{{else if val_d}}D{{else if val_e}}E{{else}}none{{/if}}
+    END_TEXT
+
+    # First condition true
+    data = { val_a: true, val_b: false, val_c: false, val_d: false, val_e: false }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'A'
+
+    # Second condition true
+    data = { val_a: false, val_b: true, val_c: false, val_d: false, val_e: false }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'B'
+
+    # Third condition true
+    data = { val_a: false, val_b: false, val_c: true, val_d: false, val_e: false }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'C'
+
+    # Fourth condition true
+    data = { val_a: false, val_b: false, val_c: false, val_d: true, val_e: false }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'D'
+
+    # Fifth condition true
+    data = { val_a: false, val_b: false, val_c: false, val_d: false, val_e: true }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'E'
+
+    # No conditions true - falls through to else
+    data = { val_a: false, val_b: false, val_c: false, val_d: false, val_e: false }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'none'
+
+    # First truthy wins even if later ones are also truthy
+    data = { val_a: false, val_b: false, val_c: true, val_d: true, val_e: true }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'C'
+  end
+
+  it 'handles arbitrary number of else if conditions without a final else' do
+    txt = '{{#if val_a}}A{{else if val_b}}B{{else if val_c}}C{{else if val_d}}D{{/if}}'
+
+    data = { val_a: false, val_b: false, val_c: false, val_d: true }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res).to eq 'D'
+
+    data = { val_a: false, val_b: false, val_c: false, val_d: false }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res).to eq ''
+  end
+
+  it 'handles a single if string with at least five else if clauses' do
+    txt = '{{#if a}}A{{else if b}}B{{else if c}}C{{else if d}}D{{else if e}}E{{else if f}}F{{else}}none{{/if}}'
+
+    data = { a: true, b: false, c: false, d: false, e: false, f: true }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res).to eq 'A'
+
+    data = { a: false, b: false, c: false, d: false, e: false, f: true }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res).to eq 'F'
+
+    data = { a: false, b: false, c: false, d: false, e: false, f: false }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res).to eq 'none'
+  end
+
+  it 'handles arbitrary number of else is conditions in is blocks' do
+    txt = <<~END_TEXT
+      {{#is val '==' "a"}}A{{else is val '==' "b"}}B{{else is val '==' "c"}}C{{else is val '==' "d"}}D{{else is val '==' "e"}}E{{else}}none{{/is}}
+    END_TEXT
+
+    data = { val: 'a' }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'A'
+
+    data = { val: 'b' }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'B'
+
+    data = { val: 'c' }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'C'
+
+    data = { val: 'd' }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'D'
+
+    data = { val: 'e' }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'E'
+
+    data = { val: 'z' }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'none'
+  end
+
+  it 'handles arbitrary else is with numeric comparisons' do
+    txt = <<~END_TEXT
+      {{#is score '>' 90}}excellent{{else is score '>' 80}}great{{else is score '>' 70}}good{{else is score '>' 60}}ok{{else is score '>' 50}}fair{{else}}poor{{/is}}
+    END_TEXT
+
+    data = { score: 95 }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'excellent'
+
+    data = { score: 85 }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'great'
+
+    data = { score: 75 }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'good'
+
+    data = { score: 65 }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'ok'
+
+    data = { score: 55 }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'fair'
+
+    data = { score: 30 }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'poor'
+  end
+
+  it 'handles multiple if blocks with arbitrary else-if in the same text' do
+    txt = <<~END_TEXT
+      Result: {{#if x}}X{{else if y}}Y{{else if z}}Z{{/if}} and {{#if a}}A{{else if b}}B{{else if c}}C{{else if d}}D{{/if}}
+    END_TEXT
+
+    data = { x: false, y: false, z: true, a: false, b: false, c: false, d: true }
+    res = Formatter::Substitution.substitute(txt.dup, data:)
+    expect(res.strip).to eq 'Result: Z and D'
   end
 end


### PR DESCRIPTION
## Summary

Adds support for an arbitrary number of `{{else if ...}}` and `{{else is ...}}` conditional blocks in the Handlebars-style substitution engine, removing the previous hard-coded limit of 2 else-if/else-is clauses.

Fixes #1061

### Changes

**Backend (`app/models/formatter/substitution.rb`)**
- Replaced fixed regex capture groups with iterative `parse_if_clauses` and `parse_is_clauses` methods that split inner content at `{{else if}}` / `{{else is}}` / `{{else}}` boundaries
- Removed `MaxElseIfs` constant — chains of any length are now supported
- Simplified the main `substitute` method by delegating clause parsing to the new helpers

**Frontend (`app/assets/javascripts/app/_fpa_substitution.js`)**
- Mirrored the Ruby changes: added `parse_if_clauses()` and `parse_is_clauses()` methods
- Replaced fixed capture group indexing with iterative boundary matching
- Removed `MaxElseIfs` constant

**Tests**
- `spec/models/formatter/substitution_spec.rb` — added RSpec tests for arbitrary-length conditional chains, including a 5-branch `{{else if}}` test
- `spec/javascripts/_fpa_substitution_spec.js` — added equivalent Jasmine tests for arbitrary-length conditional chains, including a 5-branch `{{else if}}` test
