### PR TITLE
Clarified User Access Overview search criteria labels and report ordering - fixes #1124

### DIFF
--- a/db/migrate/20260512103117_relabel_user_access_overview_search_attrs.rb
+++ b/db/migrate/20260512103117_relabel_user_access_overview_search_attrs.rb
@@ -1,0 +1,14 @@
+class RelabelUserAccessOverviewSearchAttrs < ActiveRecord::Migration[7.1]
+  def up
+    $dont_seed = true
+
+    begin
+      require "#{::Rails.root}/db/seeds.rb"
+      Seeds::ReportUserAccessOverview.setup
+    rescue StandardError => e
+      puts 'Run "bundle exec rails db:seed" at the end of migrations.'
+      puts e
+      puts e.backtrace.join("\n")
+    end
+  end
+end

--- a/db/seeds/report_user_access_overview.rb
+++ b/db/seeds/report_user_access_overview.rb
@@ -23,21 +23,26 @@ module Seeds
     end
 
     def self.create_templates
-      # Shared search attributes for all perspectives
+      # Shared search attributes for the first three perspectives (by_role,
+      # by_resource, resolved). User and App Type are required for meaningful
+      # results; Resource Type, Resource Name, and Role are optional filters.
       search_attrs = <<~END_YAML
         user:
           user:
+            label: 'User (required)'
             multiple: single
             default: current_user
-        role_name:
+        app_type_id:
           select_from_model:
-            resource_name: admin__user_roles
+            label: 'App Type (required)'
+            multiple: single
+            resource_name: admin__app_types
             selections:
-              role_name: role_name
-            all: true
+              name: id
+            default: '{{current_user_app_type_id}}'
         resource_type:
           config_selector:
-            label: Resource Type
+            label: 'Resource Type (optional)'
             multiple: single
             all: true
             filter_selector: resource_name
@@ -50,56 +55,67 @@ module Seeds
               activity_log_type: activity_log_type
         resource_name:
           select_from_model:
+            label: 'Resource Name (optional)'
             resource_name: admin__user_access_controls
             selections:
               resource_name: resource_name
             group_by: resource_type
             all: true
-        app_type_id:
+        role_name:
           select_from_model:
-            multiple: single
-            resource_name: admin__app_types
+            label: 'Role (optional)'
+            resource_name: admin__user_roles
             selections:
-              name: id
-            default: '{{current_user_app_type_id}}'
+              role_name: role_name
+            all: true
       END_YAML
 
+      # Search attributes for the roles-by-user perspective (roles_only).
+      # App Type is required; User and Role are optional filters.
       search_attrs_roles_with_user = <<~END_YAML
-        user:
-          user:
-            multiple: single
-        role_name:
-          select_from_model:
-            resource_name: admin__user_roles
-            selections:
-              role_name: role_name
-            all: true
         app_type_id:
           select_from_model:
+            label: 'App Type (required)'
             multiple: single
             resource_name: admin__app_types
             selections:
               name: id
             default: '{{current_user_app_type_id}}'
+        user:
+          user:
+            label: 'User (optional)'
+            multiple: single
+        role_name:
+          select_from_model:
+            label: 'Role (optional)'
+            resource_name: admin__user_roles
+            selections:
+              role_name: role_name
+            all: true
       END_YAML
 
+      # Search attributes for the users-by-role perspective (users_with_role).
+      # App Type is required; User and Role are optional filters.
       search_attrs_users_with_role = <<~END_YAML
-        user:
-          user:
-            multiple: single
-        role_name:
-          select_from_model:
-            resource_name: admin__user_roles
-            selections:
-              role_name: role_name
-            all: true
         app_type_id:
           select_from_model:
+            label: 'App Type (required)'
             multiple: single
             resource_name: admin__app_types
             selections:
               name: id
             default: '{{current_user_app_type_id}}'
+        user:
+          user:
+            label: 'User (optional)'
+            multiple: single
+        role_name:
+          select_from_model:
+            label: 'Role (optional)'
+            resource_name: admin__user_roles
+            selections:
+              role_name: role_name
+            all: true
       END_YAML
 
       # ── Perspective 1: By Role ──────────────────────────────────────────
