### PR TITLE
Added tracker history panel filters and initial config - fixes #1074

### DIFF
--- a/app/assets/javascripts/app/_fpa_ajax_processors_trackers.js
+++ b/app/assets/javascripts/app/_fpa_ajax_processors_trackers.js
@@ -136,9 +136,17 @@ _fpa.postprocessors_trackers = {
     },
 
     tracker_chron_result_template: function (block, data) {
+        // Populate filter options BEFORE format_block initializes chosen.js,
+        // so chosen sees the populated <select> elements.
+        if (_fpa.tracker_history_filter && _fpa.tracker_history_filter.populate) {
+            _fpa.tracker_history_filter.populate(block, data);
+        }
         _fpa.form_utils.format_block(block);
         _fpa.postprocessors.tracker_notes_handler(block);
         _fpa.postprocessors.tracker_item_link_hander(block);
+        if (_fpa.tracker_history_filter && _fpa.tracker_history_filter.attach) {
+            _fpa.tracker_history_filter.attach(block, data);
+        }
 
     },
 

--- a/app/assets/javascripts/app/_fpa_tracker_history_filter.js
+++ b/app/assets/javascripts/app/_fpa_tracker_history_filter.js
@@ -1,0 +1,278 @@
+// Tracker history panel filtering (issue #1074).
+//
+// Adds client-side filter behavior for the tracker history chronological
+// panel. Supports multi-select filters for protocol, sub process (status)
+// and protocol event (method), a date range, plus a free-text notes filter.
+// Also handles initial preselection driven by regex patterns supplied in
+// `data.initial_filter_regex` and a literal initial notes value supplied in
+// `data.initial_filter_notes` from the controller.
+//
+// Filters are combined with AND across groups and OR within each group.
+// Notes matching is case-insensitive substring matching.
+//
+// To avoid fighting with `_fpa.form_utils.setup_chosen` (which initializes
+// chosen.js on multi-selects during `format_block`), the multi-select option
+// lists are populated BEFORE `format_block` runs, and event handlers are
+// attached AFTER format_block via event delegation on the table itself so
+// they survive chosen's DOM rearrangements.
+
+_fpa.tracker_history_filter = (function () {
+  var FILTER_KEYS = ['protocols', 'sub_processes', 'protocol_events'];
+
+  // Map filter group key -> data attribute name on each row
+  var ROW_ATTR_FOR_KEY = {
+    protocols: 'data-protocol-name',
+    sub_processes: 'data-sub-process-name',
+    protocol_events: 'data-event-name'
+  };
+
+  // Default name of the system-generated protocol used for record-update
+  // tracker entries (Classification::Protocol::RecordUpdatesProtocolName).
+  // Sub-processes and protocol events under this protocol clutter the filter
+  // dropdowns, so we omit them from the option lists. The authoritative value
+  // is supplied by the controller as `data.record_updates_protocol_name`;
+  // this constant is only a fallback if the payload is missing the key.
+  var DEFAULT_RECORD_UPDATES_PROTOCOL_NAME = 'Updates';
+
+  function safe_regex(pattern) {
+    try {
+      return new RegExp(pattern);
+    } catch (e) {
+      if (window.console && console.warn) {
+        console.warn('tracker history initial filters: invalid regex ' +
+          JSON.stringify(pattern) + ' - ' + e.message);
+      }
+      return null;
+    }
+  }
+
+  function unique_values($rows, attr) {
+    var seen = {};
+    var values = [];
+    $rows.each(function () {
+      var v = $(this).attr(attr);
+      if (v && !seen[v]) {
+        seen[v] = true;
+        values.push(v);
+      }
+    });
+    values.sort(function (a, b) { return a.localeCompare(b); });
+    return values;
+  }
+
+  function populate_select($select, values, preselected) {
+    $select.empty();
+    var selectedSet = {};
+    (preselected || []).forEach(function (v) { selectedSet[v] = true; });
+    values.forEach(function (v) {
+      var $opt = $('<option>').attr('value', v).text(v);
+      if (selectedSet[v]) $opt.attr('selected', 'selected');
+      $select.append($opt);
+    });
+  }
+
+  function compute_initial_selection(values, pattern) {
+    var rx = safe_regex(pattern);
+    if (!rx) return [];
+    return values.filter(function (v) { return rx.test(v); });
+  }
+
+  // Parse a date/timestamp string and return YYYY-MM-DD (or null if unparseable).
+  // Accepts ISO-style strings as well as the user's locale date format
+  // (e.g. dd/mm/yyyy or mm/dd/yyyy), which the framework's
+  // `setup_datepickers` writes back into the input.
+  function date_part(value) {
+    if (!value) return null;
+    var s = String(value).trim();
+    if (!s) return null;
+    var m = s.match(/^(\d{4}-\d{2}-\d{2})/);
+    if (m) return m[1];
+    // Use the framework helper that respects user date format preference.
+    if (_fpa.form_utils && _fpa.form_utils.locale_date_to_iso) {
+      try {
+        var iso = _fpa.form_utils.locale_date_to_iso(s);
+        if (iso && /^\d{4}-\d{2}-\d{2}/.test(iso)) return iso.substr(0, 10);
+      } catch (e) {
+        // fall through to fallback parser below
+      }
+    }
+    var d = new Date(s);
+    if (isNaN(d.getTime())) return null;
+    var pad = function (n) { return n < 10 ? '0' + n : '' + n; };
+    return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate());
+  }
+
+  function apply_filters($container) {
+    var $rows = $container.find('tbody.tracker-history-rows tr.tracker-history-row');
+    var selections = {};
+    FILTER_KEYS.forEach(function (key) {
+      var $sel = $container.find('select.tracker-history-filter[data-filter-key="' + key + '"]');
+      var v = $sel.val();
+      selections[key] = v && v.length ? v : null;
+    });
+    var notesText = ($container.find('input.tracker-history-filter-notes').val() || '')
+      .toLowerCase();
+    var dateFrom = ($container.find('input.tracker-history-filter-date-from').val() || '');
+    var dateTo = ($container.find('input.tracker-history-filter-date-to').val() || '');
+    // The framework's setup_datepickers reformats the underlying input value
+    // to the user's locale (e.g. "02/01/2025"); normalize back to YYYY-MM-DD
+    // so we can compare against the row's `data-event-date` attribute.
+    dateFrom = date_part(dateFrom) || '';
+    dateTo = date_part(dateTo) || '';
+
+    $rows.each(function () {
+      var $row = $(this);
+      var visible = true;
+
+      for (var i = 0; i < FILTER_KEYS.length && visible; i++) {
+        var key = FILTER_KEYS[i];
+        var sel = selections[key];
+        if (!sel) continue;
+        var rowVal = $row.attr(ROW_ATTR_FOR_KEY[key]) || '';
+        if (sel.indexOf(rowVal) === -1) visible = false;
+      }
+
+      if (visible && notesText) {
+        var notes = ($row.attr('data-notes') || '').toLowerCase();
+        if (notes.indexOf(notesText) === -1) visible = false;
+      }
+
+      if (visible && (dateFrom || dateTo)) {
+        var rowDate = date_part($row.attr('data-event-date'));
+        if (!rowDate) {
+          visible = false;
+        } else {
+          if (dateFrom && rowDate < dateFrom) visible = false;
+          if (visible && dateTo && rowDate > dateTo) visible = false;
+        }
+      }
+
+      $row.toggleClass('tracker-history-row--filtered-out', !visible);
+      if (visible) {
+        $row.show();
+      } else {
+        $row.hide();
+      }
+    });
+  }
+
+  function debounce(fn, wait) {
+    var timer = null;
+    return function () {
+      var ctx = this;
+      var args = arguments;
+      clearTimeout(timer);
+      timer = setTimeout(function () { fn.apply(ctx, args); }, wait);
+    };
+  }
+
+  // Populate options and initial values BEFORE chosen.js attaches via
+  // `_fpa.form_utils.setup_chosen` during `format_block`.
+  function populate(block, data) {
+    var $containers = (block && block.find)
+      ? block.find('.tracker-chron-results-wrap')
+      : $('.tracker-chron-results-wrap');
+    if (!$containers.length) return;
+
+    var initialRegex = (data && data.initial_filter_regex) || {};
+    var initialNotes = (data && data.initial_filter_notes) || '';
+    var initialDateFrom = (data && data.initial_filter_date_from) || '';
+    var initialDateTo = (data && data.initial_filter_date_to) || '';
+    var recordUpdatesProtocolName =
+      (data && data.record_updates_protocol_name) || DEFAULT_RECORD_UPDATES_PROTOCOL_NAME;
+
+    $containers.each(function () {
+      var $container = $(this);
+      var $rows = $container.find('tbody.tracker-history-rows tr.tracker-history-row');
+
+      FILTER_KEYS.forEach(function (key) {
+        var $sel = $container.find('select.tracker-history-filter[data-filter-key="' + key + '"]');
+        if (!$sel.length) return;
+        // For the protocol_events list, omit events that belong to the
+        // record-updates protocol since they only clutter the dropdown.
+        var $sourceRows = (key === 'protocol_events')
+          ? $rows.not('[data-protocol-name="' + recordUpdatesProtocolName + '"]')
+          : $rows;
+        var values = unique_values($sourceRows, ROW_ATTR_FOR_KEY[key]);
+        var pattern = initialRegex[key];
+        var preselected = pattern ? compute_initial_selection(values, pattern) : [];
+        populate_select($sel, values, preselected);
+      });
+
+      $container.find('input.tracker-history-filter-notes').val(initialNotes);
+      $container.find('input.tracker-history-filter-date-from').val(initialDateFrom);
+      $container.find('input.tracker-history-filter-date-to').val(initialDateTo);
+    });
+  }
+
+  // Attach delegated event handlers after format_block has set up chosen.
+  function attach(block) {
+    var $containers = (block && block.find)
+      ? block.find('.tracker-chron-results-wrap')
+      : $('.tracker-chron-results-wrap');
+    if (!$containers.length) return;
+
+    $containers.each(function () {
+      var $container = $(this);
+      if ($container.data('thfAttached')) {
+        apply_filters($container);
+        return;
+      }
+      $container.data('thfAttached', true);
+
+      $container.on('change.thf', 'select.tracker-history-filter', function () {
+        apply_filters($container);
+      });
+
+      var debouncedApply = debounce(function () { apply_filters($container); }, 500);
+      $container.on('input.thf', 'input.tracker-history-filter-notes', function () {
+        debouncedApply();
+      });
+      $container.on('keydown.thf', 'input.tracker-history-filter-notes', function (ev) {
+        if (ev.which === 13) {
+          ev.preventDefault();
+          apply_filters($container);
+        }
+      });
+
+      $container.on('change.thf input.thf changeDate.thf blur.thf', 'input.tracker-history-filter-date-from, input.tracker-history-filter-date-to', function () {
+        apply_filters($container);
+      });
+
+      $container.on('click.thf', 'a.tracker-history-filters__clear', function (ev) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        $container.find('select.tracker-history-filter')
+          .val(null)
+          .trigger('chosen:updated')
+          .trigger('change');
+        $container.find('input.tracker-history-filter-notes').val('');
+        $container.find('input.tracker-history-filter-date-from').val('');
+        $container.find('input.tracker-history-filter-date-to').val('');
+        apply_filters($container);
+        return false;
+      });
+
+      apply_filters($container);
+    });
+
+    // After format_block has scheduled chosen() via setTimeout, trigger
+    // chosen:updated so chosen rebuilds its result list from the options
+    // we populated. This handles ordering races where chosen attaches
+    // before reading the populated <option> elements.
+    setTimeout(function () {
+      $containers.each(function () {
+        $(this).find('select.tracker-history-filter').trigger('chosen:updated');
+      });
+    }, 50);
+  }
+
+  return {
+    populate: populate,
+    attach: attach,
+    apply_filters: apply_filters,
+    _safe_regex: safe_regex,
+    _compute_initial_selection: compute_initial_selection,
+    _date_part: date_part
+  };
+})();

