### PR TITLE
Fixed CSV import field matching, header labels and chosen table selector - fixes #1097, fixes #1099

### DIFF
--- a/app/helpers/imports_helper.rb
+++ b/app/helpers/imports_helper.rb
@@ -1,2 +1,10 @@
 module ImportsHelper
+  # Build a clear field mismatch error for import form builders.
+  def unmatched_import_field_error(field_name)
+    name = field_name.to_s
+    match = name.match(/\Aimports_import\[([^\]]+)\]\z/)
+    name = match[1] if match
+
+    "The field #{name} was not matched. Check the model is up to date and server configuration has been refreshed"
+  end
 end

--- a/app/models/imports/import.rb
+++ b/app/models/imports/import.rb
@@ -205,7 +205,7 @@ class Imports::Import < ActiveRecord::Base
     keys = csv_rows.first.to_h.keys
     excess = keys - permitted_params_for_primary_table.map(&:to_sym) - %i[id created_at updated_at]
     if excess.present?
-      errors.add 'some columns', 'in the CSV file do not match the table columns. ' \
+      errors.add 'some columns', "in the CSV file do not match the table columns. Go back to upload another file.\n" \
                                  "Unexpected columns in the CSV file are: #{excess.join(', ')}"
       return false
     end

--- a/app/models/imports/model_generator.rb
+++ b/app/models/imports/model_generator.rb
@@ -58,6 +58,7 @@ module Imports
     # @return [Hash {fieldname: :type}]
     def analyze_csv(csv, keep_core_fields: nil)
       csv_rows = parse(csv)
+      header_labels = @header_labels || {}
 
       self.field_types = {}
       # Ensure the fields are set up in the original order
@@ -100,6 +101,13 @@ module Imports
 
       generator_config.setup_fields_config field_types
 
+      field_types.each_key do |field_name|
+        original_header = header_labels[field_name.to_sym]
+        next if original_header.blank? || original_header == field_name.to_s
+
+        generator_config.fields[field_name].label = original_header
+      end
+
       field_types
     end
 
@@ -108,9 +116,16 @@ module Imports
     # @param [String] csv
     # @return [CSV::Table]
     def parse(csv)
