### PR TITLE
Added admin user filters for email, first_name, and last_name - fixes #1096

### DIFF
--- a/app/controllers/admin/manage_users_controller.rb
+++ b/app/controllers/admin/manage_users_controller.rb
@@ -78,12 +78,15 @@ class Admin::ManageUsersController < AdminController
 
   def filters
     {
-      app_type_id: Admin::AppType.all_by_name
+      app_type_id: Admin::AppType.all_by_name,
+      email: filter_values_for(:email),
+      first_name: filter_values_for(:first_name),
+      last_name: filter_values_for(:last_name)
     }
   end
 
   def filters_on
-    [:app_type_id]
+    %i[app_type_id email first_name last_name]
   end
 
   # Override regular defaults, which force the current user's app_type_id

--- a/app/controllers/concerns/filter_utils.rb
+++ b/app/controllers/concerns/filter_utils.rb
@@ -160,4 +160,19 @@ module FilterUtils
 
     @filter_params = res
   end
+
+  #
+  # Generate a list of unique, non-blank values for a given field from the primary model.
+  # This is useful for populating filter dropdown options, excluding nil and empty string values.
+  # Results are sorted alphabetically for consistent display in filter UI dropdowns.
+  # Avoids SQL DISTINCT to prevent PostgreSQL ORDER BY conflicts with model default scopes.
+  # @param [Symbol, String] field_name the database field to retrieve values from
+  # @return [Array] sorted array of unique non-blank values from the field
+  def filter_values_for(field_name)
+    primary_model
+      .where.not(field_name => [nil, ''])
+      .pluck(field_name)
+      .uniq
+      .sort
+  end
 end

--- a/spec/system/admin/manage_users_spec.rb
+++ b/spec/system/admin/manage_users_spec.rb
@@ -14,7 +14,7 @@
 # - Server option: self-registration info shown vs hidden
 # - 2FA set up? column displays correct status per user
 #
-# Related issues: #1025 (api_access_only flag), #330, #1047 (2FA column)
+# Related issues: #1025 (api_access_only flag), #330, #1047 (2FA column), #1096 (email/first/last filters)
 
 require 'rails_helper'
 
@@ -218,6 +218,38 @@ describe 'admin manage users page - Issue #1027', js: true, driver: $browser_dri
 
       expect(page).to have_content('Adding Users')
       expect(page).not_to have_content('User Registration')
+    end
+  end
+
+  context 'when filtering users - Issue #1096' do
+    it 'filters by email, first name and last name' do
+      user, = create_user(nil, '', email: "issue1096_#{SecureRandom.hex(4)}@testing.com")
+      user.update!(
+        first_name: 'Issue1096First',
+        last_name: 'Issue1096Last'
+      )
+
+      visit '/admin/manage_users'
+      finish_page_loading
+
+      expect(page).to have_content('Email:')
+      expect(page).to have_content('First name:')
+      expect(page).to have_content('Last name:')
+
+      visit "/admin/manage_users?filter[email]=#{CGI.escape(user.email)}"
+      finish_page_loading
+      expect(page).to have_css('td', text: user.email)
+      expect(page).not_to have_css('td', text: @test_user_email)
+
+      visit "/admin/manage_users?filter[first_name]=#{CGI.escape(user.first_name)}"
+      finish_page_loading
+      expect(page).to have_css('td', text: user.email)
+      expect(page).not_to have_css('td', text: @test_user_email)
+
+      visit "/admin/manage_users?filter[last_name]=#{CGI.escape(user.last_name)}"
+      finish_page_loading
+      expect(page).to have_css('td', text: user.email)
+      expect(page).not_to have_css('td', text: @test_user_email)
     end
   end
 end


### PR DESCRIPTION
## Summary

Adds email, first_name, and last_name filter controls to the admin manage_users page, enabling admins to quickly locate specific user records without scrolling through the entire user list.

## Changes

### Controller Changes (app/controllers/admin/manage_users_controller.rb)
- Extended  method to expose email, first_name, and last_name with a new private helper
- Extended  array to permit email, first_name, last_name as filterable fields
- Added private  helper to safely generate dropdown options, excluding nil and empty strings

### System Spec (spec/system/admin/manage_users_spec.rb)
- Added new test context 'when filtering users - Issue #1096'
- Test verifies filter labels render on page
- Test validates each filter works via URL parameters (filter[email]=, filter[first_name]=, filter[last_name]=)
- Test confirms filtered results exclude non-matching users

## Testing
- ✅ Full manage_users_spec.rb suite: 10 examples, 0 failures
- ✅ No regressions in existing tests
- ✅ System spec validates UI elements and filtering behavior
- ✅ All tests run with proper Capybara wait strategy (finish_page_loading)

## Implementation Notes
- Follows existing filter pattern (filters dict + filters_on array)
- Uses  for safe dropdown generation (avoids PostgreSQL DISTINCT/ORDER BY conflicts)
- Respects existing admin authorization and filter permission checks
- Properly encodes filter values with CGI.escape in test