### PR TITLE
Allow run_at to be specified with batch_trigger frequency 'once' - fixes #1090

### DIFF
--- a/app/models/admin/defs/extra_options_top_level_configurations_defs.yaml
+++ b/app/models/admin/defs/extra_options_top_level_configurations_defs.yaml
@@ -8,8 +8,8 @@ _configurations:
     # Fire **batch_trigger:** task for each record, based on the batch_trigger in **default:** or activity log options
     # All records (up to the limit) will be triggered on the specified frequency.
     # In order to make the selection of the records in the batch conditional, consider using a dynamic_model with *view_sql*
-    frequency: n units OR 'once' - for example 1 hour, 15 minutes, or 30 days. If set to 'once' then it will run once in ten seconds after saving
-    run_at: time (or list of times) to run at on the frequency specified, for example '12:00', '6:00pm', 'sunday 8:00am' (with frequency '1 week')
+    frequency: n units OR 'once' - for example 1 hour, 15 minutes, or 30 days. If set to 'once' then it will run once in ten seconds after saving (or at the time specified by run_at if provided)
+    run_at: time (or list of times) to run at on the frequency specified, for example '12:00', '6:00pm', 'sunday 8:00am' (with frequency '1 week'). When used with frequency 'once', specify a full date and time in ISO 8601 format, for example '2026-05-01 02:00' or '2026-05-01T02:00:00'. The time is interpreted in the server's configured timezone unless a UTC offset is included, for example '2026-05-01 02:00 +0000' for UTC or '2026-05-01 02:00 -0500' for Eastern Standard Time
     limit: maximum number of records to process in a single batch
     if: conditions on the records to select for processing
     # By default, the user in the process record will be used to perform the batch action. If no user_id field is specified in

--- a/app/models/dynamic/def_handler.rb
+++ b/app/models/dynamic/def_handler.rb
@@ -217,9 +217,9 @@ module Dynamic
             list += imp_class.attribute_names
                              .select { |a| Classification::GeneralSelection.use_with_attribute?(a) }
                              .map do |a|
-                               mn = imp_class.model_name.to_s.ns_underscore
-                               mn = mn.pluralize unless imp_class.respond_to?(:is_activity_log)
-                               :"#{mn}_#{a}"
+              mn = imp_class.model_name.to_s.ns_underscore
+              mn = mn.pluralize unless imp_class.respond_to?(:is_activity_log)
+              :"#{mn}_#{a}"
             end
           end
 
@@ -240,20 +240,20 @@ module Dynamic
       def latest_stored_update(using: nil)
         using ||= active_model_configurations
         @latest_def_update = using
-          .select(:updated_at)
-          .reorder('')
-          .order('updated_at desc nulls last')
-          .limit(1)
-          .pluck(:updated_at)
-          .first
+                             .select(:updated_at)
+                             .reorder('')
+                             .order('updated_at desc nulls last')
+                             .limit(1)
+                             .pluck(:updated_at)
+                             .first
 
         cl_update = Admin::ConfigLibrary
-          .where(format: 'yaml')
-          .reorder('')
-          .order('updated_at desc nulls last')
-          .limit(1)
-          .pluck(:updated_at)
-          .first
+                    .where(format: 'yaml')
+                    .reorder('')
+                    .order('updated_at desc nulls last')
+                    .limit(1)
+                    .pluck(:updated_at)
+                    .first
 
         [@latest_def_update, cl_update].compact.max
       end
@@ -555,10 +555,11 @@ module Dynamic
         # or will be manually triggered as needed. Re-importing should not re-trigger one-time jobs.
         return if Admin::AppTypeImport.import_in_progress?
 
+        scheduled_run_at = run_at.present? ? Time.zone.parse(run_at.to_s) : DateTime.now + 10.seconds
         RecurringBatchTask.schedule_task self,
                                          { dynamic_def: to_global_id.to_s },
                                          run_every: 10_000.years,
-                                         run_at: DateTime.now + 10.seconds
+                                         run_at: scheduled_run_at
       else
         RecurringBatchTask.schedule_task self,
                                          { dynamic_def: to_global_id.to_s },
@@ -694,7 +695,7 @@ module Dynamic
       ckey = estimated_record_count_ckey
       Rails.cache.fetch(ckey, expires_in: 15.minutes) do
         implementation_class.count
-      rescue StandardError => e
+      rescue StandardError
         Rails.logger.warn "Failed to get estimated record count for #{name}"
         nil
       end

--- a/spec/models/admin/app_type_import_batch_trigger_once_spec.rb
+++ b/spec/models/admin/app_type_import_batch_trigger_once_spec.rb
@@ -218,4 +218,99 @@ RSpec.describe 'Import app configuration with batch_trigger frequency once', typ
     expect(@dm.task_schedule).not_to be_nil,
                                      'Expected batch trigger job to be scheduled after saving post-import'
   end
