### PR TITLE
Added request_source tracking to Redcap::DataRecords job requests - resolves #1118

### DIFF
--- a/app/controllers/redcap/project_admins_controller.rb
+++ b/app/controllers/redcap/project_admins_controller.rb
@@ -37,7 +37,7 @@ class Redcap::ProjectAdminsController < AdminController
     ignore_cache = params[:ignore_cache].to_s == 'true'
     retrieve_all = params[:retrieve_all].to_s == 'true'
 
-    @redcap__project_admin.dynamic_storage.request_records(ignore_cache:, retrieve_all:)
+    @redcap__project_admin.dynamic_storage.request_records(ignore_cache:, retrieve_all:, request_source: :admin_ui)
 
     msg = "Records requested at #{DateTime.now}"
     render json: { message: msg }, status: 200

--- a/app/controllers/redcap/project_user_requests_controller.rb
+++ b/app/controllers/redcap/project_user_requests_controller.rb
@@ -18,7 +18,7 @@ class Redcap::ProjectUserRequestsController < UserBaseController
             'set the dynamic model has not been set up'
     end
 
-    @redcap__project_admin.dynamic_storage.request_records
+    @redcap__project_admin.dynamic_storage.request_records(request_source: :api)
 
     msg = "Records requested at #{DateTime.now}"
     render json: { message: msg }, status: 200

--- a/app/jobs/redcap/recurring_pull_task.rb
+++ b/app/jobs/redcap/recurring_pull_task.rb
@@ -44,7 +44,7 @@ module Redcap
       # Schedule an update of the data collection instruments list in the background
       project_admin.request_data_collection_instruments
 
-      dr = Redcap::DataRecords.new(project_admin, class_name, is_manual_pull: false)
+      dr = Redcap::DataRecords.new(project_admin, class_name, is_manual_pull: false, request_source: :scheduled)
       dr.retrieve_validate_store
       project_admin.update_status(:scheduled_run_successful)
     rescue StandardError => e

--- a/app/models/redcap/data_records.rb
+++ b/app/models/redcap/data_records.rb
@@ -22,9 +22,10 @@ module Redcap
                   :skip_store_if_no_survey_identifier, :skipped_ids,
                   :external_id_fkey_name,
                   :retrieved_from_cache, :using_date_range_filter, :is_manual_pull,
-                  :date_range_begin
+                  :date_range_begin,
+                  :request_source
 
-    def initialize(project_admin, class_name, is_manual_pull: false)
+    def initialize(project_admin, class_name, is_manual_pull: false, request_source: nil)
       super()
       self.project_admin = project_admin
       self.class_name = class_name
@@ -50,6 +51,7 @@ module Redcap
       self.retrieved_from_cache = false
       self.using_date_range_filter = false
       self.is_manual_pull = is_manual_pull
+      self.request_source = request_source
     end
 
     #
@@ -65,7 +67,8 @@ module Redcap
       self.job = Redcap::CaptureRecordsJob.perform_later(project_admin, class_name, ignore_cache:, retrieve_all:)
       return if Rails.application.config.active_job.queue_adapter == :inline
 
-      project_admin.record_job_request('setup job: store records', result: { requested: true, job: job&.job_id })
+      source_result = request_source ? { request_source => true } : {}
+      project_admin.record_job_request('setup job: store records', result: { requested: true, job: job&.job_id }.merge(source_result))
     end
 
     #
@@ -706,6 +709,7 @@ module Redcap
         using_date_range_filter:,
         date_range_begin: (date_range_begin if using_date_range_filter)
       }
+      result[request_source] = true if request_source
 
       if create
         project_admin.record_job_request('store records', result:)

--- a/app/models/redcap/dynamic_storage.rb
+++ b/app/models/redcap/dynamic_storage.rb
@@ -40,13 +40,13 @@ module Redcap
     # @see Redcap::CaptureRecordsJob#perform_later
     # @param [Boolean] ignore_cache - force pull from REDCap, bypassing cache
     # @param [Boolean] retrieve_all - ignore export_only_updated_records setting and retrieve all records
-    def request_records(ignore_cache: false, retrieve_all: false)
+    def request_records(ignore_cache: false, retrieve_all: false, request_source: nil)
       unless dynamic_model
         raise FphsException,
               'dynamic model has not been set up'
       end
 
-      dr = Redcap::DataRecords.new(project_admin, dynamic_model_class_name)
+      dr = Redcap::DataRecords.new(project_admin, dynamic_model_class_name, request_source:)
       dr.request_records(ignore_cache:, retrieve_all:)
     end
 

