### PR TITLE
Added resource-focused User Access Overview report grouped by resource with role/source grouping - fixes #1128

### DIFF
--- a/db/migrate/20260512122159_add_resource_focused_user_access_overview.rb
+++ b/db/migrate/20260512122159_add_resource_focused_user_access_overview.rb
@@ -1,0 +1,14 @@
+class AddResourceFocusedUserAccessOverview < ActiveRecord::Migration[7.1]
+  def up
+    $dont_seed = true
+
+    begin
+      require "#{::Rails.root}/db/seeds.rb"
+      Seeds::ReportUserAccessOverview.setup
+    rescue StandardError => e
+      puts 'Run "bundle exec rails db:seed" at the end of migrations.'
+      puts e
+      puts e.backtrace.join("\n")
+    end
+  end
+end

--- a/db/migrate/20260512134244_rename_and_reposition_resource_focused_user_access_overview.rb
+++ b/db/migrate/20260512134244_rename_and_reposition_resource_focused_user_access_overview.rb
@@ -1,0 +1,14 @@
+class RenameAndRepositionResourceFocusedUserAccessOverview < ActiveRecord::Migration[7.1]
+  def up
+    $dont_seed = true
+
+    begin
+      require "#{::Rails.root}/db/seeds.rb"
+      Seeds::ReportUserAccessOverview.setup
+    rescue StandardError => e
+      puts 'Run "bundle exec rails db:seed" at the end of migrations.'
+      puts e
+      puts e.backtrace.join("\n")
+    end
+  end
+end

--- a/db/seeds/report_user_access_overview.rb
+++ b/db/seeds/report_user_access_overview.rb
@@ -94,9 +94,14 @@ module Seeds
             all: true
       END_YAML
 
-      # Search attributes for the users-by-role perspective (users_with_role).
-      # App Type is required; User and Role are optional filters.
-      search_attrs_users_with_role = <<~END_YAML
+      # Search attributes for the users-by-role perspective (users_with_role)
+      # match the roles-by-user perspective.
+      search_attrs_users_with_role = search_attrs_roles_with_user
+
+      # Search attributes for the resource-focused perspective.
+      # App Type is required; Resource Type and Resource Name are optional
+      # so admins can scope to a single resource or browse all resources.
+      search_attrs_resource_focus = <<~END_YAML
         app_type_id:
           select_from_model:
             label: 'App Type (required)'
@@ -105,16 +110,26 @@ module Seeds
             selections:
               name: id
             default: '{{current_user_app_type_id}}'
-        user:
-          user:
-            label: 'User (optional)'
+        resource_type:
+          config_selector:
+            label: 'Resource Type (optional)'
             multiple: single
-        role_name:
-          select_from_model:
-            label: 'Role (optional)'
-            resource_name: admin__user_roles
+            all: true
+            filter_selector: resource_name
             selections:
-              role_name: role_name
+              table: table
+              general: general
+              limited_access: limited_access
+              report: report
+              standalone_page: standalone_page
+              activity_log_type: activity_log_type
+        resource_name:
+          select_from_model:
+            label: 'Resource Name (optional)'
+            resource_name: admin__user_access_controls
+            selections:
+              resource_name: resource_name
+            group_by: resource_type
             all: true
       END_YAML
 
@@ -555,6 +570,100 @@ module Seeds
         ;
       END_SQL
 