+      @header_labels = {}
+      header_converter = lambda { |header|
+        normalized = CSV::HeaderConverters[:symbol].call(header)
+        @header_labels[normalized.to_sym] ||= header.to_s
+        normalized
+      }
+
       CSV.parse(csv,
                 headers: true,
-                header_converters: :symbol,
+                header_converters: header_converter,
                 converters: %i[
                   integer
                   float

--- a/app/views/imports/imports/_new_import_form.html.erb
+++ b/app/views/imports/imports/_new_import_form.html.erb
@@ -29,7 +29,8 @@ filled_items = 0
                 <%
                   f_index = f.index
                   unless f_index
-                    raise FphsException, "The field #{f} was not matched. Check the model is up to date and server configuration has been refreshed"
+                    field_name = f.object_name.presence || "#{@primary_table}_attributes"
+                    raise FphsException, unmatched_import_field_error(field_name)
                   end
 
                   final_blank_row = row_num == @import.item_count+1

--- a/app/views/imports/imports/_upload_form.html.erb
+++ b/app/views/imports/imports/_upload_form.html.erb
@@ -4,7 +4,7 @@
 
     <div class="form-group">
       <label for="primary_table">Select the table to import into</label>
-      <%= select_tag :primary_table, options_for_select(@primary_tables, @primary_table), include_blank: true %>
+      <%= select_tag :primary_table, options_for_select(@primary_tables, @primary_table), include_blank: true, class: 'use-chosen' %>
     </div>
     <div class="row">
       <div class="form-group col-md-6" id="browse-block">

--- a/app/views/imports/imports/index.html.erb
+++ b/app/views/imports/imports/index.html.erb
@@ -5,7 +5,7 @@
       <h3>Step 1: Select table to import into</h3>
       <%= form_tag imports_imports_path(format: :csv), method: :get, target: 'csvfile', id: 'import_template_download' do %>
         <div class="form-group">
-          <%= select_tag :get_template_for, options_for_select(@primary_tables), prompt: '- select table -' %>
+          <%= select_tag :get_template_for, options_for_select(@primary_tables), prompt: '- select table -', class: 'use-chosen' %>
         </div>
         <%= field_set_tag '', disabled: true do %>
         <p><br>Need a template CSV for this table?</p>

--- a/spec/helpers/imports_helper_spec.rb
+++ b/spec/helpers/imports_helper_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# ImportsHelper Spec
+#
+# Validates helper behavior used by CSV import views to generate actionable
+# field mismatch messages.
+
+require 'rails_helper'
+
+RSpec.describe ImportsHelper, type: :helper do
+  describe '#unmatched_import_field_error' do
+    it 'includes the field name and does not rely on object inspect output' do
+      message = helper.unmatched_import_field_error('dynamic_model__test_recs_attributes[0]')
+
+      expect(message).to include('dynamic_model__test_recs_attributes[0]')
+      expect(message).to include('was not matched')
+      expect(message).to include('model is up to date')
+    end
+
+    it 'extracts a readable field name from nested form object names' do
+      message = helper.unmatched_import_field_error('imports_import[dynamic_model__test_labels]')
+
+      expect(message).to include('dynamic_model__test_labels')
+      expect(message).not_to include('imports_import[')
+      expect(message).not_to include('] was not matched')
+    end
+  end
+end

--- a/spec/models/imports/import_spec.rb
+++ b/spec/models/imports/import_spec.rb
@@ -13,6 +13,8 @@ require 'rails_helper'
 #    Each timestamp is handled independently.
 # 2. CSV WITH id/created_at/updated_at columns: should succeed and
 #    use the values provided in the CSV (even if blank)
+# 3. CSV with columns that don't match the model: should return an actionable
+#    error message that includes guidance to go back and re-upload.
 RSpec.describe Imports::Import, type: :model do
   include ModelSupport
   include UserSupport
@@ -150,6 +152,21 @@ RSpec.describe Imports::Import, type: :model do
       expect(first_item.created_at).to be_within(1.second).of(expected_created)
       # updated_at should be auto-populated since it's not in the CSV
       expect(first_item.updated_at).to be >= before_import
+    end
+  end
+
+  describe 'check_csv_columns error messaging' do
+    let(:csv_with_bad_column) do
+      "a_string,a_int,nonexistent_column\nhello,1,bad\n"
+    end
+
+    it 'returns a message including guidance to go back and re-upload' do
+      import = Imports::Import.setup_import(@resource_name, @user, 'bad-columns.csv')
+      import.import_csv(csv_with_bad_column)
+
+      error_messages = import.errors.full_messages.join("\n")
+      expect(error_messages).to include('Go back to upload another file')
+      expect(error_messages).to include('nonexistent_column')
     end
   end
 end

--- a/spec/models/imports/model_generator_spec.rb
+++ b/spec/models/imports/model_generator_spec.rb
@@ -234,4 +234,60 @@ RSpec.describe Imports::ModelGenerator, type: :model do
     expect(mg.options).not_to be_blank
     expect(mg.options).to eq updated_yaml
   end
+
+  describe 'CSV header labels' do
+    it 'sets a field label from the original CSV header when normalization changes the name' do
+      csv = <<~CSV
+        Blood Pressure (Systolic),already_clean
+        120,ok
+      CSV
+
+      mg = Imports::ModelGenerator.new(
+        name: 'Label test',
+        dynamic_model_table: 'test_csv_imports_labels',
+        description: 'Header label test'
+      )
+
+      mg.analyze_csv(csv)
+
+      expect(mg.generator_config.fields[:blood_pressure_systolic].label).to eq('Blood Pressure (Systolic)')
+      expect(mg.generator_config.fields[:already_clean].label).to be_nil
+    end
+  end
+
+  describe 'dynamic_model_def_current? stability after label assignment' do
+    before :all do
+      csv = <<~CSV
+        A String!,A Int!
+        hello,1
+      CSV
+      table = "dynamic_test.test_importslabel#{rand 100_000_000_000_000}_recs"
+      @label_mg = Imports::ModelGenerator.new(
+        name: 'Label current test',
+        dynamic_model_table: table,
+        category: 'dynamic-test-env',
+        current_admin: @admin
+      )
+      @label_mg.analyze_csv(csv)
+      @label_mg.create_dynamic_model
+    end
+
+    it 'returns true after re-analyzing a CSV whose headers were normalized to set labels' do
+      # Confirms labels generated from CSV headers (issue #1099) are persisted to the
+      # dynamic model and remain consistent on re-analysis. Without label persistence
+      # via dynamic model default_options.labels, dynamic_model_def_current? would
+      # return false on the second analyze pass.
+      expect(@label_mg.generator_config.fields[:a_string].label).to eq('A String!')
+      expect(@label_mg.generator_config.fields[:a_int].label).to eq('A Int!')
+
+      csv = <<~CSV
+        A String!,A Int!
+        hello,1
+      CSV
+      @label_mg.analyze_csv(csv)
+
+      expect(@label_mg.generator_config.fields[:a_string].label).to eq('A String!')
+      expect(@label_mg.dynamic_model_def_current?).to be true
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Fixes two CSV import issues and improves the import table selectors.

### Changes
- Added ImportsHelper#unmatched_import_field_error to render readable unmatched field names instead of FormBuilder inspect output.
- Updated import form error raising to use the helper with f.object_name.
- Preserved original CSV header text as generated field labels when header normalization changes the field name.
- Added use-chosen class to import table selectors in Step 1 and upload form views.
- Improved CSV column mismatch messaging to include guidance to re-upload and list unexpected columns.
- Added and expanded specs in helper and model specs, including error message content and dynamic model definition stability checks.

### Testing
- bundle exec rspec spec/models/imports/import_spec.rb spec/models/imports/model_generator_spec.rb spec/helpers/imports_helper_spec.rb
