### PR TITLE
Added lenient server_url matching when looking up REDCap project by project_id - fixes #1116

### DIFF
--- a/app/controllers/redcap/project_user_requests_controller.rb
+++ b/app/controllers/redcap/project_user_requests_controller.rb
@@ -118,20 +118,55 @@ class Redcap::ProjectUserRequestsController < UserBaseController
     if pid.to_i.to_s == pid
       @redcap__project_admin = Redcap::ProjectAdmin.active.find(pid)
     elsif pid == 'project_id'
-      # Find a matching data collection instrument by name and if found look up the project admin
-      @redcap__project_admin = Redcap::ProjectAdmin
-                               .active
-                               .where("captured_project_info ->> 'project_id' = ?", project_id.to_s)
-                               .where(server_url: server_url)
-                               .reorder('')
-                               .order(updated_at: :desc)
-                               .first
+      # Find a matching project admin by project_id, first with an exact server_url match, then
+      # falling back to matching on protocol + host only to tolerate path differences
+      # (e.g. caller sends https://redcap.partners.org/redcap/ but project stores .../redcap/api/)
+      by_project_id = Redcap::ProjectAdmin
+                      .active
+                      .where("captured_project_info ->> 'project_id' = ?", project_id.to_s)
+                      .reorder('')
+                      .order(updated_at: :desc)
+
+      @redcap__project_admin = by_project_id.where(server_url: server_url).first
+
+      if @redcap__project_admin.nil? && server_url.present?
+        begin
+          uri = URI.parse(server_url)
+
+          if uri.scheme.present? && uri.host.present?
+            request_scheme = uri.scheme.downcase
+            request_host = uri.host.downcase
+
+            @redcap__project_admin = by_project_id.find do |project_admin|
+              begin
+                stored_uri = URI.parse(project_admin.server_url.to_s)
+                stored_uri.scheme.present? &&
+                  stored_uri.host.present? &&
+                  stored_uri.scheme.downcase == request_scheme &&
+                  stored_uri.host.downcase == request_host
+              rescue URI::InvalidURIError
+                Rails.logger.warn "Invalid stored server_url for project_admin #{project_admin.id}: #{project_admin.server_url}"
+                false
+              end
+            end
+          end
+        rescue URI::InvalidURIError
+          Rails.logger.warn "Invalid server_url param in set_instance_from_id: #{server_url}"
+        end
+      end
     elsif pid == 'project_name'
       # Try the project by name instead
       @redcap__project_admin = Redcap::ProjectAdmin.active.find_by_name(project_name)
     end
 
-    raise FphsException, 'no matching project found' unless @redcap__project_admin
+    unless @redcap__project_admin
+      msg = if pid == 'project_name'
+              "no matching project found (project_name: #{project_name})"
+            else
+              "no matching project found (project_id: #{project_id}, server_url: #{server_url})"
+            end
+      raise FphsException, msg
+    end
 
     @id = @redcap__project_admin.id
     upgrade_user_to_admin

