### PR TITLE
Make admin Details sections accordion-based with auto-expanding UAC panel

### DIFF
--- a/app/assets/stylesheets/admin/activity_list.scss
+++ b/app/assets/stylesheets/admin/activity_list.scss
@@ -5,10 +5,14 @@
 .activity-list-file-filters,
 .activity-list-dialogs,
 .activity-list-all-fields,
-.activity-list-view-refs {
+.activity-list-view-refs,
+.activity-list-fields,
+.activity-list-activities,
+.activity-list-field-configs {
   padding: 10px 10px;
-  margin-top: 20px;
-  margin-bottom: 20px;
+  // margin-top: 20px;
+  // margin-bottom: 20px;
+  margin: -15px;
   border-bottom: 1px solid silver;
   background-color: #f3f3f3;
 }

--- a/app/assets/stylesheets/admin/common_dynamic_def_panels.scss
+++ b/app/assets/stylesheets/admin/common_dynamic_def_panels.scss
@@ -1,8 +1,11 @@
+p.common-def-panel--access-type {
+  font-style: italic;
+  padding: 0;
+  font-weight: bold;
+  margin-top: 10px;
+  margin-bottom: 3px;
+}
 .common-def-panel--uacs {
-  span.common-def-panel--access-type {
-    font-style: italic;
-    padding: 0 10px 0 20px;
-  }
 }
 
 ul.admin-tag-list, ul.common-def-panel--uacs {

--- a/app/helpers/common_templates_helper.rb
+++ b/app/helpers/common_templates_helper.rb
@@ -52,4 +52,48 @@ module CommonTemplatesHelper
   def class_for_open_panels(resource, default_panels_length)
     "{{# is (split_lines open_panels) 'includes' '#{resource}'}}on-open-click initial_show_value-true-{{else}}initial_show_value-false-{{/is}}#{default_panels_length}".html_safe
   end
+
+  def def_uac_summary_data(object_instance:, current_user:, current_app_type_id:, resource_name: nil, resource_type: 'table')
+    resource_name = resource_name || object_instance.resource_name&.pluralize
+    return { resource_name:, resource_type:, uacs: [], no_non_template_uacs: true, current_user_has_access: false, current_app_uacs: [] } if resource_name.blank?
+
+    uacs = Admin::UserAccessControl.active_for(resource_name:).not_template_role
+    no_non_template_uacs = uacs.empty?
+
+    current_user_has_access = false
+    if current_user && current_app_type_id
+      current_user_has_access = Admin::UserAccessControl.access_for?(
+        current_user,
+        :access,
+        resource_type.to_sym,
+        resource_name,
+        alt_app_type_id: current_app_type_id
+      ).present?
+    end
+
+    current_app_uacs = uacs.select { |uac| uac.app_type_id == current_app_type_id }
+
+    {
+      resource_name:,
+      resource_type:,
+      uacs:,
+      no_non_template_uacs:,
+      current_user_has_access:,
+      current_app_uacs:
+    }
+  end
+
+  def def_uac_needs_attention?(object_instance:, current_user:, current_app_type_id:, resource_name: nil, resource_type: 'table')
+    uac_data = def_uac_summary_data(
+      object_instance:,
+      current_user:,
+      current_app_type_id:,
+      resource_name:,
+      resource_type:
+    )
+
+    uac_data[:no_non_template_uacs] ||
+      (current_app_type_id.present? && !uac_data[:current_user_has_access]) ||
+      (current_app_type_id.present? && uac_data[:current_app_uacs].empty?)
+  end
 end

--- a/app/views/admin/activity_logs/_def_details.html.erb
+++ b/app/views/admin/activity_logs/_def_details.html.erb
@@ -5,6 +5,8 @@
     <p>Using this definition will fail</p>
   <% end %>
 
+  <%= render partial: 'admin/dynamic_models/config_errors', locals: { object_instance: } %>
+
   <label>item type name</label>
   <p class="al-item-type">
   <code><%= object_instance.full_item_type_name %></code>
@@ -38,14 +40,6 @@
 
   <%= render partial: 'admin/dynamic_models/est_record_count' %>
   <%= render partial: 'admin/dynamic_models/check_tracker_updates' %>
-
-  <%= render partial: 'admin/common_templates/def_uac_summary', 
-             locals: { 
-               object_instance:, 
-               current_app_type_id: current_admin.matching_user&.app_type_id,
-               current_user: current_admin.matching_user
-             } %>
-
   <% unless object_instance.table_or_view_ready?%>
   <div class="help-block">
   <p>Typically the database table or view associated with an activity log is created when the definition is first created (or prior to this if handled manually.)</p>
@@ -55,123 +49,282 @@
   </div>
   <% end %>
 </div>
-<%= render partial: 'admin/dynamic_models/config_errors', locals: { object_instance: } %>
-<div class="activity-list-section">
-  <label>activities</label>
-  <p>Add a new <code>[activity_name]:</code> underscored activity name without indentation.</p>
-  <p>Click an activity name from the list below to jump to its definition. Each activity shown lists the fields defined for it.<br/>&nbsp;</p>
-  <ul class="activity-list">
-  <% object_instance.option_configs_names&.each do |name| 
-       conf = object_instance.option_type_config_for(name)
 
-       next if name.in?([:primary, :blank_log]) && !conf&.fields&.present?
-  %>
-    <li class="activity-list-name" data-al-elt-block="#al_ib_<%=name%>"><span class="activity-list-name"><%=name%></span> <% unless conf %>(invalid)<% end %>
-    <% if conf&.label&.present?  %><span class="activity-list-activity-label"><%= conf.label %></span><% end %>
-    </li>
-    <div class="activity-list-item-block collapse" id="al_ib_<%=name%>">  
-      <% if conf&.fields&.present?  %>
-      <ul class="activity-list-activity-fields">
-        <li><%= conf.fields.join("</li> <li>").html_safe %></li>
-      </ul>
-      <% end %>
-      <% ref_def = conf&.embed
-         if ref_def&.present?  
-            got = ref_def.dig(:resource_model_def, :resource_item_name)
-      %>
-      <ul class="activity-list-activity-embed">
-        <%= render partial: 'admin/activity_logs/def_embed_info', locals: {resource_item_name: got, ref_def:} %>
-      </ul>
-      <% end %>
-      <% act_refs = conf&.references
-         if act_refs&.present?  
-         %>
-           <ul class="activity-list-activity-references">
-         <%
-              object_instance.referenced_table_def(act_refs)&.each do |ref_def|
-                full_ref_name = ref_def[:full_ref_name]
-         %>
-          <%= render partial: 'admin/activity_logs/def_references_info', locals: {full_ref_name: full_ref_name, ref_def:} %>
-              <% end %>
-          </ul>
-      <% end %>
-      <ul class="common-def-panel--uacs">
-        <%= render partial: 'admin/activity_logs/def_activity_uac_info', locals: {app_type_id: current_admin.matching_user&.app_type_id, resource_name: conf.resource_name} %>
-      </ul>
-    </div>
-  <% end %>
-  </ul>
-  <div id="activity-list-detail" class="activity-list-detail"></div>
-</div>
-
-<div class="activity-list-all-fields">
-  <label>all fields</label>
-  <p>Set of all fields aggregated from all activities.</p>
-  <p class="al-field-list">
-  <ul class="activity-list">
-    <li><%= object_instance.all_implementation_fields
-              .reject{|f| f.index(/^placeholder_|^embedded_report_/)}
-              .join("</li> <li>")
-              .html_safe %></li>
-  </ul>
-  </p>
-</div>
-
-<%= render partial: 'admin/common_templates/def_details_libraries', locals: {object_instance: object_instance} %>
-<%= render partial: 'admin/common_templates/def_details_dialogs', locals: {object_instance: object_instance} %>
-
-<div class="activity-list-embeds">
-  <label>embeds</label>
-  <p>Add <code>embed:</code> configurations to directly embed another dynamic definition. This uses database joins, 
-  rather than an intermediate model references to access embedded records.</p>
-  <ul class="al-reference-list al-embed-list">
-  <% shown_refs = []
-     object_instance.all_direct_embed_tables.each do |ref_def| 
-  
-      got = ref_def.dig(:resource_model_def, :resource_item_name)
-      unless shown_refs.include?(got)
-        shown_refs << got
-    %>
-    <%= render partial: 'admin/activity_logs/def_embed_info', locals: {resource_item_name: got, ref_def:, show_table: true} %>
-    <%  end %>
-  <% end %>
-  </ul>
-</div>
-
-<div class="activity-list-references">
-  <label>references</label>
-  <p>Add <code>references:</code> configurations to connect to other dynamic definitions. This connects through
-  an intermediate `model_references` database table, allowing arbitrary connections to be made between records.</p>
-  
-  <ul class="al-reference-list">
-  <% shown_refs = []
-     object_instance.all_referenced_tables.each do |ref_def| 
-  %>
-  <%  full_ref_name = ref_def[:full_ref_name]
-      unless shown_refs.include?(full_ref_name)
-        shown_refs << full_ref_name
-  %>
-    <%= render partial: 'admin/activity_logs/def_references_info', locals: {full_ref_name: full_ref_name, ref_def:, show_table: true} %>
-    <%  end %>
-  <% end %>
-  </ul>
-</div>
-
-<div class="activity-list-file-filters">
-  <label>file filters</label>
-  <p>File containers use file filters to define which filenames can be viewed for a specific activity or default configuration.</p>
-  <p>
-  <%= link_to(link_label_open_in_new("edit"),
-        admin_nfs_store_filter_filters_path(filter: {resource_name: "#{object_instance.full_item_type_name}__%"}),
-        target: '_blank'
+<%
+  current_app_type_id = current_admin.matching_user&.app_type_id
+  current_user = current_admin.matching_user
+  al_accordion_id = "al-details-accordion-#{object_instance.id || 'new'}"
+  al_uac_needs_attention = def_uac_needs_attention?(
+    object_instance:,
+    current_user:,
+    current_app_type_id:
   )
-  %>
-  </p>
+%>
+<div class="panel-group al-details-accordion" id="<%= al_accordion_id %>" role="tablist">
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= al_accordion_id %>-uac-heading">
+      <h4 class="panel-title">
+        <a class="<%= al_uac_needs_attention ? '' : 'collapsed' %>" role="button" data-toggle="collapse" data-parent="#<%= al_accordion_id %>"
+           href="#<%= al_accordion_id %>-uac-collapse"
+           aria-expanded="<%= al_uac_needs_attention %>" aria-controls="<%= al_accordion_id %>-uac-collapse">
+          user access controls
+        </a>
+      </h4>
+    </div>
+    <div id="<%= al_accordion_id %>-uac-collapse" class="panel-collapse collapse <%= al_uac_needs_attention ? 'in' : '' %>"
+         role="tabpanel" aria-labelledby="<%= al_accordion_id %>-uac-heading">
+      <div class="panel-body">
+        <%= render partial: 'admin/common_templates/def_uac_summary',
+                   locals: {
+                     object_instance:,
+                     current_app_type_id:,
+                     current_user:
+                   } %>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= al_accordion_id %>-activities-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= al_accordion_id %>"
+           href="#<%= al_accordion_id %>-activities-collapse"
+           aria-expanded="false" aria-controls="<%= al_accordion_id %>-activities-collapse">
+          activities
+        </a>
+      </h4>
+    </div>
+    <div id="<%= al_accordion_id %>-activities-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= al_accordion_id %>-activities-heading">
+      <div class="panel-body">
+        <div class="activity-list-section">
+          <p>Add a new <code>[activity_name]:</code> underscored activity name without indentation.</p>
+          <p>Click an activity name from the list below to jump to its definition. Each activity shown lists the fields defined for it.<br/>&nbsp;</p>
+          <ul class="activity-list">
+          <% object_instance.option_configs_names&.each do |name|
+               conf = object_instance.option_type_config_for(name)
+
+               next if name.in?([:primary, :blank_log]) && !conf&.fields&.present?
+          %>
+            <li class="activity-list-name" data-al-elt-block="#al_ib_<%=name%>"><span class="activity-list-name"><%=name%></span> <% unless conf %>(invalid)<% end %>
+            <% if conf&.label&.present? %><span class="activity-list-activity-label"><%= conf.label %></span><% end %>
+            </li>
+            <div class="activity-list-item-block collapse" id="al_ib_<%=name%>">
+              <% if conf&.fields&.present? %>
+              <ul class="activity-list-activity-fields">
+                <li><%= conf.fields.join("</li> <li>").html_safe %></li>
+              </ul>
+              <% end %>
+              <% ref_def = conf&.embed
+                 if ref_def&.present?
+                    got = ref_def.dig(:resource_model_def, :resource_item_name)
+              %>
+              <ul class="activity-list-activity-embed">
+                <%= render partial: 'admin/activity_logs/def_embed_info', locals: {resource_item_name: got, ref_def:} %>
+              </ul>
+              <% end %>
+              <% act_refs = conf&.references
+                 if act_refs&.present?
+                 %>
+                   <ul class="activity-list-activity-references">
+                 <%
+                      object_instance.referenced_table_def(act_refs)&.each do |ref_def|
+                        full_ref_name = ref_def[:full_ref_name]
+                 %>
+                  <%= render partial: 'admin/activity_logs/def_references_info', locals: {full_ref_name: full_ref_name, ref_def:} %>
+                      <% end %>
+                  </ul>
+              <% end %>
+              <ul class="common-def-panel--uacs">
+                <%= render partial: 'admin/activity_logs/def_activity_uac_info', locals: {app_type_id: current_admin.matching_user&.app_type_id, resource_name: conf.resource_name} %>
+              </ul>
+            </div>
+          <% end %>
+          </ul>
+          <div id="activity-list-detail" class="activity-list-detail"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= al_accordion_id %>-all-fields-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= al_accordion_id %>"
+           href="#<%= al_accordion_id %>-all-fields-collapse"
+           aria-expanded="false" aria-controls="<%= al_accordion_id %>-all-fields-collapse">
+          all fields
+        </a>
+      </h4>
+    </div>
+    <div id="<%= al_accordion_id %>-all-fields-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= al_accordion_id %>-all-fields-heading">
+      <div class="panel-body">
+        <div class="activity-list-all-fields">
+          <p>Set of all fields aggregated from all activities.</p>
+          <p class="al-field-list">
+          <ul class="activity-list">
+            <li><%= object_instance.all_implementation_fields
+                      .reject{|f| f.index(/^placeholder_|^embedded_report_/)}
+                      .join("</li> <li>")
+                      .html_safe %></li>
+          </ul>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= al_accordion_id %>-libraries-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= al_accordion_id %>"
+           href="#<%= al_accordion_id %>-libraries-collapse"
+           aria-expanded="false" aria-controls="<%= al_accordion_id %>-libraries-collapse">
+          libraries
+        </a>
+      </h4>
+    </div>
+    <div id="<%= al_accordion_id %>-libraries-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= al_accordion_id %>-libraries-heading">
+      <div class="panel-body">
+        <%= render partial: 'admin/common_templates/def_details_libraries', locals: {object_instance: object_instance} %>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= al_accordion_id %>-embeds-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= al_accordion_id %>"
+           href="#<%= al_accordion_id %>-embeds-collapse"
+           aria-expanded="false" aria-controls="<%= al_accordion_id %>-embeds-collapse">
+          embeds
+        </a>
+      </h4>
+    </div>
+    <div id="<%= al_accordion_id %>-embeds-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= al_accordion_id %>-embeds-heading">
+      <div class="panel-body">
+        <div class="activity-list-embeds">
+          <p>Add <code>embed:</code> configurations to directly embed another dynamic definition. This uses database joins,
+          rather than an intermediate model references to access embedded records.</p>
+          <ul class="al-reference-list al-embed-list">
+          <% shown_refs = []
+             object_instance.all_direct_embed_tables.each do |ref_def|
+
+              got = ref_def.dig(:resource_model_def, :resource_item_name)
+              unless shown_refs.include?(got)
+                shown_refs << got
+            %>
+            <%= render partial: 'admin/activity_logs/def_embed_info', locals: {resource_item_name: got, ref_def:, show_table: true} %>
+            <% end %>
+          <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= al_accordion_id %>-references-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= al_accordion_id %>"
+           href="#<%= al_accordion_id %>-references-collapse"
+           aria-expanded="false" aria-controls="<%= al_accordion_id %>-references-collapse">
+          references
+        </a>
+      </h4>
+    </div>
+    <div id="<%= al_accordion_id %>-references-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= al_accordion_id %>-references-heading">
+      <div class="panel-body">
+        <div class="activity-list-references">
+          <p>Add <code>references:</code> configurations to connect to other dynamic definitions. This connects through
+          an intermediate `model_references` database table, allowing arbitrary connections to be made between records.</p>
+
+          <ul class="al-reference-list">
+          <% shown_refs = []
+             object_instance.all_referenced_tables.each do |ref_def|
+          %>
+          <% full_ref_name = ref_def[:full_ref_name]
+             unless shown_refs.include?(full_ref_name)
+               shown_refs << full_ref_name
+          %>
+            <%= render partial: 'admin/activity_logs/def_references_info', locals: {full_ref_name: full_ref_name, ref_def:, show_table: true} %>
+            <% end %>
+          <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= al_accordion_id %>-file-filters-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= al_accordion_id %>"
+           href="#<%= al_accordion_id %>-file-filters-collapse"
+           aria-expanded="false" aria-controls="<%= al_accordion_id %>-file-filters-collapse">
+          file filters
+        </a>
+      </h4>
+    </div>
+    <div id="<%= al_accordion_id %>-file-filters-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= al_accordion_id %>-file-filters-heading">
+      <div class="panel-body">
+        <div class="activity-list-file-filters">
+          <p>File containers use file filters to define which filenames can be viewed for a specific activity or default configuration.</p>
+          <p>
+          <%= link_to(link_label_open_in_new("edit"),
+                admin_nfs_store_filter_filters_path(filter: {resource_name: "#{object_instance.full_item_type_name}__%"}),
+                target: '_blank'
+          )
+          %>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= al_accordion_id %>-view-refs-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= al_accordion_id %>"
+           href="#<%= al_accordion_id %>-view-refs-collapse"
+           aria-expanded="false" aria-controls="<%= al_accordion_id %>-view-refs-collapse">
+          views referencing database table
+        </a>
+      </h4>
+    </div>
+    <div id="<%= al_accordion_id %>-view-refs-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= al_accordion_id %>-view-refs-heading">
+      <div class="panel-body">
+        <%= render partial: 'admin/common_templates/def_details_view_refs', locals: {object_instance: object_instance} %>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= al_accordion_id %>-field-configs-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= al_accordion_id %>"
+           href="#<%= al_accordion_id %>-field-configs-collapse"
+           aria-expanded="false" aria-controls="<%= al_accordion_id %>-field-configs-collapse">
+          field configs
+        </a>
+      </h4>
+    </div>
+    <div id="<%= al_accordion_id %>-field-configs-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= al_accordion_id %>-field-configs-heading">
+      <div class="panel-body">
+        <%= render partial: 'admin/common_templates/def_details_field_configs', locals: {object_instance: object_instance} %>
+      </div>
+    </div>
+  </div>
+
 </div>
-
-<%= render partial: 'admin/common_templates/def_details_view_refs', locals: {object_instance: object_instance} %>
-
-<%= render partial: 'admin/common_templates/def_details_field_configs', locals: {object_instance: object_instance} %>
 
 <% else %>
   <label>not yet saved</label>

--- a/app/views/admin/common_templates/_def_details_dialogs.html.erb
+++ b/app/views/admin/common_templates/_def_details_dialogs.html.erb
@@ -1,7 +1,16 @@
-<% if object_instance.persisted? && object_instance.options_text && !object_instance.disabled
-     dialogs = object_instance.option_configs.map { |d| d.dialog_before.map { |e| e.last } }.flatten %>
+<% if object_instance.persisted? && !object_instance.disabled
+     dialogs = (object_instance.option_configs || []).flat_map do |d|
+       dialog_before = d.dialog_before
+       case dialog_before
+       when Hash
+         dialog_before.values
+       when String
+         [dialog_before]
+       else
+         []
+       end
+     end %>
 <div class="activity-list-dialogs">
-  <label>dialogs</label>
   <% if dialogs.present? %>
   <ul class="al-reference-list">  
   <% dialogs.each do |l| %>       
@@ -10,8 +19,8 @@
   </li>
   <% end %>
   </ul>
-  <% end %>
   <hr />
+  <% end %>
     <p>Add a <%= link_to link_label_open_in_new("new dialog template"), admin_message_templates_path(init_with: {message_type: 'dialog', template_type: 'content', category: object_instance.category}, perform_action: 'new'), target: "_blank" %>
     with <i>message type:</i> <b>dialog</b> &amp; <i>template type:</i> <b>content</b></p>
 </div>

--- a/app/views/admin/common_templates/_def_details_field_configs.html.erb
+++ b/app/views/admin/common_templates/_def_details_field_configs.html.erb
@@ -1,12 +1,10 @@
-<% if object_instance.persisted? && object_instance.options_text && !object_instance.disabled
-     field_configs = object_instance.option_configs.map { |oc| [oc.name, oc.raw_field_configs] }.to_h %>
+<% if object_instance.persisted? && !object_instance.disabled
+     field_configs = (object_instance.option_configs || []).map { |oc| [oc.name, oc.raw_field_configs] }.to_h %>
 <div class="activity-list-field-configs">
-  <label>field configs</label>
 <% 
 if field_configs.present?
 %>
-  <p><a href="#full-field-configs" class="collapsed btn btn-default" data-toggle="collapse">show all field configs</a></p>
-  <div id="full-field-configs" class="collapse">
+  <div id="full-field-configs">
 <%
     field_configs.each do |k, v|
        next unless v&.present?

--- a/app/views/admin/common_templates/_def_details_libraries.html.erb
+++ b/app/views/admin/common_templates/_def_details_libraries.html.erb
@@ -1,7 +1,6 @@
-<% if object_instance.persisted? && object_instance.options_text 
+<% if object_instance.persisted?
      libs = OptionConfigs::ExtraOptions.requested_libraries(object_instance.options_text) %>
 <div class="activity-list-libraries">
-  <label>libraries</label>
   <% if libs.present? %>
   <ul class="al-reference-list">  
   <% libs.each do |l| %>
@@ -12,8 +11,8 @@
   </li>
   <% end %>
   </ul>
-  <% end %>
   <hr />
+  <% end %>
     <p>Add a library with <code># @library [category] [name]</code> after adding a
     <%= link_to link_label_open_in_new("config library"), admin_config_libraries_path(init_with: {category: object_instance.category, format: 'yaml'}, perform_action: 'new'), target: "_blank" %>
     </p>

--- a/app/views/admin/common_templates/_def_details_view_refs.html.erb
+++ b/app/views/admin/common_templates/_def_details_view_refs.html.erb
@@ -1,4 +1,4 @@
-<% if object_instance.persisted? && object_instance.options_text 
+<% if object_instance.persisted?
      schema = object_instance.schema_name
      table_name = object_instance.table_name
      begin
@@ -9,7 +9,6 @@
      end  
     %>
 <div class="activity-list-view-refs">
-  <label>views referencing database table</label>
   <% if view_refs.present? %>
   <ul class="al-reference-list">  
   <% view_refs.each do |l| 

--- a/app/views/admin/common_templates/_def_uac_summary.html.erb
+++ b/app/views/admin/common_templates/_def_uac_summary.html.erb
@@ -21,29 +21,23 @@
   resource_type = local_assigns[:resource_type] || 'table'
   return unless resource_name.present?
 
-  uacs = Admin::UserAccessControl.active_for(resource_name:).not_template_role
-  no_non_template_uacs = uacs.empty? 
-  
-  # Check if current user has access to this resource
-  current_user_has_access = false
-  if current_user && current_app_type_id
-    current_user_has_access = Admin::UserAccessControl.access_for?(
-      current_user,
-      :access,
-      resource_type.to_sym,
-      resource_name,
-      alt_app_type_id: current_app_type_id
-    ).present?
-  end
-  
-  # Check if there are any UACs for the current app type
-  current_app_uacs = uacs.select { |uac| uac.app_type_id == current_app_type_id }
+  uac_data = def_uac_summary_data(
+    object_instance:,
+    current_user:,
+    current_app_type_id:,
+    resource_name:,
+    resource_type:
+  )
+
+  uacs = uac_data[:uacs]
+  no_non_template_uacs = uac_data[:no_non_template_uacs]
+  current_user_has_access = uac_data[:current_user_has_access]
+  current_app_uacs = uac_data[:current_app_uacs]
   
   prev_access = :not_set
 %>
 
-<label>user access controls</label>
-<%= link_to link_label_open_in_new("view all"), 
+<%= link_to link_label_open_in_new("view all #{resource_type&.humanize&.underscore} user access controls"), 
             admin_user_access_controls_path(filter: { resource_name:, resource_type:, app_type_id: '' }), 
             target: '_blank' %>
 
@@ -68,18 +62,21 @@
   </p>
 <% end %>
 
-<ul class="common-def-panel--uacs">
 <% uacs.each do |uac|
      access_changed = prev_access != uac.access
-     prev_access = uac.access
 %>
-<% if access_changed %><span class="common-def-panel--access-type"><%= uac.access.presence || 'no access' %></span><% end %>
+<% if access_changed %>
+<% if prev_access %></ul><% end %>
+<p class="common-def-panel--access-type"><%= uac.access.presence || 'no access' %></p>
+<ul class="common-def-panel--uacs">
+<% end %>
 <li>
   <%= uac.user&.email.presence || '' %> 
-  <%= uac.role_name.nil? ? '' : link_to(uac.role_name, admin_user_roles_url(filter: { role_name: uac.role_name }), target: '_blank') %>
+  <%= uac.role_name.nil? ? '' : link_to(uac.role_name, admin_user_roles_url(filter: { role_name: uac.role_name }), target: '_blank', title: 'view users assigned to this role') %>
   <% if uac.app_type_id %>
     <small class="text-muted">(<%= uac.app_type&.name || "app #{uac.app_type_id}" %>)</small>
   <% end %>
 </li>
+<% prev_access = uac.access %>
 <% end %>
 </ul>

--- a/app/views/admin/dynamic_models/_def_details.html.erb
+++ b/app/views/admin/dynamic_models/_def_details.html.erb
@@ -5,6 +5,8 @@
     <p>Using this definition will fail</p>
   <% end %>
 
+  <%= render partial: 'admin/dynamic_models/config_errors', locals: { object_instance: } %>
+
   <label>item type name</label>
   <p class="dynamic-item-type">
   <%= object_instance.full_item_type_name %>
@@ -117,66 +119,182 @@
   </div>
   <% end %>
 
-  <%= render partial: 'admin/dynamic_models/config_errors', locals: { object_instance: } %>
-
-  <%= render partial: 'admin/common_templates/def_uac_summary', 
-             locals: { 
-               object_instance:, 
-               current_app_type_id: current_admin.matching_user&.app_type_id,
-               current_user: current_admin.matching_user
-             } %>
 <% else %>
   <p>
   <label>not yet saved</label>
   </p>
 <% end %>
-  <label>fields</label>
 <% if object_instance.persisted? && object_instance.enabled? && object_instance.table_or_view_ready?%>
   <%
     fields = object_instance.all_implementation_fields(only_real: true)
     table_cols = object_instance.table_columns.map { |c| c.name.to_s }
   %>
-  <p><%=fields.length%> fields</p>
-  <% if object_instance.fields_match_columns? %>
-  <p>Fields match table</p>
-  <% else %>
-  <p>Fields don't match table</p>
-  <p><%= "definition : table: +[#{(fields - table_cols).join(" ")}] -[#{(table_cols - fields).join(" ")}]" %><p>
-  <% end %>  
 <% end %>
 
-<label>field definitions</label>
-<p>
-<a href="#field-list-outer-block" id="expand-captions-dialogs">show all dialogs and captions</a>
-</p>
+<%
+  current_app_type_id = current_admin.matching_user&.app_type_id
+  current_user = current_admin.matching_user
+  dm_accordion_id = "dm-details-accordion-#{object_instance.id || 'new'}"
+  dm_uac_needs_attention = def_uac_needs_attention?(
+    object_instance:,
+    current_user:,
+    current_app_type_id:
+  )
+%>
+<div class="panel-group dm-details-accordion" id="<%= dm_accordion_id %>" role="tablist">
 
-  <ul class="activity-list" id="field-list-outer-block">
-    <%= sortable_block "#dynamic_model_field_list", "li" %>
-  </ul>
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= dm_accordion_id %>-uac-heading">
+      <h4 class="panel-title">
+        <a class="<%= dm_uac_needs_attention ? '' : 'collapsed' %>" role="button" data-toggle="collapse" data-parent="#<%= dm_accordion_id %>"
+           href="#<%= dm_accordion_id %>-uac-collapse"
+           aria-expanded="<%= dm_uac_needs_attention %>" aria-controls="<%= dm_accordion_id %>-uac-collapse">
+          user access controls
+        </a>
+      </h4>
+    </div>
+    <div id="<%= dm_accordion_id %>-uac-collapse" class="panel-collapse collapse <%= dm_uac_needs_attention ? 'in' : '' %>"
+         role="tabpanel" aria-labelledby="<%= dm_accordion_id %>-uac-heading">
+      <div class="panel-body">
+        <%= render partial: 'admin/common_templates/def_uac_summary',
+                   locals: {
+                     object_instance:,
+                     current_app_type_id:,
+                     current_user:
+                   } %>
+      </div>
+    </div>
+  </div>
 
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= dm_accordion_id %>-fields-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= dm_accordion_id %>"
+           href="#<%= dm_accordion_id %>-fields-collapse"
+           aria-expanded="false" aria-controls="<%= dm_accordion_id %>-fields-collapse">
+          fields
+        </a>
+      </h4>
+    </div>
+    <div id="<%= dm_accordion_id %>-fields-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= dm_accordion_id %>-fields-heading">
+      <div class="panel-body">
+        <div class="activity-list-fields">
+        <label>status</label>
 <% if object_instance.persisted? && object_instance.enabled? && object_instance.table_or_view_ready?%>
-  <label>additional table columns</label>
-  <ul class="activity-list">
-  <% (table_cols - fields).each do |f|%><li><%=f%></li><% end %>
-  </ul>
-<% end %>  
-
-</div>
-<% if object_instance.persisted? && object_instance.enabled? && object_instance.table_or_view_ready?%>
-<div class="dynamic-list-section">
-  <label>activities</label>
-  <ul class="activity-list">
-  <% object_instance.option_configs_names&.each do |name| %>
-    <li><%=name%><%= object_instance.option_type_config_for(name) ? '' : "(invalid)" %></li>
-  <% end %>
-  </ul>
-  <div id="dynamic-list-detail" class="dynamic-list-detail"></div>
-</div>
+        <p><%=fields.length%> fields</p>
+        <% if object_instance.fields_match_columns? %>
+        <p>Fields match table</p>
+        <% else %>
+        <p>Fields don't match table</p>
+        <p><%= "definition : table: +[#{(fields - table_cols).join(" ")}] -[#{(table_cols - fields).join(" ")}]" %></p>
+        <% end %>
+<% else %>
+        <p>Fields not available until definition is saved, enabled, and table/view is ready</p>
 <% end %>
-<%= render partial: 'admin/common_templates/def_details_libraries', locals: {object_instance: object_instance} %>
-<%= render partial: 'admin/common_templates/def_details_dialogs', locals: {object_instance: object_instance} %>
-<%= render partial: 'admin/common_templates/def_details_view_refs', locals: {object_instance: object_instance} %>
-<%= render partial: 'admin/common_templates/def_details_field_configs', locals: {object_instance: object_instance} %>
+
+        <label>field definitions</label>
+        <p>
+          <a href="#field-list-outer-block" id="expand-captions-dialogs">show all dialogs and captions</a>
+        </p>
+
+        <ul class="activity-list" id="field-list-outer-block">
+          <%= sortable_block "#dynamic_model_field_list", "li" %>
+        </ul>
+
+<% if object_instance.persisted? && object_instance.enabled? && object_instance.table_or_view_ready?%>
+        <label>additional table columns</label>
+        <ul class="activity-list">
+        <% (table_cols - fields).each do |f|%><li><%=f%></li><% end %>
+        </ul>
+
+        <label>activities</label>
+        <ul class="activity-list">
+        <% object_instance.option_configs_names&.each do |name| %>
+          <li><%=name%><%= object_instance.option_type_config_for(name) ? '' : "(invalid)" %></li>
+        <% end %>
+        </ul>
+        <div id="dynamic-list-detail" class="dynamic-list-detail"></div>
+<% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= dm_accordion_id %>-libraries-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= dm_accordion_id %>"
+           href="#<%= dm_accordion_id %>-libraries-collapse"
+           aria-expanded="false" aria-controls="<%= dm_accordion_id %>-libraries-collapse">
+          libraries
+        </a>
+      </h4>
+    </div>
+    <div id="<%= dm_accordion_id %>-libraries-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= dm_accordion_id %>-libraries-heading">
+      <div class="panel-body">
+        <%= render partial: 'admin/common_templates/def_details_libraries', locals: {object_instance: object_instance} %>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= dm_accordion_id %>-dialogs-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= dm_accordion_id %>"
+           href="#<%= dm_accordion_id %>-dialogs-collapse"
+           aria-expanded="false" aria-controls="<%= dm_accordion_id %>-dialogs-collapse">
+          dialogs
+        </a>
+      </h4>
+    </div>
+    <div id="<%= dm_accordion_id %>-dialogs-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= dm_accordion_id %>-dialogs-heading">
+      <div class="panel-body">
+        <%= render partial: 'admin/common_templates/def_details_dialogs', locals: {object_instance: object_instance} %>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= dm_accordion_id %>-view-refs-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= dm_accordion_id %>"
+           href="#<%= dm_accordion_id %>-view-refs-collapse"
+           aria-expanded="false" aria-controls="<%= dm_accordion_id %>-view-refs-collapse">
+          views referencing database table
+        </a>
+      </h4>
+    </div>
+    <div id="<%= dm_accordion_id %>-view-refs-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= dm_accordion_id %>-view-refs-heading">
+      <div class="panel-body">
+        <%= render partial: 'admin/common_templates/def_details_view_refs', locals: {object_instance: object_instance} %>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= dm_accordion_id %>-field-configs-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= dm_accordion_id %>"
+           href="#<%= dm_accordion_id %>-field-configs-collapse"
+           aria-expanded="false" aria-controls="<%= dm_accordion_id %>-field-configs-collapse">
+          field configs
+        </a>
+      </h4>
+    </div>
+    <div id="<%= dm_accordion_id %>-field-configs-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= dm_accordion_id %>-field-configs-heading">
+      <div class="panel-body">
+        <%= render partial: 'admin/common_templates/def_details_field_configs', locals: {object_instance: object_instance} %>
+      </div>
+    </div>
+  </div>
+
+</div>
+</div>
 
 <% # Load the appropriate configurations for showing the form correctly
    if object_instance.persisted? && object_instance.enabled? && object_instance.table_or_view_ready? %>

--- a/app/views/admin/external_identifiers/_def_details.html.erb
+++ b/app/views/admin/external_identifiers/_def_details.html.erb
@@ -1,9 +1,11 @@
-<% if object_instance.persisted? && object_instance.enabled?%>
 <div class="dynamic-details-section">
+<% if object_instance.persisted? && object_instance.enabled?%>
   <% unless object_instance.implementation_class_defined?(::ExternalIdentifier, fail_without_exception: true) %>
     <label>implementation class not ready</label>
     <p>Using this definition will fail</p>
   <% end %>
+
+  <%= render partial: 'admin/dynamic_models/config_errors', locals: { object_instance: } %>
 
   <label>item type name</label>
   <p class="dynamic-item-type">
@@ -16,14 +18,14 @@
 
   <%= render partial: 'admin/common_templates/def_details_version_mode', locals: { object_instance: } %>
 
-<label>database <%= object_instance.table_or_view || '<span class="info-danger">not defined</span>'.html_safe %></label>
+  <label>database <%= object_instance.table_or_view || '<span class="info-danger">not defined</span>'.html_safe %></label>
   <%
     schema_name = object_instance.schema_name.presence || object_instance.schema_name_in_db
   %>
   <p>
     <code><%= [schema_name, object_instance.table_name].compact.join('.') %></code>
   </p>
-  
+
   <% if object_instance.schema_name.blank? %>
     <p>The schema name is not specified in the definition.</p>
     <p>The assumed schema name from the database is: <code><%= object_instance.schema_name_in_db %></code>
@@ -46,7 +48,7 @@
     <%= link_to link_label_open_in_new('list data history'), "/reports/reference_data__table_data?schema_name=#{object_instance.schema_name}&search_attrs%5B_blank%5D=true&search_attrs%5Bno_run%5D=true&table_name=#{object_instance.history_table_name}", 
                 target: '_blank' %>
   </p>
-                
+
   <p>
     <% begin %>
     <%= link_to link_label_open_in_new('search identifier'), 
@@ -67,44 +69,182 @@
     <code>/masters/&lt;value&gt;?type=<%= object_instance.external_id_attribute %></code>
   </p>
 
-  <label>fields</label>
-  <ul class="activity-list">
-    <%= sortable_block "#external_identifier_extra_fields", "li" %>
-  </ul>
-
-
   <% unless object_instance.table_or_view_ready?%>
   <div class="help-block">
-  <p>Typically the database table or view associated with an activity log is created when the definition is first created (or prior to this if handled manually.)</p>
-  <p>To create the table for this activity log definition, either run the defined migration, or disable (and save) then re-enable and save this definition to 
+  <p>Typically the database table or view associated with an external identifier is created when the definition is first created (or prior to this if handled manually.)</p>
+  <p>To create the table for this external identifier definition, either run the defined migration, or disable (and save) then re-enable and save this definition to 
      setup the database table based on options configuration.
   </p>
   </div>
   <% end %>
 
-<%= render partial: 'admin/dynamic_models/config_errors', locals: { object_instance: } %>
-
-<%= render partial: 'admin/common_templates/def_uac_summary', 
-           locals: { 
-             object_instance:, 
-             current_app_type_id: current_admin.matching_user&.app_type_id,
-             current_user: current_admin.matching_user
-           } %>
-
-</div>
-<div class="dynamic-list-section">
-  <label>activities</label>
-  <ul class="activity-list">
-  <% object_instance.option_configs_names&.each do |name| %>
-    <li><%=name%><%= object_instance.option_type_config_for(name) ? '' : "(invalid)" %></li>
-  <% end %>
-  </ul>
-  <div id="dynamic-list-detail" class="dynamic-list-detail"></div>
-</div>
 <% else %>
   <label>not yet saved</label>
 <% end %>
-<%= render partial: 'admin/common_templates/def_details_libraries', locals: {object_instance: object_instance} %>
-<%= render partial: 'admin/common_templates/def_details_dialogs', locals: {object_instance: object_instance} %>
-<%= render partial: 'admin/common_templates/def_details_view_refs', locals: {object_instance: object_instance} %>
-<%= render partial: 'admin/common_templates/def_details_field_configs', locals: {object_instance: object_instance} %>
+
+<%
+  current_app_type_id = current_admin.matching_user&.app_type_id
+  current_user = current_admin.matching_user
+  ei_accordion_id = "ei-details-accordion-#{object_instance.id || 'new'}"
+  ei_uac_needs_attention = def_uac_needs_attention?(
+    object_instance:,
+    current_user:,
+    current_app_type_id:
+  )
+%>
+<div class="panel-group ei-details-accordion" id="<%= ei_accordion_id %>" role="tablist">
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= ei_accordion_id %>-uac-heading">
+      <h4 class="panel-title">
+        <a class="<%= ei_uac_needs_attention ? '' : 'collapsed' %>" role="button" data-toggle="collapse" data-parent="#<%= ei_accordion_id %>"
+           href="#<%= ei_accordion_id %>-uac-collapse"
+           aria-expanded="<%= ei_uac_needs_attention %>" aria-controls="<%= ei_accordion_id %>-uac-collapse">
+          user access controls
+        </a>
+      </h4>
+    </div>
+    <div id="<%= ei_accordion_id %>-uac-collapse" class="panel-collapse collapse <%= ei_uac_needs_attention ? 'in' : '' %>"
+         role="tabpanel" aria-labelledby="<%= ei_accordion_id %>-uac-heading">
+      <div class="panel-body">
+        <%= render partial: 'admin/common_templates/def_uac_summary',
+                   locals: {
+                     object_instance:,
+                     current_app_type_id:,
+                     current_user:
+                   } %>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= ei_accordion_id %>-fields-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= ei_accordion_id %>"
+           href="#<%= ei_accordion_id %>-fields-collapse"
+           aria-expanded="false" aria-controls="<%= ei_accordion_id %>-fields-collapse">
+          fields
+        </a>
+      </h4>
+    </div>
+    <div id="<%= ei_accordion_id %>-fields-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= ei_accordion_id %>-fields-heading">
+      <div class="panel-body">
+        <div class="activity-list-fields">
+        <label>status</label>
+<% if object_instance.persisted? && object_instance.enabled? && object_instance.table_or_view_ready? %>
+        <%
+          fields = object_instance.all_implementation_fields(only_real: true)
+          table_cols = object_instance.table_columns.map { |c| c.name.to_s }
+        %>
+        <p><%= fields.length %> fields</p>
+        <% if object_instance.fields_match_columns? %>
+        <p>Fields match table</p>
+        <% else %>
+        <p>Fields don't match table</p>
+        <p><%= "definition : table: +[#{(fields - table_cols).join(' ')}] -[#{(table_cols - fields).join(' ')}]" %></p>
+        <% end %>
+<% else %>
+        <p>Fields not available until definition is saved, enabled, and table/view is ready</p>
+<% end %>
+
+        <label>fields</label>
+        <ul class="activity-list" id="external-identifier-field-list-outer-block">
+          <%= sortable_block "#external_identifier_extra_fields", "li" %>
+        </ul>
+
+<% if object_instance.persisted? && object_instance.enabled? && object_instance.table_or_view_ready? %>
+        <label>additional table columns</label>
+        <ul class="activity-list">
+        <% (table_cols - fields).each do |f| %><li><%= f %></li><% end %>
+        </ul>
+<% end %>
+
+<% if object_instance.persisted? && object_instance.enabled? %>
+        <label>activities</label>
+        <ul class="activity-list">
+        <% object_instance.option_configs_names&.each do |name| %>
+          <li><%=name%><%= object_instance.option_type_config_for(name) ? '' : "(invalid)" %></li>
+        <% end %>
+        </ul>
+        <div id="dynamic-list-detail" class="dynamic-list-detail"></div>
+<% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= ei_accordion_id %>-libraries-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= ei_accordion_id %>"
+           href="#<%= ei_accordion_id %>-libraries-collapse"
+           aria-expanded="false" aria-controls="<%= ei_accordion_id %>-libraries-collapse">
+          libraries
+        </a>
+      </h4>
+    </div>
+    <div id="<%= ei_accordion_id %>-libraries-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= ei_accordion_id %>-libraries-heading">
+      <div class="panel-body">
+        <%= render partial: 'admin/common_templates/def_details_libraries', locals: {object_instance: object_instance} %>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= ei_accordion_id %>-dialogs-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= ei_accordion_id %>"
+           href="#<%= ei_accordion_id %>-dialogs-collapse"
+           aria-expanded="false" aria-controls="<%= ei_accordion_id %>-dialogs-collapse">
+          dialogs
+        </a>
+      </h4>
+    </div>
+    <div id="<%= ei_accordion_id %>-dialogs-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= ei_accordion_id %>-dialogs-heading">
+      <div class="panel-body">
+        <%= render partial: 'admin/common_templates/def_details_dialogs', locals: {object_instance: object_instance} %>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= ei_accordion_id %>-view-refs-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= ei_accordion_id %>"
+           href="#<%= ei_accordion_id %>-view-refs-collapse"
+           aria-expanded="false" aria-controls="<%= ei_accordion_id %>-view-refs-collapse">
+          views referencing database table
+        </a>
+      </h4>
+    </div>
+    <div id="<%= ei_accordion_id %>-view-refs-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= ei_accordion_id %>-view-refs-heading">
+      <div class="panel-body">
+        <%= render partial: 'admin/common_templates/def_details_view_refs', locals: {object_instance: object_instance} %>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="<%= ei_accordion_id %>-field-configs-heading">
+      <h4 class="panel-title">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#<%= ei_accordion_id %>"
+           href="#<%= ei_accordion_id %>-field-configs-collapse"
+           aria-expanded="false" aria-controls="<%= ei_accordion_id %>-field-configs-collapse">
+          field configs
+        </a>
+      </h4>
+    </div>
+    <div id="<%= ei_accordion_id %>-field-configs-collapse" class="panel-collapse collapse"
+         role="tabpanel" aria-labelledby="<%= ei_accordion_id %>-field-configs-heading">
+      <div class="panel-body">
+        <%= render partial: 'admin/common_templates/def_details_field_configs', locals: {object_instance: object_instance} %>
+      </div>
+    </div>
+  </div>
+
+</div>
+</div>

--- a/spec/system/admin/admin_activity_log_details_accordion_spec.rb
+++ b/spec/system/admin/admin_activity_log_details_accordion_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+# Admin Activity Log: Details accordion block
+#
+# Tests that the activity log admin Details tab presents its major sections as
+# a Bootstrap accordion (panel-group) with eight panels:
+# activities, all fields, libraries, embeds, references, file filters,
+# views referencing database table, and field configs.
+#
+# Also verifies all panels are collapsed by default and that opening one panel
+# collapses a previously-open panel.
+#
+# Issue: https://github.com/consected/restructure/issues/1095
+
+require 'rails_helper'
+
+describe 'admin activity log details accordion', js: true, driver: $browser_driver do
+  include ModelSupport
+  include AdminActionsSetup
+  include FeatureSupport
+
+  before(:all) do
+    SetupHelper.feature_setup
+    ENV['FPHS_ADMIN_SETUP'] = 'yes'
+    make_an_admin
+  end
+
+  let(:activity_log) do
+    ActivityLog.active.find(&:enabled?)
+  end
+
+  before do
+    skip 'No active activity logs found' unless activity_log
+
+    admin_sign_in_with_2fa
+    visit '/admin/activity_logs'
+    finish_page_loading
+
+    within "#admin-item-#{activity_log.id}" do
+      find('a.edit-entity.glyphicon-pencil').click
+    end
+
+    expect(page).to have_css('.nav-tabs', wait: 10)
+    expect(page).to have_css('#def-details-block', visible: true)
+  end
+
+  let(:accordion_id) { "al-details-accordion-#{activity_log.id}" }
+
+  it 'renders the Details sections and auto-expands UAC when warnings are present' do
+    within '#def-details-block' do
+      expect(page).to have_css("##{accordion_id}.panel-group")
+
+      %w[uac activities all-fields libraries embeds references file-filters view-refs field-configs].each do |panel|
+        expect(page).to have_css(
+          "##{accordion_id} a[data-toggle='collapse'][data-parent='##{accordion_id}']" \
+          "[href='##{accordion_id}-#{panel}-collapse']"
+        )
+        expect(page).to have_css("##{accordion_id}-#{panel}-collapse.panel-collapse.collapse", visible: false)
+      end
+
+      uac_state = page.evaluate_script(<<~JS)
+        (function(){
+          var panel = document.querySelector('##{accordion_id}-uac-collapse');
+          if (!panel) return null;
+          var hasWarnings = panel.querySelectorAll('.text-warning, .text-info').length > 0;
+          var isExpanded = panel.classList.contains('in');
+          return { hasWarnings: hasWarnings, isExpanded: isExpanded };
+        })();
+      JS
+      expect(uac_state).not_to be_nil
+      expect(uac_state['isExpanded']).to eq(uac_state['hasWarnings'])
+
+      %w[activities all-fields libraries embeds references file-filters view-refs field-configs].each do |panel|
+        expect(page).not_to have_css("##{accordion_id}-#{panel}-collapse.in", visible: true)
+      end
+
+      expect(page).to have_css("##{accordion_id} .activity-list-section", visible: false)
+      expect(page).to have_css("##{accordion_id} .activity-list-all-fields", visible: false)
+      expect(page).to have_css("##{accordion_id} .activity-list-libraries", visible: false)
+      expect(page).to have_css("##{accordion_id} .activity-list-embeds", visible: false)
+      expect(page).to have_css("##{accordion_id} .activity-list-references", visible: false)
+      expect(page).to have_css("##{accordion_id} .activity-list-file-filters", visible: false)
+      expect(page).to have_css("##{accordion_id} .activity-list-view-refs", visible: false)
+      expect(page).to have_css("##{accordion_id} .activity-list-field-configs", visible: false)
+    end
+  end
+
+  it 'expands the activities panel to reveal activities details' do
+    within '#def-details-block' do
+      find("a[data-toggle='collapse'][href='##{accordion_id}-activities-collapse']").click
+
+      expect(page).to have_css(
+        "##{accordion_id}-activities-collapse.panel-collapse.collapse.in", visible: true, wait: 5
+      )
+
+      panel = find("##{accordion_id}-activities-collapse")
+      expect(panel).to have_content('Add a new')
+      expect(panel).to have_content('[activity_name]:')
+    end
+  end
+
+  it 'opens panels exclusively (Bootstrap accordion behaviour)' do
+    within '#def-details-block' do
+      find("a[data-toggle='collapse'][href='##{accordion_id}-activities-collapse']").click
+      expect(page).to have_css("##{accordion_id}-activities-collapse.in", visible: true, wait: 5)
+
+      find("a[data-toggle='collapse'][href='##{accordion_id}-all-fields-collapse']").click
+      expect(page).to have_css("##{accordion_id}-all-fields-collapse.in", visible: true, wait: 5)
+
+      expect(page).to have_css(
+        "##{accordion_id}-activities-collapse.panel-collapse.collapse:not(.in)", visible: false, wait: 5
+      )
+    end
+  end
+end

--- a/spec/system/admin/admin_dynamic_model_details_accordion_spec.rb
+++ b/spec/system/admin/admin_dynamic_model_details_accordion_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+# Admin Dynamic Model: Details accordion block
+#
+# Tests that the dynamic model definition admin "Details" tab presents its
+# definition sections as a Bootstrap accordion (panel-group) with five panels:
+# fields (combining fields, field definitions, additional table columns, and
+# activities), libraries, dialogs, views referencing database table, and field
+# configs. All panels are collapsed by default so admins do not need to scroll
+# past long sections to reach controls below.
+#
+# Also confirms that when the "fields" panel is expanded, the sortable
+# "(drop here to remove)" trash target is visible with non-zero size and is
+# able to receive a drag-and-drop event.
+#
+# Issue: https://github.com/consected/restructure/issues/1095
+
+require 'rails_helper'
+
+describe 'admin dynamic model details accordion', js: true, driver: $browser_driver do
+  include ModelSupport
+  include AdminActionsSetup
+
+  before(:all) do
+    SetupHelper.feature_setup
+    ENV['FPHS_ADMIN_SETUP'] = 'yes'
+    make_an_admin
+  end
+
+  let(:dm) do
+    DynamicModel.active.find { |d| d.table_or_view_ready? && d.field_list.present? } ||
+      DynamicModel.active.find(&:table_or_view_ready?)
+  end
+
+  before do
+    skip 'No active dynamic models with ready tables found' unless dm
+
+    admin_sign_in_with_2fa
+    visit '/admin/dynamic_models'
+    within "#admin-item-#{dm.id}" do
+      find('a.edit-entity.glyphicon-pencil').click
+    end
+    expect(page).to have_css('.nav-tabs', wait: 10)
+    # Details tab is the default active tab
+    expect(page).to have_css('#def-details-block', visible: true)
+  end
+
+  let(:accordion_id) { "dm-details-accordion-#{dm.id}" }
+
+  it 'renders the Details panels and auto-expands UAC when warnings are present' do
+    within '#def-details-block' do
+      expect(page).to have_css("##{accordion_id}.panel-group")
+
+      %w[uac fields libraries dialogs view-refs field-configs].each do |panel|
+        expect(page).to have_css(
+          "##{accordion_id} a[data-toggle='collapse'][data-parent='##{accordion_id}']" \
+          "[href='##{accordion_id}-#{panel}-collapse']"
+        )
+        expect(page).to have_css("##{accordion_id}-#{panel}-collapse.panel-collapse.collapse", visible: false)
+      end
+
+      uac_state = page.evaluate_script(<<~JS)
+        (function(){
+          var panel = document.querySelector('##{accordion_id}-uac-collapse');
+          if (!panel) return null;
+          var hasWarnings = panel.querySelectorAll('.text-warning, .text-info').length > 0;
+          var isExpanded = panel.classList.contains('in');
+          return { hasWarnings: hasWarnings, isExpanded: isExpanded };
+        })();
+      JS
+      expect(uac_state).not_to be_nil
+      expect(uac_state['isExpanded']).to eq(uac_state['hasWarnings'])
+
+      %w[fields libraries dialogs view-refs field-configs].each do |panel|
+        expect(page).not_to have_css("##{accordion_id}-#{panel}-collapse.in", visible: true)
+      end
+
+      # Activity-list wrappers are rendered inside panel bodies and are hidden while
+      # their panel-collapse containers are collapsed.
+      expect(page).to have_css("##{accordion_id} .activity-list-fields", visible: false)
+      expect(page).to have_css("##{accordion_id} .activity-list-libraries", visible: false)
+      expect(page).to have_css("##{accordion_id} .activity-list-dialogs", visible: false)
+      expect(page).to have_css("##{accordion_id} .activity-list-view-refs", visible: false)
+      expect(page).to have_css("##{accordion_id} .activity-list-field-configs", visible: false)
+
+      # All four sub-sections collapsed within the fields panel are not visible
+      expect(page).not_to have_css('#field-list-outer-block', visible: true)
+    end
+  end
+
+  it 'expands the fields panel to reveal field definitions, activities and the trash drop target' do
+    within '#def-details-block' do
+      find("a[data-toggle='collapse'][href='##{accordion_id}-fields-collapse']").click
+
+      expect(page).to have_css(
+        "##{accordion_id}-fields-collapse.panel-collapse.collapse.in", visible: true, wait: 5
+      )
+
+      # The labels for the four sub-sections are rendered inside the panel body
+      panel = find("##{accordion_id}-fields-collapse")
+      expect(panel).to have_content('field definitions')
+
+      # The sortable block including (drop here to remove) trash target is now visible
+      expect(page).to have_css('#field-list-outer-block', visible: true)
+      expect(page).to have_css('#field-list-outer-block .make-sortable', visible: true)
+      expect(page).to have_css('#field-list-outer-block .sortable-block-trash', visible: true)
+    end
+
+    rect = page.evaluate_script(<<~JS)
+      (function(){
+        var el = document.querySelector('#field-list-outer-block .sortable-block-trash');
+        if (!el) return null;
+        var r = el.getBoundingClientRect();
+        return { width: r.width, height: r.height };
+      })();
+    JS
+    expect(rect).not_to be_nil
+    expect(rect['width']).to be > 0
+    expect(rect['height']).to be > 0
+  end
+
+  it 'opens panels exclusively (Bootstrap accordion behaviour)' do
+    within '#def-details-block' do
+      find("a[data-toggle='collapse'][href='##{accordion_id}-fields-collapse']").click
+      expect(page).to have_css("##{accordion_id}-fields-collapse.in", visible: true, wait: 5)
+
+      find("a[data-toggle='collapse'][href='##{accordion_id}-libraries-collapse']").click
+      expect(page).to have_css("##{accordion_id}-libraries-collapse.in", visible: true, wait: 5)
+
+      # Opening libraries should collapse the previously-open fields panel
+      expect(page).to have_css(
+        "##{accordion_id}-fields-collapse.panel-collapse.collapse:not(.in)", visible: false, wait: 5
+      )
+    end
+  end
+end

--- a/spec/system/admin/admin_external_identifier_details_accordion_spec.rb
+++ b/spec/system/admin/admin_external_identifier_details_accordion_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+# Admin External Identifier: Details accordion block
+#
+# Tests that the external identifier definition admin "Details" tab presents
+# its definition sections as a Bootstrap accordion (panel-group) with five
+# panels: fields (combining fields and activities), libraries, dialogs, views
+# referencing database table, and field configs - matching the dynamic model
+# Details tab. All panels are collapsed by default.
+#
+# Also confirms that when the "fields" panel is expanded, the sortable
+# "(drop here to remove)" trash target is visible with non-zero size, and that
+# the user access controls summary is rendered above the accordion.
+#
+# Issue: https://github.com/consected/restructure/issues/1095
+
+require 'rails_helper'
+
+describe 'admin external identifier details accordion', js: true, driver: $browser_driver do
+  include ModelSupport
+  include AdminActionsSetup
+  include FeatureSupport
+
+  before(:all) do
+    SetupHelper.feature_setup
+    ENV['FPHS_ADMIN_SETUP'] = 'yes'
+    make_an_admin
+  end
+
+  let(:external_identifier) do
+    ExternalIdentifier.active.find { |ei| ei.enabled? && ei.table_or_view_ready? } ||
+      ExternalIdentifier.active.find(&:enabled?)
+  end
+
+  before do
+    skip 'No active external identifiers found' unless external_identifier
+
+    admin_sign_in_with_2fa
+    visit '/admin/external_identifiers'
+    finish_page_loading
+
+    within "#admin-item-#{external_identifier.id}" do
+      find('a.edit-entity.glyphicon-pencil').click
+    end
+
+    expect(page).to have_css('.nav-tabs', wait: 10)
+    expect(page).to have_css('#def-details-block', visible: true)
+  end
+
+  let(:accordion_id) { "ei-details-accordion-#{external_identifier.id}" }
+
+  it 'renders the Details panels and auto-expands UAC when warnings are present' do
+    within '#def-details-block' do
+      expect(page).to have_css("##{accordion_id}.panel-group")
+
+      %w[uac fields libraries dialogs view-refs field-configs].each do |panel|
+        expect(page).to have_css(
+          "##{accordion_id} a[data-toggle='collapse'][data-parent='##{accordion_id}']" \
+          "[href='##{accordion_id}-#{panel}-collapse']"
+        )
+        expect(page).to have_css("##{accordion_id}-#{panel}-collapse.panel-collapse.collapse", visible: false)
+      end
+
+      uac_state = page.evaluate_script(<<~JS)
+        (function(){
+          var panel = document.querySelector('##{accordion_id}-uac-collapse');
+          if (!panel) return null;
+          var hasWarnings = panel.querySelectorAll('.text-warning, .text-info').length > 0;
+          var isExpanded = panel.classList.contains('in');
+          return { hasWarnings: hasWarnings, isExpanded: isExpanded };
+        })();
+      JS
+      expect(uac_state).not_to be_nil
+      expect(uac_state['isExpanded']).to eq(uac_state['hasWarnings'])
+
+      %w[fields libraries dialogs view-refs field-configs].each do |panel|
+        expect(page).not_to have_css("##{accordion_id}-#{panel}-collapse.in", visible: true)
+      end
+
+      expect(page).to have_css("##{accordion_id} .activity-list-fields", visible: false)
+      expect(page).to have_css("##{accordion_id} .activity-list-libraries", visible: false)
+      expect(page).to have_css("##{accordion_id} .activity-list-dialogs", visible: false)
+      expect(page).to have_css("##{accordion_id} .activity-list-view-refs", visible: false)
+      expect(page).to have_css("##{accordion_id} .activity-list-field-configs", visible: false)
+
+      expect(page).not_to have_css('#external-identifier-field-list-outer-block', visible: true)
+    end
+  end
+
+  it 'renders the user access controls section in the UAC accordion panel' do
+    within '#def-details-block' do
+      expect(page).to have_css("a[data-toggle='collapse'][href='##{accordion_id}-uac-collapse']")
+      expect(page).to have_css("##{accordion_id}-uac-collapse .common-def-panel--uacs", visible: false)
+    end
+  end
+
+  it 'expands the fields panel to reveal fields, activities and the trash drop target' do
+    within '#def-details-block' do
+      find("a[data-toggle='collapse'][href='##{accordion_id}-fields-collapse']").click
+
+      expect(page).to have_css(
+        "##{accordion_id}-fields-collapse.panel-collapse.collapse.in", visible: true, wait: 5
+      )
+
+      panel = find("##{accordion_id}-fields-collapse")
+      expect(panel).to have_content('fields')
+
+      expect(page).to have_css('#external-identifier-field-list-outer-block', visible: true)
+      expect(page).to have_css('#external-identifier-field-list-outer-block .make-sortable', visible: true)
+      expect(page).to have_css('#external-identifier-field-list-outer-block .sortable-block-trash', visible: true)
+    end
+
+    rect = page.evaluate_script(<<~JS)
+      (function(){
+        var el = document.querySelector('#external-identifier-field-list-outer-block .sortable-block-trash');
+        if (!el) return null;
+        var r = el.getBoundingClientRect();
+        return { width: r.width, height: r.height };
+      })();
+    JS
+    expect(rect).not_to be_nil
+    expect(rect['width']).to be > 0
+    expect(rect['height']).to be > 0
+  end
+
+  it 'opens panels exclusively (Bootstrap accordion behaviour)' do
+    within '#def-details-block' do
+      find("a[data-toggle='collapse'][href='##{accordion_id}-fields-collapse']").click
+      expect(page).to have_css("##{accordion_id}-fields-collapse.in", visible: true, wait: 5)
+
+      find("a[data-toggle='collapse'][href='##{accordion_id}-libraries-collapse']").click
+      expect(page).to have_css("##{accordion_id}-libraries-collapse.in", visible: true, wait: 5)
+
+      expect(page).to have_css(
+        "##{accordion_id}-fields-collapse.panel-collapse.collapse:not(.in)", visible: false, wait: 5
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This PR completes issue #1095 by unifying admin definition Details blocks into accordion panels and moving User Access Controls into a dedicated accordion section that auto-expands when attention is required.

## What changed
- Dynamic Model Details now use accordion panels and include a UAC panel.
- External Identifier Details now use accordion panels and include a UAC panel.
- Activity Log Details now use accordion panels for:
  - activities
  - all fields
  - libraries
  - embeds
  - references
  - file filters
  - views referencing database table
  - field configs
  - user access controls
- UAC panel auto-expands when any of the following apply:
  - No user access controls defined for this resource.
  - Current admin user does not have access to this resource in the current app type.
  - No user access controls defined for the current app type.
- Added shared helper logic for UAC warning-state calculation and reused it in `def_uac_summary`.
- Refined UAC summary markup/style grouping by access type.

## Key files
- `app/helpers/common_templates_helper.rb`
- `app/views/admin/common_templates/_def_uac_summary.html.erb`
- `app/views/admin/dynamic_models/_def_details.html.erb`
- `app/views/admin/external_identifiers/_def_details.html.erb`
- `app/views/admin/activity_logs/_def_details.html.erb`
- `app/assets/stylesheets/admin/activity_list.scss`
- `app/assets/stylesheets/admin/common_dynamic_def_panels.scss`
- `spec/system/admin/admin_dynamic_model_details_accordion_spec.rb`
- `spec/system/admin/admin_external_identifier_details_accordion_spec.rb`
- `spec/system/admin/admin_activity_log_details_accordion_spec.rb`

## Validation
Ran:
- `spec/system/admin/admin_dynamic_model_details_accordion_spec.rb`
- `spec/system/admin/admin_external_identifier_details_accordion_spec.rb`
- `spec/system/admin/admin_activity_log_details_accordion_spec.rb`

Result:
- 10 examples, 0 failures

Also previously verified related targeted regression suites for parsed config, YAML recovery, config-library references, app-type column visibility, and dynamic-model batch flows.