+      # ── Perspective 6: Resource Focused By Role / Source ─────────────
+
+      p6_options = <<~END_YAML
+        view_options:
+          view_as: tree
+          report_auto_submit_on_change: false
+          hide_field_names_with_comments: true
+          hide_result_count: false
+          no_results_scroll: true
+
+        tree_view_options:
+          num_levels: 2
+          expand_level: 1
+          column_levels:
+            -
+              - id0
+              - resource_type
+              - resource_name
+
+        column_options:
+          alt_column_header:
+            id0: '[expand]'
+            blank: ' '
+            source: 'Assigned via'
+            role_name: 'Role (where applicable)'
+            user_email: 'User (where applicable)'
+            resource_type: 'Resource Type'
+            resource_name: 'Resource Name'
+            access: 'Access'
+            app_scope: 'App Type Scope'
+          show_as:
+            role_name: url
+            user_email: url
+            resource_name: url
+            app_scope: url
+      END_YAML
+
+      p6_sql = <<~END_SQL
+        -- User Access Overview - Perspective 6: Resource-focused by role/source
+        -- Shows all grants for selected resource(s), grouped first by resource
+        -- (resource_type / resource_name). Each grouped child row shows the
+        -- assignment source: direct user-specific grant, role-based grant, or
+        -- default fallback. Role and user are surfaced in dedicated columns so
+        -- the source label remains short and free of duplicated identifiers.
+
+        SELECT
+          uac.resource_type || ' / ' || uac.resource_name AS id0,
+          uac.resource_type || ' / ' || uac.resource_name || '--' || uac.id AS id1,
+          CASE
+            WHEN uac.user_id IS NOT NULL THEN '(direct - user-specific)'
+            WHEN uac.role_name IS NOT NULL AND uac.role_name <> '' THEN '(role-based)'
+            ELSE '(default - fallback)'
+          END AS source,
+          CASE
+            WHEN uac.role_name IS NOT NULL AND uac.role_name <> '' THEN
+              '[' || uac.role_name || '](/admin/user_roles?filter[role_name]=' || uac.role_name || ')'
+            ELSE ''
+          END AS role_name,
+          CASE
+            WHEN uac.user_id IS NOT NULL THEN
+              '[' || u.email || '](/admin/manage_users?filter[email]=' || u.email || ')'
+            ELSE ''
+          END AS user_email,
+          uac.resource_type,
+          '[' || uac.resource_name || '](/admin/user_access_controls?filter[resource_name]=' || uac.resource_name || '&filter[resource_type]=' || uac.resource_type || ')' AS resource_name,
+          uac.access,
+          CASE
+            WHEN uac.app_type_id IS NULL THEN '(all)'
+            ELSE '[' || at.name || '](/admin/app_types/' || uac.app_type_id || ')'
+          END AS app_scope
+
+        FROM ml_app.user_access_controls uac
+        LEFT JOIN ml_app.users u ON uac.user_id = u.id
+        LEFT JOIN ml_app.app_types at ON uac.app_type_id = at.id
+
+        WHERE uac.disabled IS NOT TRUE
+          AND (u.id IS NULL OR u.disabled IS NOT TRUE)
+          AND (uac.app_type_id = CAST(NULLIF(:app_type_id, '') AS INTEGER) OR uac.app_type_id IS NULL)
+          AND (COALESCE(:resource_type, '') = '' OR uac.resource_type = :resource_type)
+          AND (COALESCE(:resource_name, '') = '' OR uac.resource_name = :resource_name)
+
+        ORDER BY
+          uac.resource_type ASC,
+          uac.resource_name ASC,
+          CASE
+            WHEN uac.user_id IS NOT NULL THEN '0-direct'
+            WHEN uac.role_name IS NOT NULL AND uac.role_name <> '' THEN '1-' || uac.role_name
+            ELSE '2-default'
+          END,
+          uac.app_type_id ASC NULLS LAST,
+          u.email ASC NULLS LAST
+        ;
+      END_SQL
+
       # ── Build report and UAC arrays ─────────────────────────────────────
 
       report_values = [
@@ -605,7 +714,7 @@ module Seeds
           report_type: 'regular_report',
           auto: false,
           searchable: false,
-          position: 4,
+          position: 5,
           options: p4_options,
           sql: p4_sql,
           search_attrs: search_attrs_roles_with_user
@@ -618,10 +727,23 @@ module Seeds
           report_type: 'regular_report',
           auto: false,
           searchable: false,
-          position: 5,
+          position: 6,
           options: p5_options,
           sql: p5_sql,
           search_attrs: search_attrs_users_with_role
+        },
+        {
+          name: 'User Access Controls - Resource Grants by Role/Source',
+          item_type: 'admin-user-access-overview',
+          short_name: 'user_access_overview_resource_by_role',
+          description: 'Lists access controls for selected resource(s), grouped by assignment source so admins can audit role-based grants, direct user assignments, and default fallback controls.',
+          report_type: 'regular_report',
+          auto: false,
+          searchable: false,
+          position: 4,
+          options: p6_options,
+          sql: p6_sql,
+          search_attrs: search_attrs_resource_focus
         }
       ]
 
@@ -650,6 +772,11 @@ module Seeds
           resource_type: 'report',
           access: nil,
           resource_name: 'admin_user_access_overview__user_access_overview_users_with_role'
