### PR TITLE
Added resolved definition versioning indicator to admin details panels and record id to Edit Entry title - fixes #1066

### DIFF
--- a/app/assets/stylesheets/app/admin_handler.css.scss
+++ b/app/assets/stylesheets/app/admin_handler.css.scss
@@ -244,6 +244,10 @@ p.like-type {
   font-size: 127%;
   font-weight: bold;
   color: rgb(121, 121, 121);
+
+  small {
+    font-weight: normal;
+  }
 }
 
 .alert.alert-success.logged-in-as-admin {

--- a/app/models/admin/config_library.rb
+++ b/app/models/admin/config_library.rb
@@ -190,7 +190,7 @@ class Admin::ConfigLibrary < Admin::AdminBase
       # resolve to the correct library content via versioned definitions.
       # Skip the touch when versioning is disabled globally (DisableVDef)
       # or when the definition uses use_current_version (always uses latest).
-      unless Settings::DisableVDef || m.use_current_version
+      unless m.uses_current_definition_version?
         m.current_admin ||= current_admin
         m.touch
       end

--- a/app/models/dynamic/def_handler.rb
+++ b/app/models/dynamic/def_handler.rb
@@ -372,6 +372,21 @@ module Dynamic
       @use_current_version = configurations && configurations[:use_current_version]
     end
 
+    # Resolve whether this definition should use the current configuration version
+    # instead of definition-at-record-creation versioning.
+    # This follows the existing behavior used by version selection and library resolution.
+    def uses_current_definition_version?
+      versioning_disabled_globally? || definition_uses_current_version_option?
+    end
+
+    def versioning_disabled_globally?
+      Settings::DisableVDef
+    end
+
+    def definition_uses_current_version_option?
+      respond_to?(:use_current_version) && use_current_version
+    end
+
     def prevent_migrations
       return @prevent_migrations if @prevent_migrations_set
 

--- a/app/models/option_configs/extra_options.rb
+++ b/app/models/option_configs/extra_options.rb
@@ -637,8 +637,14 @@ module OptionConfigs
       #   - Settings::DisableVDef is true (versioning disabled globally, e.g. development)
       #   - use_current_version is set on the definition (always uses latest)
       version_at = nil
-      if !(Settings::DisableVDef ||
-           (config_obj.respond_to?(:use_current_version) && config_obj.use_current_version)) &&
+      uses_current_definition_version = if config_obj.respond_to?(:uses_current_definition_version?)
+                                          config_obj.uses_current_definition_version?
+                                        else
+                                          Settings::DisableVDef ||
+                                            (config_obj.respond_to?(:use_current_version) && config_obj.use_current_version)
+                                        end
+
+      if !uses_current_definition_version &&
          config_obj.respond_to?(:def_version) && config_obj.def_version.present?
         version_at = config_obj.updated_at || config_obj.created_at
       end

--- a/app/views/admin/activity_logs/_def_details.html.erb
+++ b/app/views/admin/activity_logs/_def_details.html.erb
@@ -18,6 +18,8 @@
     Options may simply reference this as: <code>definition_resources</code>
   </p>
 
+  <%= render partial: 'admin/common_templates/def_details_version_mode', locals: { object_instance: } %>
+
   <label>database <%= object_instance.table_or_view || '<span class="info-danger">not defined</span>'.html_safe %></label>
   <p>
     <code><%= [object_instance.schema_name, object_instance.table_name].compact.join('.') %></code>

--- a/app/views/admin/common_templates/_def_details_version_mode.html.erb
+++ b/app/views/admin/common_templates/_def_details_version_mode.html.erb
@@ -1,0 +1,13 @@
+<%
+  setting = object_instance.respond_to?(:versioning_disabled_globally?) && object_instance.versioning_disabled_globally?
+  config_ucv = object_instance.respond_to?(:definition_uses_current_version_option?) && object_instance.definition_uses_current_version_option?
+  uses_current_version = object_instance.respond_to?(:uses_current_definition_version?) && object_instance.uses_current_definition_version?
+
+%>
+<label>definition versioning</label>
+<span class="def-version-resolution">
+  <%= uses_current_version ? 'current version' : 'version at record creation' %>
+</span>
+<p class="help-block">
+  Resolved from <% if setting.present? %><%= link_to link_label_open_in_new("application setting DisableVDef"), "/admin/server_info", target: "_blank" %><% end %> <% if setting && config_ucv %>and<% end %> <% if config_ucv.present? %>the definition <code>_configurations.use_current_version</code> option<% end %>.
+</p>

--- a/app/views/admin/dynamic_models/_def_details.html.erb
+++ b/app/views/admin/dynamic_models/_def_details.html.erb
@@ -15,6 +15,8 @@
   <%= object_instance.resource_name %>
   </p>
 
+  <%= render partial: 'admin/common_templates/def_details_version_mode', locals: { object_instance: } %>
+
   <label>database <%= object_instance.table_or_view || '<span class="info-danger">not defined</span>'.html_safe %></label>
   <%
     schema_name = object_instance.schema_name.presence || object_instance.schema_name_in_db

--- a/app/views/admin/external_identifiers/_def_details.html.erb
+++ b/app/views/admin/external_identifiers/_def_details.html.erb
@@ -14,6 +14,8 @@
   <%= object_instance.resource_name %>
   </p>
 
+  <%= render partial: 'admin/common_templates/def_details_version_mode', locals: { object_instance: } %>
+
 <label>database <%= object_instance.table_or_view || '<span class="info-danger">not defined</span>'.html_safe %></label>
   <%
     schema_name = object_instance.schema_name.presence || object_instance.schema_name_in_db

--- a/app/views/admin_handler/_form_errors.html.erb
+++ b/app/views/admin_handler/_form_errors.html.erb
@@ -1,5 +1,5 @@
 <p class="admin-form-title">
-  <%= @copy_with ? "Copy Entry" : object_instance.id ? "Edit Entry" : "New Entry" %>
+  <%= @copy_with ? "Copy Entry" : object_instance.id ? "Edit Entry <small>##{object_instance.id}</small>".html_safe : "New Entry" %>
 </p>
 <% if object_instance.errors.any?
     shown = []

--- a/spec/controllers/admin/activity_logs_controller_spec.rb
+++ b/spec/controllers/admin/activity_logs_controller_spec.rb
@@ -2,8 +2,12 @@
 
 require 'rails_helper'
 
+# Tests for issue #1066:
+# - Show resolved definition versioning in activity log admin details
 RSpec.describe Admin::ActivityLogsController, type: :controller do
   include AdminActivityLogSupport
+
+  render_views
 
   def object_class
     ActivityLog
@@ -21,5 +25,53 @@ RSpec.describe Admin::ActivityLogsController, type: :controller do
     raise "Bad Seed! #{PlayerContact.valid_rec_types}" if PlayerContact.valid_rec_types.empty?
   end
 
+  before_each_login_admin
+
   it_behaves_like 'a standard admin controller'
+
+  describe 'GET #edit issue #1066 details display' do
+    it 'shows current version when current-definition mode is resolved' do
+      suffix = Array.new(8) { ('a'..'z').to_a.sample }.join
+
+      al = create_item(
+        {
+          name: "test_al_version_mode_#{suffix}",
+          item_type: 'player_contact',
+          rec_type: 'email',
+          action_when_attribute: 'emailed_when',
+          current_admin: @admin
+        },
+        @admin
+      )
+
+      allow_any_instance_of(ActivityLog).to receive(:uses_current_definition_version?).and_return(true)
+
+      get :edit, params: { id: al.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to have_selector('.def-version-resolution', text: /current version/i)
+    end
+
+    it 'shows version at record creation when definition-time versioning is resolved' do
+      suffix = Array.new(8) { ('a'..'z').to_a.sample }.join
+
+      al = create_item(
+        {
+          name: "test_al_version_mode_#{suffix}",
+          item_type: 'player_contact',
+          rec_type: 'email',
+          action_when_attribute: 'emailed_when',
+          current_admin: @admin
+        },
+        @admin
+      )
+
+      allow_any_instance_of(ActivityLog).to receive(:uses_current_definition_version?).and_return(false)
+
+      get :edit, params: { id: al.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to have_selector('.def-version-resolution', text: /record creation/i)
+    end
+  end
 end

--- a/spec/controllers/admin/dynamic_models_index_table_spec.rb
+++ b/spec/controllers/admin/dynamic_models_index_table_spec.rb
@@ -7,9 +7,15 @@ require 'rails_helper'
 # - Added resource_name to index_params as a regular column
 # - Added extra index columns: batch_jobs status, "Is a view?" boolean
 # - These new columns use the existing extra_index_columns mechanism
+#
+# Additional tests for issue #1066:
+# - Show resolved definition versioning in definition details
+# - Show the edited record id in the Edit Entry title
 RSpec.describe Admin::DynamicModelsController, type: :controller do
   include ModelSupport
   include DynamicModelSupport
+
+  render_views
 
   before :all do
     create_admin
@@ -108,6 +114,49 @@ RSpec.describe Admin::DynamicModelsController, type: :controller do
       result = controller.send(:view_sql_column, dm)
       # Should render a checked boolean field
       expect(result).to include('val-checked')
+    end
+  end
+
+  describe 'GET #edit issue #1066 details display' do
+    it 'shows current version when current-definition mode is resolved and includes record id in the title' do
+      suffix = Array.new(8) { ('a'..'z').to_a.sample }.join
+
+      dm = DynamicModel.create!(
+        current_admin: @admin,
+        name: "test version mode #{suffix}",
+        table_name: "test_version_mode_#{suffix}_recs",
+        schema_name: 'dynamic_test',
+        category: 'test',
+        disabled: true,
+        options: "_configurations:\n  use_current_version: true\ndefault:\n  label: Test"
+      )
+
+      allow_any_instance_of(DynamicModel).to receive(:uses_current_definition_version?).and_return(true)
+
+      get :edit, params: { id: dm.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to have_selector('.def-version-resolution', text: /current version/i)
+      expect(response.body).to include("Edit Entry <small>##{dm.id}</small>")
+    end
+
+    it 'shows that definition-time versioning is used when current-version mode is not enabled' do
+      suffix = Array.new(8) { ('a'..'z').to_a.sample }.join
+
+      dm = DynamicModel.create!(
+        current_admin: @admin,
+        name: "test versioned mode #{suffix}",
+        table_name: "test_versioned_mode_#{suffix}_recs",
+        schema_name: 'dynamic_test',
+        category: 'test',
+        disabled: true,
+        options: "default:\n  label: Test"
+      )
+
+      get :edit, params: { id: dm.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to have_selector('.def-version-resolution', text: /record creation/i)
     end
   end
 end

--- a/spec/controllers/admin/external_identifiers_controller_spec.rb
+++ b/spec/controllers/admin/external_identifiers_controller_spec.rb
@@ -2,9 +2,13 @@
 
 require 'rails_helper'
 
+# Tests for issue #1066:
+# - Show resolved definition versioning in external identifier admin details
 RSpec.describe Admin::ExternalIdentifiersController, type: :controller do
   include MasterSupport
   include ExternalIdentifierSupport
+
+  render_views
 
   def object_class
     ExternalIdentifier
@@ -45,5 +49,31 @@ RSpec.describe Admin::ExternalIdentifiersController, type: :controller do
     }
     put :create, params: { object_symbol => inv }
     expect(assigns(object_symbol).errors.empty?).not_to be true
+  end
+
+  describe 'GET #edit issue #1066 details display' do
+    it 'shows current version when current-definition mode is resolved' do
+      ext = ExternalIdentifier.active.first
+      expect(ext).to be_present
+
+      allow_any_instance_of(ExternalIdentifier).to receive(:uses_current_definition_version?).and_return(true)
+
+      get :edit, params: { id: ext.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to have_selector('.def-version-resolution', text: /current version/i)
+    end
+
+    it 'shows version at record creation when definition-time versioning is resolved' do
+      ext = ExternalIdentifier.active.first
+      expect(ext).to be_present
+
+      allow_any_instance_of(ExternalIdentifier).to receive(:uses_current_definition_version?).and_return(false)
+
+      get :edit, params: { id: ext.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to have_selector('.def-version-resolution', text: /record creation/i)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Displays the resolved definition versioning mode ("current version" vs "version at record creation") near the top of admin details panels for dynamic models, activity logs, and external identifiers. Also adds the record ID to the Edit Entry form title.

Fixes #1066

### Changes

**New files:**
- `app/views/admin/common_templates/_def_details_version_mode.html.erb` — shared partial showing resolved versioning mode with explanation of source (global setting and/or definition config)

**Model changes:**
- `app/models/dynamic/def_handler.rb` — added `uses_current_definition_version?`, `versioning_disabled_globally?`, and `definition_uses_current_version_option?` helper methods centralizing version-resolution logic
- `app/models/option_configs/extra_options.rb` — refactored `prepare_options_text` to use the new helper
- `app/models/admin/config_library.rb` — refactored `refresh_dependencies` touch condition to use the new helper

**View changes:**
- `app/views/admin/activity_logs/_def_details.html.erb` — renders version mode partial
- `app/views/admin/dynamic_models/_def_details.html.erb` — renders version mode partial
- `app/views/admin/external_identifiers/_def_details.html.erb` — renders version mode partial
- `app/views/admin_handler/_form_errors.html.erb` — added record ID (`#123`) to Edit Entry title

**Style changes:**
- `app/assets/stylesheets/app/admin_handler.css.scss` — added `small` tag styling inside `.admin-form-title`

**Specs:**
- `spec/controllers/admin/activity_logs_controller_spec.rb` — two deterministic tests for both versioning states
- `spec/controllers/admin/dynamic_models_index_table_spec.rb` — two deterministic tests for both versioning states + record ID in title
- `spec/controllers/admin/external_identifiers_controller_spec.rb` — two deterministic tests for both versioning states

### Testing

49 examples, 0 failures. Brakeman reports no warnings.
