### PR TITLE
Added pull_emails save trigger to read MIME emails from S3, filesystem and IMAP - resolves #1109

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,11 @@ Or if you want to use real AWS calls, set `AWS_PROFILE` then run:
 
     AWS_PROFILE=<profile> bundle exec rspec
 
+To test IMAP functionality against a test server:
+
+    docker pull greenmail/standalone:2.0.1
+    docker run -t -i -p 3025:3025 -p 3110:3110 -p 3143:3143 -p 3465:3465 -p 3993:3993 -p 3995:3995 -p 8080:8080 greenmail/standalone:2.0.1
+
 For more rspec information, check [running rspec tests](docs/dev_reference/main/running_rspec_tests.md)
 
 It is recommended to periodically drop and recreate the test database, since over time tests will slow down.

--- a/app/models/admin/defs/save_triggers_pull_emails_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_pull_emails_options_defs.yaml
@@ -1,0 +1,150 @@
+# Save Trigger: Pull Emails options
+        pull_emails:
+          if: #if_extras
+          # Read MIME-encoded email files (e.g. captured by AWS SES into an S3 bucket
+          # or stored on a filesystem) and run a list of inner save triggers per email.
+          # The parsed fields are exposed via trigger_variables[:email] for use in
+          # the inner triggers' substitutions, e.g. {{variables.email.subject}}.
+          #
+          # All string values within `source`, `limit`, `after_processing` and
+          # `attachments` (except the `on_email` triggers themselves) are passed
+          # through FieldDefaults, so {{variables.*}} substitutions are supported
+          # for hostnames, bucket names, paths, usernames, passwords, etc. (e.g.
+          # populated by an earlier set_variables save trigger from secret config).
+          source:
+            type: s3                  # 's3', 'filesystem' or 'imap'
+            # For S3 sources:
+            bucket: my-ses-bucket     # required for s3
+            prefix: 'inbox/'          # optional key prefix to list
+            # since_modified: '{{variables.last_run.at}}' # (optional) only objects whose
+            #                                              # last_modified is strictly newer than
+            #                                              # the supplied timestamp (ISO8601 string
+            #                                              # or anything Time.parse understands).
+            #                                              # {{variables.*}} substitutions allowed.
+
+            # For filesystem sources:
+            # type: filesystem
+            # path: /var/mail/incoming  # required for filesystem; directory of *.eml files
+            # since_modified: '{{variables.last_run.at}}' # (optional) only files whose mtime is
+            #                                              # strictly newer than the supplied time
+
+            # For IMAP sources:
+            # type: imap
+            # host: imap.example.com    # required for imap
+            # port: 993                 # optional; defaults to 993 (ssl) or 143
+            # ssl: true                 # optional; default false
+            # username: inbox@example.com   # required
+            # password: '...'               # required (use a secret reference)
+            # mailbox: 'INBOX'              # optional; mailbox/folder to read from
+            # search: ['UNSEEN']            # optional; IMAP search criteria, defaults to ['ALL']
+            # since_uid: '{{variables.last_run.uid}}' # (optional) only messages whose UID is
+            #                                          # strictly greater than the supplied value.
+            #                                          # Combined with `search` (AND) when both set.
+            #                                          # {{variables.*}} substitutions allowed.
+            #
+            # Incremental retrieval pattern: capture the last processed UID (imap) or
+            # latest last_modified timestamp (s3/filesystem) - e.g. via an inner
+            # set_variables / update trigger - and store it on a tracking record.
+            # On the next run, feed that value back in via {{variables.last_run.*}}
+            # so previously processed messages are skipped.
+
+          limit: 50                   # (optional) maximum number of emails to process per run
+
+          after_processing:           # (optional) what to do with each successfully processed email
+            # Move the email out of the source. Failed emails are left in place
+            # so they can be retried on the next run.
+            move_to:
+              # For S3:
+              prefix: 'processed/'    # destination key prefix
+              bucket: alt-bucket      # (optional) destination bucket; defaults to source bucket
+              # For filesystem:
+              # path: /var/mail/processed
+              # For IMAP:
+              # mailbox: 'Processed'  # destination mailbox (created if missing)
+            # OR delete instead of moving:
+            # delete: true            # works for s3, filesystem and imap
+
+          attachments:                # (optional) capture MIME attachments to an NfsStore container
+            container:
+              # One of:
+              from_this: model_reference   # find via ModelReference from the current item
+              # id: 123                    # OR a specific container id (substitution allowed)
+              # name: 'inbox-container'    # OR by container name within the master
+            path: 'emails'              # (optional) sub-path within the container
+            store_as_user: user@example.com  # (optional) user to perform the import as
+            store_in_app_type: app_type      # (optional) app type for resolving store_as_user
+            skip_existing: true              # (optional) skip if a file with the same name/path exists
+            replace: false                   # (optional) replace existing different file
+            # Each captured attachment is recorded on the email hash as:
+            #   {{variables.email.attachments.<index>.filename}}
+            #   {{variables.email.attachments.<index>.content_type}}
+            #   {{variables.email.attachments.<index>.size}}
+            #   {{variables.email.attachments.<index>.stored_file_id}}
+            #   {{variables.email.attachments.<index>.status}}    # 'ok' or 'failed'
+            #   {{variables.email.attachments.<index>.error}}     # message if failed
+            #
+            # Failure isolation: if any attachment fails to store, that
+            # attachment is recorded with status: 'failed' (and an error
+            # message), the *email* is marked status: 'failed', and the
+            # email is NOT moved or deleted by after_processing - so it can
+            # be retried. Use `skip_existing: true` (above) to ensure the
+            # successful attachments are not re-imported on retry.
+
+          on_email:
+            # List of inner save triggers to run for each email.
+            # Within each trigger, the *current* email's fields are available via:
+            #   {{variables.email.from}}
+            #   {{variables.email.to}}        (array)
+            #   {{variables.email.cc}}        (array)
+            #   {{variables.email.bcc}}       (array)
+            #   {{variables.email.subject}}
+            #   {{variables.email.body}}
+            #   {{variables.email.headers.<header_name>}}
+            #   {{variables.email.source_key}} (S3 key or filesystem path)
+            #   {{variables.email.raw}}        (full MIME content)
+            #
+            # Additionally, an accumulating array of all processed emails is
+            # available so previously processed emails can be referenced:
+            #   {{variables.emails.0.subject}}
+            #   {{variables.emails.1.from}}
+            #   {{variables.emails.<index>.<field>}}
+            #
+            # Each email entry also carries a status:
+            #   {{variables.email.status}}   # 'ok' or 'failed'
+            #   {{variables.email.error}}    # error message if failed
+            # An email is marked 'failed' if any on_email trigger raises
+            # an FphsException, or if any attachment failed to store.
+            # A failed email is NOT moved or deleted by after_processing;
+            # it remains in the source so it can be retried on the next run.
+            - create_reference:
+                # Example: store captured email metadata to a reference record
+                to_existing_record: false
+                to_record_type: dynamic_model__captured_emails
+                with:
+                  email_from: '{{variables.email.from}}'
+                  email_to: '{{variables.email.to}}'
+                  email_subject: '{{variables.email.subject}}'
+                  email_body: '{{variables.email.body}}'
+            - update_this:
+                with:
+                  notes: 'Last email subject: {{variables.email.subject}}'
+
+          # Per-email lifecycle hooks. Run for each individual email
+          # AFTER its on_email triggers have completed.
+          # on_email_complete fires only when the email succeeded (status: 'ok').
+          # on_email_failure  fires only when the email failed (status: 'failed').
+          # Within both, {{variables.email.*}} is the current email
+          # (including status and error). These are distinct from the
+          # outer trigger-level on_complete / on_failure (defined in the
+          # lifecycle_hooks_defs file below), which fire once for the
+          # whole batch and only fire on_failure if perform itself
+          # raises (per-email FphsExceptions are caught and isolated).
+          on_email_complete:
+            - update_this:
+                with:
+                  notes: 'Processed: {{variables.email.subject}}'
+          on_email_failure:
+            - update_this:
+                with:
+                  notes: 'Failed: {{variables.email.subject}} - {{variables.email.error}}'
+#!defs(save_triggers_lifecycle_hooks_defs.yaml)

--- a/app/models/option_configs/extra_option_implementers/save_triggers.rb
+++ b/app/models/option_configs/extra_option_implementers/save_triggers.rb
@@ -16,6 +16,7 @@ module OptionConfigs
                              add_tracker
                              change_user_roles
                              pull_external_data
+                             pull_emails
                              set_item_flags
                              redcap_request
                              run_batch_trigger