+        },
+        {
+          resource_type: 'report',
+          access: nil,
+          resource_name: 'admin_user_access_overview__user_access_overview_resource_by_role'
         }
       ]
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -23393,6 +23393,8 @@ ALTER TABLE ONLY ref_data.redcap_data_dictionary_history
 SET search_path TO ml_app,ref_data;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260512134244'),
+('20260512122159'),
 ('20260512103117'),
 ('20260512101920'),
 ('20260507095650'),

--- a/spec/models/reports/user_access_overview_spec.rb
+++ b/spec/models/reports/user_access_overview_spec.rb
@@ -183,6 +183,26 @@ RSpec.describe 'User Access Overview Reports', type: :model do
         .to eq("User Roles - Each Role's Users")
     end
 
+    it 'creates a resource-focused perspective without changing existing identifiers (issue #1128)' do
+      %w[
+        user_access_overview_by_role
+        user_access_overview_by_resource
+        user_access_overview_resolved
+        user_access_overview_roles_only
+        user_access_overview_users_with_role
+      ].each do |short_name|
+        existing = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
+        expect(existing).to be_present, "Expected existing report '#{short_name}' to remain unchanged"
+      end
+
+      new_report = Report.find_by(
+        short_name: 'user_access_overview_resource_by_role',
+        item_type: 'admin-user-access-overview'
+      )
+      expect(new_report).to be_present,
+                             "Expected resource-focused report 'user_access_overview_resource_by_role' to exist"
+    end
+
     it 'includes search_attrs with app_type_id and user for all reports' do
       report_short_names.each do |short_name|
         report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
@@ -317,11 +337,12 @@ RSpec.describe 'User Access Overview Reports', type: :model do
                                        "Expected source alt_column_header to include '(role name)' in resolved report"
     end
 
-    it 'sets a consistent position order for the five reports (issue #1124)' do
+    it 'sets a consistent position order for the seeded reports (issues #1124, #1128)' do
       expected_order = %w[
         user_access_overview_by_role
         user_access_overview_by_resource
         user_access_overview_resolved
+        user_access_overview_resource_by_role
         user_access_overview_roles_only
         user_access_overview_users_with_role
       ]
@@ -452,6 +473,13 @@ RSpec.describe 'User Access Overview Reports', type: :model do
         expect(uac).to be_present,
                        "Expected a UAC with resource_name '#{alt_name}' for report '#{short_name}'"
       end
+
+      resource_focus_uac = Admin::UserAccessControl.active.find_by(
+        resource_type: 'report',
+        resource_name: 'admin_user_access_overview__user_access_overview_resource_by_role'
+      )
+      expect(resource_focus_uac).to be_present,
+                                     "Expected a UAC with resource_name 'admin_user_access_overview__user_access_overview_resource_by_role'"
     end
   end
 
@@ -461,6 +489,13 @@ RSpec.describe 'User Access Overview Reports', type: :model do
         report = Report.find_by(short_name: short_name, item_type: 'admin-user-access-overview')
         expect(report.alt_resource_name).to eq("admin_user_access_overview__#{short_name}")
       end
+
+      resource_focus = Report.find_by(
+        short_name: 'user_access_overview_resource_by_role',
+        item_type: 'admin-user-access-overview'
+      )
+      expect(resource_focus.alt_resource_name)
+        .to eq('admin_user_access_overview__user_access_overview_resource_by_role')
     end
   end
 
@@ -629,6 +664,88 @@ RSpec.describe 'User Access Overview Reports', type: :model do
                         'Expected P3 results to include id0 for tree grouping'
       expect(fields).to include('id1'),
                         'Expected P3 results to include id1 for tree row identity'