@@ -550,6 +566,7 @@ module Seeds
           report_type: 'regular_report',
           auto: false,
           searchable: false,
+          position: 1,
           options: p1_options,
           sql: p1_sql,
           search_attrs: search_attrs
@@ -562,6 +579,7 @@ module Seeds
           report_type: 'regular_report',
           auto: false,
           searchable: false,
+          position: 2,
           options: p2_options,
           sql: p2_sql,
           search_attrs: search_attrs
@@ -574,6 +592,7 @@ module Seeds
           report_type: 'regular_report',
           auto: false,
           searchable: false,
+          position: 3,
           options: p3_options,
           sql: p3_sql,
           search_attrs: search_attrs
@@ -586,6 +605,7 @@ module Seeds
           report_type: 'regular_report',
           auto: false,
           searchable: false,
+          position: 4,
           options: p4_options,
           sql: p4_sql,
           search_attrs: search_attrs_roles_with_user
@@ -598,6 +618,7 @@ module Seeds
           report_type: 'regular_report',
           auto: false,
           searchable: false,
+          position: 5,
           options: p5_options,
           sql: p5_sql,
           search_attrs: search_attrs_users_with_role

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -23393,6 +23393,7 @@ ALTER TABLE ONLY ref_data.redcap_data_dictionary_history
 SET search_path TO ml_app,ref_data;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260512103117'),
 ('20260512101920'),
 ('20260507095650'),
 ('20260507095442'),

--- a/spec/models/reports/user_access_overview_spec.rb
+++ b/spec/models/reports/user_access_overview_spec.rb
@@ -316,6 +316,129 @@ RSpec.describe 'User Access Overview Reports', type: :model do
       expect(alt_headers['source']).to include('(role name)'),
                                        "Expected source alt_column_header to include '(role name)' in resolved report"
     end
+
+    it 'sets a consistent position order for the five reports (issue #1124)' do
+      expected_order = %w[
+        user_access_overview_by_role
+        user_access_overview_by_resource
+        user_access_overview_resolved
+        user_access_overview_roles_only
+        user_access_overview_users_with_role
+      ]
+
+      positions = expected_order.map do |short_name|
+        report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
+        [short_name, report.position]
+      end
+
+      # Each report has an assigned position
+      positions.each do |short_name, position|
+        expect(position).to be_present, "Expected report '#{short_name}' to have a position set"
+      end
+
+      # Positions are unique
+      position_values = positions.map(&:last)
+      expect(position_values).to eq(position_values.uniq),
+                                 "Expected unique positions, got: #{position_values}"
+
+      # Ordering reports by position yields the expected sequence
+      ordered_short_names = Report
+                            .where(item_type: 'admin-user-access-overview', short_name: expected_order)
+                            .order(position: :asc)
+                            .pluck(:short_name)
+      expect(ordered_short_names).to eq(expected_order)
+    end
+
+    # Issue #1124 - search criteria field labels must indicate required vs
+    # optional inputs so admins can use each report without trial and error.
+    describe 'search criteria labels (issue #1124)' do
+      # Helper to load the configured label for a search attribute key
+      def label_for(report, attr_key)
+        config = report.search_attributes_config[attr_key.to_sym]
+        config&.label
+      end
+
+      let(:resource_reports) do
+        %w[
+          user_access_overview_by_role
+          user_access_overview_by_resource
+          user_access_overview_resolved
+        ]
+      end
+
+      let(:role_reports) do
+        %w[
+          user_access_overview_roles_only
+          user_access_overview_users_with_role
+        ]
+      end
+
+      it 'marks user and app_type_id as required in the first three reports' do
+        resource_reports.each do |short_name|
+          report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
+          expect(label_for(report, :user)).to match(/required/i),
+                                              "Expected 'user' label to indicate required in '#{short_name}'"
+          expect(label_for(report, :app_type_id)).to match(/required/i),
+                                                     "Expected 'app_type_id' label to indicate required in '#{short_name}'"
+        end
+      end
+
+      it 'marks resource_type, resource_name, and role_name as optional in the first three reports' do
+        resource_reports.each do |short_name|
+          report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
+          expect(label_for(report, :resource_type)).to match(/optional/i),
+                                                       "Expected 'resource_type' label to indicate optional in '#{short_name}'"
+          expect(label_for(report, :resource_name)).to match(/optional/i),
+                                                       "Expected 'resource_name' label to indicate optional in '#{short_name}'"
+          expect(label_for(report, :role_name)).to match(/optional/i),
+                                                   "Expected 'role_name' label to indicate optional in '#{short_name}'"
+        end
+      end
+
+      it 'marks app_type_id as required in the roles-by-user and users-by-role reports' do
+        role_reports.each do |short_name|
+          report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
+          expect(label_for(report, :app_type_id)).to match(/required/i),
+                                                     "Expected 'app_type_id' label to indicate required in '#{short_name}'"
+        end
+      end
+
+      it 'marks user and role_name as optional in the roles-by-user and users-by-role reports' do
+        role_reports.each do |short_name|
+          report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
+          expect(label_for(report, :user)).to match(/optional/i),
+                                              "Expected 'user' label to indicate optional in '#{short_name}'"
+          expect(label_for(report, :role_name)).to match(/optional/i),
+                                                   "Expected 'role_name' label to indicate optional in '#{short_name}'"
+        end
+      end
+
+      it 'uses consistent required/optional label copy across all five reports' do
+        # The exact label strings must match across reports for the same
+        # required/optional designation, so admins see consistent copy.
+        required_user_labels = resource_reports.map do |short_name|
+          report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
+          label_for(report, :user)
+        end
+        expect(required_user_labels.uniq.length).to eq(1),
+                                                    "Expected consistent required 'user' label, got: #{required_user_labels.uniq}"
+
+        all_reports = resource_reports + role_reports
+        app_type_labels = all_reports.map do |short_name|
+          report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
+          label_for(report, :app_type_id)
+        end
+        expect(app_type_labels.uniq.length).to eq(1),
+                                               "Expected consistent required 'app_type_id' label across all reports, got: #{app_type_labels.uniq}"
+
+        optional_role_labels = (resource_reports + role_reports).map do |short_name|
+          report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
+          label_for(report, :role_name)
+        end
+        expect(optional_role_labels.uniq.length).to eq(1),
+                                                    "Expected consistent optional 'role_name' label across all reports, got: #{optional_role_labels.uniq}"
+      end
+    end
   end
 
   describe 'UAC seed records' do