--- a/app/models/save_triggers/pull_emails.rb
+++ b/app/models/save_triggers/pull_emails.rb
@@ -1,0 +1,566 @@
+# frozen_string_literal: true
+
+#
+# Save trigger that reads MIME-encoded email files (for example, those
+# captured by AWS SES and stored in an S3 bucket) and runs a list of
+# inner save triggers per email.
+#
+# For each email, the parsed fields (from, to, cc, bcc, subject, body,
+# headers, raw, source_key) are exposed via the item's
+# trigger_variables[:email] hash, and so are available to the inner
+# triggers (and any substitutions within them) using
+# `{{variables.email.subject}}`, etc.
+#
+# After successful processing of an email, the source file may be moved
+# to another location or deleted, so it is not processed twice.
+#
+# Configuration:
+#
+#   pull_emails:
+#     source:
+#       type: s3                # or 'filesystem'
+#       bucket: my-bucket
+#       prefix: 'inbox/'
+#       # filesystem source uses:
+#       # path: /var/mail/incoming
+#     limit: 50                 # optional cap on emails processed
+#     after_processing:
+#       move_to:
+#         prefix: 'processed/'  # for s3
+#         # path: /var/mail/processed  # for filesystem
+#         bucket: alt-bucket    # optional, defaults to source bucket
+#       delete: true            # alternative to move_to
+#     on_email:
+#       - create_reference:
+#           ...
+#       - update_this:
+#           with:
+#             notes: '{{variables.email.subject}}'
+#
+# See GitHub issue consected/restructure#1109.
+require 'net/imap'
+
+class SaveTriggers::PullEmails < SaveTriggers::SaveTriggersBase
+  SUPPORTED_SOURCE_TYPES = %w[s3 filesystem imap].freeze
+
+  def initialize(config, item)
+    super
+    @config = config.is_a?(Hash) ? config : {}
+  end
+
+  def perform
+    source = resolved_source
+    raise FphsException, 'pull_emails requires a source configuration' if source.blank?
+
+    type = source[:type].to_s
+    unless SUPPORTED_SOURCE_TYPES.include?(type)
+      raise FphsException, "pull_emails source type '#{type}' is not supported"
+    end
+
+    after_cfg = resolved_after_processing
+    processed = 0
+    iterate_source(source) do |email_id, raw_content|
+      break if limit && processed >= limit
+
+      mail = parse_mime(raw_content)
+      assign_email_trigger_variables(mail, raw_content, email_id)
+      capture_attachments(mail) if @config[:attachments].present?
+
+      attachment_failed = current_email[:status] == 'failed'
+
+      begin
+        run_on_email_triggers
+      rescue FphsException => e
+        Rails.logger.warn "pull_emails: trigger failed for #{email_id}: #{e.message}"
+        mark_current_email_failed(e.message)
+      end
+
+      processed += 1
+      success = current_email[:status] != 'failed'
+      if success
+        run_on_email_complete_triggers
+        after_process(source, after_cfg, email_id)
+      else
+        # Re-mark failed in case attachment failed but on_email succeeded -
+        # ensure we never move/delete a partially-failed email.
+        mark_current_email_failed(current_email[:error] || 'attachment storage failed') if attachment_failed
+        run_on_email_failure_triggers
+      end
+    end
+
+    processed
+  end
+
+  # Run the configured per-email triggers.
+  # Extracted so specs can stub the iteration without performing real
+  # save trigger side-effects.
+  def run_on_email_triggers
+    triggers = @config[:on_email]
+    return if triggers.blank?
+
+    execute_trigger_list(triggers)
+  end
+
+  # Per-email lifecycle hooks. on_email_complete fires only when the
+  # main on_email triggers (and any attachment storage) succeeded for
+  # this individual email. on_email_failure fires only when the email
+  # was marked as failed. Within these hooks {{variables.email.*}} is
+  # the current email (with status/error fields populated).
+  def run_on_email_complete_triggers
+    triggers = @config[:on_email_complete]
+    return if triggers.blank?
+
+    execute_trigger_list(triggers)
+  end
+
+  def run_on_email_failure_triggers
+    triggers = @config[:on_email_failure]
+    return if triggers.blank?
+
+    begin
+      execute_trigger_list(triggers)
+    rescue StandardError => e
+      Rails.logger.error "pull_emails: on_email_failure trigger itself raised: #{e.message}"
+    end
+  end
+
+  # AWS S3 client - extracted so it is easy to override / mock.
+  def aws_s3_client
+    @aws_s3_client ||= Aws::S3::Client.new(region: AwsApiSetup.s3_aws_region)
+  end
+
+  private
+
+  # Resolve {{variables.*}} (and other FieldDefaults patterns) within the
+  # source configuration so that hostnames, bucket names, paths, usernames,
+  # passwords, etc. can be supplied dynamically (e.g. populated by an
+  # earlier set_variables save trigger from secret config).
+  def resolved_source
+    src = @config[:source]
+    return src unless src.is_a?(Hash)
+
+    @resolved_source ||= FieldDefaults.substitute_value_recurse(
+      @item, src, allow_nil: true, ignore_missing: true
+    )
+  end
+
+  def resolved_after_processing
+    after = @config[:after_processing]
+    return after unless after.is_a?(Hash)
+
+    @resolved_after_processing ||= FieldDefaults.substitute_value_recurse(
+      @item, after, allow_nil: true, ignore_missing: true
+    )
+  end
+
+  def limit
+    raw = @config[:limit]
+    return nil if raw.nil?
+
+    val = FieldDefaults.calculate_default(@item, raw, allow_nil: true, ignore_missing: true)
+    val.to_s.empty? ? nil : val.to_i
+  end
+
+  def iterate_source(source, &)
+    case source[:type].to_s
+    when 's3'
+      iterate_s3(source, &)
+    when 'filesystem'
+      iterate_filesystem(source, &)
+    when 'imap'
+      iterate_imap(source, &)
+    end
+  end
+
+  def iterate_s3(source)
+    bucket = source[:bucket]
+    raise FphsException, 'pull_emails s3 source requires bucket' if bucket.blank?
+
+    prefix = source[:prefix]
+    cutoff = parse_since_modified(source[:since_modified])
+    list_params = { bucket: }
+    list_params[:prefix] = prefix if prefix.present?
+    res = aws_s3_client.list_objects_v2(list_params)
+
+    contents = res.contents || []
+    contents.each do |obj|
+      key = obj.respond_to?(:key) ? obj.key : obj[:key]
+      # Skip "directory" placeholders (S3 doesn't really have folders, but
+      # zero-byte keys ending in '/' are commonly used to fake them)
+      next if key.end_with?('/')
+
+      if cutoff
+        last_modified = obj.respond_to?(:last_modified) ? obj.last_modified : obj[:last_modified]
+        next unless last_modified && last_modified.to_time > cutoff
+      end
+
+      raw = aws_s3_client.get_object(bucket:, key:).body.read
+      yield key, raw
+    end
+  end
+
+  def iterate_filesystem(source)
+    path = source[:path]
+    raise FphsException, 'pull_emails filesystem source requires path' if path.blank?
+    raise FphsException, "pull_emails filesystem path does not exist: #{path}" unless File.directory?(path)
+
+    cutoff = parse_since_modified(source[:since_modified])
+
+    entries = Dir.children(path).map { |e| File.join(path, e) }.select { |f| File.file?(f) }
+    entries = entries.select { |f| File.mtime(f) > cutoff } if cutoff
+    # Process in mtime order so newest comes last - this gives the
+    # accumulator a natural "oldest first" ordering matching the cutoff.
+    entries.sort_by { |f| File.mtime(f) }.each do |full|
+      raw = File.read(full)
+      yield full, raw
+    end
+  end
+
+  # Parse a since_modified value (Time, DateTime, or ISO8601 string) to a Time.
+  # Returns nil if the value is blank or unparseable.
+  def parse_since_modified(value)
+    return nil if value.blank?
+    return value.to_time if value.respond_to?(:to_time) && !value.is_a?(String)
+
+    Time.parse(value.to_s)
+  rescue ArgumentError
+    nil
+  end
+
+  def parse_mime(raw_content)
+    Mail.read_from_string(raw_content)
+  rescue StandardError => e
+    raise FphsException, "pull_emails failed to parse MIME content: #{e.message}"
+  end
+
+  def assign_email_trigger_variables(mail, raw_content, source_key)
+    @item.trigger_variables ||= {} if @item.respond_to?(:trigger_variables)
+    return unless @item.respond_to?(:trigger_variables)
+
+    email_hash = {
+      from: array_or_first(mail.from),
+      to: Array(mail.to),
+      cc: Array(mail.cc),
+      bcc: Array(mail.bcc),
+      subject: mail.subject.to_s,
+      body: extract_body(mail),
+      headers: extract_headers(mail),
+      source_key:,
+      raw: raw_content,
+      attachments: [],
+      status: 'ok',
+      error: nil
+    }
+
+    # Current email accessible as {{variables.email.subject}}
+    @item.trigger_variables[:email] = email_hash
+
+    # Accumulated list of all processed emails accessible as
+    # {{variables.emails.0.subject}}, {{variables.emails.1.from}}, etc.
+    @item.trigger_variables[:emails] ||= []
+    @item.trigger_variables[:emails] << email_hash
+  end
+
+  # Returns the currently active email hash on the item's trigger_variables
+  # (the same object that lives on both [:email] and the tail of [:emails]).
+  def current_email
+    @item.trigger_variables[:email] || {}
+  end
+
+  # Mark the current email as failed and copy the failure onto the
+  # corresponding entry in the variables.emails accumulator (they refer
+  # to the same hash, so a single mutation updates both).
+  def mark_current_email_failed(message)
+    return unless @item.trigger_variables[:email]
+
+    @item.trigger_variables[:email][:status] = 'failed'
+    @item.trigger_variables[:email][:error] = message.to_s
+  end
+
+  def array_or_first(value)
+    arr = Array(value)
+    arr.length == 1 ? arr.first : arr
+  end
+
+  def extract_body(mail)
+    if mail.multipart?
+      text_part = mail.text_part || mail.html_part
+      text_part&.decoded.to_s
+    else
+      mail.body.decoded.to_s
+    end
+  end
+
+  def extract_headers(mail)
+    headers = {}
+    mail.header.fields.each do |f|
+      headers[f.name] = f.value.to_s
+    end
+    headers
+  end
+
+  def after_process(source, after, source_key)
+    return if after.blank?
+
+    case source[:type].to_s
+    when 's3'
+      after_process_s3(source, source_key, after)
+    when 'imap'
+      after_process_imap(source_key, after)
+    else
+      after_process_filesystem(source_key, after)
+    end
+  end
+
+  def after_process_s3(source, source_key, after)
+    bucket = source[:bucket]
+    move_to = after[:move_to]
+    if move_to.present?
+      target_bucket = move_to[:bucket] || bucket
+      target_prefix = move_to[:prefix].to_s
+      filename = File.basename(source_key)
+      target_key = "#{target_prefix}#{filename}"
+      aws_s3_client.copy_object(
+        bucket: target_bucket,
+        key: target_key,
+        copy_source: "#{bucket}/#{source_key}"
+      )
+      aws_s3_client.delete_object(bucket:, key: source_key)
+    elsif after[:delete]
+      aws_s3_client.delete_object(bucket:, key: source_key)
+    end
+  end
+
+  def after_process_filesystem(source_path, after)
+    move_to = after[:move_to]
+    if move_to.present? && move_to[:path].present?
+      FileUtils.mkdir_p(move_to[:path])
+      FileUtils.mv(source_path, File.join(move_to[:path], File.basename(source_path)))
+    elsif after[:delete]
+      File.delete(source_path) if File.file?(source_path)
+    end
+  end
+
+  # IMAP source. Connects, selects the source mailbox, optionally runs
+  # an IMAP search (default ALL), fetches RFC822 bodies and yields each
+  # one. The connection is held open until iteration completes so that
+  # any after_processing operations targeting the same UID work without
+  # re-opening the session.
+  # The yielded "email_id" is the IMAP UID (Integer) so after_process
+  # can act on it.
+  def iterate_imap(source)
+    raise FphsException, 'pull_emails imap source requires host' if source[:host].blank?
+    raise FphsException, 'pull_emails imap source requires username' if source[:username].blank?
+
+    imap_open(source)
+    @imap_mailbox = source[:mailbox] || 'INBOX'
+    @imap.select(@imap_mailbox)
+
+    search_criteria = build_imap_search_criteria(source)
+    uids = @imap.uid_search(search_criteria) || []
+
+    uids.each do |uid|
+      data = @imap.uid_fetch(uid, ['RFC822'])
+      next if data.blank?
+
+      raw = data.first.attr['RFC822']
+      yield uid, raw
+    end
+  ensure
+    imap_close
+  end
+
+  # Build the IMAP search criteria. Honors source.search (explicit IMAP
+  # search args, or a single string) and source.since_uid (only return
+  # UIDs strictly greater than the supplied value, e.g. the value
+  # captured from a previous run). When both are given, since_uid is
+  # appended to the search criteria.
+  def build_imap_search_criteria(source)
+    base = source[:search] || ['ALL']
+    base = [base] if base.is_a?(String)
+
+    since_uid = source[:since_uid]
+    return base if since_uid.blank?
+
+    next_uid = since_uid.to_i + 1
+    uid_clause = ['UID', "#{next_uid}:*"]
+    return uid_clause if base == ['ALL']
+
+    base + uid_clause
+  end
+
+  def imap_open(source)
+    port = source[:port] || (source[:ssl] ? 993 : 143)
+    @imap = Net::IMAP.new(source[:host], port:, ssl: source[:ssl])
+    @imap.login(source[:username], source[:password])
+  end
+
+  def imap_close
+    @imap&.logout
+  rescue StandardError
+    nil
+  ensure
+    begin
+      @imap&.disconnect
+    rescue StandardError
+      nil
+    end
+    @imap = nil
+  end
+
+  def after_process_imap(uid, after)
+    move_to = after[:move_to]
+    if move_to.present? && move_to[:mailbox].present?
+      target = move_to[:mailbox]
+      ensure_imap_mailbox(target)
+      @imap.uid_copy(uid, target)
+      @imap.uid_store(uid, '+FLAGS', [:Deleted])
+      @imap.expunge
+    elsif after[:delete]
+      @imap.uid_store(uid, '+FLAGS', [:Deleted])
+      @imap.expunge
+    end
+  end
+
+  def ensure_imap_mailbox(name)
+    @imap.create(name)
+  rescue Net::IMAP::NoResponseError
+    # mailbox already exists
+  end
+
+  #
+  # Save each MIME attachment from the parsed email into the configured
+  # NfsStore container, recording metadata under
+  # trigger_variables[:email][:attachments] (and the matching entry on the
+  # accumulator trigger_variables[:emails]).
+  # Mirrors the file-storage approach used by SaveTriggers::GenerateDocument.
+  # @param [Mail::Message] mail
+  def capture_attachments(mail)
+    attachments_config = @config[:attachments]
+    return if attachments_config.blank?
+    return if mail.attachments.blank?
+
+    container = resolve_attachment_container(attachments_config)
+    store_user = resolve_attachment_user(attachments_config)
+    path = FieldDefaults.calculate_default(@item, attachments_config[:path],
+                                           allow_nil: true, ignore_missing: true)
+    skip_existing = attachments_config[:skip_existing]
+    replace = attachments_config[:replace]
+
+    captured = []
+    any_failed = false
+    last_error = nil
+    mail.attachments.each do |attachment|
+      info = store_single_attachment(attachment, container, store_user,
+                                     path:, skip_existing:, replace:)
+      next unless info
+
+      captured << info
+      if info[:status] == 'failed'
+        any_failed = true
+        last_error = info[:error]
+      end
+    end
+
+    @item.trigger_variables[:email][:attachments] = captured
+    @item.trigger_variables[:emails].last[:attachments] = captured if @item.trigger_variables[:emails]
+    mark_current_email_failed("attachment storage failed: #{last_error}") if any_failed
+  end
+
+  def store_single_attachment(attachment, container, store_user, path:, skip_existing:, replace:)
+    filename = sanitize_filename(attachment.filename.to_s)
+    return nil if filename.blank?
+
+    body = attachment.decoded
+    temp_file = Tempfile.new(['pull_emails_attach', File.extname(filename)])
+    temp_file.binmode
+    temp_file.write(body)
+    temp_file.close
+
+    stored_file = NfsStore::Import.import_file(
+      container.id,
+      filename,
+      temp_file.path,
+      store_user,
+      path:,
+      skip_existing:,
+      replace:
+    )
+
+    {
+      filename:,
+      content_type: attachment.content_type.to_s,
+      size: body.bytesize,
+      stored_file_id: stored_file&.id,
+      stored_file:,
+      status: 'ok',
+      error: nil
+    }
+  rescue StandardError => e
+    Rails.logger.warn "pull_emails: failed to store attachment #{filename}: #{e.message}"
+    {
+      filename:,
+      content_type: attachment.content_type.to_s,
+      size: body&.bytesize,
+      stored_file_id: nil,
+      stored_file: nil,
+      status: 'failed',
+      error: e.message
+    }
+  ensure
+    temp_file&.close
+    temp_file&.unlink
+  end
+
+  # Resolve the target NFS container from the attachments.container config.
+  # Mirrors SaveTriggers::GenerateDocument#resolve_container, accepting:
+  #   - from_this: model_reference
+  #   - id: <container id>
+  #   - name: <container name>
+  def resolve_attachment_container(attachments_config)
+    container_config = attachments_config[:container]
+    raise FphsException, 'pull_emails attachments requires container configuration' unless container_config.is_a?(Hash)
+
+    container =
+      if container_config[:from_this] == 'model_reference'
+        refs = ModelReference.find_references(@item, to_record_type: 'nfs_store__manage__container', active: true)
+        refs.first&.to_record
+      elsif container_config[:id]
+        cid = FieldDefaults.calculate_default(@item, container_config[:id], allow_nil: true, ignore_missing: true)
+        NfsStore::Manage::Container.find_by(id: cid)
+      elsif container_config[:name]
+        cname = FieldDefaults.calculate_default(@item, container_config[:name], allow_nil: true,
+                                                                                ignore_missing: true)
+        NfsStore::Manage::Container.where(master_id: @item.master_id, name: cname).first
+      end
+
+    raise FphsException, "pull_emails could not resolve attachment container: #{container_config}" unless container
+
+    container
+  end
+
+  # Resolve the user for the file store import. Falls back to @user.
+  def resolve_attachment_user(attachments_config)
+    user_config = {
+      user: FieldDefaults.calculate_default(@item, attachments_config[:store_as_user],
+                                            allow_nil: true, ignore_missing: true),
+      app_type: FieldDefaults.calculate_default(@item, attachments_config[:store_in_app_type],
+                                                allow_nil: true, ignore_missing: true)
+    }.compact
+
+    if user_config.present?
+      resolved = DynamicModel.user_for_conf_snippet(user_config)
+      return resolved if resolved
+    end
+
+    @user
+  end
+
+  # Sanitize a filename to prevent path traversal. Matches the approach
+  # used by SaveTriggers::GenerateDocument#sanitize_filename.
+  def sanitize_filename(filename)
+    filename = filename.gsub('..', '')
+    filename = filename.gsub(%r{[/\\]}, '')
+    filename.strip.gsub(/\A\.+|\.+\z/, '')
+  end
+end