+    end
+  end
+
+  describe 'Perspective 6 — resource-focused by role/source (issue #1128)' do
+    let(:report) do
+      Report.find_by(
+        short_name: 'user_access_overview_resource_by_role',
+        item_type: 'admin-user-access-overview'
+      )
+    end
+
+    it 'defines search criteria for app type, resource type, and resource name' do
+      expect(report).to be_present,
+                        'Expected resource-focused report to exist before validating search_attrs'
+
+      attrs = YAML.safe_load(report.search_attrs)
+
+      expect(attrs).to have_key('app_type_id')
+      expect(attrs).to have_key('resource_type')
+      expect(attrs).to have_key('resource_name')
+    end
+
+    it 'groups by resource and labels source as direct, role-based, or default' do
+      expect(report).to be_present,
+                        'Expected resource-focused report to exist before validating grouping'
+
+      results = run_report_sql(report, resource_type: 'table', resource_name: 'trackers')
+      expect(results).not_to be_empty,
+                             'Expected rows for table/trackers in resource-focused perspective'
+
+      # Primary grouping is by resource (id0 = resource_type / resource_name)
+      id0_values = results.map { |r| r['id0'] }.uniq
+      expect(id0_values).to all(include('trackers')),
+                            "Expected id0 to group rows by resource (trackers), got: #{id0_values}"
+
+      # Source column carries short, distinct category labels — not the role name itself
+      sources = results.map { |r| r['source'].to_s }
+      expect(sources).to include(a_string_matching(/direct/i)),
+                         'Expected a direct user-specific source label'
+      expect(sources).to include(a_string_matching(/default|fallback/i)),
+                         'Expected a default/fallback source label'
+      expect(sources).to include(a_string_matching(/role-based/i)),
+                         'Expected a role-based source label'
+
+      # Role-based rows must carry the role link in role_name (not duplicated in source)
+      role_rows = results.select { |r| r['source'].to_s.match?(/role-based/i) }
+      expect(role_rows).not_to be_empty
+      role_rows.each do |row|
+        expect(row['role_name']).to match(%r{\[.+\]\(/admin/user_roles}),
+                                    "Expected role_name to carry the role link, got: #{row['role_name']}"
+        expect(row['source']).not_to match(%r{/admin/user_roles}),
+                                     "Expected source not to duplicate the role link, got: #{row['source']}"
+      end
+    end
+
+    it 'returns access, scope, user/role, resource type and resource name columns' do
+      expect(report).to be_present,
+                        'Expected resource-focused report to exist before validating columns'
+
+      results = run_report_sql(report, resource_type: 'table', resource_name: 'trackers')
+      expect(results).not_to be_empty
+
+      fields = results.first.keys
+      expect(fields).to include('access')
+      expect(fields).to include('app_scope')
+      expect(fields).to include('user_email')
+      expect(fields).to include('role_name')
+      expect(fields).to include('resource_type')
+      expect(fields).to include('resource_name')
+    end
+
+    it 'applies app type, resource type and resource name filters to the selected resource' do
+      expect(report).to be_present,
+                        'Expected resource-focused report to exist before validating filters'
+
+      results = run_report_sql(report, resource_type: 'table', resource_name: 'trackers')
+      expect(results).not_to be_empty
+
+      results.each do |row|
+        expect(row['resource_type']).to eq('table')
+        expect(row['resource_name']).to include('trackers')
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Adds a new 'Resource Grants by Role/Source' perspective (P6) to the User Access Overview admin reports. This perspective lets admins audit which roles, direct user assignments, and default fallbacks grant access to a specific resource — with the resource as the primary grouping rather than the user.

Closes #1128.

### Changes

- **New report** `user_access_overview_resource_by_role` (position 4):
  - Title: *User Access Controls - Resource Grants by Role/Source*
  - Grouped by `resource_type / resource_name` (tree view, 2 levels)
  - Child rows show assignment source as one of three short labels: `(direct - user-specific)`, `(role-based)`, `(default - fallback)`
  - Role identity surfaced in a dedicated `role_name` column (markdown link to admin user_roles filter); user identity in `user_email` column — neither duplicated in the `source` label
  - Filters: app type (required), resource type and resource name (both optional)
  - Excludes disabled UAC records and disabled users
- **Repositioned** existing roles-only (P4→5) and users-with-role (P5→6) perspectives to accommodate the new report at position 4
- **Search attributes** (`search_attrs_resource_focus`): app type, resource type (config selector with filter_selector), resource name (select_from_model with group_by)
- **Two migrations** to reseed existing environments:
  - `20260512122159` — initial add
  - `20260512134244` — rename and reposition (idempotent, reruns seed setup)
- **Default UAC** seeded for the new report (`admin_user_access_overview__user_access_overview_resource_by_role`)
- **Specs** (75 examples, 0 failures):
  - Existence and non-disruption of existing identifiers
  - Search criteria keys
  - Resource-first grouping via `id0`
  - Source label categories and role/user column separation
  - Column presence
  - Filter application
  - Position ordering (updated expected sequence)