### PR TITLE
Fixed trackers_length SQL error and zero-count memoization bug - fixes #1106

### DIFF
--- a/app/models/master.rb
+++ b/app/models/master.rb
@@ -572,12 +572,12 @@ class Master < ActiveRecord::Base
   # if we have already preloaded the trackers
   # since we don't want to run individual queries for each item
   def trackers_length
-    return @trackers_length if @trackers_length
+    return @trackers_length unless @trackers_length.nil?
 
     @trackers_length = if association(:trackers).loaded?
                          trackers.length
                        else
-                         trackers.count
+                         trackers.unscope(:eager_load, :includes, :order).count
                        end
   end
 

--- a/spec/models/tracker_spec.rb
+++ b/spec/models/tracker_spec.rb
@@ -219,4 +219,66 @@ RSpec.describe Tracker, type: :model do
       expect(panel_entries.first.sub_process_id).to eq @sp1_2.id
     end
   end
+
+  # Regression specs for issue #1106: Master#trackers_length raised
+  # PG::SyntaxError ("syntax error at or near 'Table'") when the trackers
+  # association carried eager_load values (from TrackerHandler default_scope
+  # and the has_many lambda), causing an Arel::Attribute object to leak into
+  # the generated SQL.  The memoization guard also had a falsy-zero bug.
+  describe 'Master#trackers_length' do
+    it 'returns the correct count when the association is not preloaded' do
+      master = create_master
+      # Use two distinct protocols so the trackers view shows two rows
+      # (the view returns one row per protocol per master)
+      master.trackers.create!(
+        protocol_id: @p1.id, sub_process_id: @sp1_1.id, event_date: DateTime.now
+      )
+      master.trackers.create!(
+        protocol_id: @p2.id, sub_process_id: @sp2_1.id, event_date: DateTime.now
+      )
+
+      # Reload so the association is NOT cached
+      fresh = Master.find(master.id)
+      fresh.current_user = @user
+
+      expect { fresh.trackers_length }.not_to raise_error
+      expect(fresh.trackers_length).to eq 2
+    end
+
+    it 'returns 0 (not nil) and does not re-query when the master has no trackers' do
+      master = create_master
+      fresh = Master.find(master.id)
+      fresh.current_user = @user
+
+      expect(fresh.trackers_length).to eq 0
+
+      # Second call must use the memoized value, not hit the DB again
+      query_count = 0
+      counter = ->(_name, _started, _finished, _unique_id, payload) {
+        query_count += 1 if payload[:sql]&.match?(/tracker/i)
+      }
+      ActiveSupport::Notifications.subscribed(counter, 'sql.active_record') do
+        fresh.trackers_length
+      end
+      expect(query_count).to eq 0
+    end
+
+    it 'uses trackers.length (not a SQL count) when the association is already loaded' do
+      master = create_master
+      master.trackers.create!(
+        protocol_id: @p1.id, sub_process_id: @sp1_1.id, event_date: DateTime.now
+      )
+      master.trackers.load # preload
+
+      query_count = 0
+      counter = ->(_name, _started, _finished, _unique_id, payload) {
+        query_count += 1 if payload[:sql]&.match?(/tracker/i)
+      }
+      ActiveSupport::Notifications.subscribed(counter, 'sql.active_record') do
+        master.trackers_length
+      end
+      expect(query_count).to eq 0
+      expect(master.trackers_length).to eq 1
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes two bugs in `Master#trackers_length` introduced after `trackers` was converted from a real table to a PostgreSQL view (#941).

## Bug 1: `PG::SyntaxError` — SQL contains `#<Arel::Table:0x00...>`

**Symptom:** `MastersController#show` (and any endpoint calling `Master#as_json`) raises a 500 error in production with:
```
PG::SyntaxError: ERROR: syntax error at or near "Table"
SELECT DISTINCT #<Arel::Table:0x00007f...> FROM ...
```

**Root cause:** `trackers.count` triggers Rails' `has_include?` code path in `calculations.rb` because the association carries `eager_load` values (from `TrackerHandler`'s `default_scope` and the `has_many :trackers` lambda). Inside `apply_join_dependency` (line 236):
```ruby
relation.select_values = Array(klass.primary_key || table[Arel.star])
```
Because `klass.primary_key` returns `nil` for a DB view, `table[Arel.star]` (an `Arel::Attribute` node) is stored in `select_values`. It is later serialised via `.to_s` → `"#<Arel::Table:0x00...>"` which ends up literally in the SQL.

**Fix:** Strip eager_load, includes and order before counting — these are unnecessary for a plain count and their presence is the sole trigger for the broken code path. The `WHERE master_id = ?` condition from the association is preserved, so the count value is unchanged.

## Bug 2: Zero-count memoization falsy guard

`return @trackers_length if @trackers_length` is falsy when the count is `0`, causing an extra database hit on every `as_json` call for masters with no tracker records.

**Fix:** `return @trackers_length unless @trackers_length.nil?`

## Changes

- `app/models/master.rb` — `trackers_length` method (2-line fix)
- `spec/models/tracker_spec.rb` — 3 new regression specs covering the count bug, the zero-count memoization bug, and the preloaded-association path