### PR TITLE
Added warn logging for failed API authentication attempts - fixes #1114

### DIFF
--- a/config/initializers/reopen_devise.rb
+++ b/config/initializers/reopen_devise.rb
@@ -115,4 +115,20 @@ Rails.application.config.to_prepare do
       throw(:warden, scope:, message: 'This account is configured for API access only.')
     end
   end
+
+  Warden::Manager.send(:before_failure) do |env|
+    # Log failed API authentication attempts
+    request = Rack::Request.new(env)
+    user_token = request.params['user_token']
+    user_email = request.params['user_email']
+    app_type = request.params['use_app_type']
+
+    # Only log if this appears to be an API request
+    if user_token.present? || user_email.present?
+      log_message = "API authentication failed: path=#{request.path}, method=#{request.request_method}, " \
+                    "user_email=#{user_email || 'not_provided'}, app_type=#{app_type || 'not_specified'}, " \
+                    "reason=#{env['warden.options']&.dig(:reason) || 'unknown'}"
+      Rails.logger.warn(log_message)
+    end
+  end
 end

--- a/config/initializers/reopen_devise.rb
+++ b/config/initializers/reopen_devise.rb
@@ -125,8 +125,11 @@ Rails.application.config.to_prepare do
 
     # Only log if this appears to be an API request
     if user_token.present? || user_email.present?
+      # Strip newlines from user-supplied values to prevent log injection
+      safe_email = (user_email || 'not_provided').gsub(/[\r\n]/, '')
+      safe_app_type = (app_type || 'not_specified').gsub(/[\r\n]/, '')
       log_message = "API authentication failed: path=#{request.path}, method=#{request.request_method}, " \
-                    "user_email=#{user_email || 'not_provided'}, app_type=#{app_type || 'not_specified'}, " \
+                    "user_email=#{safe_email}, app_type=#{safe_app_type}, " \
                     "reason=#{env['warden.options']&.dig(:reason) || 'unknown'}"
       Rails.logger.warn(log_message)
     end