+
+  # Tests for GitHub issue #1090: Allow admin to specify run_at time for frequency: 'once' batch triggers.
+  #
+  # handle_batch_schedule currently hardcodes run_at: DateTime.now + 10.seconds for the 'once' branch,
+  # ignoring any run_at value present in _configurations.batch_trigger. The fix should read run_at
+  # from config (when present) and only fall back to DateTime.now + 10.seconds when it is absent.
+  describe 'run_at configuration for frequency once - issue #1090' do
+    it 'schedules the batch trigger job at the configured run_at time when frequency is once and run_at is specified' do
+      # Given: a future datetime specified explicitly in the batch_trigger configuration
+      specified_time = 2.hours.from_now.change(usec: 0)
+      run_at_string = specified_time.strftime('%Y-%m-%d %H:%M:%S')
+
+      dm = DynamicModel.find(@dm_id)
+      dm.options = <<~YAML
+        _configurations:
+          batch_trigger:
+            frequency: 'once'
+            run_at: '#{run_at_string}'
+            label: test once batch
+            user: batch_test@example.com
+
+        default:
+          label: Default
+          fields:
+            - test_field
+          batch_trigger:
+            on_record:
+              update_this:
+                one:
+                  with:
+                    test_field: processed
+      YAML
+
+      # When: the dynamic model is saved, capture the run_at argument passed to schedule_task
+      captured_run_at = nil
+      allow(RecurringBatchTask).to receive(:schedule_task) do |_owner, _data, **kwargs|
+        captured_run_at = kwargs[:run_at]
+      end
+
+      dm.current_admin = @admin
+      dm.save!
+
+      # Then: schedule_task must have been called with the configured time, NOT DateTime.now + 10s
+      # This test FAILS until the fix is applied because the current implementation always passes
+      # DateTime.now + 10.seconds and ignores the configured run_at value.
+      expect(captured_run_at).not_to be_nil,
+                                     'Expected RecurringBatchTask.schedule_task to have been called with a run_at argument'
+      # Compare as unix timestamps to avoid DateTime vs TimeWithZone type errors
+      expect(captured_run_at.to_time.to_i).to be_within(60).of(specified_time.to_i),
+                                             "Expected run_at to be near #{specified_time} (from config), " \
+                                             "but got #{captured_run_at} — the implementation is ignoring the configured run_at"
+    end
+
+    it 'schedules the batch trigger job approximately 10 seconds from now when frequency is once and run_at is not specified' do
+      # Given: a batch_trigger with frequency: once but NO run_at configured (existing default behaviour)
+      dm = DynamicModel.find(@dm_id)
+      dm.options = <<~YAML
+        _configurations:
+          batch_trigger:
+            frequency: 'once'
+            label: test once batch
+            user: batch_test@example.com
+
+        default:
+          label: Default
+          fields:
+            - test_field
+          batch_trigger:
+            on_record:
+              update_this:
+                one:
+                  with:
+                    test_field: processed
+      YAML
+
+      # When: the dynamic model is saved, capture the run_at argument passed to schedule_task
+      captured_run_at = nil
+      before_save = DateTime.now
+      allow(RecurringBatchTask).to receive(:schedule_task) do |_owner, _data, **kwargs|
+        captured_run_at = kwargs[:run_at]
+      end
+
+      dm.current_admin = @admin
+      dm.save!
+
+      # Then: schedule_task must have been called with approximately DateTime.now + 10 seconds
+      # This preserves the existing default behaviour when no run_at is configured.
+      expect(captured_run_at).not_to be_nil,
+                                     'Expected RecurringBatchTask.schedule_task to have been called with a run_at argument'
+      # Compare as unix timestamps to avoid DateTime vs TimeWithZone type errors
+      expect(captured_run_at.to_time.to_i).to be_within(5).of((before_save + 10.seconds).to_time.to_i),
+                                             "Expected run_at to be approximately #{before_save + 10.seconds} " \
+                                             "(DateTime.now + 10s), but got #{captured_run_at}"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

When `_configurations.batch_trigger` uses `frequency: 'once'`, the admin can now specify a `run_at` datetime to control exactly when the one-time batch job runs, rather than always executing 10 seconds after saving.

If no `run_at` is provided, the existing default behaviour (10 seconds from save) is preserved.

Closes #1090

### Changes

- **`app/models/dynamic/def_handler.rb`** — In `handle_batch_schedule`, the `frequency == 'once'` branch now uses the configured `run_at` value (parsed via `Time.zone.parse`) when present, falling back to `DateTime.now + 10.seconds` when absent.

- **`app/models/admin/defs/extra_options_top_level_configurations_defs.yaml`** — Updated documentation for both `frequency:` and `run_at:` to note that `run_at` is honoured alongside `'once'`, with guidance on ISO 8601 datetime format and timezone handling (server timezone by default; UTC offset supported in the string).

- **`spec/models/admin/app_type_import_batch_trigger_once_spec.rb`** — Two new specs added:
  1. `frequency: 'once'` with `run_at` configured → `schedule_task` receives the configured time
  2. `frequency: 'once'` without `run_at` → `schedule_task` receives `DateTime.now + 10.seconds` (regression guard)

### Example configuration

```yaml
_configurations:
  batch_trigger:
    frequency: once
    run_at: '2026-05-01 02:00'   # server timezone; use '+0000' suffix for UTC
    limit: 500
```