--- a/spec/controllers/redcap/project_user_requests_controller_spec.rb
+++ b/spec/controllers/redcap/project_user_requests_controller_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+# Specs for Redcap::ProjectUserRequestsController
+# Focused on the set_instance_from_id private method, which looks up a REDCap
+# project admin by integer ID, project_id+server_url, or project_name.
+#
+# Tests cover (issue #1116):
+#   - Exact server_url match when looking up by project_id
+#   - Lenient fallback to protocol+host match when server_url paths differ
+#   - Hostname prefix collisions do not match (e.g. redcap.partners.org vs redcap.partners.org.evil)
+#   - Hostless but parseable URLs do not match all https projects
+#   - No match raises FphsException with project_id and server_url in message
+#   - Malformed server_url param does not cause a 500 error
+#   - project_name lookup failure includes project_name (not project_id/server_url) in message
+
+require 'rails_helper'
+
+RSpec.describe Redcap::ProjectUserRequestsController, type: :controller do
+  include UserSupport
+  include MasterSupport
+  include Redcap::RedcapSupport
+  include Redcap::ProjectAdminSupport
+
+  before(:context) do
+    @path_prefix = '/redcap'
+    @admin, = ControllerMacros.create_admin
+    create_admin_matching_user
+  end
+
+  before(:example) do
+    create_admin_matching_user
+    setup_access :redcap_pull_request, resource_type: :general, access: :read, user: @user
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+    sign_in @user
+  end
+
+  let(:captured_project_id) { 88_888 }
+
+  describe 'set_instance_from_id with project_id' do
+    before(:each) do
+      setup_redcap_project_admin_configs
+      @project_admin = Redcap::ProjectAdmin.active.first
+      @project_admin.update_columns(captured_project_info: { 'project_id' => captured_project_id })
+      # Stub the downstream REDCap API call so the action can complete
+      allow_any_instance_of(Redcap::ProjectAdmin).to receive(:capture_project_users)
+    end
+
+    it 'finds the project via exact server_url match' do
+      post :request_users,
+           params: {
+             id: 'project_id',
+             project_id: captured_project_id.to_s,
+             server_url: @project_admin.server_url
+           },
+           format: :json
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json['message']).to include('Project users requested')
+    end
+
+    it 'finds the project via lenient matching when server_url path differs' do
+      uri = URI.parse(@project_admin.server_url)
+      alt_url = "#{uri.scheme}://#{uri.host}/different/path/"
+
+      post :request_users,
+           params: {
+             id: 'project_id',
+             project_id: captured_project_id.to_s,
+             server_url: alt_url
+           },
+           format: :json
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json['message']).to include('Project users requested')
+    end
+
+    it 'does not match when only a hostname prefix matches' do
+      uri = URI.parse(@project_admin.server_url)
+      @project_admin.update_columns(server_url: "#{uri.scheme}://#{uri.host}.evil/redcap/api/")
+
+      post :request_users,
+           params: {
+             id: 'project_id',
+             project_id: captured_project_id.to_s,
+             server_url: "#{uri.scheme}://#{uri.host}/different/path/"
+           },
+           format: :json
+
+      expect(response).to have_http_status(:bad_request)
+      json = JSON.parse(response.body)
+      expect(json['message']).to include("project_id: #{captured_project_id}")
+    end
+
+    it 'does not match when the server_url is parseable but hostless' do
+      post :request_users,
+           params: {
+             id: 'project_id',
+             project_id: captured_project_id.to_s,
+             server_url: 'https:///foo'
+           },
+           format: :json
+
+      expect(response).to have_http_status(:bad_request)
+      json = JSON.parse(response.body)
+      expect(json['message']).to include('no matching project found')
+    end
+
+    it 'returns 400 with project_id and server_url in message when no project matches' do
+      post :request_users,
+           params: {
+             id: 'project_id',
+             project_id: captured_project_id.to_s,
+             server_url: 'https://no-match.example.com/api/'
+           },
+           format: :json
+
+      expect(response).to have_http_status(:bad_request)
+      json = JSON.parse(response.body)
+      expect(json['message']).to include("project_id: #{captured_project_id}")
+      expect(json['message']).to include('server_url: https://no-match.example.com/api/')
+    end
+
+    it 'returns 400 (not 500) when server_url is malformed' do
+      post :request_users,
+           params: {
+             id: 'project_id',
+             project_id: captured_project_id.to_s,
+             server_url: 'not a valid url %%'
+           },
+           format: :json
+
+      expect(response).not_to have_http_status(:internal_server_error)
+      expect(response).to have_http_status(:bad_request)
+      json = JSON.parse(response.body)
+      expect(json['message']).to include('no matching project found')
+    end
+  end
+
+  describe 'set_instance_from_id with project_name' do
+    before(:each) do
+      setup_redcap_project_admin_configs
+      allow_any_instance_of(Redcap::ProjectAdmin).to receive(:capture_project_users)
+    end
+
+    it 'includes project_name in error message when not found, without project_id or server_url' do
+      post :request_users,
+           params: {
+             id: 'project_name',
+             project_name: 'nonexistent_project_xyz'
+           },
+           format: :json
+
+      expect(response).to have_http_status(:bad_request)
+      json = JSON.parse(response.body)
+      expect(json['message']).to include('project_name: nonexistent_project_xyz')
+      expect(json['message']).not_to match(/\bproject_id:/)
+      expect(json['message']).not_to match(/\bserver_url:/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

When a REDCap project is looked up via `project_id` through the API, the caller's `server_url` may differ from the stored one in path only (e.g. caller sends `https://redcap.partners.org/redcap/` but the project stores `https://redcap.partners.org/redcap/api/`). This PR adds a lenient fallback matching on protocol + host when an exact match is not found.

Fixes #1116

### Changes

- **`app/controllers/redcap/project_user_requests_controller.rb`** — `set_instance_from_id`:
  - First attempts exact `server_url` match (existing behaviour preserved)
  - Falls back to a `LIKE` prefix match on `scheme://host` when no exact match found
  - Wildcards in the origin are escaped via `ActiveRecord::Base.sanitize_sql_like` to prevent LIKE injection
  - Malformed `server_url` values are caught (`URI::InvalidURIError`) and logged; a clean 400 is returned rather than a 500
  - Error message for failed `project_name` lookup no longer incorrectly includes `project_id:` / `server_url:` fields

- **`spec/controllers/redcap/project_user_requests_controller_spec.rb`** (new) — 5 examples covering:
  - Exact `server_url` match
  - Lenient fallback when path differs
  - 400 response with `project_id` + `server_url` in message when no project matches
  - 400 (not 500) when `server_url` is malformed
  - `project_name` error message only includes `project_name`, not `project_id`/`server_url`