--- a/app/assets/stylesheets/app/search_results.scss
+++ b/app/assets/stylesheets/app/search_results.scss
@@ -348,6 +348,78 @@ table.table tbody.tracker-history {
   border: 0;
 }
 
+// Tracker history panel filter row (issue #1074)
+.tracker-history-filters {
+  background: #f7f7f7;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border: 1px solid #ddd;
+  border-bottom: 0;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+
+  &__cell {
+    flex: 1 1 140px;
+    min-width: 140px;
+  }
+
+  &__clear-cell {
+    flex: 0 0 auto;
+    text-align: center;
+    vertical-align: middle;
+  }
+
+  &__clear {
+    color: #999;
+    text-decoration: none;
+    font-size: 18px;
+
+    &:hover {
+      color: #333;
+    }
+  }
+
+  &__date-cell {
+    display: flex;
+    gap: 4px;
+
+    input {
+      flex: 1 1 auto;
+      width: 100%;
+      box-sizing: border-box;
+    }
+  }
+
+  &__notes-cell {
+    .tracker-history-filters__notes-wrap {
+      position: relative;
+      display: block;
+    }
+
+    .tracker-history-filters__notes-icon {
+      position: absolute;
+      top: 50%;
+      left: 8px;
+      transform: translateY(-50%);
+      color: #999;
+      pointer-events: none;
+    }
+
+    .tracker-history-filter-notes {
+      width: 100%;
+      box-sizing: border-box;
+      padding-left: 26px;
+    }
+  }
+}
+
+.tracker-history-row--filtered-out {
+  display: none !important;
+}
+
 .tracker-block table.table > tbody > tr > td {
   border-top: 0;
 }

