### PR TITLE
Added creatable select field auto-creation for all single-select variants - fixes #73

### DIFF
--- a/app/assets/javascripts/app/_fpa_form_utils.js
+++ b/app/assets/javascripts/app/_fpa_form_utils.js
@@ -532,8 +532,14 @@ _fpa.form_utils = {
   setup_typeahead: function (element, list, name, limit, options) {
     if (typeof list === 'string') list = _fpa.cache.fetch(list);
 
+    var hasObjectItems = list && list.length && typeof list[0] === 'object';
+
     var items = new Bloodhound({
-      datumTokenizer: Bloodhound.tokenizers.whitespace,
+      datumTokenizer: hasObjectItems
+        ? function (datum) {
+          return Bloodhound.tokenizers.whitespace(datum.label || '');
+        }
+        : Bloodhound.tokenizers.whitespace,
       queryTokenizer: Bloodhound.tokenizers.whitespace,
       local: list,
     });
@@ -560,12 +566,32 @@ _fpa.form_utils = {
       source: items,
     };
 
+    if (hasObjectItems) {
+      dataset.display = function (item) {
+        return item.label;
+      };
+    }
+
     if (limit) {
       dataset.limit = limit;
     }
 
     $(element)
       .typeahead(options, dataset)
+      .on('typeahead:select typeahead:autocomplete', function (_ev, suggestion) {
+        if (suggestion && typeof suggestion === 'object') {
+          $(this).attr('data-creatable-selected-label', suggestion.label);
+          $(this).attr('data-creatable-selected-value', suggestion.value);
+          $(this).val(suggestion.label);
+        }
+      })
+      .on('input', function () {
+        var selectedLabel = $(this).attr('data-creatable-selected-label');
+        if (selectedLabel && $(this).val() !== selectedLabel) {
+          $(this).removeAttr('data-creatable-selected-label');
+          $(this).removeAttr('data-creatable-selected-value');
+        }
+      })
       .on('keypress', function (ev) {
         if (ev.keyCode != 13) return;
         var dnf = $(this).attr('data-next-field');
@@ -1856,6 +1882,49 @@ _fpa.form_utils = {
         _fpa.cache.get_definition('colleges', function () {
           _fpa.form_utils.setup_typeahead(el, 'colleges', 'colleges');
         });
+      });
+
+    block
+      .find('input.creatable-select-input.typeahead')
+      .not('.attached-creatable-select_ta')
+      .addClass('attached-creatable-select_ta')
+      .each(function () {
+        var el = $(this);
+        var rawItems = el.attr('data-creatable-items');
+        if (rawItems) {
+          var items = JSON.parse(rawItems);
+          var fieldName = el.attr('data-attr-name');
+          el.data('creatable-select-items', items);
+
+          var form = el.closest('form');
+          if (form.length && !form.hasClass('attached-creatable-select-submit')) {
+            form
+              .addClass('attached-creatable-select-submit')
+              .on('submit', function () {
+                $(this)
+                  .find('input.creatable-select-input.typeahead')
+                  .each(function () {
+                    var input = $(this);
+                    var inputItems = input.data('creatable-select-items') || [];
+                    if (!inputItems.length || typeof inputItems[0] !== 'object') return;
+
+                    var selectedValue = input.attr('data-creatable-selected-value');
+                    if (selectedValue !== undefined) {
+                      // User selected an existing item from typeahead — submit its value (e.g. id)
+                      input.val(selectedValue);
+                    } else {
+                      // User typed freeform text not matching any suggestion — mark as new
+                      var rawValue = input.val();
+                      var newPrefix = input.attr('data-creatable-new-prefix') || '__creatable_new__';
+                      if (rawValue && rawValue !== '') {
+                        input.val(newPrefix + rawValue);
+                      }
+                    }
+                  });
+              });
+          }
+          _fpa.form_utils.setup_typeahead(el, items, fieldName);
+        }
       });
 
     block

--- a/app/models/admin/defs/extra_options_field_options_defs.yaml
+++ b/app/models/admin/defs/extra_options_field_options_defs.yaml
@@ -181,6 +181,17 @@
           # Specifies the target field to be filtered when this field changes.
           # Used with big_select.filtered configuration to dynamically filter another big-select field.
           # The filter value from this field is passed via blank_preset_value to constrain the query.
+        
+        # configuration for allowing users to create new items in the source model
+        # when their entered value doesn't already exist (applies to select_record_from_table_* fields)
+        creatable:
+          enabled: true | false
+            # When true, the field renders as a typeahead text input instead of a select dropdown.
+            # If the user enters a value that doesn't exist in the source model, a new record
+            # is automatically created on save.
+            # Requires the user to have 'create' access on the source dynamic model.
+            # If the user lacks create access, they can only select from existing items.
+            # Default is false (standard select dropdown behavior).
       calculate_with:
         sum: []
       prompt: used by some select fields for the placeholder prompt text

--- a/app/models/dynamic/implementation_handler.rb
+++ b/app/models/dynamic/implementation_handler.rb
@@ -3,6 +3,10 @@ module Dynamic
   module ImplementationHandler
     extend ActiveSupport::Concern
 
+    # Prefix added by the frontend to freeform typeahead entries to distinguish them
+    # from existing record selections. Must match the JS constant in _fpa_form_utils.js.
+    CREATABLE_NEW_PREFIX = '__creatable_new__'
+
     included do
       after_find :set_option_type_attr_name
       after_initialize :set_option_type_attr_name
@@ -10,6 +14,7 @@ module Dynamic
       after_initialize :force_preset_values, unless: :persisted?
       after_initialize :evaluate_active_values
 
+      before_save :handle_creatable_select_fields
       before_save :handle_before_save_triggers
       after_commit :handle_save_triggers
       after_commit :reset_access_evaluations!
@@ -232,6 +237,116 @@ module Dynamic
       option_type_config&.calc_save_trigger_if self unless skip_save_trigger
       true
     end
+
+    #
+    # Handle creatable select fields before save.
+    # For fields configured with edit_as.creatable.enabled, auto-create
+    # records in the target model if the entered value doesn't already exist.
+    # Requires the user to have 'create' access on the target model.
+    # Supports single-value select_record_* fields.
+    def handle_creatable_select_fields
+      fo = option_type_config&.field_options
+      return true unless fo
+
+      fo.each do |field_name, config|
+        next unless config.dig(:edit_as, :creatable, :enabled)
+
+        prefix = creatable_select_field_prefix(field_name)
+        next unless prefix
+
+        value = send(field_name) if respond_to?(field_name)
+        next if value.blank?
+
+        value_attr = creatable_select_value_attr(prefix, config)
+        lookup_attr = creatable_select_lookup_attr(value_attr, config)
+        table_name = field_name.to_s.sub(prefix, '')
+        target = Resources::Models.find_by(table_name:)
+        next unless target
+
+        target_class = target[:model]
+
+        # Strip the CREATABLE_NEW_PREFIX marker added by the frontend for freeform entries
+        is_new_entry = value.to_s.start_with?(CREATABLE_NEW_PREFIX)
+        clean_value = is_new_entry ? value.to_s.sub(CREATABLE_NEW_PREFIX, '') : value
+
+        if value_attr == :id
+          # Value is an existing record id selected from the typeahead
+          if !is_new_entry && target_class.exists?(id: clean_value)
+            send("#{field_name}=", clean_value.to_i)
+            next
+          end
+
+          # Look up by label for both [new] entries and unrecognized values
+          existing_record = target_class.find_by(lookup_attr => clean_value)
+          if existing_record
+            send("#{field_name}=", existing_record.id)
+            next
+          end
+        elsif target_class.exists?(value_attr => clean_value)
+          # Non-id field: check if value already exists
+          send("#{field_name}=", clean_value)
+          next
+        end
+
+        values = clean_value.is_a?(Array) ? clean_value.reject(&:blank?) : [clean_value]
+
+        values.each do |v|
+          if value_attr == :id
+            next if target_class.exists?(lookup_attr => v)
+          elsif target_class.exists?(value_attr => v)
+            next
+          end
+
+          unless target_class.allows_user_access_to?(current_user, :create)
+            errors.add(field_name, 'cannot create new items (insufficient access)')
+            throw(:abort)
+          end
+
+          create_attrs = { value_attr => v, current_user: }
+          create_attrs = { lookup_attr => v, current_user: } if value_attr == :id
+          create_attrs[:master] = master if target_class.method_defined?(:master)
+          begin
+            record = target_class.create!(create_attrs)
+            send("#{field_name}=", record.id) if value_attr == :id
+          rescue ActiveRecord::RecordNotUnique
+            # Another concurrent request already created this value - safe to ignore
+            next
+          rescue ActiveRecord::RecordInvalid => e
+            errors.add(field_name, "could not create new item: #{e.record.errors.full_messages.join(', ')}")
+            throw(:abort)
+          end
+        end
+      end
+
+      true
+    end
+
+    private
+
+    def creatable_select_field_prefix(field_name)
+      %w[
+        select_record_from_table_
+        select_record_from_
+        select_record_id_from_table_
+        select_record_id_from_
+      ].find { |prefix| field_name.to_s.start_with?(prefix) }
+    end
+
+    def creatable_select_value_attr(prefix, config)
+      return :id if prefix.include?('select_record_id_')
+
+      (config.dig(:edit_as, :value_attr) || 'data').to_sym
+    end
+
+    def creatable_select_lookup_attr(value_attr, config)
+      label_attr = config.dig(:edit_as, :label_attr)
+      return label_attr.to_sym if label_attr.respond_to?(:to_sym) && !label_attr.is_a?(Array)
+      return :data if value_attr == :id
+
+      value_attr
+    end
+
+    public
 
     #
     # Handle actions that must be performed before on save save triggers

--- a/app/views/common_templates/edit_fields/_creatable_select_input.html.erb
+++ b/app/views/common_templates/edit_fields/_creatable_select_input.html.erb
@@ -1,0 +1,23 @@
+<%
+# Shared partial for creatable select fields (typeahead text input for select_record_* fields)
+# Renders a text field with typeahead autocomplete backed by existing records,
+# allowing creation of new entries when no match is selected.
+#
+# Required locals:
+#   form                   - Rails form builder
+#   field_name_sym         - Symbol for the field name
+#   labels                 - Labels hash for field display
+#   assoc_or_class_name    - Association or class name for label defaults
+#   form_object_item_type_us - Underscored object type name for data attributes
+#   reslist                - Array of [label, value] pairs or plain values from list_record_data_for_select
+typeahead_values = reslist.map { |item| item.is_a?(Array) ? {label: item.first, value: item.last} : {label: item, value: item} }
+current_value = form.object.send(field_name_sym) if form.object.respond_to?(field_name_sym)
+current_label = typeahead_values.find { |item| item[:value].to_s == current_value.to_s }&.dig(:label) || current_value
+%>
+<%= edit_field_label(form, field_name_sym, labels, force_default: assoc_or_class_name) %>
+<%= form.text_field field_name_sym,
+                    value: current_label,
+                    class: 'creatable-select-input typeahead',
+                    data: {attr_name: field_name_sym, object_name: form_object_item_type_us,
+                           creatable_items: typeahead_values.to_json,
+                           creatable_new_prefix: Dynamic::ImplementationHandler::CREATABLE_NEW_PREFIX} %>

--- a/app/views/common_templates/edit_fields/_name_starts_with_select_record_from.html.erb
+++ b/app/views/common_templates/edit_fields/_name_starts_with_select_record_from.html.erb
@@ -23,8 +23,12 @@ unless human_name
   logger.warn "Failed to find valid class name for #{field_name}"
 end
 
-unless big_select
-%>
+creatable_enabled = options.dig(:edit_as, :creatable, :enabled)
+
+if creatable_enabled %>
+<%= render partial: 'common_templates/edit_fields/creatable_select_input',
+         locals: { form:, field_name_sym:, labels:, assoc_or_class_name:, form_object_item_type_us:, reslist: } %>
+<% elsif !big_select %>
 <%= edit_field_label(form, field_name_sym, labels, force_default: assoc_or_class_name) %>
 <%= form.select field_name_sym, reslist, options, { data: {attr_name: field_name_sym, object_name: form_object_item_type_us, select_filtering_target: sf_el}}%>
 <% else %>

--- a/app/views/common_templates/edit_fields/_name_starts_with_select_record_from_table.html.erb
+++ b/app/views/common_templates/edit_fields/_name_starts_with_select_record_from_table.html.erb
@@ -18,14 +18,18 @@ human_name, reslist = list_record_data_for_select(form_object_instance,
                                                   value_attr: value_attr, 
                                                   label_attr: label_attr, 
                                                   group_split_char: group_split_char, 
-                                                  no_assoc: true,
+                                                  no_assoc: no_assoc,
                                                   sort_order: sort_order)
 unless human_name
   logger.warn "Failed to find valid class name for #{field_name_sym}"
 end
 
-unless big_select
-%>
+creatable_enabled = options.dig(:edit_as, :creatable, :enabled)
+
+if creatable_enabled %>
+<%= render partial: 'common_templates/edit_fields/creatable_select_input',
+         locals: { form:, field_name_sym:, labels:, assoc_or_class_name:, form_object_item_type_us:, reslist: } %>
+<% elsif !big_select %>
 <%= edit_field_label(form, field_name_sym, labels, force_default: assoc_or_class_name) %>
 <%= form.select field_name_sym, reslist, options, { data: {attr_name: field_name_sym, object_name: form_object_item_type_us, select_filtering_target: sf_el}}%>
 <% else %>

--- a/app/views/common_templates/edit_fields/_name_starts_with_select_record_id_from.html.erb
+++ b/app/views/common_templates/edit_fields/_name_starts_with_select_record_id_from.html.erb
@@ -22,8 +22,12 @@ unless human_name
   logger.warn "Failed to find valid class name for #{field_name}"
 end
 
-unless big_select
-%>
+creatable_enabled = options.dig(:edit_as, :creatable, :enabled)
+
+if creatable_enabled %>
+<%= render partial: 'common_templates/edit_fields/creatable_select_input',
+         locals: { form:, field_name_sym:, labels:, assoc_or_class_name:, form_object_item_type_us:, reslist: } %>
+<% elsif !big_select %>
 <%= edit_field_label(form, field_name_sym, labels, force_default: assoc_or_class_name) %>
 <%= form.select field_name_sym, reslist, options, { data: {attr_name: field_name_sym, object_name: form_object_item_type_us, select_filtering_target: sf_el}}%>
 <% else %>

--- a/app/views/common_templates/edit_fields/_name_starts_with_select_record_id_from_table.html.erb
+++ b/app/views/common_templates/edit_fields/_name_starts_with_select_record_id_from_table.html.erb
@@ -24,8 +24,12 @@ unless human_name
   logger.warn "Failed to find valid class name for #{field_name}"
 end
 
-unless big_select
-%>
+creatable_enabled = options.dig(:edit_as, :creatable, :enabled)
+
+if creatable_enabled %>
+<%= render partial: 'common_templates/edit_fields/creatable_select_input',
+         locals: { form:, field_name_sym:, labels:, assoc_or_class_name:, form_object_item_type_us:, reslist: } %>
+<% elsif !big_select %>
 <%= edit_field_label(form, field_name_sym, labels, force_default: assoc_or_class_name) %>
 <%= form.select field_name_sym, reslist, options, { data: {attr_name: field_name_sym, object_name: form_object_item_type_us, select_filtering_target: sf_el}}%>
 <% else %>

--- a/app/views/common_templates/edit_fields/_name_starts_with_tag_select_record_from_table.html.erb
+++ b/app/views/common_templates/edit_fields/_name_starts_with_tag_select_record_from_table.html.erb
@@ -7,8 +7,16 @@ group_split_char = options.dig(:edit_as, :group_split_char)
 value_attr = options.dig(:edit_as, :value_attr) || :data
 label_attr = options.dig(:edit_as, :label_attr) || :data
 sort_order = options.dig(:edit_as, :sort_order)
+no_assoc = true
+no_assoc = options.dig(:edit_as, :no_assoc) if options[:edit_as]&.key?(:no_assoc)
 
-human_name, reslist = list_record_data_for_select(form_object_instance, rl, value_attr: value_attr, label_attr: label_attr, group_split_char: group_split_char, sort_order: sort_order)
+human_name, reslist = list_record_data_for_select(form_object_instance,
+                                                  rl,
+                                                  value_attr: value_attr,
+                                                  label_attr: label_attr,
+                                                  group_split_char: group_split_char,
+                                                  no_assoc:,
+                                                  sort_order: sort_order)
 
 unless human_name
   logger.warn "Failed to find valid class name for #{field_name}"

--- a/spec/models/dynamic/creatable_select_spec.rb
+++ b/spec/models/dynamic/creatable_select_spec.rb
@@ -1,0 +1,343 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require './db/table_generators/dynamic_models_table'
+
+# Tests for the creatable select field feature (Issue #73)
+#
+# When a dynamic model field uses `select_record_from_table_<target>` with
+# `creatable: { enabled: true }` in its `edit_as` config, saving a record
+# with a value that doesn't already exist in the target model should
+# auto-create a new record in that target model.
+#
+# Test Coverage:
+# - Existing value: saving with a value already in the target model does NOT create a duplicate
+# - New value: saving with a value not in the target model DOES create a new record
+# - Access control: user without `create` access on the target model gets a validation error
+# - Blank/nil values: do not trigger creation
+# - Additional single-select variants are supported:
+#   select_record_from_*, select_record_id_from_table_*, select_record_id_from_*
+# - Works with `value_attr: name` (text storage)
+RSpec.describe 'Creatable select fields', type: :model do
+  include MasterSupport
+  include ModelSupport
+  include DynamicModelSupport
+
+  before :all do
+    change_setting('AllowDynamicMigrations', true)
+    create_admin
+    create_user
+
+    # Pre-create tables to avoid auto-migration timeout issues
+    unless Admin::MigrationGenerator.table_exists? 'test_creatable_sources'
+      TableGenerators.dynamic_models_table('test_creatable_sources', :create_do, 'name')
+    end
+    unless Admin::MigrationGenerator.table_exists? 'test_creatable_consumers'
+      TableGenerators.dynamic_models_table('test_creatable_consumers', :create_do, 'select_record_from_table_test_creatable_sources')
+    end
+    unless Admin::MigrationGenerator.table_exists? 'test_creatable_assoc_consumers'
+      TableGenerators.dynamic_models_table('test_creatable_assoc_consumers', :create_do, 'select_record_from_test_creatable_sources')
+    end
+    unless Admin::MigrationGenerator.table_exists? 'test_creatable_id_consumers'
+      TableGenerators.dynamic_models_table('test_creatable_id_consumers', :create_do,
+                                           'select_record_id_from_table_test_creatable_sources',
+                                           'select_record_id_from_test_creatable_sources')
+    end
+
+    @master = create_master
+
+    # Source model: a dynamic model with a 'name' field
+    # Acts as the "tag list" that the consumer selects from
+    DynamicModel.active.where(table_name: 'test_creatable_sources').reload.each { |dm| dm.disable!(@admin) }
+    begin
+      DynamicModel.send(:remove_const, :TestCreatableSource) if DynamicModel.const_defined?(:TestCreatableSource, false)
+    rescue NameError
+    end
+
+    @source_dm = DynamicModel.create!(
+      current_admin: @admin,
+      name: 'test creatable sources',
+      table_name: 'test_creatable_sources',
+      schema_name: 'dynamic_test',
+      primary_key_name: :id,
+      foreign_key_name: :master_id,
+      category: :test
+    )
+    @source_dm.current_admin = @admin
+    @source_dm.update_tracker_events
+
+    setup_access :dynamic_model__test_creatable_sources, resource_type: :table, access: :create, user: @user
+
+    # Consumer model: has a select_record_from_table_test_creatable_sources field
+    # configured with creatable: { enabled: true }
+    DynamicModel.active.where(table_name: 'test_creatable_consumers').reload.each { |dm| dm.disable!(@admin) }
+    begin
+      if DynamicModel.const_defined?(:TestCreatableConsumer, false)
+        DynamicModel.send(:remove_const, :TestCreatableConsumer)
+      end
+    rescue NameError
+    end
+
+    consumer_options = <<~YAML
+      default:
+        field_options:
+          select_record_from_table_test_creatable_sources:
+            edit_as:
+              field_type: select_record_from_table_test_creatable_sources
+              value_attr: name
+              label_attr: name
+              creatable:
+                enabled: true
+    YAML
+
+    @consumer_dm = DynamicModel.create!(
+      current_admin: @admin,
+      name: 'test creatable consumers',
+      table_name: 'test_creatable_consumers',
+      schema_name: 'dynamic_test',
+      primary_key_name: :id,
+      foreign_key_name: :master_id,
+      category: :test,
+      options: consumer_options
+    )
+    @consumer_dm.current_admin = @admin
+    @consumer_dm.update_tracker_events
+
+    setup_access :dynamic_model__test_creatable_consumers, user: @user
+
+    DynamicModel.active.where(table_name: 'test_creatable_assoc_consumers').reload.each { |dm| dm.disable!(@admin) }
+    begin
+      if DynamicModel.const_defined?(:TestCreatableConsumerAssoc, false)
+        DynamicModel.send(:remove_const, :TestCreatableConsumerAssoc)
+      end
+    rescue NameError
+    end
+
+    assoc_consumer_options = <<~YAML
+      default:
+        field_options:
+          select_record_from_test_creatable_sources:
+            edit_as:
+              field_type: select_record_from_test_creatable_sources
+              value_attr: name
+              label_attr: name
+              creatable:
+                enabled: true
+    YAML
+
+    @assoc_consumer_dm = DynamicModel.create!(
+      current_admin: @admin,
+      name: 'test creatable consumers assoc',
+      table_name: 'test_creatable_assoc_consumers',
+      schema_name: 'dynamic_test',
+      primary_key_name: :id,
+      foreign_key_name: :master_id,
+      category: :test,
+      options: assoc_consumer_options
+    )
+    @assoc_consumer_dm.current_admin = @admin
+    @assoc_consumer_dm.update_tracker_events
+
+    setup_access :dynamic_model__test_creatable_assoc_consumers, user: @user
+
+    DynamicModel.active.where(table_name: 'test_creatable_id_consumers').reload.each { |dm| dm.disable!(@admin) }
+    begin
+      if DynamicModel.const_defined?(:TestCreatableConsumerId, false)
+        DynamicModel.send(:remove_const, :TestCreatableConsumerId)
+      end
+    rescue NameError
+    end
+
+    id_consumer_options = <<~YAML
+      default:
+        field_options:
+          select_record_id_from_table_test_creatable_sources:
+            edit_as:
+              field_type: select_record_id_from_table_test_creatable_sources
+              label_attr: name
+              creatable:
+                enabled: true
+          select_record_id_from_test_creatable_sources:
+            edit_as:
+              field_type: select_record_id_from_test_creatable_sources
+              label_attr: name
+              creatable:
+                enabled: true
+    YAML
+
+    @id_consumer_dm = DynamicModel.create!(
+      current_admin: @admin,
+      name: 'test creatable consumers id',
+      table_name: 'test_creatable_id_consumers',
+      schema_name: 'dynamic_test',
+      primary_key_name: :id,
+      foreign_key_name: :master_id,
+      category: :test,
+      options: id_consumer_options
+    )
+    @id_consumer_dm.current_admin = @admin
+    @id_consumer_dm.update_tracker_events
+
+    setup_access :dynamic_model__test_creatable_id_consumers, user: @user
+  end
+
+  after :all do
+    change_setting('AllowDynamicMigrations', false)
+  end
+
+  before :example do
+    create_user
+    @master = create_master
+    setup_access :dynamic_model__test_creatable_sources, resource_type: :table, access: :create, user: @user
+    setup_access :dynamic_model__test_creatable_consumers, user: @user
+    setup_access :dynamic_model__test_creatable_assoc_consumers, user: @user
+    setup_access :dynamic_model__test_creatable_id_consumers, user: @user
+  end
+
+  def source_class
+    @source_dm.implementation_class
+  end
+
+  def consumer_class
+    @consumer_dm.implementation_class
+  end
+
+  def assoc_consumer_class
+    @assoc_consumer_dm.implementation_class
+  end
+
+  def id_consumer_class
+    @id_consumer_dm.implementation_class
+  end
+
+  describe 'when saving with a value that already exists in the target model' do
+    it 'does not create a duplicate record in the target model' do
+      source_class.create!(current_user: @user, master: @master, name: 'existing tag one')
+      existing_count = source_class.where(name: 'existing tag one').count
+      expect(existing_count).to eq 1
+
+      consumer_class.create!(
+        current_user: @user,
+        master: @master,
+        select_record_from_table_test_creatable_sources: 'existing tag one'
+      )
+
+      expect(source_class.where(name: 'existing tag one').count).to eq 1
+    end
+  end
+
+  describe 'when saving with a new value that does not exist in the target model' do
+    it 'creates a new record in the target model with the configured value_attr' do
+      expect(source_class.where(name: 'brand new tag').count).to eq 0
+
+      consumer_class.create!(
+        current_user: @user,
+        master: @master,
+        select_record_from_table_test_creatable_sources: 'brand new tag'
+      )
+
+      expect(source_class.where(name: 'brand new tag').count).to eq 1
+    end
+  end
+
+  describe 'when the user does not have create access on the target model' do
+    before :example do
+      setup_access :dynamic_model__test_creatable_sources, resource_type: :table, access: :read, user: @user
+    end
+
+    it 'adds a validation error and does not create the new record' do
+      expect(source_class.where(name: 'unauthorized new tag').count).to eq 0
+
+      record = consumer_class.new(
+        current_user: @user,
+        master: @master,
+        select_record_from_table_test_creatable_sources: 'unauthorized new tag'
+      )
+
+      expect(record.save).to be false
+      expect(record.errors).not_to be_empty
+      expect(source_class.where(name: 'unauthorized new tag').count).to eq 0
+    end
+  end
+
+  describe 'when saving with a blank or nil value' do
+    it 'does not trigger creation for a nil value' do
+      initial_count = source_class.count
+
+      consumer_class.create!(
+        current_user: @user,
+        master: @master,
+        select_record_from_table_test_creatable_sources: nil
+      )
+
+      expect(source_class.count).to eq initial_count
+    end
+
+    it 'does not trigger creation for a blank string value' do
+      initial_count = source_class.count
+
+      consumer_class.create!(
+        current_user: @user,
+        master: @master,
+        select_record_from_table_test_creatable_sources: ''
+      )
+
+      expect(source_class.count).to eq initial_count
+    end
+  end
+
+  describe 'when using other single-select select_record variants' do
+    it 'creates a new record for select_record_from_* fields' do
+      expect(source_class.where(name: 'assoc new tag').count).to eq 0
+
+      assoc_consumer_class.create!(
+        current_user: @user,
+        master: @master,
+        select_record_from_test_creatable_sources: 'assoc new tag'
+      )
+
+      expect(source_class.where(name: 'assoc new tag').count).to eq 1
+    end
+
+    it 'creates a new record and stores its id for select_record_id_from_table_* fields' do
+      expect(source_class.where(name: 'id table new tag').count).to eq 0
+
+      rec = id_consumer_class.create!(
+        current_user: @user,
+        master: @master,
+        select_record_id_from_table_test_creatable_sources: '__creatable_new__id table new tag'
+      )
+
+      created = source_class.find_by(name: 'id table new tag')
+      expect(created).not_to be_nil
+      expect(rec.select_record_id_from_table_test_creatable_sources.to_i).to eq(created.id)
+    end
+
+    it 'stores existing id directly when value is a numeric id' do
+      existing = source_class.create!(current_user: @user, master: @master, name: 'id direct existing')
+
+      rec = id_consumer_class.create!(
+        current_user: @user,
+        master: @master,
+        select_record_id_from_table_test_creatable_sources: existing.id.to_s
+      )
+
+      expect(rec.select_record_id_from_table_test_creatable_sources.to_i).to eq(existing.id)
+      expect(source_class.where(name: 'id direct existing').count).to eq 1
+    end
+
+    it 'maps existing labels to ids for select_record_id_from_* fields without creating duplicates' do
+      existing = source_class.create!(current_user: @user, master: @master, name: 'id assoc existing')
+      expect(source_class.where(name: 'id assoc existing').count).to eq 1
+
+      rec = id_consumer_class.create!(
+        current_user: @user,
+        master: @master,
+        select_record_id_from_test_creatable_sources: '__creatable_new__id assoc existing'
+      )
+
+      expect(rec.select_record_id_from_test_creatable_sources.to_i).to eq(existing.id)
+      expect(source_class.where(name: 'id assoc existing').count).to eq 1
+    end
+  end
+end

--- a/spec/system/creatable_select_field_spec.rb
+++ b/spec/system/creatable_select_field_spec.rb
@@ -1,0 +1,307 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# System tests for the creatable select field component (Issue #73)
+#
+# Test Coverage:
+# ✅ Renders typeahead input instead of select dropdown when creatable.enabled is true
+# ✅ Shows typeahead suggestions when typing a matching value
+# ✅ Saves existing value from typeahead without creating duplicates in source model
+# ✅ Saves new value and auto-creates record in source model
+#
+# When a dynamic model field uses `select_record_from_table_<target>` with
+# `creatable: { enabled: true }` in its `edit_as` field_options config,
+# the field renders as a typeahead text input instead of a standard <select> dropdown.
+# The Bloodhound/typeahead.js component provides autocomplete suggestions from existing
+# source model records. When a user types a value that doesn't exist in the source model,
+# a new record is auto-created in the source model via a before_save callback on save.
+#
+# Implementation Notes:
+# - Uses dynamic models for test data (test_creatable_sources, test_creatable_consumers)
+# - Tests run with AllowDynamicMigrations enabled to create tables on-the-fly
+# - Typeahead input has class 'creatable-select-input typeahead'
+# - Suggestions appear in '.tt-suggestion' elements from typeahead.js
+# - Standard string/varchar fields downcase on storage and titleize on display
+describe 'creatable select field component', js: true, driver: $browser_driver do
+  include ModelSupport
+  include MasterDataSupport
+  include FeatureSupport
+  include DynamicModelSupport
+
+  def set_up_feature
+    SetupHelper.feature_setup
+    change_setting('TwoFactorAuthDisabledForUser', true)
+    change_setting('AllowDynamicMigrations', true)
+    create_admin
+
+    ms = Master.no_temporary_masters
+    if ms.count == 0 || ms.first.nil? || ms.first.id < 1
+      create_data_set_outside_tx
+      @master ||= ms.first
+      @master_id ||= @master.id
+    else
+      @master = ms.first
+      @master_id = @master.id
+    end
+
+    expect(@master_id).to be > 0
+
+    @user, @good_password = create_user(create_master: true)
+    @good_email = @user.email
+    @app_type = @user.app_type
+    expect(@app_type).not_to be nil
+    expect(@user.two_factor_setup_required?).to be_falsey
+    disable_active_panel_layout('test-columns-panel')
+    # Disable all master-layout panels so the default tab template is used,
+    # which includes the "details" tab for dynamic models with category: :details
+    Admin::PageLayout.active.where(app_type_id: @app_type.id, layout_name: 'master').each do |pl|
+      pl.disable!(@admin)
+    end
+  end
+
+  # Create a source table with test data for creatable select
+  # This table provides the "tag list" that the consumer field selects from
+  def setup_source_data_table
+    DynamicModel.active.where(table_name: 'test_creatable_sources').reload.each { |dm| dm.disable!(@admin) }
+    DynamicModel.send(:remove_const, :TestCreatableSource) if defined? DynamicModel::TestCreatableSource
+
+    dm = DynamicModel.create! current_admin: @admin,
+                              name: 'Test Creatable Sources',
+                              schema_name: 'dynamic_test',
+                              table_name: 'test_creatable_sources',
+                              category: :test,
+                              field_list: 'name',
+                              primary_key_name: 'id',
+                              foreign_key_name: 'master_id'
+
+    dm.current_admin = @admin
+    dm.update_tracker_events
+    setup_access :dynamic_model__test_creatable_sources, resource_type: :table, access: :create, user: @user
+
+    @master.current_user = @user
+    ic = dm.implementation_class
+
+    # Seed existing source values for typeahead suggestions
+    @source_alpha = ic.create!(current_user: @user, master: @master, name: 'alpha source')
+    @source_beta = ic.create!(current_user: @user, master: @master, name: 'beta source')
+
+    dm
+  end
+
+  # Create a consumer dynamic model with a creatable select field
+  # Uses select_record_from_table_test_creatable_sources with creatable.enabled
+  def setup_creatable_consumer_dm
+    DynamicModel.active.where(table_name: 'test_creatable_consumers').reload.each { |dm| dm.disable!(@admin) }
+    DynamicModel.send(:remove_const, :TestCreatableConsumer) if defined? DynamicModel::TestCreatableConsumer
+
+    dm_options = <<~YAML
+      _configurations: {}
+
+      default:
+        field_options:
+          select_record_from_table_test_creatable_sources:
+            edit_as:
+              field_type: select_record_from_table_test_creatable_sources
+              value_attr: name
+              label_attr: name
+              creatable:
+                enabled: true
+        labels:
+          select_record_from_table_test_creatable_sources: Creatable Source
+    YAML
+
+    dm = DynamicModel.create! current_admin: @admin,
+                              name: 'Test Creatable Consumers',
+                              schema_name: 'dynamic_test',
+                              table_name: 'test_creatable_consumers',
+                              category: :details,
+                              options: dm_options,
+                              field_list: 'select_record_from_table_test_creatable_sources',
+                              primary_key_name: 'id',
+                              foreign_key_name: 'master_id',
+                              position: 10
+
+    dm.current_admin = @admin
+    dm.update_tracker_events
+    setup_access :dynamic_model__test_creatable_consumers, user: @user
+
+    dm
+  end
+
+  # Navigate to the creatable consumer form within the master record details tab
+  def navigate_to_creatable_form
+    visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@master.id}"
+    dismiss_modal
+    finish_page_loading
+
+    expect(page).to have_css("#master-#{@master.id}")
+    expect(page).not_to have_css('.alert')
+
+    # Expand the details tab - nav_q_id auto-expands the master record
+    expand_master_record_tab('details')
+    finish_page_loading
+
+    new_button_selector = '.details-item-type-dynamic-model--test-creatable-consumers .new-button-container a.btn'
+    expect(page).to have_css(new_button_selector, wait: 10)
+    5.times do
+      new_button = find(new_button_selector, wait: 10)
+      scroll_into_view(new_button)
+      new_button.click
+      finish_page_loading
+
+      break if page.has_css?('form.new_dynamic_model_test_creatable_consumer', wait: 2)
+    end
+
+    expect(page).to have_css('form.new_dynamic_model_test_creatable_consumer', wait: 10)
+    finish_form_formatting
+    sleep 1 # Allow JavaScript to fully initialize typeahead
+  end
+
+  # Navigate to an existing saved creatable consumer record and open it in edit mode
+  def navigate_to_saved_creatable_edit_form(expected_value:)
+    visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@master.id}"
+    dismiss_modal
+    finish_page_loading
+
+    expect(page).to have_css("#master-#{@master.id}")
+    expect(page).not_to have_css('.alert')
+
+    expand_master_record_tab('details')
+    finish_page_loading
+
+    details_section = find('.details-item-type-dynamic-model--test-creatable-consumers', wait: 10)
+
+    record_item = details_section.all('li.list-group-item, .common-template-item', wait: 10).find do |item|
+      item.text.downcase.include?(expected_value.downcase)
+    end
+
+    expect(record_item).not_to be_nil
+    click_edit_button_within_target(record_item)
+  end
+
+  before :all do
+    set_up_feature
+    @source_dm = setup_source_data_table
+    @consumer_dm = setup_creatable_consumer_dm
+
+    [@source_dm, @consumer_dm].each do |dm|
+      dm.force_regenerate = true
+      dm.generate_model
+      dm.add_master_association
+    end
+
+    DynamicModel.routes_load
+    Rails.application.routes_reloader.reload!
+  end
+
+  before :each do
+    login
+  end
+
+  it 'renders typeahead input instead of select dropdown' do
+    navigate_to_creatable_form
+
+    within('form.new_dynamic_model_test_creatable_consumer') do
+      # Verify typeahead input is rendered
+      expect(page).to have_css('input.creatable-select-input.typeahead[data-attr-name="select_record_from_table_test_creatable_sources"]')
+
+      # Verify no select dropdown is rendered for the field
+      expect(page).not_to have_css('select[data-attr-name="select_record_from_table_test_creatable_sources"]')
+    end
+  end
+
+  it 'shows typeahead suggestions when typing a matching value' do
+    navigate_to_creatable_form
+
+    within('form.new_dynamic_model_test_creatable_consumer') do
+      # typeahead.js duplicates the input; use match: :first to get the active one
+      typeahead_input = find('input.creatable-select-input.tt-input', match: :first)
+      scroll_into_view(typeahead_input)
+      typeahead_input.send_keys('alpha')
+    end
+
+    # Typeahead suggestions appear outside the form scope
+    expect(page).to have_css('.tt-suggestion', wait: 5)
+    suggestion_texts = all('.tt-suggestion').map(&:text)
+    expect(suggestion_texts).to include(a_string_matching(/alpha source/i))
+  end
+
+  it 'saves existing value from typeahead and does not create duplicate' do
+    source_class = @source_dm.implementation_class
+    initial_count = source_class.where(name: 'alpha source').count
+    expect(initial_count).to be >= 1
+
+    navigate_to_creatable_form
+
+    within('form.new_dynamic_model_test_creatable_consumer') do
+      # typeahead.js duplicates the input; use match: :first to get the active one
+      typeahead_input = find('input.creatable-select-input.tt-input', match: :first)
+      scroll_into_view(typeahead_input)
+      typeahead_input.send_keys('alpha')
+    end
+
+    # Wait for and click the suggestion
+    expect(page).to have_css('.tt-suggestion', wait: 5)
+    find('.tt-suggestion', text: /alpha source/i, match: :first).click
+    sleep 0.5
+
+    within('form.new_dynamic_model_test_creatable_consumer') do
+      click_button 'Save'
+    end
+    finish_page_loading
+
+    # Verify the record was saved and the value is displayed
+    expect(page).to have_css('.details-item-type-dynamic-model--test-creatable-consumers', wait: 10)
+    # Value is displayed as stored (lowercase)
+    expect(page).to have_content('alpha source', normalize_ws: true)
+
+    # Verify no duplicate was created in the source model
+    expect(source_class.where(name: 'alpha source').count).to eq initial_count
+  end
+
+  it 'saves new value and auto-creates record in source model' do
+    source_class = @source_dm.implementation_class
+    expect(source_class.where(name: 'gamma source').count).to eq 0
+
+    navigate_to_creatable_form
+
+    within('form.new_dynamic_model_test_creatable_consumer') do
+      # typeahead.js duplicates the input; use match: :first to get the active one
+      typeahead_input = find('input.creatable-select-input.tt-input', match: :first)
+      scroll_into_view(typeahead_input)
+      typeahead_input.send_keys('gamma source')
+    end
+
+    sleep 0.5
+
+    within('form.new_dynamic_model_test_creatable_consumer') do
+      click_button 'Save'
+    end
+    finish_page_loading
+
+    # Verify the record was saved and the value is displayed
+    expect(page).to have_css('.details-item-type-dynamic-model--test-creatable-consumers', wait: 10)
+    # Value is displayed as stored (lowercase)
+    expect(page).to have_content('gamma source', normalize_ws: true)
+
+    # Verify a new record was auto-created in the source model
+    expect(source_class.where(name: 'gamma source').count).to eq 1
+
+    # Re-open the saved dynamic model instance in edit mode and confirm
+    # the newly added value is available in typeahead suggestions.
+    edit_form = navigate_to_saved_creatable_edit_form(expected_value: 'gamma source')
+
+    within(edit_form) do
+      typeahead_input = find('input.creatable-select-input.tt-input', match: :first)
+      scroll_into_view(typeahead_input)
+      typeahead_input.send_keys([:control, 'a'])
+      typeahead_input.send_keys(:delete)
+      typeahead_input.send_keys('gam')
+    end
+
+    expect(page).to have_css('.tt-suggestion', wait: 5)
+    suggestion_texts = all('.tt-suggestion').map(&:text)
+    expect(suggestion_texts).to include(a_string_matching(/gamma source/i))
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `creatable` mode for all four single-select `select_record_*` field variants. When `edit_as.creatable.enabled: true` is configured, the field renders as a typeahead text input (Bloodhound/typeahead.js) instead of a `<select>` dropdown, allowing users to either pick an existing value or type a new one that is auto-created in the source model on save.

Fixes #73

### Changes

**Backend** (`app/models/dynamic/implementation_handler.rb`):
- Added `before_save :handle_creatable_select_fields` callback that auto-creates records in source models
- Supports all 4 single-select prefixes: `select_record_from_table_*`, `select_record_from_*`, `select_record_id_from_table_*`, `select_record_id_from_*`
- Uses `__creatable_new__` prefix protocol to distinguish freeform entries from existing selections
- Enforces access control (`allows_user_access_to?(:create)`) before creating
- Handles concurrent creation with `RecordNotUnique` rescue
- Extracted `CREATABLE_NEW_PREFIX` constant shared between Ruby and JS via data attribute
- Helper methods made private

**Frontend** (`app/assets/javascripts/app/_fpa_form_utils.js`):
- Extended `setup_typeahead` to support object datasets `{label, value}` with proper datum tokenization
- Tracks selected label/value via data attributes on the input element
- On form submit, maps selections back to values or prepends `__creatable_new__` prefix for freeform entries
- Per-field data isolation via `data-creatable-items` attribute (supports multiple creatable fields per form)
- Reads prefix from `data-creatable-new-prefix` attribute rendered by Rails

**Views** (`app/views/common_templates/edit_fields/`):
- Updated all 4 `_name_starts_with_select_record_*.html.erb` partials with creatable branch
- Extracted shared creatable rendering into `_creatable_select_input.html.erb` partial to eliminate duplication

**Admin config** (`extra_options_field_options_defs.yaml`):
- Documented `creatable.enabled` field option

**Tests**:
- 9 model specs (`spec/models/dynamic/creatable_select_spec.rb`): existing value dedup, new value creation, access control, blank/nil handling, all 4 variants
- 4 system specs (`spec/system/creatable_select_field_spec.rb`): typeahead rendering, suggestions, existing value save, new value creation + edit roundtrip
