### PR TITLE
Fixed api_access_only 2FA edge cases: missing otp_secret generation and flag reset

### DIFF
--- a/app/models/concerns/standard_authentication.rb
+++ b/app/models/concerns/standard_authentication.rb
@@ -401,7 +401,7 @@ module StandardAuthentication
   def handle_api_access_only_on_create
     return unless respond_to?(:api_access_only)
 
-    self.otp_required_for_login = true if api_access_only?
+    ensure_api_access_only_otp if api_access_only?
   end
 
   # Ensure API-only users always get a generated password on create,
@@ -418,10 +418,24 @@ module StandardAuthentication
     return if new_record?
 
     if api_access_only? && api_access_only_changed?
-      self.otp_required_for_login = true
+      ensure_api_access_only_otp
     elsif api_access_only_changed? && !api_access_only?
+      # Always reset otp_required_for_login before calling setup_two_factor_auth.
+      # If 2FA is currently disabled globally, setup_two_factor_auth returns early without
+      # clearing this flag, leaving the user appearing "set up" with an API-generated secret
+      # they never registered. Resetting it here ensures they go through QR setup when
+      # 2FA is later re-enabled.
+      self.otp_required_for_login = false
       setup_two_factor_auth
     end
+  end
+
+  #
+  # Ensure an API-only user has an otp_secret and otp_required_for_login is set.
+  # otp_secret may be absent if the user was created when 2FA was globally disabled.
+  def ensure_api_access_only_otp
+    self.otp_secret = self.class.generate_otp_secret unless otp_secret.present?
+    self.otp_required_for_login = true
   end
 
   #

--- a/spec/models/user_api_access_only_spec.rb
+++ b/spec/models/user_api_access_only_spec.rb
@@ -16,6 +16,9 @@
 # - Admin permitted_params includes api_access_only
 # - Bug fix: API-only user created without explicit password (registration admin scenario)
 # - Bug fix: force_password_reset on API-only user preserves new_token for views
+# - Bug fix: toggling api_access_only on a user created without 2FA generates missing otp_secret
+# - Bug fix: creating an api_access_only user while 2FA is disabled still generates otp_secret
+# - Bug fix: toggling api_access_only off while 2FA is globally disabled still resets otp_required_for_login
 
 require 'rails_helper'
 
@@ -61,6 +64,31 @@ RSpec.describe 'User api_access_only flag', type: :model do
       expect(user.two_factor_setup_required?).to be false
     end
 