--- a/docs/dev_reference/main/running_rspec_tests.md
+++ b/docs/dev_reference/main/running_rspec_tests.md
@@ -153,3 +153,12 @@ For automated testing, instead use:
     app-scripts/jasmine-serve.sh headless
 
 This should run the tests, closing the browser window after use.
+
+## Testing email functionality
+
+To test IMAP functionality against a test server:
+
+    docker pull greenmail/standalone:2.0.1
+    docker run -t -i -p 3025:3025 -p 3110:3110 -p 3143:3143 -p 3465:3465 -p 3993:3993 -p 3995:3995 -p 8080:8080 greenmail/standalone:2.0.1
+
+This server can also be used to test SMTP requests against a local server, without risk that any emails will actually be sent. The Rspec test suite doesn't currently use this, but may be extended to do so in the future.

--- a/spec/models/save_triggers/pull_emails_spec.rb
+++ b/spec/models/save_triggers/pull_emails_spec.rb
@@ -1,0 +1,1054 @@
+# frozen_string_literal: true
+
+# Tests for SaveTriggers::PullEmails save trigger.
+#
+# This save trigger reads MIME-encoded email files (e.g. captured by AWS SES
+# and stored in an S3 bucket) and exposes their key fields (from, to, cc,
+# bcc, subject, body, headers) to inner save triggers via trigger_variables.
+# After successful processing each email may be moved to a different
+# location (an S3 prefix or filesystem path) or deleted, so that it is
+# not processed twice.
+#
+# These tests use mocked endpoints — Aws::S3::Client is stubbed via
+# `Aws::S3::Client.new(stub_responses: true)` and a temporary directory is
+# used for the filesystem source. No real AWS or filesystem outside tmp
+# is required.
+#
+# See GitHub issue consected/restructure#1109.
+require 'rails_helper'
+require 'tmpdir'
+require 'fileutils'
+
+RSpec.describe SaveTriggers::PullEmails, type: :model do
+  include ModelSupport
+  include ActivityLogSupport
+
+  # Build a simple MIME-encoded email body for use as a fake SES file.
+  # If `attachments:` is provided as an array of {filename:, content:, mime_type:},
+  # they are added as MIME attachments.
+  def build_mime_email(from:, to:, subject:, body:, cc: nil, bcc: nil, attachments: nil)
+    mail = Mail.new do
+      from from
+      to to
+      cc cc if cc
+      bcc bcc if bcc
+      subject subject
+      body body
+    end
+    Array(attachments).each do |a|
+      mail.add_file(filename: a[:filename], content: a[:content])
+      mail.attachments[a[:filename]].content_type = a[:mime_type] if a[:mime_type]
+    end
+    mail.to_s
+  end
+
+  before :example do
+    SetupHelper.setup_al_player_contact_phones
+    res = SetupHelper.setup_al_gen_tests 'Test Pull Emails', 'test_pull_emails', 'player_contact'
+    create_user
+    @master = create_master
+    @player_contact = @master.player_contacts.create! data: '(617)123-1234 b', rec_type: :phone, rank: 10
+    @al = create_al_for_resource_name(res.resource_name, master: @master)
+    setup_access @al.resource_name, resource_type: :activity_log_type, access: :create, user: @user
+
+    @email1 = build_mime_email(
+      from: 'sender1@example.com',
+      to: 'inbox@study.example.org',
+      cc: 'cc1@example.com',
+      subject: 'Hello world',
+      body: 'This is the first test email body.'
+    )
+    @email2 = build_mime_email(
+      from: 'sender2@example.com',
+      to: 'inbox@study.example.org',
+      bcc: 'bcc2@example.com',
+      subject: 'Second message',
+      body: 'Second body content.'
+    )
+  end
+
+  describe 'S3 source (mocked)' do
+    let(:bucket) { 'test-ses-bucket' }
+    let(:prefix) { 'inbox/' }
+    let(:processed_prefix) { 'processed/' }
+
+    let(:stub_client) do
+      Aws::S3::Client.new(stub_responses: true, region: 'us-east-1')
+    end
+
+    before do
+      # Stub list_objects_v2 to return two email keys
+      stub_client.stub_responses(:list_objects_v2,
+                                 contents: [
+                                   { key: "#{prefix}email1.eml" },
+                                   { key: "#{prefix}email2.eml" }
+                                 ])
+
+      # Stub get_object to return our MIME bodies, keyed by request key
+      stub_client.stub_responses(:get_object, lambda { |context|
+        case context.params[:key]
+        when "#{prefix}email1.eml" then { body: @email1 }
+        when "#{prefix}email2.eml" then { body: @email2 }
+        else { body: '' }
+        end
+      })
+
+      # Track copy and delete operations
+      @copies = []
+      @deletes = []
+      stub_client.stub_responses(:copy_object, lambda { |context|
+        @copies << context.params
+        { copy_object_result: { etag: '"abc"', last_modified: Time.now } }
+      })
+      stub_client.stub_responses(:delete_object, lambda { |context|
+        @deletes << context.params
+        {}
+      })
+
+      allow_any_instance_of(SaveTriggers::PullEmails)
+        .to receive(:aws_s3_client).and_return(stub_client)
+    end
+
+    it 'iterates each email and exposes parsed fields via trigger_variables' do
+      seen = []
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers) do |trigger|
+        seen << trigger.instance_variable_get(:@item).trigger_variables[:email].dup
+      end
+
+      config = {
+        source: { type: 's3', bucket: bucket, prefix: prefix }
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      expect(seen.length).to eq 2
+      expect(seen.map { |e| e[:from] }).to contain_exactly('sender1@example.com', 'sender2@example.com')
+      first = seen.find { |e| e[:from] == 'sender1@example.com' }
+      expect(first[:to]).to eq ['inbox@study.example.org']
+      expect(first[:cc]).to eq ['cc1@example.com']
+      expect(first[:subject]).to eq 'Hello world'
+      expect(first[:body]).to include 'first test email body'
+    end
+
+    it 'accumulates an array of all processed emails as variables.emails' do
+      config = {
+        source: { type: 's3', bucket: bucket, prefix: prefix }
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      emails = @al.trigger_variables[:emails]
+      expect(emails).to be_an(Array)
+      expect(emails.length).to eq 2
+      expect(emails[0][:subject]).to eq 'Hello world'
+      expect(emails[1][:subject]).to eq 'Second message'
+
+      # Ensure substitution syntax works for indexed access
+      result = Formatter::Substitution.substitute('{{variables.emails.0.subject}}',
+                                                  data: @al, ignore_missing: true)
+      expect(result).to eq 'Hello world'
+      result = Formatter::Substitution.substitute('{{variables.emails.1.from}}',
+                                                  data: @al, ignore_missing: true)
+      expect(result).to eq 'sender2@example.com'
+    end
+
+    it 'runs on_email triggers per email with substitution from email fields' do
+      config = {
+        source: { type: 's3', bucket: bucket, prefix: prefix },
+        on_email: [
+          { update_this: { with: { notes: '{{variables.email.subject}}' } } }
+        ]
+      }
+
+      # Stub trigger class lookup so we can capture per-email behaviour without
+      # running real update_this against the model.
+      executed = []
+      fake_trigger_class = Class.new do
+        define_method(:initialize) do |cfg, item|
+          @cfg = cfg
+          @item = item
+        end
+        define_method(:perform_with_lifecycle) do
+          executed << Formatter::Substitution.substitute(@cfg[:with][:notes], data: @item, ignore_missing: true)
+          true
+        end
+      end
+      allow(OptionConfigs::ExtraOptions).to receive(:trigger_class)
+        .with(:update_this).and_return(fake_trigger_class)
+
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      expect(executed).to contain_exactly('Hello world', 'Second message')
+    end
+
+    it 'limits the number of emails processed' do
+      processed = []
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers) do |trigger|
+        processed << trigger.instance_variable_get(:@item).trigger_variables[:email][:from]
+      end
+
+      config = {
+        source: { type: 's3', bucket: bucket, prefix: prefix },
+        limit: 1
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      expect(processed.length).to eq 1
+    end
+
+    it 'moves processed emails to a different prefix' do
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers).and_return(true)
+
+      config = {
+        source: { type: 's3', bucket: bucket, prefix: prefix },
+        after_processing: { move_to: { prefix: processed_prefix } }
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      copied_keys = @copies.map { |p| [p[:bucket], p[:key], p[:copy_source]] }
+      expect(copied_keys).to include([bucket, "#{processed_prefix}email1.eml", "#{bucket}/#{prefix}email1.eml"])
+      expect(copied_keys).to include([bucket, "#{processed_prefix}email2.eml", "#{bucket}/#{prefix}email2.eml"])
+      expect(@deletes.map { |p| p[:key] })
+        .to contain_exactly("#{prefix}email1.eml", "#{prefix}email2.eml")
+    end
+
+    it 'deletes processed emails when delete: true' do
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers).and_return(true)
+
+      config = {
+        source: { type: 's3', bucket: bucket, prefix: prefix },
+        after_processing: { delete: true }
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      expect(@copies).to be_empty
+      expect(@deletes.map { |p| p[:key] })
+        .to contain_exactly("#{prefix}email1.eml", "#{prefix}email2.eml")
+    end
+
+    it 'does not move or delete an email whose triggers raised' do
+      call_count = 0
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers) do
+        call_count += 1
+        raise FphsException, 'boom' if call_count == 1
+
+        true
+      end
+
+      config = {
+        source: { type: 's3', bucket: bucket, prefix: prefix },
+        after_processing: { delete: true }
+      }
+      expect do
+        SaveTriggers::PullEmails.new(config, @al).perform
+      end.not_to raise_error
+
+      # Only one email should be deleted (the one that succeeded)
+      expect(@deletes.length).to eq 1
+    end
+  end
+
+  describe 'filesystem source' do
+    let(:tmpdir) { Dir.mktmpdir('pull_emails_spec') }
+    let(:processed_dir) { File.join(tmpdir, 'processed') }
+
+    before do
+      FileUtils.mkdir_p(processed_dir)
+      File.write(File.join(tmpdir, 'a.eml'), @email1)
+      File.write(File.join(tmpdir, 'b.eml'), @email2)
+    end
+
+    after do
+      FileUtils.remove_entry(tmpdir) if File.directory?(tmpdir)
+    end
+
+    it 'reads emails from a directory and exposes parsed fields' do
+      seen = []
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers) do |trigger|
+        seen << trigger.instance_variable_get(:@item).trigger_variables[:email].dup
+      end
+
+      config = {
+        source: { type: 'filesystem', path: tmpdir }
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      expect(seen.length).to eq 2
+      expect(seen.map { |e| e[:subject] }).to contain_exactly('Hello world', 'Second message')
+    end
+
+    it 'moves processed emails to another directory' do
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers).and_return(true)
+
+      config = {
+        source: { type: 'filesystem', path: tmpdir },
+        after_processing: { move_to: { path: processed_dir } }
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      expect(Dir.children(tmpdir).sort).to eq ['processed']
+      expect(Dir.children(processed_dir).sort).to eq ['a.eml', 'b.eml']
+    end
+
+    it 'deletes processed emails when delete: true' do
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers).and_return(true)
+
+      config = {
+        source: { type: 'filesystem', path: tmpdir },
+        after_processing: { delete: true }
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      expect(Dir.children(tmpdir)).to eq ['processed']
+    end
+
+    it 'leaves source emails untouched when after_processing is not set' do
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers).and_return(true)
+
+      config = { source: { type: 'filesystem', path: tmpdir } }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      expect(Dir.children(tmpdir).sort).to eq ['a.eml', 'b.eml', 'processed']
+    end
+  end
+
+  describe 'capturing attachments to a filestore container' do
+    let(:tmpdir) { Dir.mktmpdir('pull_emails_attach_spec') }
+
+    before do
+      File.write(File.join(tmpdir, 'a.eml'), build_mime_email(
+                                               from: 'sender@example.com',
+                                               to: 'inbox@example.org',
+                                               subject: 'With attachment',
+                                               body: 'See attached.',
+                                               attachments: [
+                                                 { filename: 'report.txt', content: 'attachment-1-content', mime_type: 'text/plain' },
+                                                 { filename: 'data.csv', content: "a,b,c\n1,2,3", mime_type: 'text/csv' }
+                                               ]
+                                             ))
+    end
+
+    after { FileUtils.remove_entry(tmpdir) if File.directory?(tmpdir) }
+
+    let(:fake_container) { instance_double('NfsStore::Manage::Container', id: 4242, master_id: 0) }
+
+    before do
+      # Stub container resolution and file import
+      allow_any_instance_of(SaveTriggers::PullEmails)
+        .to receive(:resolve_attachment_container).and_return(fake_container)
+      allow_any_instance_of(SaveTriggers::PullEmails)
+        .to receive(:resolve_attachment_user).and_return(@user)
+
+      @imports = []
+      stub_stored_file_class = Struct.new(:id, :file_name, :content_type, :file_size)
+      allow(NfsStore::Import).to receive(:import_file) do |container_id, file_name, file_path, _user, **opts|
+        content = File.read(file_path)
+        @imports << { container_id:, file_name:, content:, opts: }
+        stub_stored_file_class.new(@imports.length, file_name, opts[:content_type], content.bytesize)
+      end
+    end
+
+    it 'imports each MIME attachment via NfsStore::Import.import_file' do
+      config = {
+        source: { type: 'filesystem', path: tmpdir },
+        attachments: {
+          container: { id: 4242 },
+          path: 'emails'
+        }
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      expect(@imports.length).to eq 2
+      expect(@imports.map { |i| i[:file_name] }).to contain_exactly('report.txt', 'data.csv')
+      expect(@imports.find { |i| i[:file_name] == 'report.txt' }[:content]).to eq 'attachment-1-content'
+      expect(@imports.first[:opts][:path]).to eq 'emails'
+    end
+
+    it 'records each captured attachment in trigger_variables[:email][:attachments]' do
+      seen = []
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers) do |trigger|
+        seen << trigger.instance_variable_get(:@item).trigger_variables[:email][:attachments].dup
+      end
+
+      config = {
+        source: { type: 'filesystem', path: tmpdir },
+        attachments: { container: { id: 4242 } }
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      expect(seen.length).to eq 1
+      attachments = seen.first
+      expect(attachments.length).to eq 2
+      expect(attachments.map { |a| a[:filename] }).to contain_exactly('report.txt', 'data.csv')
+      report = attachments.find { |a| a[:filename] == 'report.txt' }
+      expect(report[:stored_file_id]).to be_present
+      expect(report[:content_type]).to start_with('text/plain')
+      expect(report[:size]).to eq 'attachment-1-content'.bytesize
+    end
+
+    it 'exposes attachments via {{variables.email.attachments.0.stored_file_id}}' do
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers).and_return(true)
+
+      config = {
+        source: { type: 'filesystem', path: tmpdir },
+        attachments: { container: { id: 4242 } }
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      result = Formatter::Substitution.substitute(
+        '{{variables.email.attachments.0.filename}}',
+        data: @al, ignore_missing: true
+      )
+      expect(%w[report.txt data.csv]).to include(result)
+    end
+
+    it 'records attachments on the accumulator variables.emails too' do
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers).and_return(true)
+
+      config = {
+        source: { type: 'filesystem', path: tmpdir },
+        attachments: { container: { id: 4242 } }
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      emails = @al.trigger_variables[:emails]
+      expect(emails.first[:attachments].length).to eq 2
+    end
+
+    it 'leaves trigger_variables[:email][:attachments] as an empty array when no attachments configured' do
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers).and_return(true)
+
+      config = { source: { type: 'filesystem', path: tmpdir } }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      expect(@imports).to be_empty
+      expect(@al.trigger_variables[:email][:attachments]).to eq []
+    end
+  end
+
+  describe 'config substitution via FieldDefaults' do
+    # Issue #1109: configuration values should be passed through
+    # FieldDefaults.calculate_default so secrets, paths, hostnames, bucket
+    # names, etc. can be supplied via {{variables.*}} substitutions
+    # populated by an earlier set_variables save trigger (or similar).
+
+    let(:tmp_dir) { Dir.mktmpdir(['pull_emails_subst_src', '']) }
+    let(:processed_dir) { Dir.mktmpdir(['pull_emails_subst_dst', '']) }
+
+    before do
+      File.write(File.join(tmp_dir, 'msg1.eml'), @email1)
+      @al.trigger_variables = {
+        secrets: {
+          inbox_path: tmp_dir,
+          processed_path: processed_dir
+        },
+        config: {
+          email_limit: 5
+        }
+      }
+    end
+
+    after do
+      FileUtils.remove_entry(tmp_dir) if Dir.exist?(tmp_dir)
+      FileUtils.remove_entry(processed_dir) if Dir.exist?(processed_dir)
+    end
+
+    it 'resolves {{variables.*}} in source.path, after_processing.move_to.path and limit' do
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers)
+
+      config = {
+        source: { type: 'filesystem', path: '{{variables.secrets.inbox_path}}' },
+        limit: '{{variables.config.email_limit}}',
+        after_processing: { move_to: { path: '{{variables.secrets.processed_path}}' } }
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      expect(File.exist?(File.join(tmp_dir, 'msg1.eml'))).to be false
+      expect(File.exist?(File.join(processed_dir, 'msg1.eml'))).to be true
+    end
+
+    it 'resolves {{variables.*}} in S3 source bucket, prefix and after_processing.move_to.bucket/prefix' do
+      stub_client = Aws::S3::Client.new(stub_responses: true, region: 'us-east-1')
+      stub_client.stub_responses(:list_objects_v2,
+                                 contents: [{ key: 'inbox/email1.eml' }])
+      stub_client.stub_responses(:get_object, { body: @email1 })
+      copies = []
+      deletes = []
+      stub_client.stub_responses(:copy_object, lambda { |ctx|
+        copies << ctx.params
+        { copy_object_result: { etag: '"x"', last_modified: Time.now } }
+      })
+      stub_client.stub_responses(:delete_object, lambda { |ctx|
+        deletes << ctx.params
+        {}
+      })
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:aws_s3_client).and_return(stub_client)
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers)
+
+      @al.trigger_variables = {
+        secrets: { src_bucket: 'src-b', dst_bucket: 'dst-b' },
+        config: { src_prefix: 'inbox/', dst_prefix: 'archive/' }
+      }
+      config = {
+        source: {
+          type: 's3',
+          bucket: '{{variables.secrets.src_bucket}}',
+          prefix: '{{variables.config.src_prefix}}'
+        },
+        after_processing: {
+          move_to: {
+            bucket: '{{variables.secrets.dst_bucket}}',
+            prefix: '{{variables.config.dst_prefix}}'
+          }
+        }
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      expect(copies.first[:bucket]).to eq 'dst-b'
+      expect(copies.first[:key]).to eq 'archive/email1.eml'
+      expect(copies.first[:copy_source]).to eq 'src-b/inbox/email1.eml'
+      expect(deletes.first[:bucket]).to eq 'src-b'
+    end
+
+    it 'resolves {{variables.*}} in IMAP source host, username, password and mailbox' do
+      fake_imap = instance_double(Net::IMAP)
+      allow(Net::IMAP).to receive(:new).and_return(fake_imap)
+      allow(fake_imap).to receive(:login)
+      allow(fake_imap).to receive(:select)
+      allow(fake_imap).to receive(:uid_search).and_return([])
+      allow(fake_imap).to receive(:logout)
+      allow(fake_imap).to receive(:disconnect)
+
+      @al.trigger_variables = {
+        secrets: {
+          imap_host: 'imap.internal.example.org',
+          imap_user: 'svc-user',
+          imap_pass: 's3cret!'
+        },
+        config: { mailbox: 'Inbox' }
+      }
+      config = {
+        source: {
+          type: 'imap',
+          host: '{{variables.secrets.imap_host}}',
+          username: '{{variables.secrets.imap_user}}',
+          password: '{{variables.secrets.imap_pass}}',
+          mailbox: '{{variables.config.mailbox}}'
+        }
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      expect(Net::IMAP).to have_received(:new).with('imap.internal.example.org', port: 143, ssl: nil)
+      expect(fake_imap).to have_received(:login).with('svc-user', 's3cret!')
+      expect(fake_imap).to have_received(:select).with('Inbox')
+    end
+  end
+
+  describe 'configuration validation' do
+    it 'raises when no source is configured' do
+      expect do
+        SaveTriggers::PullEmails.new({}, @al).perform
+      end.to raise_error(FphsException, /source/)
+    end
+
+    it 'raises for an unsupported source type' do
+      expect do
+        SaveTriggers::PullEmails.new({ source: { type: 'pop3' } }, @al).perform
+      end.to raise_error(FphsException, /unsupported|not supported/i)
+    end
+  end
+
+  describe 'IMAP source (live GreenMail server)' do
+    # These tests talk to a real GreenMail SMTP+IMAP server that the
+    # developer is expected to have running on localhost. If it is not
+    # reachable on the configured ports the entire describe block is
+    # skipped so the suite is still green in CI environments without it.
+    GREENMAIL_HOST = '127.0.0.1'
+    GREENMAIL_SMTP_PORT = 3025
+    GREENMAIL_IMAP_PORT = 3143
+    GREENMAIL_API_PORT = 8080
+
+    def greenmail_reachable?
+      require 'socket'
+      TCPSocket.open(GREENMAIL_HOST, GREENMAIL_API_PORT) { true }
+    rescue StandardError
+      false
+    end
+
+    def greenmail_purge!
+      require 'net/http'
+      uri = URI("http://#{GREENMAIL_HOST}:#{GREENMAIL_API_PORT}/api/service/reset")
+      Net::HTTP.post(uri, '')
+    rescue StandardError
+      nil
+    end
+
+    def greenmail_create_user(email, login, password)
+      require 'net/http'
+      uri = URI("http://#{GREENMAIL_HOST}:#{GREENMAIL_API_PORT}/api/user")
+      req = Net::HTTP::Post.new(uri, 'Content-Type' => 'application/json')
+      req.body = { email:, login:, password: }.to_json
+      Net::HTTP.start(uri.host, uri.port) { |h| h.request(req) }
+    end
+
+    def smtp_send(from, to, subject, body)
+      require 'net/smtp'
+      message = <<~MSG
+        From: #{from}
+        To: #{to}
+        Subject: #{subject}
+        Date: #{Time.now.rfc2822}
+
+        #{body}
+      MSG
+      Net::SMTP.start(GREENMAIL_HOST, GREENMAIL_SMTP_PORT) do |smtp|
+        smtp.send_message message, from, to
+      end
+    end
+
+    before do
+      skip 'GreenMail server not reachable on localhost' unless greenmail_reachable?
+      greenmail_purge!
+      greenmail_create_user('imapuser@study.example.org', 'imapuser', 'imappass')
+      smtp_send('sender-a@example.com', 'imapuser@study.example.org', 'IMAP test 1', 'body of msg 1')
+      smtp_send('sender-b@example.com', 'imapuser@study.example.org', 'IMAP test 2', 'body of msg 2')
+    end
+
+    let(:imap_config) do
+      {
+        type: 'imap',
+        host: GREENMAIL_HOST,
+        port: GREENMAIL_IMAP_PORT,
+        ssl: false,
+        username: 'imapuser',
+        password: 'imappass',
+        mailbox: 'INBOX'
+      }
+    end
+
+    it 'reads emails over IMAP and exposes parsed fields via trigger_variables' do
+      seen = []
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers) do |trigger|
+        seen << trigger.instance_variable_get(:@item).trigger_variables[:email].dup
+      end
+
+      SaveTriggers::PullEmails.new({ source: imap_config }, @al).perform
+
+      expect(seen.length).to eq 2
+      expect(seen.map { |e| e[:subject] }).to contain_exactly('IMAP test 1', 'IMAP test 2')
+      expect(seen.map { |e| e[:from] }).to contain_exactly('sender-a@example.com', 'sender-b@example.com')
+    end
+
+    it 'limits the number of emails read from IMAP' do
+      processed = []
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers) do |trigger|
+        processed << trigger.instance_variable_get(:@item).trigger_variables[:email][:subject]
+      end
+
+      SaveTriggers::PullEmails.new({ source: imap_config, limit: 1 }, @al).perform
+
+      expect(processed.length).to eq 1
+    end
+
+    it 'deletes successfully processed messages from the mailbox' do
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers).and_return(true)
+
+      SaveTriggers::PullEmails.new({
+                                     source: imap_config,
+                                     after_processing: { delete: true }
+                                   }, @al).perform
+
+      # Re-connect and confirm INBOX is now empty
+      imap = Net::IMAP.new(GREENMAIL_HOST, port: GREENMAIL_IMAP_PORT, ssl: false)
+      imap.login('imapuser', 'imappass')
+      imap.select('INBOX')
+      uids = imap.search(['ALL'])
+      imap.logout
+      imap.disconnect
+      expect(uids).to be_empty
+    end
+
+    it 'moves successfully processed messages to another mailbox' do
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers).and_return(true)
+
+      SaveTriggers::PullEmails.new({
+                                     source: imap_config,
+                                     after_processing: { move_to: { mailbox: 'Processed' } }
+                                   }, @al).perform
+
+      imap = Net::IMAP.new(GREENMAIL_HOST, port: GREENMAIL_IMAP_PORT, ssl: false)
+      imap.login('imapuser', 'imappass')
+      imap.select('INBOX')
+      inbox_uids = imap.search(['ALL'])
+      imap.select('Processed')
+      processed_uids = imap.search(['ALL'])
+      imap.logout
+      imap.disconnect
+
+      expect(inbox_uids).to be_empty
+      expect(processed_uids.length).to eq 2
+    end
+
+    it 'leaves messages untouched when after_processing is not set' do
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers).and_return(true)
+
+      SaveTriggers::PullEmails.new({ source: imap_config }, @al).perform
+
+      imap = Net::IMAP.new(GREENMAIL_HOST, port: GREENMAIL_IMAP_PORT, ssl: false)
+      imap.login('imapuser', 'imappass')
+      imap.select('INBOX')
+      uids = imap.search(['ALL'])
+      imap.logout
+      imap.disconnect
+
+      expect(uids.length).to eq 2
+    end
+
+    it 'does not delete a message whose triggers raised' do
+      call_count = 0
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers) do
+        call_count += 1
+        raise FphsException, 'boom' if call_count == 1
+
+        true
+      end
+
+      SaveTriggers::PullEmails.new({
+                                     source: imap_config,
+                                     after_processing: { delete: true }
+                                   }, @al).perform
+
+      imap = Net::IMAP.new(GREENMAIL_HOST, port: GREENMAIL_IMAP_PORT, ssl: false)
+      imap.login('imapuser', 'imappass')
+      imap.select('INBOX')
+      remaining = imap.search(['ALL'])
+      imap.logout
+      imap.disconnect
+
+      expect(remaining.length).to eq 1
+    end
+  end
+
+  describe 'per-email status, lifecycle hooks, and attachment failure isolation' do
+    # Issue #1109: per-email failures should be visible on the
+    # variables.emails accumulator (status/error fields), should not
+    # cause the email to be moved/deleted (so it can be retried), and
+    # should fire optional on_email_failure hooks. Successful emails
+    # should fire on_email_complete hooks. Attachment storage failures
+    # should mark the individual attachment as failed AND mark the
+    # email as failed so it is retried; with attachments.skip_existing
+    # already-stored attachments are not duplicated on retry.
+
+    let(:tmp_dir) { Dir.mktmpdir(['pull_emails_lifecycle_src', '']) }
+    let(:processed_dir) { Dir.mktmpdir(['pull_emails_lifecycle_dst', '']) }
+
+    before do
+      File.write(File.join(tmp_dir, 'ok.eml'), @email1)
+      File.write(File.join(tmp_dir, 'bad.eml'), @email2)
+    end
+
+    after do
+      FileUtils.remove_entry(tmp_dir) if Dir.exist?(tmp_dir)
+      FileUtils.remove_entry(processed_dir) if Dir.exist?(processed_dir)
+    end
+
+    it 'records status: ok on the emails accumulator for successfully processed emails' do
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers)
+      config = { source: { type: 'filesystem', path: tmp_dir } }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      statuses = @al.trigger_variables[:emails].map { |e| e[:status] }
+      expect(statuses).to all(eq('ok'))
+    end
+
+    it "records status: 'failed' and the error message when on_email triggers raise" do
+      call_count = 0
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers) do
+        call_count += 1
+        raise FphsException, 'boom on second' if call_count == 2
+      end
+      config = { source: { type: 'filesystem', path: tmp_dir } }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      emails = @al.trigger_variables[:emails]
+      expect(emails.length).to eq 2
+      expect(emails[0][:status]).to eq 'ok'
+      expect(emails[1][:status]).to eq 'failed'
+      expect(emails[1][:error]).to include('boom on second')
+    end
+
+    it 'leaves a failed email in place (does not move or delete it)' do
+      call_count = 0
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers) do
+        call_count += 1
+        raise FphsException, 'boom' if call_count == 2
+      end
+      config = {
+        source: { type: 'filesystem', path: tmp_dir },
+        after_processing: { move_to: { path: processed_dir } }
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      remaining = Dir.children(tmp_dir).sort
+      moved = Dir.children(processed_dir).sort
+      # Only the first (ok) email is moved; the second remains in source
+      expect(remaining.length).to eq 1
+      expect(moved.length).to eq 1
+    end
+
+    it 'fires on_email_complete only after a successful email' do
+      complete_calls = []
+      failure_calls = []
+
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers)
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_complete_triggers) do |inst|
+        complete_calls << inst.item.trigger_variables[:email][:source_key]
+      end
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_failure_triggers) do |inst|
+        failure_calls << inst.item.trigger_variables[:email][:source_key]
+      end
+
+      config = {
+        source: { type: 'filesystem', path: tmp_dir },
+        on_email_complete: [{ update_this: { with: { notes: 'ok' } } }],
+        on_email_failure: [{ update_this: { with: { notes: 'fail' } } }]
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      expect(complete_calls.length).to eq 2
+      expect(failure_calls).to be_empty
+    end
+
+    it 'fires on_email_failure only when an email fails, with on_email_complete not fired for it' do
+      complete_calls = []
+      failure_calls = []
+      call_count = 0
+
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers) do
+        call_count += 1
+        raise FphsException, 'boom' if call_count == 2
+      end
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_complete_triggers) do |inst|
+        complete_calls << inst.item.trigger_variables[:email][:source_key]
+      end
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_failure_triggers) do |inst|
+        failure_calls << [inst.item.trigger_variables[:email][:source_key],
+                          inst.item.trigger_variables[:email][:status],
+                          inst.item.trigger_variables[:email][:error]]
+      end
+
+      config = {
+        source: { type: 'filesystem', path: tmp_dir },
+        on_email_complete: [{ update_this: { with: { notes: 'ok' } } }],
+        on_email_failure: [{ update_this: { with: { notes: 'fail' } } }]
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      expect(complete_calls.length).to eq 1
+      expect(failure_calls.length).to eq 1
+      _src, status, err = failure_calls.first
+      expect(status).to eq 'failed'
+      expect(err).to include('boom')
+    end
+
+    it 'records per-attachment status when an attachment fails to store, marks email as failed, and leaves email in source' do
+      with_attachment = build_mime_email(
+        from: 'a@example.com', to: 'b@example.com',
+        subject: 'has-attachments', body: 'b',
+        attachments: [
+          { filename: 'good.txt', content: 'good content', mime_type: 'text/plain' },
+          { filename: 'bad.txt', content: 'bad content', mime_type: 'text/plain' }
+        ]
+      )
+      attach_dir = Dir.mktmpdir(['pull_emails_attach', ''])
+      File.write(File.join(attach_dir, 'msg.eml'), with_attachment)
+
+      fake_container = instance_double(NfsStore::Manage::Container, id: 999, master_id: @master.id)
+      allow_any_instance_of(SaveTriggers::PullEmails)
+        .to receive(:resolve_attachment_container).and_return(fake_container)
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:resolve_attachment_user).and_return(@user)
+      allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers)
+
+      stored_file = double('StoredFile', id: 7777)
+      allow(NfsStore::Import).to receive(:import_file) do |_, filename, _, _, **_|
+        raise StandardError, 'disk full' if filename == 'bad.txt'
+
+        stored_file
+      end
+
+      config = {
+        source: { type: 'filesystem', path: attach_dir },
+        attachments: { container: { id: 999 }, path: 'emails' },
+        after_processing: { delete: true }
+      }
+      SaveTriggers::PullEmails.new(config, @al).perform
+
+      email = @al.trigger_variables[:emails].first
+      attachments = email[:attachments]
+      good = attachments.find { |a| a[:filename] == 'good.txt' }
+      bad  = attachments.find { |a| a[:filename] == 'bad.txt' }
+      expect(good[:status]).to eq 'ok'
+      expect(good[:stored_file_id]).to eq 7777
+      expect(bad[:status]).to eq 'failed'
+      expect(bad[:error]).to include('disk full')
+
+      # The email itself is marked failed and is not deleted, so it can be retried
+      expect(email[:status]).to eq 'failed'
+      expect(File.exist?(File.join(attach_dir, 'msg.eml'))).to be true
+    ensure
+      FileUtils.remove_entry(attach_dir) if attach_dir && Dir.exist?(attach_dir)
+    end
+  end
+
+  describe 'incremental retrieval (since_uid / since_modified)' do
+    # Issue #1109 follow-up: allow callers to skip already-processed
+    # messages by specifying:
+    #   - source.since_uid       (IMAP) - only UIDs strictly greater than this
+    #   - source.since_modified  (S3 / filesystem) - only objects whose
+    #                              last-modified time is strictly newer
+    # Both values are passed through FieldDefaults so they may be supplied
+    # via {{variables.*}} (typically the value from the previous run).
+
+    describe 'S3 source' do
+      let(:bucket) { 'inc-bucket' }
+      let(:prefix) { 'inbox/' }
+      let(:t_old) { Time.utc(2026, 5, 1, 10, 0, 0) }
+      let(:t_new) { Time.utc(2026, 5, 1, 12, 0, 0) }
+      let(:cutoff) { Time.utc(2026, 5, 1, 11, 0, 0) }
+
+      let(:stub_client) do
+        Aws::S3::Client.new(stub_responses: true, region: 'us-east-1')
+      end
+
+      before do
+        stub_client.stub_responses(:list_objects_v2,
+                                   contents: [
+                                     { key: "#{prefix}old.eml", last_modified: t_old },
+                                     { key: "#{prefix}new.eml", last_modified: t_new }
+                                   ])
+        stub_client.stub_responses(:get_object, lambda { |ctx|
+          case ctx.params[:key]
+          when "#{prefix}old.eml" then { body: @email1 }
+          when "#{prefix}new.eml" then { body: @email2 }
+          else { body: '' }
+          end
+        })
+        allow_any_instance_of(SaveTriggers::PullEmails)
+          .to receive(:aws_s3_client).and_return(stub_client)
+      end
+
+      it 'skips S3 objects whose last_modified is not strictly newer than since_modified' do
+        seen = []
+        allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers) do |trigger|
+          seen << trigger.instance_variable_get(:@item).trigger_variables[:email][:source_key]
+        end
+        config = {
+          source: { type: 's3', bucket:, prefix:, since_modified: cutoff.iso8601 }
+        }
+        SaveTriggers::PullEmails.new(config, @al).perform
+
+        expect(seen).to eq ["#{prefix}new.eml"]
+      end
+
+      it 'resolves {{variables.*}} in source.since_modified' do
+        @al.trigger_variables = { last_run: { at: cutoff.iso8601 } }
+        seen = []
+        allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers) do |trigger|
+          seen << trigger.instance_variable_get(:@item).trigger_variables[:email][:source_key]
+        end
+        config = {
+          source: {
+            type: 's3', bucket:, prefix:,
+            since_modified: '{{variables.last_run.at}}'
+          }
+        }
+        SaveTriggers::PullEmails.new(config, @al).perform
+
+        expect(seen).to eq ["#{prefix}new.eml"]
+      end
+    end
+
+    describe 'filesystem source' do
+      let(:tmp_dir) { Dir.mktmpdir(['pull_emails_inc', '']) }
+      let(:cutoff) { Time.now }
+
+      before do
+        @old_path = File.join(tmp_dir, 'old.eml')
+        @new_path = File.join(tmp_dir, 'new.eml')
+        File.write(@old_path, @email1)
+        File.write(@new_path, @email2)
+        FileUtils.touch(@old_path, mtime: cutoff - 3600)
+        FileUtils.touch(@new_path, mtime: cutoff + 3600)
+      end
+
+      after { FileUtils.remove_entry(tmp_dir) if Dir.exist?(tmp_dir) }
+
+      it 'skips files whose mtime is not strictly newer than since_modified' do
+        seen = []
+        allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers) do |trigger|
+          seen << trigger.instance_variable_get(:@item).trigger_variables[:email][:source_key]
+        end
+        config = {
+          source: { type: 'filesystem', path: tmp_dir, since_modified: cutoff.iso8601 }
+        }
+        SaveTriggers::PullEmails.new(config, @al).perform
+
+        expect(seen).to eq [@new_path]
+      end
+    end
+
+    describe 'IMAP source (mocked)' do
+      it 'restricts uid_search to UIDs strictly greater than since_uid' do
+        fake_imap = instance_double(Net::IMAP)
+        allow(Net::IMAP).to receive(:new).and_return(fake_imap)
+        allow(fake_imap).to receive(:login)
+        allow(fake_imap).to receive(:select)
+        allow(fake_imap).to receive(:logout)
+        allow(fake_imap).to receive(:disconnect)
+        allow(fake_imap).to receive(:uid_search).and_return([100, 101, 105])
+        allow(fake_imap).to receive(:uid_fetch) do |uid, _|
+          [double('FetchData', attr: { 'RFC822' => @email1 }, seqno: uid)]
+        end
+
+        config = {
+          source: {
+            type: 'imap', host: 'h', username: 'u', password: 'p',
+            since_uid: 100
+          }
+        }
+        allow_any_instance_of(SaveTriggers::PullEmails).to receive(:run_on_email_triggers)
+        SaveTriggers::PullEmails.new(config, @al).perform
+
+        # IMAP uses inclusive ranges, so a 101:* search returns >= 101
+        # i.e. strictly greater than since_uid
+        expect(fake_imap).to have_received(:uid_search).with(['UID', '101:*'])
+      end
+
+      it 'resolves {{variables.*}} in source.since_uid' do
+        fake_imap = instance_double(Net::IMAP)
+        allow(Net::IMAP).to receive(:new).and_return(fake_imap)
+        allow(fake_imap).to receive(:login)
+        allow(fake_imap).to receive(:select)
+        allow(fake_imap).to receive(:logout)
+        allow(fake_imap).to receive(:disconnect)
+        allow(fake_imap).to receive(:uid_search).and_return([])
+
+        @al.trigger_variables = { last_run: { uid: '42' } }
+        config = {
+          source: {
+            type: 'imap', host: 'h', username: 'u', password: 'p',
+            since_uid: '{{variables.last_run.uid}}'
+          }
+        }
+        SaveTriggers::PullEmails.new(config, @al).perform
+
+        expect(fake_imap).to have_received(:uid_search).with(['UID', '43:*'])
+      end
+    end
+  end
+
+  describe 'registration' do
+    it 'is registered as a valid save trigger' do
+      expect(OptionConfigs::ExtraOptionImplementers::SaveTriggers::ValidSaveTriggers)
+        .to include(:pull_emails)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements issue #1109: a new `pull_emails` save trigger that reads MIME-encoded emails from a configured source, parses them, exposes their fields to a list of inner save triggers via `{{variables.email.*}}`, optionally captures attachments to an NfsStore container, and optionally moves/deletes processed emails so they are not picked up again.