### PR DESCRIPTION
## Summary

Improves the usability of the five User Access Overview admin reports by adding required/optional guidance to the search criteria field labels and setting an explicit position so the reports appear in a predictable order in the admin report list.

Closes #1124. Part of umbrella #1122.

### Changes

- **Label copy** in `db/seeds/report_user_access_overview.rb`:
  - First three reports (`by_role`, `by_resource`, `resolved`):
    - `User (required)`, `App Type (required)`
    - `Resource Type (optional)`, `Resource Name (optional)`, `Role (optional)`
  - Roles-by-user (`roles_only`) and users-by-role (`users_with_role`) reports:
    - `App Type (required)`
    - `User (optional)`, `Role (optional)`
  - Required fields are ordered first in each report's search form. Required/optional copy is consistent across all five reports.
- **Position** field set on each report (1–5) so the list ordering is stable:
  1. `user_access_overview_by_role`
  2. `user_access_overview_by_resource`
  3. `user_access_overview_resolved`
  4. `user_access_overview_roles_only`
  5. `user_access_overview_users_with_role`
- Added migration `db/migrate/20260512103117_relabel_user_access_overview_search_attrs.rb` re-running the seed so existing environments pick up the new labels and positions.
- Extended `spec/models/reports/user_access_overview_spec.rb` with:
  - A new `search criteria labels (issue #1124)` describe block covering required/optional copy per AC1–AC5 and consistency across reports.
  - A test asserting positions are present, unique, and order the reports in the expected sequence.
- Added the new migration to `db/structure.sql` `schema_migrations`.

### Verification

- `bundle exec rspec spec/models/reports/user_access_overview_spec.rb` — 70 examples, 0 failures.
- Re-running the seed in the dev environment produces positions 1–5 in the expected order and renders the updated labels.

### Out of scope

Per the issue:

1. Renaming report titles and descriptions (handled in #1123 / PR #1126).
2. Adding navigation links from admin pages.
3. Adding links between report perspectives.