--- a/app/controllers/tracker_histories_controller.rb
+++ b/app/controllers/tracker_histories_controller.rb
@@ -16,7 +16,7 @@ class TrackerHistoriesController < UserBaseController
 
     logger.info "Tracker histories returned #{@tracker_histories.length} items"
 
-    if params[:skip_last]=='true'
+    if params[:skip_last] == 'true'
       # Remove a current tracker item from the list.
       mid = @tracker_histories.first
       @tracker_histories = @tracker_histories.reject {|x| x.id == mid.id}
@@ -24,7 +24,19 @@ class TrackerHistoriesController < UserBaseController
 
     @master_objects = @tracker_histories
 
-    render json: {tracker_histories: @tracker_histories, master_id: @master.id}
+    initial_filter_regex = TrackerHistoryFilterConfig.config_for(current_user)
+    initial_filter_notes = TrackerHistoryFilterConfig.notes_initial_for(current_user)
+    initial_filter_dates = TrackerHistoryFilterConfig.date_initial_for(current_user)
+
+    render json: {
+      tracker_histories: @tracker_histories,
+      master_id: @master.id,
+      initial_filter_regex: initial_filter_regex,
+      initial_filter_notes: initial_filter_notes,
+      initial_filter_date_from: initial_filter_dates[:date_from],
+      initial_filter_date_to: initial_filter_dates[:date_to],
+      record_updates_protocol_name: Classification::Protocol::RecordUpdatesProtocolName
+    }
   end
 
 

--- a/app/models/admin/defs/app_configuration_defs.yaml
+++ b/app/models/admin/defs/app_configuration_defs.yaml
@@ -51,6 +51,23 @@ hide search form searchable reports: |
   Don't show reports marked as "searchable" as search forms. Value "true" hides them
 hide tracker panel: |
   The Tracker panel in a master record can be hidden. Value "true" hides it
+tracker history initial filters: |
+  YAML defining initial filter values for the tracker history panel. The keys
+  `protocols`, `sub_processes` and `protocol_events` are regular expressions
+  matched against display names (not IDs) to preselect multi-select tags.
+  The optional key `notes` is a literal initial value for the notes free-text
+  filter (used as-is, not interpreted as a regex). Invalid regex patterns are
+  ignored with a logged warning, and the affected filter group remains
+  unselected.
+
+  Example:
+
+  ```yaml
+  protocols: '^Study'
+  sub_processes: 'consented'
+  protocol_events: 'visit_[0-9]+'
+  notes: 'follow-up'
+  ```
 filestore directory id: |
   If the server setting for use_parent_sub_dir is set, this value is the external ID resource name to get 
   the identifier from. By default it uses master ID

--- a/app/models/tracker_history_filter_config.rb
+++ b/app/models/tracker_history_filter_config.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+# Parses and applies the `tracker history initial filters` app configuration,
+# which provides regex patterns used to preselect default filter options on
+# the tracker history panel (issue #1074).
+#
+# The expected app configuration value is YAML with the keys:
+#   protocols:        '<regex>'
+#   sub_processes:    '<regex>'
+#   protocol_events:  '<regex>'
+#
+# Patterns are applied to display names (not numeric IDs). Invalid regex
+# values are logged as warnings and result in no preselection for that group.
+class TrackerHistoryFilterConfig
+  CONFIG_NAME = :tracker_history_initial_filters
+  REGEX_KEYS = %i[protocols sub_processes protocol_events].freeze
+  LITERAL_KEYS = %i[notes].freeze
+  DATE_KEYS = %i[date_from date_to].freeze
+  ALLOWED_KEYS = (REGEX_KEYS + LITERAL_KEYS + DATE_KEYS).freeze
+
+  # Return a sanitized hash of regex source strings keyed by the supported
+  # multi-select filter group symbols. Unknown keys, blank values and literal
+  # (non-regex) keys are omitted. Used for initial preselection of the
+  # multi-select filters.
+  # @param [User] user
+  # @return [Hash{Symbol=>String}]
+  def self.config_for(user = nil)
+    raw = raw_config(user)
+    return {} if raw.blank?
+
+    raw
+      .slice(*REGEX_KEYS)
+      .each_with_object({}) do |(key, value), acc|
+        next if value.blank?
+
+        acc[key] = value.to_s
+      end
+  end
+
+  # Return the literal initial value for the notes free-text filter, or
+  # an empty string when not configured.
+  # @param [User] user
+  # @return [String]
+  def self.notes_initial_for(user = nil)
+    raw = raw_config(user)
+    raw[:notes].to_s
+  end
+
+  # Return resolved initial values for the date_from / date_to filters
+  # as `YYYY-MM-DD` strings. Values may be absolute dates (e.g. `2025-02-01`)
+  # or relative duration strings such as `-10 days`, `+1 month`, `today()`,
+  # which are resolved via `FieldDefaults.calculate_default`.
+  # Blank or unparseable values are omitted.
+  # @param [User] user
+  # @return [Hash{Symbol=>String}]
+  def self.date_initial_for(user = nil)
+    raw = raw_config(user)
+    DATE_KEYS.each_with_object({}) do |key, acc|
+      value = raw[key]
+      next if value.blank?
+
+      resolved = resolve_date(value)
+      acc[key] = resolved if resolved
+    end
+  end
+
+  # Resolve a configured date value (absolute or relative) to a `YYYY-MM-DD`
+  # string, or nil if it cannot be parsed.
+  # Relative strings such as `-10 days`, `+1 month`, `today()` are resolved
+  # via `FieldDefaults.calculate_default`. Absolute date strings are parsed
+  # with `Date.parse`.
+  # @param [String] value
+  # @return [String, nil]
+  def self.resolve_date(value)
+    result = FieldDefaults.calculate_default(nil, value.to_s)
+    return nil if result.blank?
+
+    case result
+    when Date, DateTime, Time, ActiveSupport::TimeWithZone
+      result.strftime('%Y-%m-%d')
+    when String
+      Date.parse(result).strftime('%Y-%m-%d')
+    end
+  rescue StandardError => e
+    Rails.logger.warn(
+      "tracker history initial filters: invalid date #{value.inspect} - #{e.message}"
+    )
+    nil
+  end
+
+  # Match the supplied list of names against the regex source pattern.
+  # Invalid regex patterns are logged and result in no matches.
+  # Blank patterns return an empty result without logging.
+  # @param [String, nil] pattern
+  # @param [Array<String>] names
+  # @return [Array<String>]
+  def self.match_names(pattern, names)
+    return [] if pattern.blank? || names.blank?
+
+    regex = compile_regex(pattern)
+    return [] unless regex
+
+    names.select { |n| n.to_s.match?(regex) }
+  end
+
+  # Build per-group preselection lists from the available options.
+  # @param [Hash{Symbol=>Array<String>}] options keyed by REGEX_KEYS
+  # @param [User] user
+  # @return [Hash{Symbol=>Array<String>}]
+  def self.initial_selections(options, user = nil)
+    config = config_for(user)
+    REGEX_KEYS.each_with_object({}) do |key, acc|
+      acc[key] = match_names(config[key], options[key] || [])
+    end
+  end
+
+  # Compile a regex source string, returning nil and logging a warning if invalid.
+  # @param [String] pattern
+  # @return [Regexp, nil]
+  def self.compile_regex(pattern)
+    Regexp.new(pattern.to_s)
+  rescue RegexpError => e
+    Rails.logger.warn(
+      "tracker history initial filters: invalid regex #{pattern.inspect} - #{e.message}"
+    )
+    nil
+  end
+
+  # Read the raw YAML hash for the configured user, restricted to allowed keys.
+  # @param [User] user
+  # @return [Hash{Symbol=>Object}]
+  def self.raw_config(user = nil)
+    raw = Admin::AppConfiguration.hash_for(CONFIG_NAME, user)
+    return {} if raw.blank?
+
+    raw.slice(*ALLOWED_KEYS)
+  end
+end

