### PR TITLE
Fixed CSV model generation error feedback and added request/controller specs - fixes #1098

### DIFF
--- a/app/controllers/imports/model_generators_controller.rb
+++ b/app/controllers/imports/model_generators_controller.rb
@@ -44,6 +44,10 @@ class Imports::ModelGeneratorsController < AdminController
     raise FphsException, 'Failed to generate the dynamic model table' unless @dynamic_model
 
     redirect_to edit_imports_model_generator_path(@model_generator, from_upload: 'generated_model')
+  rescue StandardError => e
+    logger.warn "Failed to generate model from CSV for Imports::ModelGenerator ##{@model_generator&.id}: #{e.class}"
+    logger.warn e.full_message
+    render plain: model_generation_error_message(e), status: :bad_request
   end
 
   private
@@ -87,5 +91,19 @@ class Imports::ModelGeneratorsController < AdminController
     return if object_instance.file_store
 
     object_instance.create_file_store
+  end
+
+  def model_generation_error_message(exception)
+    details = extract_model_generation_error_details(exception)
+    return 'Failed to generate the dynamic model table' if details.blank?
+
+    "Failed to generate the dynamic model table: #{details}"
+  end
+
+  def extract_model_generation_error_details(exception)
+    [exception.message, exception.cause&.message]
+      .filter_map { |message| message.to_s.squish.presence }
+      .uniq
+      .join(' | ')
   end
 end

--- a/spec/controllers/imports/model_generators_controller_spec.rb
+++ b/spec/controllers/imports/model_generators_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Tests for issue #1098:
+# - Model generation from CSV should return a usable error when migration fails.
+RSpec.describe Imports::ModelGeneratorsController, type: :controller do
+  include ::UserSupport
+
+  render_views
+
+  before :each do
+    create_admin
+  end
+
+  before_each_login_admin
+
+  describe 'POST #create_model' do
+    it 'returns an actionable error when the migration fails for a reserved field name' do
+      model_generator = Imports::ModelGenerator.create!(
+        name: 'Reserved field test',
+        dynamic_model_table: "dynamic_test.test_reserved_field_#{SecureRandom.hex(4)}_recs",
+        category: 'dynamic-test-env',
+        current_admin: @admin
+      )
+
+      allow(Imports::ModelGenerator).to receive(:find).with(model_generator.id.to_s).and_return(model_generator)
+      allow(model_generator).to receive(:create_dynamic_model)
+        .and_raise(ActiveRecord::StatementInvalid.new('PG::SyntaxError: ERROR: syntax error at or near "group"'))
+
+      post :create_model, params: { id: model_generator.id }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.body).to include('group')
+      expect(response.body).to include('syntax error')
+    end
+  end
+end

--- a/spec/requests/imports/model_generators_request_spec.rb
+++ b/spec/requests/imports/model_generators_request_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Tests for issue #1098:
+# - create_model returns a usable 400 error body for migration failures from CSV-derived fields.
+RSpec.describe 'Imports::ModelGenerators create_model', type: :request do
+  include ::UserSupport
+
+  before :each do
+    @admin, = create_admin
+    sign_in @admin
+  end
+
+  describe 'POST /imports/model_generators/:id/create_model' do
+    it 'returns a bad request with actionable details when model generation raises a DB error' do
+      model_generator = Imports::ModelGenerator.create!(
+        name: 'Reserved field request test',
+        dynamic_model_table: "dynamic_test.test_reserved_field_req_#{SecureRandom.hex(4)}_recs",
+        category: 'dynamic-test-env',
+        current_admin: @admin
+      )
+
+      allow(Imports::ModelGenerator).to receive(:find).with(model_generator.id.to_s).and_return(model_generator)
+      allow(model_generator).to receive(:create_dynamic_model)
+        .and_raise(ActiveRecord::StatementInvalid.new('PG::SyntaxError: ERROR: syntax error at or near "group"'))
+
+      post create_model_imports_model_generator_path(model_generator)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.body).to include('Failed to generate the dynamic model table')
+      expect(response.body).to include('group')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Improve error handling when generating a dynamic model from CSV so migration failures return a usable message instead of an unhandled server error.

### Changes
- Added rescue handling in create_model to return HTTP 400 with actionable error details.
- Added helper methods to normalize and construct model generation error details safely.
- Added controller spec for create_model migration failure behavior.
- Added request spec for POST /imports/model_generators/:id/create_model failure response behavior.
- Validated related imports specs remain green.

### Validation
- bundle exec rspec spec/requests/imports/model_generators_request_spec.rb spec/controllers/imports/model_generators_controller_spec.rb spec/controllers/imports/imports_controller_spec.rb