+    it 'generates otp_secret when created as api_access_only while 2FA is globally disabled' do
+      # If the server has 2FA disabled at creation time, setup_two_factor_auth returns early.
+      # handle_api_access_only_on_create must still generate otp_secret so the user
+      # passes two_factor_setup_required? when 2FA is later enabled.
+      change_setting('TwoFactorAuthDisabledForUser', true)
+      begin
+        user = User.create!(
+          email: "api-no2fa-#{SecureRandom.hex(6)}@testing.com",
+          current_admin: @admin,
+          first_name: 'ApiNo2fa',
+          last_name: 'User',
+          password: Devise.friendly_token(30),
+          api_access_only: true
+        )
+      ensure
+        change_setting('TwoFactorAuthDisabledForUser', false)
+      end
+
+      user.reload
+      expect(user.otp_secret).to be_present
+      expect(user.otp_required_for_login).to be true
+      # two_factor_setup_required? now returns false even though 2FA is globally enabled
+      expect(user.two_factor_setup_required?).to be false
+    end
+
     it 'does not change otp_required_for_login for a non-API-only user' do
       user = User.create!(
         email: "regular-#{SecureRandom.hex(6)}@testing.com",
@@ -94,6 +122,40 @@ RSpec.describe 'User api_access_only flag', type: :model do
       expect(user.otp_required_for_login).to be true
     end
 
+    it 'generates otp_secret and sets otp_required_for_login when toggled to API-only and otp_secret was never set' do
+      # Simulate a user created when 2FA was globally disabled: no otp_secret was ever generated.
+      # This can happen when a server has 2FA disabled, creates users, then later enables 2FA
+      # and an admin converts an existing user to api_access_only.
+      change_setting('TwoFactorAuthDisabledForUser', true)
+      begin
+        user = User.create!(
+          email: "no-otp-secret-#{SecureRandom.hex(6)}@testing.com",
+          current_admin: @admin,
+          first_name: 'NoOtp',
+          last_name: 'Secret',
+          password: Devise.friendly_token(30)
+        )
+      ensure
+        change_setting('TwoFactorAuthDisabledForUser', false)
+      end
+
+      user.reload
+      expect(user.otp_secret).to be_nil
+      expect(user.otp_required_for_login).to be_falsey
+      expect(user.two_factor_setup_required?).to be true
+
+      # Toggle to api_access_only (with 2FA now enabled globally)
+      user.current_admin = @admin
+      user.api_access_only = true
+      user.save!
+      user.reload
+
+      # Both conditions for two_factor_setup_required? must be satisfied
+      expect(user.otp_secret).to be_present
+      expect(user.otp_required_for_login).to be true
+      expect(user.two_factor_setup_required?).to be false
+    end
+
     it 'resets 2FA when toggled from API-only back to regular' do
       user = User.create!(
         email: "toggle-back-#{SecureRandom.hex(6)}@testing.com",
@@ -115,6 +177,39 @@ RSpec.describe 'User api_access_only flag', type: :model do
       user.reload
 
       # 2FA should be reset so the user has to set up an authenticator interactively
+      expect(user.otp_required_for_login).to be false
+      expect(user.two_factor_setup_required?).to be true
+    end
+
+    it 'resets otp_required_for_login when toggled off while 2FA is globally disabled' do
+      # Bug: if an API-only user is converted back to a regular user while 2FA is
+      # globally disabled, setup_two_factor_auth returns early — leaving
+      # otp_required_for_login = true and the API-generated otp_secret intact.
+      # When 2FA is later re-enabled the user appears fully set-up but has never
+      # scanned a QR code, locking them out permanently.
+      user = User.create!(
+        email: "api-toggle-no2fa-#{SecureRandom.hex(6)}@testing.com",
+        current_admin: @admin,
+        first_name: 'ApiToggle',
+        last_name: 'No2fa',
+        password: Devise.friendly_token(30),
+        api_access_only: true
+      )
+      user.reload
+      expect(user.otp_required_for_login).to be true
+
+      change_setting('TwoFactorAuthDisabledForUser', true)
+      begin
+        user.current_admin = @admin
+        user.api_access_only = false
+        user.save!
+      ensure
+        change_setting('TwoFactorAuthDisabledForUser', false)
+      end
+
+      user.reload
+      # otp_required_for_login must be false so that when 2FA is later re-enabled
+      # the user is routed through proper QR-code setup instead of being locked out
       expect(user.otp_required_for_login).to be false
       expect(user.two_factor_setup_required?).to be true
     end


### PR DESCRIPTION
## Summary

Fixes #1083

Three related edge cases in `api_access_only` / 2FA interaction are addressed:

### 1. Toggle to API-only: missing `otp_secret` not generated
When toggling an existing user to `api_access_only = true`, `handle_api_access_only_change` now generates a missing `otp_secret` if one was never set. This occurs when a user was created while `TwoFactorAuthDisabledForUser` was `true`, so `setup_two_factor_auth` skipped secret generation at creation time.

Without the fix: `otp_secret = nil` + `otp_required_for_login = true` → `two_factor_setup_required?` returns `true` → `UserBaseController` before_action redirects every request (including token-authenticated API calls) to `/users/show_otp`.

### 2. Create as API-only with 2FA globally disabled: `otp_secret` not generated
`handle_api_access_only_on_create` previously only set `otp_required_for_login = true` without generating an `otp_secret`. When a user is created as `api_access_only` while 2FA is globally disabled, `setup_two_factor_auth` returns early (no secret generated) and the original callback did not compensate. When 2FA was later re-enabled, the user was blocked by `two_factor_setup_required?`.

### 3. Toggle off API-only with 2FA globally disabled: `otp_required_for_login` not cleared
When converting an API-only user back to a regular user while 2FA is globally disabled, `setup_two_factor_auth` returns early without clearing `otp_required_for_login`. The user retains `otp_required_for_login = true` with the API-generated secret. When 2FA is later re-enabled, `two_factor_setup_required?` returns `false` (appears fully set up) but the user never scanned a QR code — permanently locking them out.

`otp_required_for_login = false` is now set unconditionally before calling `setup_two_factor_auth` so the flag is always reset regardless of whether 2FA is currently enabled globally.

## Changes

- `app/models/concerns/standard_authentication.rb`:
  - Extracted shared logic into new private `ensure_api_access_only_otp` helper that generates `otp_secret` if absent and sets `otp_required_for_login = true`
  - `handle_api_access_only_on_create`: calls `ensure_api_access_only_otp` instead of bare flag assignment
  - `handle_api_access_only_change` (toggle to API-only): calls `ensure_api_access_only_otp`
  - `handle_api_access_only_change` (toggle off API-only): resets `otp_required_for_login = false` before `setup_two_factor_auth`
- `spec/models/user_api_access_only_spec.rb`: Three new tests, one per scenario above