--- a/spec/requests/api_auth_failure_logging_spec.rb
+++ b/spec/requests/api_auth_failure_logging_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# This spec tests that failed API authentication attempts are logged to the Rails logger
+# at warn severity, with appropriate context including request path, HTTP method, and
+# failure reason. This helps detect bad credentials, integration mistakes, and probing.
+
+describe 'API authentication failure logging', type: :request do
+  include ModelSupport
+  include MasterSupport
+
+  before(:all) do
+    SetupHelper.feature_setup
+    change_setting('TwoFactorAuthDisabledForUser', false)
+
+    @user, @good_password = create_user(nil, '', create_master: true)
+    @user_authentication_token = @user.authentication_token
+    expect(@user_authentication_token).to be_present
+    @good_email = @user.email
+    @good_app_type = @user.app_type_id
+  end
+
+  after(:all) do
+    # Cleanup
+  end
+
+  describe 'failed API authentication attempts' do
+    it 'logs a warn message when API request has a bad user_token' do
+      # Arrange: Stub Rails.logger to capture warn calls
+      allow(Rails.logger).to receive(:warn).and_call_original
+
+      # Act: Make an API request with a bad token
+      get '/masters.json',
+          params: {
+            use_app_type: @good_app_type,
+            user_email: @good_email,
+            user_token: 'invalid_token_xyz'
+          }
+
+      # Assert: Response should be unauthenticated
+      expect(response).to have_http_status(:unauthorized)
+      expect(JSON.parse(response.body)['error']).to eq 'You need to sign in or sign up before continuing.'
+
+      # Assert: Verify that a warn message was logged
+      expect(Rails.logger).to have_received(:warn).with(
+        a_string_matching(/API.*authentication.*fail|failed.*API.*auth|invalid.*token|bad.*token/i)
+      )
+    end
+
+    it 'logs a warn message when API request has a bad user email' do
+      # Arrange
+      allow(Rails.logger).to receive(:warn).and_call_original
+
+      # Act: Make an API request with a bad email
+      get '/masters.json',
+          params: {
+            use_app_type: @good_app_type,
+            user_email: 'nonexistent@example.com',
+            user_token: @user_authentication_token
+          }
+
+      # Assert: Response should be unauthenticated
+      expect(response).to have_http_status(:unauthorized)
+      expect(JSON.parse(response.body)['error']).to eq 'You need to sign in or sign up before continuing.'
+
+      # Assert: Verify that a warn message was logged
+      expect(Rails.logger).to have_received(:warn).with(
+        a_string_matching(/API.*authentication.*fail|failed.*API.*auth|unknown.*user|invalid.*user/i)
+      )
+    end
+
+    it 'logs a warn message when API request has no user_token' do
+      # Arrange
+      allow(Rails.logger).to receive(:warn).and_call_original
+
+      # Act: Make an API request with no token
+      get '/masters.json',
+          params: {
+            use_app_type: @good_app_type,
+            user_email: @good_email
+          }
+
+      # Assert: Response should be unauthenticated
+      expect(response).to have_http_status(:unauthorized)
+      expect(JSON.parse(response.body)['error']).to eq 'You need to sign in or sign up before continuing.'
+
+      # Assert: Verify that a warn message was logged
+      expect(Rails.logger).to have_received(:warn).with(
+        a_string_matching(/API.*authentication.*fail|missing.*token|no.*token|unauthenticated/i)
+      )
+    end
+
+    it 'does not log sensitive tokens in the warn message' do
+      # Arrange: Verify filtered params configuration
+      expect(Rails.application.config.filter_parameters).to include(:user_token)
+
+      allow(Rails.logger).to receive(:warn).and_call_original
+
+      # Act: Make an API request with a bad token
+      bad_token = 'super_secret_bad_token_12345'
+      get '/masters.json',
+          params: {
+            use_app_type: @good_app_type,
+            user_email: @good_email,
+            user_token: bad_token
+          }
+
+      # Assert: Verify that the warn message does not contain the actual token
+      expect(Rails.logger).to have_received(:warn) do |message|
+        expect(message).not_to include(bad_token)
+        expect(message).not_to include('super_secret')
+      end
+    end
+
+    it 'logs request context in the warn message' do
+      # Arrange
+      allow(Rails.logger).to receive(:warn).and_call_original
+
+      # Act: Make an API request with a bad token
+      get '/masters.json',
+          params: {
+            use_app_type: @good_app_type,
+            user_email: @good_email,
+            user_token: 'badtoken'
+          }
+
+      # Assert: Verify that context is logged (path, method, email, app_type)
+      expect(Rails.logger).to have_received(:warn).with(
+        a_string_matching(/masters|GET|#{Regexp.escape(@good_email)}|use_app_type|#{@good_app_type}/)
+      )
+    end
+
+    it 'does not log warn when API request succeeds with good token' do
+      # Arrange
+      allow(Rails.logger).to receive(:warn).and_call_original
+
+      # Create a master record for the user so we can query it
+      master = create_master(@user)
+
+      # Act: Make an authenticated API request with good token to get a specific master
+      get "/masters/#{master.id}.json",
+          params: {
+            use_app_type: @good_app_type,
+            user_email: @good_email,
+            user_token: @user_authentication_token
+          }
+
+      # Assert: Response should be successful (200 or redirect that succeeds)
+      expect([200, 301, 302]).to include(response.status)
+
+      # Assert: Verify that NO warn message related to auth failure was logged
+      # (normal request logs are okay, we're just checking for failure-specific warns)
+      expect(Rails.logger).not_to have_received(:warn).with(
+        a_string_matching(/API.*authentication.*fail|failed.*API.*auth/i)
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds warn-level logging for failed API authentication attempts so that bad credentials, integration mistakes, and probing attempts are visible in the Rails log for investigation.

### Changes

- **config/initializers/reopen_devise.rb**: Added a `Warden::Manager.before_failure` callback that fires whenever Warden is about to return an authentication failure. When the request carries API authentication parameters (`user_token` or `user_email`), a `warn`-level log message is emitted with:
  - Request path and HTTP method
  - Provided `user_email` (non-sensitive)
  - App type if present
  - Warden failure reason
  - The raw `user_token` is **never** included (already filtered by Rails `filter_parameters`)

- **spec/requests/api_auth_failure_logging_spec.rb**: New request spec with 6 test cases covering:
  - Bad `user_token` triggers warn log
  - Bad `user_email` triggers warn log
  - Missing `user_token` triggers warn log
  - Sensitive token value does not appear in the log message
  - Request context (path, method, email, app_type) is present in the log
  - Successful authentication does **not** trigger a failure warn log

### Validation

All 6 new specs pass. All 17 request specs pass with no regressions.

Fixes #1114