--- a/spec/models/redcap/data_records_request_source_spec.rb
+++ b/spec/models/redcap/data_records_request_source_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require './db/table_generators/dynamic_models_table'
+
+# Test Summary: Redcap::DataRecords request source recording (GitHub issue #1118)
+# ===============================================================================
+#
+# A REDCap project `request_records` call may originate from:
+#   - The admin UI (ProjectAdminsController)
+#   - An API call (ProjectUserRequestsController)
+#   - An automated scheduled job (RecurringPullTask)
+#
+# These tests verify that the source of the request is captured in the
+# project admin job request result, so admins can tell how a pull was triggered.
+#
+# The implementation adds a `request_source` attribute to Redcap::DataRecords
+# (values: :admin_ui, :api, :scheduled, or nil) and threads the value through to
+# the relevant `record_job_request` / `update_job_request` calls.
+#
+# Tests:
+#   1. request_records with request_source: :admin_ui records admin_ui: true in
+#      the 'setup job: store records' job request result.
+#   2. request_records with request_source: :api records api: true in the
+#      'setup job: store records' job request result.
+#   3. request_records with no request_source does NOT include admin_ui: true
+#      or api: true in the job request result.
+#   4. When request_source: :scheduled is set on a DataRecords instance,
+#      retrieve_validate_store records scheduled: true in the
+#      'store records' job request result.
+
+RSpec.describe 'Redcap::DataRecords request source recording', type: :model do
+  include MasterSupport
+  include ModelSupport
+  include Redcap::RedcapSupport
+
+  before :all do
+    @bad_admin, = create_admin
+    @bad_admin.update! disabled: true
+    create_admin
+    @projects = setup_redcap_project_admin_configs
+    @project = @projects.first
+  end
+
+  before :example do
+    @bad_admin, = create_admin
+    @bad_admin.update! disabled: true
+    create_admin
+    change_setting('RedcapJobUserEmail', @admin.email)
+    setup_file_store
+    @projects = setup_redcap_project_admin_configs
+    @project = @projects.first
+    reset_mocks
+  end
+
+  #
+  # Helper: return a ProjectAdmin with current_admin set and a valid dynamic model class_name
+  def project_admin_with_dm
+    dm = create_dynamic_model_for_sample_response
+    rc = Redcap::ProjectAdmin.active.first
+    rc.current_admin = @admin
+    [rc, dm.implementation_class.name]
+  end
+
+  #
+  # Helper: configure stubs so request_records proceeds past the inline adapter guard
+  # and past the existing-jobs guard, without running a real background job.
+  def stub_for_request_records(rc)
+    # Prevent the "already queued" early return
+    allow(Redcap::ProjectAdmin).to receive(:existing_jobs).and_return(double(count: 0))
+
+    # Prevent the real job from running
+    fake_job = double('job', job_id: 'test-job-id')
+    allow(Redcap::CaptureRecordsJob).to receive(:perform_later).and_return(fake_job)
+
+    # Make the code believe the adapter is NOT inline so it continues to record_job_request
+    allow(Rails.application.config.active_job).to receive(:queue_adapter).and_return(:test)
+  end
+
+  describe 'request_records with request_source: :admin_ui' do
+    it 'records admin_ui: true in the setup job: store records job request result' do
+      rc, class_name = project_admin_with_dm
+      stub_for_request_records(rc)
+
+      # Expect the job request to include admin_ui: true in the result
+      expect(rc).to receive(:record_job_request).with(
+        'setup job: store records',
+        result: hash_including(admin_ui: true)
+      )
+
+      dr = Redcap::DataRecords.new(rc, class_name, request_source: :admin_ui)
+      dr.request_records
+    end
+  end
+
+  describe 'request_records with request_source: :api' do
+    it 'records api: true in the setup job: store records job request result' do
+      rc, class_name = project_admin_with_dm
+      stub_for_request_records(rc)
+
+      expect(rc).to receive(:record_job_request).with(
+        'setup job: store records',
+        result: hash_including(api: true)
+      )
+
+      dr = Redcap::DataRecords.new(rc, class_name, request_source: :api)
+      dr.request_records
+    end
+  end
+
+  describe 'request_records with no request_source' do
+    it 'does not include admin_ui: true or api: true in the job request result' do
+      rc, class_name = project_admin_with_dm
+      stub_for_request_records(rc)
+
+      expect(rc).to receive(:record_job_request) do |action, result:|
+        expect(action).to eq 'setup job: store records'
+        expect(result).not_to include(admin_ui: true)
+        expect(result).not_to include(api: true)
+      end
+
+      dr = Redcap::DataRecords.new(rc, class_name)
+      dr.request_records
+    end
+  end
+
+  describe 'retrieve_validate_store with request_source: :scheduled' do
+    it 'records scheduled: true in the store records job request result' do
+      dm = create_dynamic_model_for_sample_response
+      rc = Redcap::ProjectAdmin.active.first
+      rc.current_admin = @admin
+
+      stub_request_records @project[:server_url], @project[:api_key]
+
+      # Allow any other record_job_request calls (e.g., api_client initialization calls :project)
+      allow(rc).to receive(:record_job_request).and_call_original
+      # Capture what record_job_request is called with when create: true
+      expect(rc).to receive(:record_job_request).with(
+        'store records',
+        result: hash_including(scheduled: true)
+      ).and_call_original
+
+      # Allow any subsequent update_job_request calls (e.g., during store steps)
+      allow(rc).to receive(:update_job_request)
+
+      dr = Redcap::DataRecords.new(rc, dm.implementation_class.name, request_source: :scheduled)
+      dr.retrieve_validate_store
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Records the source of a REDCap `request_records` call in the project admin job request result, so admins can identify how a data pull was triggered.

Closes #1118

### Changes

- **`Redcap::DataRecords`**: Added `request_source` attribute (keyword arg on `initialize`). In `request_records`, merges `{ request_source => true }` (e.g. `admin_ui: true`) into the `'setup job: store records'` job request result. In `update_job_request`, adds `{ request_source => true }` (e.g. `scheduled: true`) to the `'store records'` job request result.
- **`Redcap::DynamicStorage#request_records`**: Accepts and passes through `request_source:`.
- **`Redcap::ProjectAdminsController`**: Passes `request_source: :admin_ui` when requesting records via the admin UI.
- **`Redcap::ProjectUserRequestsController`**: Passes `request_source: :api` when requesting records via the API endpoint.
- **`Redcap::RecurringPullTask`**: Passes `request_source: :scheduled` when the automated scheduler triggers a pull.
- **Spec**: Added `spec/models/redcap/data_records_request_source_spec.rb` with 4 examples covering all three sources and the nil case.