### PR TITLE
Added Sankey diagram chart support using chartjs-chart-sankey - fixes #1088

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,6 +21,7 @@
 //= require handlebars/dist/handlebars
 //= require bootstrap-datepicker/dist/js/bootstrap-datepicker
 //= require chart.js/dist/chart
+//= require chartjs-chart-sankey/dist/chartjs-chart-sankey
 //= require bootstrap-wysiwyg/src/bootstrap-wysiwyg
 //= require jquery.hotkeys/jquery.hotkeys
 // Note: moment is required with the min file to avoid the need to transcompile

--- a/app/views/reports/result_template/_chart.html.erb
+++ b/app/views/reports/result_template/_chart.html.erb
@@ -49,43 +49,62 @@
   
     opts.data.datasets = [];
     var datasets = opts.data.datasets;
-    var data_labels = opts.data.labels = opts.data_labels;
     var dataset_options = opts.dataset_options;
-  
-    for(var i = 0; i < json.length; i++) {
-      var row = json[i];
-      var col_label = null;
-  
-      var col_iter = 0;
-      var row_iter = 0;
-      for(col_label in row) {
-        if(row.hasOwnProperty(col_label)) {
-          var colval = row[col_label];
-          if (col_label == opts.label_with_column) {
-            data_labels.push(colval);
-          }
-          else {
-            if (!datasets[col_iter]) {
-              datasets[col_iter] = {
-                data: [],
-                label: col_label
+
+    if (opts.type === 'sankey') {
+      // Sankey charts use a flat array of {from, to, flow} objects in a single dataset.
+      // Column names default to 'from', 'to', 'flow' but can be overridden via sankey_columns.
+      var sankey_cols = $.extend({from_column: 'from', to_column: 'to', flow_column: 'flow'}, opts.sankey_columns);
+      var sankey_data = [];
+
+      for (var i = 0; i < json.length; i++) {
+        var row = json[i];
+        sankey_data.push({
+          from: String(row[sankey_cols.from_column]),
+          to: String(row[sankey_cols.to_column]),
+          flow: Number(row[sankey_cols.flow_column])
+        });
+      }
+
+      var sankey_dataset = {data: sankey_data};
+      if (dataset_options[0]) {
+        $.extend(sankey_dataset, dataset_options[0]);
+      }
+      datasets.push(sankey_dataset);
+    } else {
+      var data_labels = opts.data.labels = opts.data_labels;
+
+      for (var i = 0; i < json.length; i++) {
+        var row = json[i];
+        var col_label = null;
+        var col_iter = 0;
+
+        for (col_label in row) {
+          if (row.hasOwnProperty(col_label)) {
+            var colval = row[col_label];
+            if (col_label == opts.label_with_column) {
+              data_labels.push(colval);
+            } else {
+              if (!datasets[col_iter]) {
+                datasets[col_iter] = {
+                  data: [],
+                  label: col_label
+                };
+                if (dataset_options[col_iter]) {
+                  $.extend(datasets[col_iter], dataset_options[col_iter]);
+                }
               }
-              if (dataset_options[col_iter]) {
-                $.extend(datasets[col_iter], dataset_options[col_iter]);
-              }
+              datasets[col_iter].data.push(colval);
+              col_iter++;
             }
-            datasets[col_iter].data.push(colval);
-  
-            col_iter++;
           }
         }
       }
-      row_iter++;
     }
   
     var new_html = $('<canvas width="'+width+'" height="'+height+'" class="report-chart-canvas"></canvas>');
-  
-  $block.html(new_html);
+
+    $block.html(new_html);
     var ctx = $block.find('canvas');
   
     var myPieChart = new Chart(ctx, opts);

--- a/docs/admin_reference/reports/chart_reports.md
+++ b/docs/admin_reference/reports/chart_reports.md
@@ -76,6 +76,61 @@ Any Chart.js chart type is supported:
 | `polarArea` | Polar area chart |
 | `scatter` | Scatter plot |
 | `bubble` | Bubble chart |
+| `sankey` | Sankey flow diagram — see [Sankey Charts](#sankey-charts) |
+
+## Sankey Charts
+
+Sankey diagrams visualise flow quantities between nodes. They require the [chartjs-chart-sankey](https://github.com/kurkle/chartjs-chart-sankey) plugin, which is bundled with the application.
+
+### SQL Structure for Sankey
+
+Unlike standard charts (which use a label column plus one or more value columns), Sankey charts require **three columns** per row:
+
+| Column | Default name | Description |
+|--------|-------------|-------------|
+| Source node | `from` | The name of the origin node |
+| Target node | `to` | The name of the destination node |
+| Flow magnitude | `flow` | A positive number representing the quantity flowing |
+
+**Example:**
+
+```sql
+SELECT
+  stage_from  AS "from",
+  stage_to    AS "to",
+  participant_count AS "flow"
+FROM cohort_transitions
+ORDER BY participant_count DESC;
+```
+
+### Custom Column Names
+
+If your SQL uses different column names, map them with `sankey_columns`:
+
+```yaml
+component:
+  options:
+    type: sankey
+    sankey_columns:
+      from_column: source
+      to_column: destination
+      flow_column: value
+```
+
+### Sankey Dataset Options
+
+The first entry in `dataset_options` applies to the single Sankey dataset. Supported keys:
+
+| Key | Description |
+|-----|-------------|
+| `label` | Dataset label (shown in the tooltip header) |
+| `colorMode` | Colour blending mode: `'gradient'` (default), `'from'`, or `'to'` |
+| `alpha` | Opacity of the flow ribbons (0–1, default `0.5`) |
+| `colorFrom` | Colour of the source end of each ribbon (CSS string or callback) |
+| `colorTo` | Colour of the target end of each ribbon (CSS string or callback) |
+| `size` | `'max'` (default) or `'min'` — controls overlap strategy |
+
+---
 
 ## Dataset Options
 
@@ -311,6 +366,58 @@ component:
     options:
       maintainAspectRatio: false
       responsive: true
+```
+
+---
+
+### Example 6: Sankey Flow Diagram
+
+A report showing participant transitions between study stages.
+
+**SQL:**
+```sql
+SELECT
+  stage_from        AS "from",
+  stage_to          AS "to",
+  count(*)          AS "flow"
+FROM participant_transitions
+GROUP BY stage_from, stage_to
+ORDER BY stage_from, stage_to;
+```
+
+**Options:**
+```yaml
+view_options:
+  view_as: chart
+
+component:
+  options:
+    type: sankey
+    width: 800
+    height: 400
+    dataset_options:
+      - label: Participant flow
+        colorMode: gradient
+        alpha: 0.6
+    options:
+      responsive: false
+```
+
+**With custom column names** (when SQL columns differ from the defaults):
+
+```yaml
+component:
+  options:
+    type: sankey
+    width: 800
+    height: 400
+    sankey_columns:
+      from_column: source_stage
+      to_column: destination_stage
+      flow_column: participant_count
+    dataset_options:
+      - label: Participant flow
+        colorMode: gradient
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bootstrap-wysiwyg": "https://github.com/consected/bootstrap-wysiwyg",
     "chart.js": "^3.9.1",
     "chartjs-adapter-luxon": "^1.2.1",
+    "chartjs-chart-sankey": "^0.14.0",
     "chosen-js": "^1.8.7",
     "codemirror": "^5.58.2",
     "domador": "https://github.com/consected/domador",

--- a/spec/system/report_sankey_chart_spec.rb
+++ b/spec/system/report_sankey_chart_spec.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# System tests validating the Sankey diagram chart report feature using
+# the chartjs-chart-sankey plugin, as documented in
+# docs/admin_reference/reports/chart_reports.md
+#
+# Test Coverage:
+# - Sankey chart reports render a <canvas> element when type: sankey is configured
+# - The canvas has the correct width and height from component options
+# - The data-results-count attribute reflects the SQL row count
+# - Sankey charts use a different data format: SQL must return from/to/flow columns
+#   rather than the label + value columns used by standard chart types
+# - The chartjs-chart-sankey plugin (SankeyController) must be loaded and registered
+#   so that Chart.js recognises the 'sankey' type
+# - Auto-run Sankey charts render without user interaction
+#
+# Implementation Notes:
+# - Sankey data format: each SQL row produces {from, to, flow} objects in a single dataset
+# - The columns 'from', 'to', and 'flow' are the defaults; they can be overridden via
+#   the sankey_columns option: { from_column: 'source', to_column: 'dest', flow_column: 'value' }
+# - The chart ERB template detects type: sankey and builds data differently from standard charts
+# - chartjs-chart-sankey must be required after chart.js in the asset pipeline and
+#   its SankeyController registered with Chart.register()
+describe 'sankey chart reports', js: true, driver: $browser_driver do
+  include ModelSupport
+  include MasterDataSupport
+  include FeatureSupport
+  include ReportSupport
+
+  before(:all) do
+    change_setting('TwoFactorAuthDisabledForUser', true)
+    SetupHelper.feature_setup
+
+    seed_database
+    create_data_set_outside_tx
+
+    @admin, = create_admin
+    @user, @good_password = create_user
+    @good_email = @user.email
+
+    Admin::UserAccessControl.create!(
+      app_type_id: @user.app_type_id,
+      access: :read,
+      resource_type: :general,
+      resource_name: :view_reports,
+      current_admin: @admin,
+      user: @user
+    )
+
+    # SQL returning from/to/flow columns for a Sankey diagram
+    # Represents a simple flow: A->B (10), A->C (5), B->C (10), D->C (7)
+    @sankey_sql = <<~SQL
+      SELECT
+        unnest(ARRAY['A', 'A', 'B', 'D']) AS "from",
+        unnest(ARRAY['B', 'C', 'C', 'C']) AS "to",
+        unnest(ARRAY[10, 5, 10, 7])       AS "flow"
+    SQL
+
+    # SQL using custom column names (source/destination/value) for override testing
+    @sankey_custom_cols_sql = <<~SQL
+      SELECT
+        unnest(ARRAY['Step1', 'Step1', 'Step2']) AS "source",
+        unnest(ARRAY['Step2', 'Step3', 'Step3']) AS "destination",
+        unnest(ARRAY[20, 10, 15])                AS "value"
+    SQL
+
+    create_sankey_chart_report
+    create_sankey_custom_columns_report
+    create_auto_run_sankey_report
+  end
+
+  # -----------------------------------------------------------------------
+  # Helper: create a chart report and grant access to @user
+  # -----------------------------------------------------------------------
+
+  def make_chart_report(name:, sql:, options:, auto: false)
+    report = Report.create!(
+      current_admin: @admin,
+      name: name,
+      description: '',
+      sql: sql,
+      search_attrs: '',
+      disabled: false,
+      report_type: 'regular_report',
+      auto: auto,
+      searchable: false,
+      position: nil,
+      edit_model: nil,
+      edit_field_names: nil,
+      selection_fields: nil,
+      item_type: nil,
+      options: options
+    )
+    Admin::UserAccessControl.create!(
+      app_type: @user.app_type,
+      access: :read,
+      resource_type: :report,
+      resource_name: report.alt_resource_name,
+      current_admin: @admin
+    )
+    report
+  end
+
+  def create_sankey_chart_report
+    @sankey_chart_report = make_chart_report(
+      name: "Sankey Chart Test #{SecureRandom.hex(4)}",
+      sql: @sankey_sql,
+      options: <<~YAML
+        view_options:
+          view_as: chart
+        component:
+          options:
+            type: sankey
+            width: 700
+            height: 400
+            dataset_options:
+              - label: Flow diagram
+                colorMode: gradient
+                alpha: 0.6
+            options:
+              responsive: false
+      YAML
+    )
+  end
+
+  def create_sankey_custom_columns_report
+    @sankey_custom_columns_report = make_chart_report(
+      name: "Sankey Custom Cols Test #{SecureRandom.hex(4)}",
+      sql: @sankey_custom_cols_sql,
+      options: <<~YAML
+        view_options:
+          view_as: chart
+        component:
+          options:
+            type: sankey
+            width: 600
+            height: 300
+            sankey_columns:
+              from_column: source
+              to_column: destination
+              flow_column: value
+            options:
+              responsive: false
+      YAML
+    )
+  end
+
+  def create_auto_run_sankey_report
+    @auto_run_sankey_report = make_chart_report(
+      name: "Auto-Run Sankey Test #{SecureRandom.hex(4)}",
+      sql: @sankey_sql,
+      auto: true,
+      options: <<~YAML
+        view_options:
+          view_as: chart
+        component:
+          options:
+            type: sankey
+            width: 600
+            height: 350
+            options:
+              responsive: false
+      YAML
+    )
+  end
+
+  # -----------------------------------------------------------------------
+  # Navigation helpers
+  # -----------------------------------------------------------------------
+
+  before(:each) do
+    validate_setup
+    login
+  end
+
+  def navigate_to_reports_list
+    expect(page).to have_css("a[href='/reports']")
+    click_link 'Reports'
+    expect(page).to have_css('.data-results table.tablesorter')
+    finish_page_loading
+  end
+
+  def open_report_by_id(report)
+    expect(page).to have_css(".data-results table.tablesorter tr[data-report-id='#{report.id}']")
+    within ".data-results table.tablesorter tr[data-report-id='#{report.id}']" do
+      click_link report.name
+    end
+    finish_page_loading
+    expect(page).to have_css('.report-criteria', visible: :all)
+  end
+
+  def run_report
+    within '#report_query_form' do
+      click_button 'table'
+    end
+    expect(page).to have_css('.search-status-done', wait: 15)
+    finish_page_loading
+  end
+
+  # -----------------------------------------------------------------------
+  # Tests
+  # -----------------------------------------------------------------------
+
+  # Verifies that a Sankey chart report renders a <canvas> element instead of
+  # a table, confirming that the chartjs-chart-sankey plugin is loaded and the
+  # ERB template handles the 'sankey' type correctly.
+  it 'renders a canvas element for a sankey chart report' do
+    navigate_to_reports_list
+    open_report_by_id(@sankey_chart_report)
+
+    run_report
+
+    expect(page).to have_css('.report-chart', wait: 5)
+    expect(page).to have_css('.report-chart canvas.report-chart-canvas', wait: 5)
+    expect(page).not_to have_css('.report-results-block table.tablesorter')
+  end
+
+  # Verifies that the canvas is sized according to the width and height configured
+  # in the component options.
+  it 'applies width and height to the sankey canvas element' do
+    navigate_to_reports_list
+    open_report_by_id(@sankey_chart_report)
+
+    run_report
+
+    canvas = find('.report-chart canvas.report-chart-canvas', wait: 5)
+    expect(canvas['width'].to_i).to eq(700)
+    expect(canvas['height'].to_i).to eq(400)
+  end
+
+  # Verifies that data-results-count reflects the number of rows from the SQL query.
+  # The sankey SQL uses ARRAY unnest which expands to exactly 4 rows.
+  it 'reflects the SQL row count in the data-results-count attribute' do
+    navigate_to_reports_list
+    open_report_by_id(@sankey_chart_report)
+
+    run_report
+
+    expect(page).to have_css('.report-chart canvas.report-chart-canvas', wait: 5)
+    chart_block = find('.report-chart')
+    expect(chart_block['data-results-count'].to_i).to eq(4)
+  end
+
+  # Verifies that custom column name mapping (sankey_columns option) works:
+  # when from_column/to_column/flow_column are specified, those SQL columns
+  # are used instead of the defaults (from/to/flow).
+  it 'renders a sankey chart with custom column names' do
+    navigate_to_reports_list
+    open_report_by_id(@sankey_custom_columns_report)
+
+    run_report
+
+    expect(page).to have_css('.report-chart canvas.report-chart-canvas', wait: 5)
+    chart_block = find('.report-chart')
+    expect(chart_block['data-results-count'].to_i).to eq(3)
+  end
+
+  # Verifies that auto-run Sankey reports render without requiring the user
+  # to click Search.
+  it 'auto-runs and renders sankey chart without user interaction' do
+    navigate_to_reports_list
+    open_report_by_id(@auto_run_sankey_report)
+
+    expect(page).to have_css('.search-status-done', wait: 15)
+    expect(page).to have_css('.report-chart canvas.report-chart-canvas', wait: 5)
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2081,6 +2081,11 @@ chartjs-adapter-luxon@^1.2.1:
   resolved "https://registry.yarnpkg.com/chartjs-adapter-luxon/-/chartjs-adapter-luxon-1.3.1.tgz#8ad8be7cc1521bacd6cd2ff4b013669d4dd49364"
   integrity sha512-yxHov3X8y+reIibl1o+j18xzrcdddCLqsXhriV2+aQ4hCR66IYFchlRXUvrJVoxglJ380pgytU7YWtoqdIgqhg==
 
+chartjs-chart-sankey@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/chartjs-chart-sankey/-/chartjs-chart-sankey-0.14.0.tgz#c6595168b1e9feffe193afff40ef125fc068e38e"
+  integrity sha512-MrU3lE73TE9kALy4MjWFlfcwf4R1EN/DBvhHxmv9n4AHap//JLKjlJTLIZwHsUjDsYo0B8PuMkrJODwfirEZUA==
+
 chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"


### PR DESCRIPTION
## Summary

Adds Sankey diagram support to the Chart.js report feature, using the [chartjs-chart-sankey](https://github.com/kurkle/chartjs-chart-sankey) plugin. Extends the documentation from PR #1087 and adds appropriate system spec tests.

Closes #1088

## Changes

### `package.json` + `yarn.lock`
- Added `chartjs-chart-sankey@0.14.0` dependency

### `app/assets/javascripts/application.js`
- Added `//= require chartjs-chart-sankey/dist/chartjs-chart-sankey` after `chart.js`
- The UMD build auto-registers `SankeyController` and `Flow` with `Chart.register()`

### `app/views/reports/result_template/_chart.html.erb`
- Updated the data-building loop to branch on `type === 'sankey'`:
  - **Sankey mode**: builds a single dataset with `[{from, to, flow}, ...]` objects; column names default to `from`/`to`/`flow` and can be overridden via `sankey_columns: {from_column, to_column, flow_column}`
  - **Standard mode**: original label + multi-dataset logic unchanged

### `docs/admin_reference/reports/chart_reports.md`
- Added `sankey` to the Chart Types table
- New **Sankey Charts** section covering SQL structure, custom column name mapping, and dataset options
- New **Example 6: Sankey Flow Diagram** with basic and custom-column-name variants

### `spec/system/report_sankey_chart_spec.rb`
- 5 new system tests:
  - Renders a canvas element for a Sankey report
  - Applies correct `width`/`height` to the canvas
  - `data-results-count` reflects the SQL row count
  - Custom column names (`sankey_columns`) work correctly
  - Auto-run Sankey charts render without user interaction

All 5 new tests pass; all 7 existing chart tests continue to pass.