### PR TITLE
Fixed incomplete 'Resolved from .' text in admin definition versioning details - fixes #1094

### DIFF
--- a/app/views/admin/common_templates/_def_details_version_mode.html.erb
+++ b/app/views/admin/common_templates/_def_details_version_mode.html.erb
@@ -2,6 +2,21 @@
   setting = object_instance.respond_to?(:versioning_disabled_globally?) && object_instance.versioning_disabled_globally?
   config_ucv = object_instance.respond_to?(:definition_uses_current_version_option?) && object_instance.definition_uses_current_version_option?
   uses_current_version = object_instance.respond_to?(:uses_current_definition_version?) && object_instance.uses_current_definition_version?
+  resolution_sources = []
+
+  if setting.present?
+    resolution_sources << link_to(link_label_open_in_new("application setting DisableVDef"), "/admin/server_info", target: "_blank")
+  end
+
+  if config_ucv.present?
+    resolution_sources << 'the definition <code>_configurations.use_current_version</code> option'.html_safe
+  end
+
+  resolution_sources_text = if resolution_sources.present?
+                              safe_join(resolution_sources, ' and '.html_safe)
+                            else
+                              'the default definition-at-record-creation versioning behavior'
+                            end
 
 %>
 <label>definition versioning</label>
@@ -9,5 +24,5 @@
   <%= uses_current_version ? 'current version' : 'version at record creation' %>
 </span>
 <p class="help-block">
-  Resolved from <% if setting.present? %><%= link_to link_label_open_in_new("application setting DisableVDef"), "/admin/server_info", target: "_blank" %><% end %> <% if setting && config_ucv %>and<% end %> <% if config_ucv.present? %>the definition <code>_configurations.use_current_version</code> option<% end %>.
+  Resolved from <%= resolution_sources_text %>.
 </p>

--- a/spec/controllers/admin/dynamic_models_index_table_spec.rb
+++ b/spec/controllers/admin/dynamic_models_index_table_spec.rb
@@ -140,6 +140,52 @@ RSpec.describe Admin::DynamicModelsController, type: :controller do
       expect(response.body).to include("Edit Entry <small>##{dm.id}</small>")
     end
 
+    it 'shows complete default versioning help text for definition-at-record-creation mode issue #1094' do
+      suffix = Array.new(8) { ('a'..'z').to_a.sample }.join
+
+      dm = DynamicModel.create!(
+        current_admin: @admin,
+        name: "test default version help #{suffix}",
+        table_name: "test_default_version_help_#{suffix}_recs",
+        schema_name: 'dynamic_test',
+        category: 'test',
+        disabled: true,
+        options: "default:\n  label: Test"
+      )
+
+      allow_any_instance_of(DynamicModel).to receive(:versioning_disabled_globally?).and_return(false)
+      allow_any_instance_of(DynamicModel).to receive(:definition_uses_current_version_option?).and_return(false)
+
+      get :edit, params: { id: dm.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Resolved from the default definition-at-record-creation versioning behavior.')
+    end
+
+    it 'renders the use_current_version option as a code element when config_ucv resolves it issue #1094' do
+      suffix = Array.new(8) { ('a'..'z').to_a.sample }.join
+
+      dm = DynamicModel.create!(
+        current_admin: @admin,
+        name: "test config ucv mode #{suffix}",
+        table_name: "test_config_ucv_mode_#{suffix}_recs",
+        schema_name: 'dynamic_test',
+        category: 'test',
+        disabled: true,
+        options: "_configurations:\n  use_current_version: true\ndefault:\n  label: Test"
+      )
+
+      allow_any_instance_of(DynamicModel).to receive(:versioning_disabled_globally?).and_return(false)
+      allow_any_instance_of(DynamicModel).to receive(:definition_uses_current_version_option?).and_return(true)
+      allow_any_instance_of(DynamicModel).to receive(:uses_current_definition_version?).and_return(true)
+
+      get :edit, params: { id: dm.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to have_selector('p.help-block code', text: '_configurations.use_current_version')
+      expect(response.body).to include('Resolved from')
+    end
+
     it 'shows that definition-time versioning is used when current-version mode is not enabled' do
       suffix = Array.new(8) { ('a'..'z').to_a.sample }.join
 


### PR DESCRIPTION
## Summary

The admin edit view for dynamic model definitions (and the shared partial used by activity logs and external identifiers) was rendering an incomplete help line:

> Resolved from .

when neither the global `DisableVDef` setting nor the per-definition `_configurations.use_current_version` option was active (i.e. the default definition-at-record-creation versioning path).

## Changes

### `app/views/admin/common_templates/_def_details_version_mode.html.erb`
- Replaced the inline conditional chain in the `Resolved from` help paragraph with explicit source collection logic.
- When one or both override sources are active they are joined with 'and' as before.
- When neither source applies, a complete fallback sentence is shown: _'the default definition-at-record-creation versioning behavior'_.
- Fixed an HTML-escaping regression: the `<code>` tag in the `use_current_version` label is now marked `.html_safe` (hard-coded literal, not user input) so `safe_join` does not escape it.

### `spec/controllers/admin/dynamic_models_index_table_spec.rb`
- Added example: _'shows complete default versioning help text for definition-at-record-creation mode issue #1094'_ — directly reproduces the reported bug (red before fix, green after).
- Added example: _'renders the use_current_version option as a code element when config_ucv resolves it issue #1094'_ — guards against the HTML-escaping regression.

All 14 examples in the spec file pass.