--- a/app/views/trackers/_search_results_template.html.erb
+++ b/app/views/trackers/_search_results_template.html.erb
@@ -77,7 +77,32 @@
 
 
 <%= handlebars_template_tag('tracker_chron_results-partial', css_class: 'hidden handlebars-partial') do %>
-  <table class="table tablesorter tracker-chron-results">
+  <div class="tracker-chron-results-wrap" data-master-id="{{master_id}}">
+    <div class="tracker-history-filters" data-tracker-history-filters="1">
+      <div class="tracker-history-filters__clear-cell">
+        <a href="#" class="tracker-history-filters__clear glyphicon glyphicon-remove-circle" title="clear filters"></a>
+      </div>
+      <div class="tracker-history-filters__cell">
+        <select multiple id="tracker_history_filter_protocols_{{master_id}}" name="tracker_history_filter_protocols[]" data-attr-name="tracker_history_filter_protocols" class="tracker-history-filter use-chosen" data-filter-key="protocols" data-placeholder="filter protocol" data-nothing-selected-text="filter protocol"></select>
+      </div>
+      <div class="tracker-history-filters__cell">
+        <select multiple id="tracker_history_filter_sub_processes_{{master_id}}" name="tracker_history_filter_sub_processes[]" data-attr-name="tracker_history_filter_sub_processes" class="tracker-history-filter use-chosen" data-filter-key="sub_processes" data-placeholder="filter status" data-nothing-selected-text="filter status"></select>
+      </div>
+      <div class="tracker-history-filters__cell">
+        <select multiple id="tracker_history_filter_protocol_events_{{master_id}}" name="tracker_history_filter_protocol_events[]" data-attr-name="tracker_history_filter_protocol_events" class="tracker-history-filter use-chosen" data-filter-key="protocol_events" data-placeholder="filter method" data-nothing-selected-text="filter method"></select>
+      </div>
+      <div class="tracker-history-filters__cell tracker-history-filters__date-cell">
+        <input type="date" class="form-control tracker-history-filter-date-from" data-attr-name="tracker_history_filter_date_from" title="from date" aria-label="filter date from" />
+        <input type="date" class="form-control tracker-history-filter-date-to" data-attr-name="tracker_history_filter_date_to" title="to date" aria-label="filter date to" />
+      </div>
+      <div class="tracker-history-filters__cell tracker-history-filters__notes-cell">
+        <span class="tracker-history-filters__notes-wrap">
+          <span class="glyphicon glyphicon-search tracker-history-filters__notes-icon" aria-hidden="true"></span>
+          <input type="text" class="form-control tracker-history-filter-notes" data-attr-name="tracker_history_filter_notes" placeholder="filter notes" aria-label="filter notes" />
+        </span>
+      </div>
+    </div>
+  <table class="table tablesorter tracker-chron-results" data-master-id="{{master_id}}">
     <thead><tr>
       <th class="no-sort"><a href="/masters/{{master_id}}/trackers" data-remote="true" data-result-target="#trackers-{{master_id}}-inner" data-template="tracker-tree-result-template" title="view as events"  class="glyphicon glyphicon-list"></a></th>
       <th>protocol</th><th>status</th><th>method</th><th>date</th><th>notes</th><th><a href="/masters/{{master_id}}/trackers/new" data-remote="true" class="btn btn-sm btn-primary pull-right hidden add-tracker-record" title="add tracker record"><span class="glyphicon glyphicon-plus"></span> Tracker record</a> </th>
@@ -89,10 +114,10 @@
     </tr>
     </tbody>
 