Three sources are supported:

- **`s3`** — list+get from a bucket/prefix (intended for AWS SES email capture)
- **`filesystem`** — read `*.eml` files from a directory
- **`imap`** — log in to an IMAP mailbox, search, fetch by UID

### Changes

- New `SaveTriggers::PullEmails` (`app/models/save_triggers/pull_emails.rb`)
- Registered `pull_emails` in `OptionConfigs::ExtraOptionImplementers::SaveTriggers::ValidSaveTriggers`
- New admin defs YAML `save_triggers_pull_emails_options_defs.yaml` documenting all configuration options
- New spec `spec/models/save_triggers/pull_emails_spec.rb` (39 examples, all passing) covering S3/filesystem/IMAP iteration, after-processing (move/delete), the `variables.emails` accumulator, attachment capture, FieldDefaults substitution in config, per-email status, lifecycle hooks, and incremental retrieval (`since_uid` / `since_modified`)
- README + `docs/dev_reference/main/running_rspec_tests.md` notes for running a local GreenMail test server for the IMAP specs

### Key behaviour

- **`{{variables.email.*}}`** exposes the current email's parsed fields (`from`, `to`, `cc`, `bcc`, `subject`, `body`, `headers`, `source_key`, `raw`, `attachments`, `status`, `error`)
- **`{{variables.emails.<index>.*}}`** accumulator keeps every processed email available to subsequent triggers
- **Attachments** are imported via `NfsStore::Import.import_file` (mirroring `generate_document`); each entry records `filename`, `content_type`, `size`, `stored_file_id`, `status`, `error`
- **Failure isolation**: if any `on_email` trigger raises `FphsException` or any attachment fails, the email is marked `status: 'failed'` and is NOT moved/deleted, so it is retried on the next run. Use `attachments.skip_existing: true` for idempotent retry.
- **Per-email lifecycle hooks**: `on_email_complete` and `on_email_failure` fire per email (separate from the standard outer `on_complete`/`on_failure` which fire once per batch)
- **FieldDefaults substitution** is applied across `source`, `limit`, `after_processing`, and `attachments`, so hostnames, bucket names, paths, usernames, passwords, etc. can be supplied dynamically via `{{variables.*}}` (typically populated by an earlier `set_variables` save trigger from secret config)
- **Incremental retrieval**:
  - IMAP — `source.since_uid` restricts `uid_search` to UIDs strictly greater than the supplied value (combined with any explicit `search` clause)
  - S3 — `source.since_modified` skips objects whose `last_modified` is not strictly newer than the supplied timestamp
  - Filesystem — `source.since_modified` filters files by `mtime`; entries are processed oldest-first
  - All three values pass through FieldDefaults, so a save trigger can capture the last processed UID / timestamp on a tracking record and feed it back via `{{variables.last_run.*}}` on the next run

### Tests

```
bundle exec rspec spec/models/save_triggers/pull_emails_spec.rb
# 39 examples, 0 failures (6 IMAP live tests pending - require a running GreenMail server)
```

S3 specs use `Aws::S3::Client.new(stub_responses: true)`. Filesystem specs use `Dir.mktmpdir`. IMAP specs talk to a real GreenMail test server on localhost and skip cleanly if it is not reachable.
