### PR TITLE
Added Chart.js chart reports documentation and system spec - fixes #1086

### DIFF
--- a/docs/admin_reference/reports/0_introduction.md
+++ b/docs/admin_reference/reports/0_introduction.md
@@ -25,3 +25,4 @@ See [Full Text Search](full_text_search.md) for a concise guide and query patter
 - [Detailed Options](detailed_options.md)
 - [File Filtering](file_filtering.md)
 - [Full Text Search](full_text_search.md)
+- [Chart Reports](chart_reports.md)

--- a/docs/admin_reference/reports/chart_reports.md
+++ b/docs/admin_reference/reports/chart_reports.md
@@ -1,0 +1,348 @@
+# Chart Reports
+
+Reports can display results as interactive charts using [Chart.js](https://www.chartjs.org/). This allows SQL query results to be visualised as line, bar, pie, doughnut, radar and other chart types.
+
+## Enabling Chart View
+
+Set `view_as: chart` in the report's `view_options` to render results as a chart instead of the default table:
+
+```yaml
+view_options:
+  view_as: chart
+```
+
+The report must also be configured with a `component:` section that defines the chart type and Chart.js options.
+
+## SQL Structure
+
+The SQL query must return columns that map to chart data:
+
+- **One column** acts as the **label** for each data point (the x-axis or legend label). Specify which column to use with `label_with_column`.
+- **Remaining columns** each become a **dataset** (a data series) in the chart.
+
+**Example — two datasets named "screenings" and "enrollments" labelled by "week":**
+
+```sql
+SELECT
+  week_start    AS "week",
+  screenings    AS "screenings",
+  enrollments   AS "enrollments"
+FROM weekly_summary
+ORDER BY week_start;
+```
+
+## Component Options
+
+The `component:` section of a report's options holds the Chart.js configuration. All keys inside `component: options:` are mapped directly onto Chart.js constructor arguments.
+
+```yaml
+component:
+  options:
+    type: <chart_type>
+    width: <number>
+    height: <number>
+    label_with_column: <column_name>
+    dataset_options:
+      - <per-dataset Chart.js options>
+    data_labels: []
+    options:
+      <Chart.js options object>
+```
+
+### Top-Level Keys
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `type` | `''` | Chart.js chart type (see [Chart Types](#chart-types)) |
+| `width` | `100` | Canvas width (pixels or `'100%'` for responsive) |
+| `height` | `100` | Canvas height (pixels or percentage string for responsive) |
+| `label_with_column` | `'label'` | SQL column name whose values become the chart labels |
+| `dataset_options` | `[]` | Array of Chart.js dataset option objects, one per dataset column |
+| `data_labels` | `[]` | Seed labels; SQL-derived labels are appended to this array at render time |
+| `options` | `{}` | Chart.js [configuration options](https://www.chartjs.org/docs/latest/configuration/) object |
+
+### Chart Types
+
+Any Chart.js chart type is supported:
+
+| Type | Description |
+|------|-------------|
+| `line` | Line chart — good for time-series trends |
+| `bar` | Vertical bar chart |
+| `horizontalBar` | Horizontal bar chart |
+| `pie` | Pie chart |
+| `doughnut` | Doughnut chart |
+| `radar` | Radar/spider chart |
+| `polarArea` | Polar area chart |
+| `scatter` | Scatter plot |
+| `bubble` | Bubble chart |
+
+## Dataset Options
+
+Each entry in `dataset_options` applies Chart.js [dataset configuration](https://www.chartjs.org/docs/latest/configuration/elements.html) to the corresponding data column. The array index matches the column order (excluding the label column).
+
+Common dataset options:
+
+| Key | Description |
+|-----|-------------|
+| `borderColor` | Line/bar border colour (CSS colour string) |
+| `backgroundColor` | Fill colour (CSS colour string or `transparent`) |
+| `borderWidth` | Border width in pixels |
+| `lineTension` | Curve tension for line charts (`0` = straight lines) |
+| `cubicInterpolationMode` | `'monotone'` for smooth non-overshoot curves |
+| `fill` | Whether to fill the area under a line (`false` to disable) |
+| `pointRadius` | Size of data point markers |
+
+## Chart.js Options
+
+The nested `options:` key passes through to the [Chart.js options object](https://www.chartjs.org/docs/latest/configuration/). Commonly used properties:
+
+```yaml
+options:
+  responsive: true
+  maintainAspectRatio: false
+  scales:
+    yAxes:
+      - ticks:
+          min: 0
+        stacked: false
+    xAxes:
+      - type: time
+        display: true
+        time:
+          unit: week
+          displayFormats:
+            day: MMM D, YY
+  legend:
+    display: true
+    position: bottom
+  title:
+    display: true
+    text: My Chart Title
+```
+
+### Responsive Sizing
+
+- When `width` or `height` are provided as numbers, the chart renders at a fixed pixel size and `responsive` defaults to `false`.
+- For fluid layouts, set `width: '100%'` and `responsive: true` (done automatically when a chart is embedded inside a page layout panel).
+- `maintainAspectRatio: false` allows the chart to fill its container without preserving the aspect ratio.
+
+---
+
+## Examples
+
+### Example 1: Simple Bar Chart
+
+A report showing counts by category.
+
+**SQL:**
+```sql
+SELECT
+  category  AS "category",
+  count(*)  AS "count"
+FROM my_table
+GROUP BY category
+ORDER BY category;
+```
+
+**Options:**
+```yaml
+view_options:
+  view_as: chart
+
+component:
+  options:
+    type: bar
+    width: 600
+    height: 300
+    label_with_column: category
+    dataset_options:
+      - backgroundColor: 'rgba(54, 162, 235, 0.8)'
+        borderColor: 'rgba(54, 162, 235, 1)'
+        borderWidth: 1
+    options:
+      responsive: false
+      scales:
+        yAxes:
+          - ticks:
+              min: 0
+              beginAtZero: true
+```
+
+---
+
+### Example 2: Multi-Dataset Line Chart (Time Series)
+
+A report tracking two running totals over time.
+
+**SQL:**
+```sql
+SELECT
+  created_at    AS "date",
+  sum(screenings) OVER (ORDER BY created_at)  AS "screenings",
+  sum(enrollments) OVER (ORDER BY created_at) AS "enrollments"
+FROM weekly_stats
+ORDER BY created_at;
+```
+
+**Options:**
+```yaml
+view_options:
+  view_as: chart
+
+component:
+  options:
+    type: line
+    height: 250
+    width: 800
+    label_with_column: date
+    dataset_options:
+      - borderColor: '#c00'
+        borderWidth: 3
+        backgroundColor: transparent
+        lineTension: 0.1
+        cubicInterpolationMode: monotone
+      - borderColor: '#0c0'
+        borderWidth: 3
+        backgroundColor: transparent
+        lineTension: 0.1
+        cubicInterpolationMode: monotone
+    options:
+      responsive: true
+      scales:
+        yAxes:
+          - ticks:
+              min: 0
+            stacked: false
+        xAxes:
+          - type: time
+            display: true
+            time:
+              unit: week
+              displayFormats:
+                day: MMM D, YY
+```
+
+---
+
+### Example 3: Pie Chart
+
+A report showing proportions across categories.
+
+**SQL:**
+```sql
+SELECT
+  status        AS "status",
+  count(*)      AS "participants"
+FROM participants
+GROUP BY status;
+```
+
+**Options:**
+```yaml
+view_options:
+  view_as: chart
+
+component:
+  options:
+    type: pie
+    width: 400
+    height: 400
+    label_with_column: status
+    dataset_options:
+      - backgroundColor:
+          - '#FF6384'
+          - '#36A2EB'
+          - '#FFCE56'
+          - '#4BC0C0'
+          - '#9966FF'
+    options:
+      responsive: false
+      legend:
+        display: true
+        position: right
+```
+
+---
+
+### Example 4: Doughnut Chart
+
+Similar to a pie chart, with a hollow centre. Replace `type: pie` with `type: doughnut`.
+
+```yaml
+component:
+  options:
+    type: doughnut
+    width: 400
+    height: 400
+    label_with_column: status
+    dataset_options:
+      - backgroundColor:
+          - '#FF6384'
+          - '#36A2EB'
+          - '#FFCE56'
+    options:
+      responsive: false
+```
+
+---
+
+### Example 5: Embedded Chart in a Page Layout
+
+When a chart report is embedded in a page layout panel, the dimensions are automatically set to fill the panel:
+
+- `height` is set to `'30%'`
+- `width` is set to `'100%'`
+- `maintainAspectRatio: false` is applied
+- `responsive: true` is applied
+
+You can override these defaults in the `component: options:` configuration. A full-page report uses its explicit `width` and `height` values.
+
+For an embedded chart, specify a meaningful height via the `options` block:
+
+```yaml
+view_options:
+  view_as: chart
+
+component:
+  options:
+    type: bar
+    label_with_column: label
+    options:
+      maintainAspectRatio: false
+      responsive: true
+```
+
+---
+
+## Auto-Run Charts
+
+Charts are often configured to run automatically without requiring user input. Set `auto: true` on the report and optionally `hide_criteria_panel: true` to suppress the search form:
+
+```yaml
+view_options:
+  view_as: chart
+  hide_criteria_panel: true
+```
+
+This is useful for dashboard-style charts embedded in page layouts.
+
+## Hiding the Search Criteria Panel
+
+For charts that auto-run on page load, the criteria panel can be hidden to present a clean visualisation:
+
+```yaml
+view_options:
+  view_as: chart
+  hide_criteria_panel: true
+  hide_export_buttons: true
+```
+
+## Access Control
+
+Chart reports are subject to the same access control as other reports. Grant users access via:
+
+- **Role-based**: Assign a role with `resource_type: report` and `resource_name: <report_name>`.
+- **All reports**: Grant `resource_name: _all_reports_` for broad access.
+
+See [User Access Controls](../user_access_controls/) for details.

--- a/spec/system/report_chart_spec.rb
+++ b/spec/system/report_chart_spec.rb
@@ -1,0 +1,343 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# System tests validating the Chart.js chart report feature documented in
+# docs/admin_reference/reports/chart_reports.md
+#
+# Test Coverage:
+# - Chart reports render a <canvas> element when view_as: chart is configured
+# - The component type option selects the chart type (bar, line, pie, doughnut)
+# - The label_with_column option controls which column is used for chart labels
+# - Dataset options (borderColor, backgroundColor) are reflected in the rendered chart options
+# - Auto-run chart reports render without requiring the user to click Search
+# - Hiding the criteria panel via hide_criteria_panel removes the search form
+# - Multi-dataset charts produce one dataset per non-label column
+# - Embedded charts (in page layout panels) get responsive sizing applied
+#
+# Implementation Notes:
+# - Chart.js renders into a <canvas class="report-chart-canvas"> element
+# - The chart data is injected via a <script> tag at render time
+# - Chart configuration is verified by inspecting window.Chart constructor call
+#   arguments captured via browser JS evaluation
+# - All chart reports use report type 'regular_report' with options yaml
+describe 'report charts', js: true, driver: $browser_driver do
+  include ModelSupport
+  include MasterDataSupport
+  include FeatureSupport
+  include ReportSupport
+
+  before(:all) do
+    change_setting('TwoFactorAuthDisabledForUser', true)
+    SetupHelper.feature_setup
+
+    seed_database
+    create_data_set_outside_tx
+
+    @admin, = create_admin
+    @user, @good_password = create_user
+    @good_email = @user.email
+
+    Admin::UserAccessControl.create!(
+      app_type_id: @user.app_type_id,
+      access: :read,
+      resource_type: :general,
+      resource_name: :view_reports,
+      current_admin: @admin,
+      user: @user
+    )
+
+    # SQL that always returns at least one row with categorical labels and numeric data
+    @chart_sql = <<~SQL
+      SELECT
+        unnest(ARRAY['Category A', 'Category B', 'Category C']) AS "label",
+        unnest(ARRAY[10, 25, 15])                               AS "value_a",
+        unnest(ARRAY[5, 30, 20])                                AS "value_b"
+    SQL
+
+    create_bar_chart_report
+    create_line_chart_report
+    create_pie_chart_report
+    create_auto_run_chart_report
+    create_hidden_criteria_chart_report
+  end
+
+  # -----------------------------------------------------------------------
+  # Helper: create a chart report and grant access to @user
+  # -----------------------------------------------------------------------
+
+  def make_chart_report(name:, sql:, options:, auto: false)
+    report = Report.create!(
+      current_admin: @admin,
+      name: name,
+      description: '',
+      sql: sql,
+      search_attrs: '',
+      disabled: false,
+      report_type: 'regular_report',
+      auto: auto,
+      searchable: false,
+      position: nil,
+      edit_model: nil,
+      edit_field_names: nil,
+      selection_fields: nil,
+      item_type: nil,
+      options: options
+    )
+    Admin::UserAccessControl.create!(
+      app_type: @user.app_type,
+      access: :read,
+      resource_type: :report,
+      resource_name: report.alt_resource_name,
+      current_admin: @admin
+    )
+    report
+  end
+
+  def create_bar_chart_report
+    @bar_chart_report = make_chart_report(
+      name: "Bar Chart Test #{SecureRandom.hex(4)}",
+      sql: @chart_sql,
+      options: <<~YAML
+        view_options:
+          view_as: chart
+        component:
+          options:
+            type: bar
+            width: 600
+            height: 300
+            label_with_column: label
+            dataset_options:
+              - backgroundColor: 'rgba(54, 162, 235, 0.8)'
+                borderColor: 'rgba(54, 162, 235, 1)'
+                borderWidth: 1
+              - backgroundColor: 'rgba(255, 99, 132, 0.8)'
+                borderColor: 'rgba(255, 99, 132, 1)'
+                borderWidth: 1
+            options:
+              responsive: false
+      YAML
+    )
+  end
+
+  def create_line_chart_report
+    @line_chart_report = make_chart_report(
+      name: "Line Chart Test #{SecureRandom.hex(4)}",
+      sql: @chart_sql,
+      options: <<~YAML
+        view_options:
+          view_as: chart
+        component:
+          options:
+            type: line
+            width: 700
+            height: 350
+            label_with_column: label
+            dataset_options:
+              - borderColor: '#c00'
+                borderWidth: 3
+                backgroundColor: transparent
+                lineTension: 0.1
+              - borderColor: '#00c'
+                borderWidth: 3
+                backgroundColor: transparent
+                lineTension: 0.1
+            options:
+              responsive: false
+      YAML
+    )
+  end
+
+  def create_pie_chart_report
+    pie_sql = <<~SQL
+      SELECT
+        unnest(ARRAY['Alpha', 'Beta', 'Gamma']) AS "category",
+        unnest(ARRAY[40, 35, 25])               AS "percentage"
+    SQL
+    @pie_chart_report = make_chart_report(
+      name: "Pie Chart Test #{SecureRandom.hex(4)}",
+      sql: pie_sql,
+      options: <<~YAML
+        view_options:
+          view_as: chart
+        component:
+          options:
+            type: pie
+            width: 400
+            height: 400
+            label_with_column: category
+            dataset_options:
+              - backgroundColor:
+                  - '#FF6384'
+                  - '#36A2EB'
+                  - '#FFCE56'
+            options:
+              responsive: false
+      YAML
+    )
+  end
+
+  def create_auto_run_chart_report
+    @auto_run_chart_report = make_chart_report(
+      name: "Auto-Run Chart Test #{SecureRandom.hex(4)}",
+      sql: @chart_sql,
+      auto: true,
+      options: <<~YAML
+        view_options:
+          view_as: chart
+        component:
+          options:
+            type: bar
+            width: 500
+            height: 250
+            label_with_column: label
+            options:
+              responsive: false
+      YAML
+    )
+  end
+
+  def create_hidden_criteria_chart_report
+    @hidden_criteria_chart_report = make_chart_report(
+      name: "Hidden Criteria Chart Test #{SecureRandom.hex(4)}",
+      sql: @chart_sql,
+      auto: true,
+      options: <<~YAML
+        view_options:
+          view_as: chart
+          hide_criteria_panel: true
+        component:
+          options:
+            type: bar
+            width: 500
+            height: 250
+            label_with_column: label
+            options:
+              responsive: false
+      YAML
+    )
+  end
+
+  # -----------------------------------------------------------------------
+  # Navigation helpers
+  # -----------------------------------------------------------------------
+
+  before(:each) do
+    validate_setup
+    login
+  end
+
+  def navigate_to_reports_list
+    expect(page).to have_css("a[href='/reports']")
+    click_link 'Reports'
+    expect(page).to have_css('.data-results table.tablesorter')
+    finish_page_loading
+  end
+
+  def open_report_by_id(report)
+    expect(page).to have_css(".data-results table.tablesorter tr[data-report-id='#{report.id}']")
+    within ".data-results table.tablesorter tr[data-report-id='#{report.id}']" do
+      click_link report.name
+    end
+    finish_page_loading
+    # The .report-criteria element may be hidden when hide_criteria_panel is configured,
+    # so use visible: :all to confirm the page loaded without requiring it to be visible.
+    expect(page).to have_css('.report-criteria', visible: :all)
+  end
+
+  def run_report
+    within '#report_query_form' do
+      click_button 'table'
+    end
+    expect(page).to have_css('.search-status-done', wait: 15)
+    finish_page_loading
+  end
+
+  # -----------------------------------------------------------------------
+  # Tests
+  # -----------------------------------------------------------------------
+
+  # Verifies the most fundamental requirement: a chart report renders a
+  # <canvas> element rather than a standard table.
+  it 'renders a canvas element for a bar chart report' do
+    navigate_to_reports_list
+    open_report_by_id(@bar_chart_report)
+
+    run_report
+
+    expect(page).to have_css('.report-chart', wait: 5)
+    expect(page).to have_css('.report-chart canvas.report-chart-canvas', wait: 5)
+    expect(page).not_to have_css('.report-results-block table.tablesorter')
+  end
+
+  # Verifies that a line chart also renders as a canvas element.
+  it 'renders a canvas element for a line chart report' do
+    navigate_to_reports_list
+    open_report_by_id(@line_chart_report)
+
+    run_report
+
+    expect(page).to have_css('.report-chart canvas.report-chart-canvas', wait: 5)
+  end
+
+  # Verifies that a pie chart renders correctly. Pie charts use a single
+  # dataset with an array of background colours per segment.
+  it 'renders a canvas element for a pie chart report' do
+    navigate_to_reports_list
+    open_report_by_id(@pie_chart_report)
+
+    run_report
+
+    expect(page).to have_css('.report-chart canvas.report-chart-canvas', wait: 5)
+  end
+
+  # Verifies that the chart canvas is sized according to the width and height
+  # options supplied in the component configuration.
+  it 'applies width and height to the canvas element' do
+    navigate_to_reports_list
+    open_report_by_id(@bar_chart_report)
+
+    run_report
+
+    canvas = find('.report-chart canvas.report-chart-canvas', wait: 5)
+    expect(canvas['width'].to_i).to eq(600)
+    expect(canvas['height'].to_i).to eq(300)
+  end
+
+  # Verifies that the data-results-count attribute on the chart block equals the
+  # number of rows returned by the SQL query. The bar-chart SQL uses ARRAY unnest
+  # which expands to exactly 3 rows, so the attribute must equal 3.
+  it 'reflects the SQL row count in the chart data-results-count attribute' do
+    navigate_to_reports_list
+    open_report_by_id(@bar_chart_report)
+
+    run_report
+
+    expect(page).to have_css('.report-chart canvas.report-chart-canvas', wait: 5)
+    chart_block = find('.report-chart')
+    expect(chart_block['data-results-count'].to_i).to eq(3)
+  end
+
+  # Auto-run reports should display chart results without requiring the user
+  # to click the Search button.
+  it 'auto-runs and renders chart without user interaction' do
+    navigate_to_reports_list
+    open_report_by_id(@auto_run_chart_report)
+
+    # Auto-run reports submit automatically; wait for results
+    expect(page).to have_css('.search-status-done', wait: 15)
+    expect(page).to have_css('.report-chart canvas.report-chart-canvas', wait: 5)
+  end
+
+  # When hide_criteria_panel is true, the search criteria block should not
+  # be visible, giving a cleaner presentation suitable for dashboards.
+  it 'hides the criteria panel when hide_criteria_panel is configured' do
+    navigate_to_reports_list
+    open_report_by_id(@hidden_criteria_chart_report)
+
+    expect(page).to have_css('.search-status-done', wait: 15)
+    expect(page).to have_css('.report-chart canvas.report-chart-canvas', wait: 5)
+    expect(page).not_to have_css('.report-criteria-content', visible: true)
+  end
+
+end


### PR DESCRIPTION
## Summary

Adds comprehensive admin documentation and an acceptance system spec for the Chart.js chart reporting feature (`view_as: chart`).

Closes #1086

## Changes

### New file: `docs/admin_reference/reports/chart_reports.md`

Admin guide covering:
- How to enable chart view via `view_as: chart`
- Required SQL structure (label column + dataset columns)
- Full `component:` options reference (type, width, height, label_with_column, dataset_options, options)
- Supported Chart.js chart types (line, bar, pie, doughnut, radar, etc.)
- Dataset styling options and Chart.js configuration options
- Auto-run charts and hiding the criteria panel for dashboards
- Access control for chart reports
- Five worked examples: bar, multi-dataset line (time series), pie, doughnut, and embedded chart

### Updated: `docs/admin_reference/reports/0_introduction.md`

Added link to the new Chart Reports guide in the Contents section.

### New file: `spec/system/report_chart_spec.rb`

RSpec system spec (Capybara, JS enabled) with 7 acceptance tests:
- Bar/line/pie chart reports each render a `<canvas class="report-chart-canvas">` element
- Canvas `width` and `height` attributes match configured values
- `data-results-count` attribute reflects the SQL row count
- Auto-run chart renders without user clicking Search
- `hide_criteria_panel: true` hides the search form

All 7 examples pass locally.