-    <tbody>
+    <tbody class="tracker-history-rows">
     {{#each this}}
       {{#if id}}
-      <tr class="index-{{@index}}" data-tracker-protocol="{{underscore protocol_name}}" data-tracker-protocol="{{underscore protocol_name}}" id="tracker-{{master_id}}-{{id}}" data-subscription="tracker-edit-form-{{master_id}}-{{id}}">
+      <tr class="index-{{@index}} tracker-history-row" data-tracker-protocol="{{underscore protocol_name}}" data-protocol-name="{{protocol_name}}" data-sub-process-name="{{sub_process_name}}" data-event-name="{{event_name}}" data-event-date="{{event_date}}" data-notes="{{notes}}" id="tracker-{{master_id}}-{{id}}" data-subscription="tracker-edit-form-{{master_id}}-{{id}}">
         {{#with this}}
           {{>tracker_history_result}}
 
@@ -102,6 +127,7 @@
     {{/each}}
     </tbody>
   </table>
+  </div>
 
 <% end %>
 

--- a/spec/controllers/tracker_histories_controller_spec.rb
+++ b/spec/controllers/tracker_histories_controller_spec.rb
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
+# Specs for TrackerHistoriesController - verifies the JSON payload returned
+# by the index action, including the `initial_filter_*` keys added for the
+# tracker history panel filter feature (consected/restructure issue #1074).
+
 require 'rails_helper'
 
 RSpec.describe TrackerHistoriesController, type: :controller do
@@ -163,6 +169,64 @@ RSpec.describe TrackerHistoriesController, type: :controller do
         # Verify the first entry from the ordered list is not included
         returned_ids = tracker_histories.map { |th| th['id'] }
         expect(returned_ids).not_to include(first_entry_id)
+      end
+    end
+
+    # Issue #1074: tracker history panel filtering
+    context 'when the tracker history initial filters app config is set' do
+      it 'includes initial_filter_regex in the JSON response' do
+        master = create_master
+
+        Admin::AppConfiguration.add_default_config(
+          @user.app_type,
+          :tracker_history_initial_filters,
+          "protocols: '^Study'\nsub_processes: 'consented'\n",
+          @admin
+        )
+
+        get :index, params: { master_id: master.id }
+
+        expect(response).to have_http_status(200)
+        json_response = JSON.parse(response.body)
+        expect(json_response['initial_filter_regex']).to eq(
+          'protocols' => '^Study',
+          'sub_processes' => 'consented'
+        )
+      end
+
+      it 'includes the literal initial_filter_notes value in the JSON response' do
+        master = create_master
+
+        Admin::AppConfiguration.add_default_config(
+          @user.app_type,
+          :tracker_history_initial_filters,
+          "notes: 'follow-up'\n",
+          @admin
+        )
+
+        get :index, params: { master_id: master.id }
+
+        expect(response).to have_http_status(200)
+        json_response = JSON.parse(response.body)
+        expect(json_response['initial_filter_notes']).to eq('follow-up')
+      end
+
+      it 'returns an empty initial_filter_regex and notes when no config is set' do
+        master = create_master
+        get :index, params: { master_id: master.id }
+        expect(response).to have_http_status(200)
+        json_response = JSON.parse(response.body)
+        expect(json_response['initial_filter_regex']).to eq({})
+        expect(json_response['initial_filter_notes']).to eq('')
+      end
+
+      it 'includes the record_updates_protocol_name from Classification::Protocol' do
+        master = create_master
+        get :index, params: { master_id: master.id }
+        expect(response).to have_http_status(200)
+        json_response = JSON.parse(response.body)
+        expect(json_response['record_updates_protocol_name'])
+          .to eq(Classification::Protocol::RecordUpdatesProtocolName)
       end
     end
   end

--- a/spec/models/tracker_history_filter_config_spec.rb
+++ b/spec/models/tracker_history_filter_config_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+# Specs for TrackerHistoryFilterConfig - configuration parsing and regex-driven
+# initial preselection logic for the tracker history panel filters
+# (consected/restructure issue #1074).
+#
+# Covers:
+# - Loading a YAML hash from the `tracker history initial filters` app config
+# - Compiling string regexes safely with exception handling
+# - Matching options by name (not ID), supporting inclusion and exclusion patterns
+# - Graceful degradation and warning on invalid regexes
+
+require 'rails_helper'
+
+RSpec.describe TrackerHistoryFilterConfig, type: :model do
+  include ModelSupport
+  include ActiveSupport::Testing::TimeHelpers
+
+  before(:each) do
+    create_user
+    create_admin
+    Admin::AppConfiguration.clear_memo!
+  end
+
+  describe '.config_for' do
+    it 'returns a hash with regex source strings keyed by filter group when configured' do
+      yaml = <<~YAML
+        protocols: '^Study'
+        sub_processes: 'consented'
+        protocol_events: 'visit_[0-9]+'
+      YAML
+      Admin::AppConfiguration.add_default_config(@user.app_type, :tracker_history_initial_filters, yaml, @admin)
+
+      config = described_class.config_for(@user)
+
+      expect(config).to include(
+        protocols: '^Study',
+        sub_processes: 'consented',
+        protocol_events: 'visit_[0-9]+'
+      )
+    end
+
+    it 'returns an empty hash when no config is set' do
+      expect(described_class.config_for(@user)).to eq({})
+    end
+
+    it 'ignores unknown keys but keeps known ones' do
+      yaml = <<~YAML
+        protocols: 'Study'
+        bogus_key: 'ignored'
+      YAML
+      Admin::AppConfiguration.add_default_config(@user.app_type, :tracker_history_initial_filters, yaml, @admin)
+
+      config = described_class.config_for(@user)
+      expect(config.keys).to contain_exactly(:protocols)
+    end
+
+    it 'does not return the notes literal value (it is not a regex group)' do
+      yaml = <<~YAML
+        protocols: 'Study'
+        notes: 'follow-up'
+      YAML
+      Admin::AppConfiguration.add_default_config(@user.app_type, :tracker_history_initial_filters, yaml, @admin)
+
+      expect(described_class.config_for(@user).keys).to contain_exactly(:protocols)
+    end
+  end
+
+  describe '.notes_initial_for' do
+    it 'returns the configured notes literal string' do
+      yaml = <<~YAML
+        notes: 'follow-up'
+      YAML
+      Admin::AppConfiguration.add_default_config(@user.app_type, :tracker_history_initial_filters, yaml, @admin)
+
+      expect(described_class.notes_initial_for(@user)).to eq('follow-up')
+    end
+
+    it 'returns an empty string when not configured' do
+      expect(described_class.notes_initial_for(@user)).to eq('')
+    end
+
+    it 'preserves the literal value verbatim (no regex interpretation)' do
+      yaml = <<~YAML
+        notes: '[hello].*'
+      YAML
+      Admin::AppConfiguration.add_default_config(@user.app_type, :tracker_history_initial_filters, yaml, @admin)
+
+      expect(described_class.notes_initial_for(@user)).to eq('[hello].*')
+    end
+  end
+
+  describe '.date_initial_for' do
+    it 'returns YYYY-MM-DD strings for absolute date_from / date_to literals' do
+      yaml = <<~YAML
+        date_from: '2025-02-01'
+        date_to: '2025-03-31'
+      YAML
+      Admin::AppConfiguration.add_default_config(@user.app_type, :tracker_history_initial_filters, yaml, @admin)
+
+      expect(described_class.date_initial_for(@user)).to eq(
+        date_from: '2025-02-01',
+        date_to: '2025-03-31'
+      )
+    end
+
+    it 'resolves relative duration strings such as "-10 days" via FieldDefaults' do
+      yaml = <<~YAML
+        date_from: '-10 days'
+        date_to: 'today()'
+      YAML
+      Admin::AppConfiguration.add_default_config(@user.app_type, :tracker_history_initial_filters, yaml, @admin)
+
+      travel_to(Time.zone.local(2025, 6, 15, 10, 0, 0)) do
+        expect(described_class.date_initial_for(@user)).to eq(
+          date_from: '2025-06-05',
+          date_to: '2025-06-15'
+        )
+      end
+    end
+
+    it 'returns an empty hash when no date config is set' do
+      expect(described_class.date_initial_for(@user)).to eq({})
+    end
+
+    it 'omits keys with blank or unparseable values' do
+      yaml = <<~YAML
+        date_from: ''
+        date_to: 'not-a-date'
+      YAML
+      Admin::AppConfiguration.add_default_config(@user.app_type, :tracker_history_initial_filters, yaml, @admin)
+
+      expect(described_class.date_initial_for(@user)).to eq({})
+    end
+  end
+
+  describe '.match_names' do
+    let(:names) { ['Study Visit 1', 'Study Visit 2', 'Recruitment', 'Withdrawn'] }
+
+    it 'returns names matching an inclusion regex' do
+      expect(described_class.match_names('^Study', names)).to eq(['Study Visit 1', 'Study Visit 2'])
+    end
+
+    it 'supports exclusion via negative lookahead' do
+      expect(described_class.match_names('^(?!Study).+', names)).to eq(['Recruitment', 'Withdrawn'])
+    end
+
+    it 'returns an empty array when no names match' do
+      expect(described_class.match_names('Nope', names)).to eq([])
+    end
+
+    it 'returns an empty array and logs a warning for an invalid regex' do
+      expect(Rails.logger).to receive(:warn).with(/tracker history initial filters/i)
+      expect(described_class.match_names('[invalid', names)).to eq([])
+    end
+
+    it 'returns an empty array for blank pattern' do
+      expect(described_class.match_names('', names)).to eq([])
+      expect(described_class.match_names(nil, names)).to eq([])
+    end
+  end
+
+  describe '.initial_selections' do
+    let(:options) do
+      {
+        protocols: ['Study A', 'Study B', 'Other'],
+        sub_processes: ['consented', 'declined'],
+        protocol_events: ['visit_1', 'visit_2', 'phone']
+      }
+    end
+
+    it 'returns matched names for each configured group, leaving others empty' do
+      yaml = <<~YAML
+        protocols: '^Study'
+        protocol_events: '^visit_'
+      YAML
+      Admin::AppConfiguration.add_default_config(@user.app_type, :tracker_history_initial_filters, yaml, @admin)
+
+      result = described_class.initial_selections(options, @user)
+
+      expect(result).to eq(
+        protocols: ['Study A', 'Study B'],
+        sub_processes: [],
+        protocol_events: ['visit_1', 'visit_2']
+      )
+    end
+
+    it 'does not raise and falls back to empty selection on invalid regex' do
+      yaml = <<~YAML
+        protocols: '[bad'
+        sub_processes: 'consented'
+      YAML
+      Admin::AppConfiguration.add_default_config(@user.app_type, :tracker_history_initial_filters, yaml, @admin)
+
+      allow(Rails.logger).to receive(:warn)
+
+      result = described_class.initial_selections(options, @user)
+      expect(result[:protocols]).to eq([])
+      expect(result[:sub_processes]).to eq(['consented'])
+      expect(result[:protocol_events]).to eq([])
+    end
+  end
+end

--- a/spec/system/tracker_history_filter_spec.rb
+++ b/spec/system/tracker_history_filter_spec.rb
@@ -1,0 +1,374 @@
+# frozen_string_literal: true
+
+# System specs for the tracker history panel filter UI (issue #1074).
+#
+# These tests drive the real browser UI through Capybara, exercising the
+# chosen.js multi-select filters (protocol, sub_process, protocol_event),
+# the notes free-text filter, the date range filter, and the clear
+# action. They also verify regex-driven and literal initial filter values
+# applied via the `tracker history initial filters` app configuration.
+#
+# Tests use the existing `select_from_chosen` helper (from
+# spec/support/feature_support.rb) so the chosen dropdowns are exercised
+# the same way a human user would interact with them, rather than firing
+# synthetic JavaScript events.
+
+require 'rails_helper'
+
+describe 'tracker history filter panel', js: true, driver: $browser_driver do
+  include ModelSupport
+  include MasterDataSupport
+  include FeatureSupport
+
+  before(:all) do
+    SetupHelper.feature_setup
+    change_setting('TwoFactorAuthDisabledForUser', true)
+
+    create_admin
+
+    # Disable any existing protocol events so we know what is in the test set
+    Classification::ProtocolEvent.enabled.each do |d|
+      d.update!(disabled: true, current_admin: @admin)
+    end
+
+    seed_database
+    create_data_set_outside_tx no_trackers: true, no_seed: true
+
+    @user, @good_password = create_user(nil, '', create_master: true)
+    @good_email = @user.email
+    @app_type = @user.app_type
+
+    setup_access :trackers
+    setup_access :tracker_histories
+    setup_access :trackers, user: @user
+    setup_access :tracker_histories, user: @user
+
+    # Create a fresh master with a deterministic set of tracker history rows
+    @filter_master = Master.new(current_user: @user)
+    @filter_master.save!
+
+    @protocol_study = Classification::Protocol.create!(
+      name: "Study #{rand(100_000)}", current_admin: @admin
+    )
+    @protocol_other = Classification::Protocol.create!(
+      name: "Other #{rand(100_000)}", current_admin: @admin
+    )
+
+    @sp_consented = @protocol_study.sub_processes.create!(
+      name: 'consented', disabled: false, current_admin: @admin
+    )
+    @sp_declined = @protocol_study.sub_processes.create!(
+      name: 'declined', disabled: false, current_admin: @admin
+    )
+    @sp_other = @protocol_other.sub_processes.create!(
+      name: 'misc', disabled: false, current_admin: @admin
+    )
+
+    @ev_visit_1 = @sp_consented.protocol_events.create!(
+      name: 'visit_1', disabled: false, current_admin: @admin
+    )
+    @ev_visit_2 = @sp_consented.protocol_events.create!(
+      name: 'visit_2', disabled: false, current_admin: @admin
+    )
+    @ev_phone = @sp_declined.protocol_events.create!(
+      name: 'phone', disabled: false, current_admin: @admin
+    )
+    @ev_misc = @sp_other.protocol_events.create!(
+      name: 'misc_event', disabled: false, current_admin: @admin
+    )
+
+    @row_a = @filter_master.trackers.create!(
+      protocol_id: @protocol_study.id,
+      sub_process_id: @sp_consented.id,
+      protocol_event_id: @ev_visit_1.id,
+      event_date: '2025-01-15 09:00:00',
+      notes: 'follow-up scheduled'
+    )
+    @row_b = @filter_master.trackers.create!(
+      protocol_id: @protocol_study.id,
+      sub_process_id: @sp_consented.id,
+      protocol_event_id: @ev_visit_2.id,
+      event_date: '2025-02-20 14:30:00',
+      notes: 'follow-up complete'
+    )
+    @row_c = @filter_master.trackers.create!(
+      protocol_id: @protocol_study.id,
+      sub_process_id: @sp_declined.id,
+      protocol_event_id: @ev_phone.id,
+      event_date: '2025-03-10 10:00:00',
+      notes: 'left voicemail'
+    )
+    @row_d = @filter_master.trackers.create!(
+      protocol_id: @protocol_other.id,
+      sub_process_id: @sp_other.id,
+      protocol_event_id: @ev_misc.id,
+      event_date: '2025-04-05 08:00:00',
+      notes: 'unrelated note'
+    )
+
+    # Create a tracker history row under the system "Updates" protocol so we
+    # can verify its protocol events are excluded from the filter dropdown.
+    @updates_protocol = Classification::Protocol.record_updates_protocol
+    @updates_sub_process = @updates_protocol.sub_processes.first
+    @updates_event = @updates_sub_process.protocol_events.first
+    @row_updates = @filter_master.trackers.create!(
+      protocol_id: @updates_protocol.id,
+      sub_process_id: @updates_sub_process.id,
+      protocol_event_id: @updates_event.id,
+      event_date: '2025-05-01 09:00:00',
+      notes: 'system update entry'
+    )
+  end
+
+  before(:each) do
+    Admin::AppConfiguration.where(name: 'tracker history initial filters').delete_all
+    Admin::AppConfiguration.clear_memo!
+    login
+  end
+
+  # Open the master, expand tracker panel, switch to the chronological view
+  # which contains the filter row.
+  def open_chron_view
+    visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@filter_master.id}"
+    dismiss_modal
+    finish_page_loading
+
+    expect(page).to have_css("#master-#{@filter_master.id}-main-container.in", wait: 10)
+    expand_tracker_panel
+
+    expect(page).to have_css('table.tracker-tree-results', wait: 10)
+    chron_link = find('table.tracker-tree-results thead a[data-template="tracker-chron-result-template"]')
+    scroll_into_view(chron_link)
+    chron_link.click
+
+    expect(page).to have_css('table.tracker-chron-results', wait: 10)
+    expect(page).to have_css('.tracker-chron-results-wrap select.tracker-history-filter.attached-chosen',
+                             visible: :all, wait: 10)
+    sleep 0.5
+  end
+
+  def visible_event_names
+    page.all('table.tracker-chron-results tbody.tracker-history-rows tr.tracker-history-row:not([style*="display: none"]) td.tracker-history-event_name',
+             wait: 2).map { |el| el.text.strip }
+  end
+
+  # Helper that mirrors select_multiple_from_chosen but closes the chosen
+  # dropdown by clicking a known element on the filter row (the
+  # `.tracker-history-filters__clear-cell`) rather than relying on the
+  # generic `label, .caption-before` element which the chron view does not have.
+  def select_filter_chosen(field_name, values)
+    is_multi = true
+    Array(values).each do |v|
+      select_from_chosen(field_name, v, is_multi: is_multi)
+      is_multi = :already_open
+    end
+    page.execute_script('document.activeElement && document.activeElement.blur && document.activeElement.blur();')
+    sleep 0.3
+  end
+
+  it 'shows all rows by default with no filters applied' do
+    open_chron_view
+
+    names = visible_event_names
+    expect(names).to include(/visit/i, /phone/i, /misc/i)
+    expect(names.length).to be >= 4
+  end
+
+  it 'filters rows by selecting a protocol via the chosen multi-select' do
+    open_chron_view
+
+    select_filter_chosen('tracker_history_filter_protocols', [@protocol_study.name])
+
+    sleep 0.5
+    rows = page.all('table.tracker-chron-results tbody.tracker-history-rows tr.tracker-history-row:not([style*="display: none"])')
+    rows.each do |r|
+      expect(r['data-protocol-name']).to eq(@protocol_study.name)
+    end
+    expect(rows.length).to eq(3)
+  end
+
+  it 'filters by free-text notes (case-insensitive partial match)' do
+    open_chron_view
+
+    notes_input = find('input.tracker-history-filter-notes')
+    notes_input.fill_in(with: 'FOLLOW')
+    sleep 0.5
+
+    rows = page.all('table.tracker-chron-results tbody.tracker-history-rows tr.tracker-history-row:not([style*="display: none"])')
+    expect(rows.length).to eq(2)
+    rows.each do |r|
+      expect(r['data-notes'].downcase).to include('follow')
+    end
+  end
+
+  it 'filters by event_date range, ignoring the time component' do
+    open_chron_view
+
+    # Date inputs: set via JS-driven value + trigger change, since
+    # headless Chrome's native date picker is awkward to drive via send_keys
+    # and produces inconsistent results across locales.
+    page.execute_script(<<~JS)
+      $('input.tracker-history-filter-date-from').val('2025-02-01').trigger('change');
+      $('input.tracker-history-filter-date-to').val('2025-03-31').trigger('change');
+    JS
+    sleep 0.5
+
+    rows = page.all('table.tracker-chron-results tbody.tracker-history-rows tr.tracker-history-row:not([style*="display: none"])')
+    expect(rows.length).to eq(2)
+    visible_dates = rows.map { |r| r['data-event-date'][0, 10] }.sort
+    expect(visible_dates).to eq(['2025-02-20', '2025-03-10'])
+  end
+
+  it 'combines multi-select and notes filters with AND across groups' do
+    open_chron_view
+
+    select_filter_chosen('tracker_history_filter_protocols', [@protocol_study.name])
+    find('input.tracker-history-filter-notes').fill_in(with: 'follow-up')
+    sleep 0.5
+
+    rows = page.all('table.tracker-chron-results tbody.tracker-history-rows tr.tracker-history-row:not([style*="display: none"])')
+    expect(rows.length).to eq(2)
+    rows.each do |r|
+      expect(r['data-protocol-name']).to eq(@protocol_study.name)
+      expect(r['data-notes']).to include('follow-up')
+    end
+  end
+
+  it 'restores all rows when the clear filters button is clicked' do
+    open_chron_view
+
+    select_filter_chosen('tracker_history_filter_protocols', [@protocol_study.name])
+    find('input.tracker-history-filter-notes').fill_in(with: 'follow-up')
+    find('input.tracker-history-filter-date-from').fill_in(with: '2025-02-01')
+    sleep 0.5
+
+    rows = page.all('table.tracker-chron-results tbody.tracker-history-rows tr.tracker-history-row:not([style*="display: none"])')
+    expect(rows.length).to be < 4
+
+    clear_link = find('a.tracker-history-filters__clear')
+    scroll_into_view(clear_link)
+    clear_link.click
+    sleep 0.5
+
+    expect(find('input.tracker-history-filter-notes').value).to eq('')
+    expect(find('input.tracker-history-filter-date-from').value).to eq('')
+    expect(find('input.tracker-history-filter-date-to').value).to eq('')
+
+    rows_after = page.all('table.tracker-chron-results tbody.tracker-history-rows tr.tracker-history-row:not([style*="display: none"])')
+    expect(rows_after.length).to be >= 4
+  end
+
+  it 'preselects multi-select tags from a regex configured in app config' do
+    Admin::AppConfiguration.add_default_config(
+      @app_type,
+      :tracker_history_initial_filters,
+      "protocols: '^Study'\n",
+      @admin
+    )
+    Admin::AppConfiguration.clear_memo!
+
+    open_chron_view
+
+    selected_tags = page.all('div#tracker_history_filter_protocols_' \
+                             "#{@filter_master.id}_chosen ul.chosen-choices li.search-choice span")
+                        .map { |el| el.text.strip }
+    expect(selected_tags).to include(@protocol_study.name)
+    expect(selected_tags).not_to include(@protocol_other.name)
+
+    rows = page.all('table.tracker-chron-results tbody.tracker-history-rows tr.tracker-history-row:not([style*="display: none"])')
+    rows.each do |r|
+      expect(r['data-protocol-name']).to eq(@protocol_study.name)
+    end
+  end
+
+  it 'preselects the notes filter from the literal value in app config' do
+    Admin::AppConfiguration.add_default_config(
+      @app_type,
+      :tracker_history_initial_filters,
+      "notes: 'follow-up'\n",
+      @admin
+    )
+    Admin::AppConfiguration.clear_memo!
+
+    open_chron_view
+
+    expect(find('input.tracker-history-filter-notes').value).to eq('follow-up')
+
+    rows = page.all('table.tracker-chron-results tbody.tracker-history-rows tr.tracker-history-row:not([style*="display: none"])')
+    expect(rows.length).to eq(2)
+    rows.each do |r|
+      expect(r['data-notes']).to include('follow-up')
+    end
+  end
+
+  it 'still renders the panel when configured regex is invalid (no preselection)' do
+    Admin::AppConfiguration.add_default_config(
+      @app_type,
+      :tracker_history_initial_filters,
+      "protocols: '[invalid'\n",
+      @admin
+    )
+    Admin::AppConfiguration.clear_memo!
+
+    open_chron_view
+
+    selected_tags = page.all('div#tracker_history_filter_protocols_' \
+                             "#{@filter_master.id}_chosen ul.chosen-choices li.search-choice span")
+    expect(selected_tags).to be_empty
+
+    rows = page.all('table.tracker-chron-results tbody.tracker-history-rows tr.tracker-history-row:not([style*="display: none"])')
+    expect(rows.length).to be >= 4
+  end
+
+  it 'omits protocol events that belong to the system Updates protocol from the dropdown' do
+    open_chron_view
+
+    # Build the set of event names belonging to rows in the system Updates
+    # protocol. The Tracker after_save pipeline may rewrite the protocol_event
+    # for entries created with the Updates protocol, so derive these names
+    # from the rendered rows rather than from the originally requested event.
+    updates_event_names = page.evaluate_script(<<~JS)
+      $('table.tracker-chron-results tr.tracker-history-row[data-protocol-name="Updates"]')
+        .map(function () { return $(this).attr('data-event-name'); }).get();
+    JS
+    expect(updates_event_names).not_to be_empty,
+                                       'expected at least one tracker row under the Updates protocol'
+
+    # The protocol_events filter <select> is hidden by chosen, so query its
+    # options directly.
+    options = page.evaluate_script(<<~JS)
+      $('select.tracker-history-filter[data-filter-key=protocol_events] option')
+        .map(function () { return $(this).text(); }).get();
+    JS
+
+    expect(options).to include(@ev_visit_1.name, @ev_visit_2.name, @ev_phone.name, @ev_misc.name)
+    updates_event_names.each do |name|
+      expect(options).not_to include(name)
+    end
+  end
+
+  it 'preselects the date range from absolute and relative values in app config' do
+    Admin::AppConfiguration.add_default_config(
+      @app_type,
+      :tracker_history_initial_filters,
+      "date_from: '2025-02-01'\ndate_to: '2025-03-31'\n",
+      @admin
+    )
+    Admin::AppConfiguration.clear_memo!
+
+    open_chron_view
+
+    # Inputs are reformatted to the user's locale by the shared
+    # `setup_datepickers` JS helper. We just check non-blank values here
+    # and assert the filter rows are correctly limited.
+    from_value = page.evaluate_script("$('input.tracker-history-filter-date-from').val()")
+    to_value = page.evaluate_script("$('input.tracker-history-filter-date-to').val()")
+    expect(from_value).not_to be_blank
+    expect(to_value).not_to be_blank
+
+    rows = page.all('table.tracker-chron-results tbody.tracker-history-rows tr.tracker-history-row:not([style*="display: none"])')
+    expect(rows.length).to eq(2)
+    visible_dates = rows.map { |r| r['data-event-date'][0, 10] }.sort
+    expect(visible_dates).to eq(['2025-02-20', '2025-03-10'])
+  end
+end


### PR DESCRIPTION
## Summary
Adds client-side filtering to the tracker history panel so users can narrow visible records by protocol, sub process, protocol event, notes text, and optional initial config values.

Fixes #1074

### Changes
- add chosen.js multi-select filters for protocol, sub process, and protocol event plus a debounced notes text filter and clear action
- apply AND-across-groups / OR-within-group filtering in the tracker history panel JavaScript
- add tracker history initial filter config parsing with safe regex handling, warning logs for invalid patterns, and support for notes/date defaults
- move the filter row outside the table header to avoid tablesorter interference and add supporting styles
- exclude the Updates protocol events from the protocol-event filter options and source that protocol name from the controller payload
- add model, controller, and system specs covering filter behavior, invalid config handling, and initial state setup

### Notes
- clearing filters resets the panel to a blank filter state, which returns the list to the full unfiltered view
