### PR TITLE
Add drill-down links between User Access Overview reports and admin pages

### DIFF
--- a/app/controllers/admin/user_roles_controller.rb
+++ b/app/controllers/admin/user_roles_controller.rb
@@ -69,11 +69,36 @@ class Admin::UserRolesController < AdminController
   def admin_links(item = nil)
     return [true] if item.nil?
 
-    [
+    links = [
       ['description', admin_role_descriptions_path(filter: { role_name: item.role_name })],
       ['user profile', admin_manage_users_path(filter: { id: item.user_id })],
       ['access controls', admin_user_access_controls_path(filter: { role_name: item.role_name })]
     ]
+
+    if item.user_id.present?
+      links << [
+        'access overview',
+        view_context.user_access_overview_report_path(
+          :by_role,
+          user: item.user_id,
+          app_type_id: item.app_type_id,
+          role_name: item.role_name
+        )
+      ]
+    end
+
+    if item.role_name.present?
+      links << [
+        'users with role',
+        view_context.user_access_overview_report_path(
+          :users_with_role,
+          app_type_id: item.app_type_id,
+          role_name: item.role_name
+        )
+      ]
+    end
+
+    links
   end
 
   def index_params

--- a/app/helpers/user_access_overview_links_helper.rb
+++ b/app/helpers/user_access_overview_links_helper.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Helpers for building drill-down links into the User Access Overview admin
+# reports. These reports are seeded with a known item_type of
+# 'admin-user-access-overview' and stable short_names. The helpers build the
+# report URL using the alt_resource_name and forward only the search_attrs
+# that are meaningful for the target report.
+module UserAccessOverviewLinksHelper
+  USER_ACCESS_OVERVIEW_ITEM_TYPE = 'admin-user-access-overview'
+
+  # The short_names map to the corresponding seeded reports.
+  USER_ACCESS_OVERVIEW_REPORTS = {
+    by_role: 'user_access_overview_by_role',
+    by_resource: 'user_access_overview_by_resource',
+    resolved: 'user_access_overview_resolved',
+    resource_by_role: 'user_access_overview_resource_by_role',
+    roles_only: 'user_access_overview_roles_only',
+    users_with_role: 'user_access_overview_users_with_role'
+  }.freeze
+
+  # Build the report path for one of the User Access Overview perspectives,
+  # filtering blank search_attrs so the URL stays compact and links only
+  # appear when they carry meaningful filters.
+  # @param key [Symbol] one of USER_ACCESS_OVERVIEW_REPORTS keys
+  # @param search_attrs [Hash] filter values to pass through as search_attrs[]
+  # @return [String]
+  def user_access_overview_report_path(key, search_attrs = {})
+    short = USER_ACCESS_OVERVIEW_REPORTS.fetch(key)
+    alt_resource_name = "admin_user_access_overview__#{short}"
+    cleaned = search_attrs.reject { |_, v| v.nil? || v.to_s.strip.empty? }
+    report_path(id: alt_resource_name, search_attrs: cleaned)
+  end
+
+  # Render a drill-down link to a User Access Overview report. Returns nil
+  # when the filter values needed for the link are not meaningful, so the
+  # link is suppressed in that case.
+  # @param label [String] display text for the link
+  # @param key [Symbol] target report key (see USER_ACCESS_OVERVIEW_REPORTS)
+  # @param search_attrs [Hash] filter values to forward
+  # @param required [Array<Symbol>] keys in search_attrs that must be present
+  # @param html_options [Hash] extra link attributes
+  def user_access_overview_link(label, key, search_attrs: {}, required: [], **html_options)
+    return if required.any? { |k| search_attrs[k].nil? || search_attrs[k].to_s.strip.empty? }
+
+    href = user_access_overview_report_path(key, search_attrs)
+    link_to label, href, html_options
+  end
+end

--- a/app/views/admin/manage_users/_index.html.erb
+++ b/app/views/admin/manage_users/_index.html.erb
@@ -16,6 +16,7 @@
           <th class="no-sort"></th>
           <th class="no-sort"></th>
           <th class="no-sort"></th>
+          <th class="no-sort"></th>
           <th>User</th>
           <th>First Name</th>
           <th>Last Name</th>
@@ -38,6 +39,7 @@
             <td><%= admin_edit_btn list_item.id%> &nbsp; <%= admin_edit_btn list_item.id, copy: list_item%> </td>
             <td><%= link_to "contact", users_contact_infos_path(filter: {user_id: list_item.id})  %></td>
             <td><%= link_to "roles", admin_user_roles_path(filter: {user_id: list_item.id}) %></td>
+            <td><%= user_access_overview_link 'access overview', :by_role, search_attrs: { user: list_item.id }, required: %i[user] %></td>
             <td><%= list_item.email %></td>
             <td><%= list_item.first_name %></td>
             <td><%= list_item.last_name %></td>

--- a/app/views/admin/user_access_controls/_index.html.erb
+++ b/app/views/admin/user_access_controls/_index.html.erb
@@ -38,6 +38,7 @@
       <th>Resource Type</th>
       <th>Resource Name</th>
       <th>Category</th>
+      <th class="no-sort">Drill down</th>
     </tr>
   </thead>
 

--- a/app/views/admin/user_access_controls/_item.html.erb
+++ b/app/views/admin/user_access_controls/_item.html.erb
@@ -23,4 +23,29 @@
   <td><%= list_item.bad_resource_name(@resource_names_for_type) ? '<strong>BAD RESOURCE NAME</strong>'.html_safe : '' %> <%= list_item.resource_name %></td>
   <td><%= category %></td>
   <td><%= list_item.options %></td>
+  <td class="admin-item-admin-links uac-overview-links">
+    <%
+      # User Access Overview drill-down links - only render when the filter
+      # combination is meaningful for the target report. See
+      # UserAccessOverviewLinksHelper for the report keys.
+      base_attrs = { app_type_id: list_item.app_type_id }
+      base_attrs[:resource_type] = list_item.resource_type if list_item.resource_type.present?
+      base_attrs[:resource_name] = list_item.resource_name if list_item.resource_name.present?
+    %>
+    <% if list_item.user_id.present? %>
+      <%= user_access_overview_link 'access overview', :by_role,
+                                    search_attrs: { user: list_item.user_id, app_type_id: list_item.app_type_id },
+                                    required: %i[user] %>
+    <% end %>
+    <% if list_item.role_name.present? %>
+      <%= user_access_overview_link 'users with role', :users_with_role,
+                                    search_attrs: { app_type_id: list_item.app_type_id, role_name: list_item.role_name },
+                                    required: %i[role_name] %>
+    <% end %>
+    <% if list_item.resource_name.present? %>
+      <%= user_access_overview_link 'resource grants', :resource_by_role,
+                                    search_attrs: base_attrs,
+                                    required: %i[resource_name] %>
+    <% end %>
+  </td>
 </tr>

--- a/app/views/reports/_admin_user_access_overview_related.html.erb
+++ b/app/views/reports/_admin_user_access_overview_related.html.erb
@@ -1,0 +1,69 @@
+<%
+  # Cross-perspective navigation panel for the User Access Overview admin
+  # reports (GitHub Issue #1125). Renders links to related report
+  # perspectives that share filters with the current report, preserving the
+  # filter values so admins can switch perspective without re-entering them.
+  #
+  # The list of related perspectives depends on the current report's
+  # short_name. Filter forwarding is done by mapping the current
+  # search_attrs to the target report's parameters.
+
+  related_groups = {
+    'user_access_overview_by_role' => %w[
+      user_access_overview_by_resource
+      user_access_overview_resolved
+      user_access_overview_resource_by_role
+    ],
+    'user_access_overview_by_resource' => %w[
+      user_access_overview_by_role
+      user_access_overview_resolved
+      user_access_overview_resource_by_role
+    ],
+    'user_access_overview_resolved' => %w[
+      user_access_overview_by_role
+      user_access_overview_by_resource
+      user_access_overview_resource_by_role
+    ],
+    'user_access_overview_resource_by_role' => %w[
+      user_access_overview_by_role
+      user_access_overview_by_resource
+      user_access_overview_resolved
+    ],
+    'user_access_overview_roles_only' => %w[
+      user_access_overview_users_with_role
+    ],
+    'user_access_overview_users_with_role' => %w[
+      user_access_overview_roles_only
+    ]
+  }
+
+  related_short_names = related_groups[@report&.short_name] || []
+  related_reports = Report.active.where(
+    item_type: UserAccessOverviewLinksHelper::USER_ACCESS_OVERVIEW_ITEM_TYPE,
+    short_name: related_short_names
+  ).to_a
+
+  current_search_attrs = search_attrs_params_hash || {}
+%>
+<% if related_reports.any? %>
+  <div class="uao-related-perspectives panel panel-default">
+    <div class="panel-heading">
+      <strong>Other views with the same filters</strong>
+    </div>
+    <ul class="list-group">
+      <% related_reports.each do |r|
+           forwarded = current_search_attrs.slice(:user, :app_type_id, :resource_type, :resource_name, :role_name)
+           forwarded = forwarded.reject { |_, v| v.nil? || v.to_s.strip.empty? }
+      %>
+        <li class="list-group-item">
+          <%= link_to r.name,
+                      report_path(id: r.alt_resource_name, search_attrs: forwarded),
+                      class: 'uao-related-perspective-link' %>
+          <% if r.description.present? %>
+            <span class="text-muted small uao-related-perspective-desc">&mdash; <%= r.description %></span>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/reports/_show.html.erb
+++ b/app/views/reports/_show.html.erb
@@ -34,6 +34,9 @@
         <%= table_comment %>
         <% end %>
         <%= render partial: 'description_content' %>
+        <% if @report.item_type == UserAccessOverviewLinksHelper::USER_ACCESS_OVERVIEW_ITEM_TYPE && !embedded_report %>
+          <%= render partial: 'admin_user_access_overview_related' %>
+        <% end %>
         <%= render partial: 'criteria' %>
       </div>
     </div>

--- a/spec/system/admin_user_access_overview_drill_down_spec.rb
+++ b/spec/system/admin_user_access_overview_drill_down_spec.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Purpose: System spec for drill-down links between admin pages and the
+# User Access Overview reports, and for cross-report navigation between
+# the report perspectives (GitHub Issue #1125).
+#
+# Acceptance criteria covered:
+#   1. The Usernames and Passwords admin page (manage_users) provides links
+#      into the relevant User Access Overview reports for a selected user.
+#   2. The User Roles admin page provides links into the relevant User Access
+#      Overview reports using the selected user, role, and app type where
+#      available.
+#   3. The User Access Controls admin page provides links into the relevant
+#      User Access Overview reports using the selected user or role, resource
+#      type, resource name, and app type where available.
+#   4. Where it makes sense, a User Access Overview report provides links to
+#      related report perspectives with filters preserved.
+#   5. Links are only shown when the target report and filter combination are
+#      meaningful (e.g. role-based links require a role_name).
+#
+# These tests sign in as an admin and inspect the rendered HTML of each
+# admin index page (no JS interactions required - the links are emitted
+# server-side from the admin views/controllers).
+describe 'User Access Overview drill-down links', type: :system do
+  include ModelSupport
+  include AdminActionsSetup
+  include FeatureSupport
+
+  before(:all) do
+    SetupHelper.feature_setup
+
+    @setup_admin = Admin.active.first || Admin.create!(
+      email: "setup_admin_#{rand(1_000_000)}@test.com",
+      password: 'Pass1234!',
+      password_confirmation: 'Pass1234!',
+      disabled: false
+    )
+
+    @app_type = Admin::AppType.active.first || Admin::AppType.create!(
+      name: 'test_app_drill_down',
+      label: 'Test App Drill Down',
+      current_admin: @setup_admin
+    )
+
+    @drill_user, = create_user(email: "drill_user_#{rand(1_000_000_000)}@testing.com")
+
+    @role = Admin::UserRole.create!(
+      user: @drill_user,
+      app_type: @app_type,
+      role_name: "drill_role_#{rand(1_000_000)}",
+      current_admin: @setup_admin
+    )
+
+    @uac_user = Admin::UserAccessControl.create!(
+      user: @drill_user,
+      app_type: @app_type,
+      access: :read,
+      resource_type: :table,
+      resource_name: :player_infos,
+      current_admin: @setup_admin
+    )
+
+    @uac_role = Admin::UserAccessControl.create!(
+      app_type: @app_type,
+      role_name: @role.role_name,
+      access: :update,
+      resource_type: :table,
+      resource_name: :addresses,
+      current_admin: @setup_admin
+    )
+
+    # A regular user with permission to view all reports - required for
+    # the cross-perspective tests that load a User Access Overview report.
+    @report_user, @report_user_password = create_user(
+      email: "drill_report_user_#{rand(1_000_000_000)}@testing.com"
+    )
+    Admin::UserAccessControl.create!(
+      app_type: @report_user.app_type,
+      user: @report_user,
+      access: :read,
+      resource_type: :general,
+      resource_name: :view_reports,
+      current_admin: @setup_admin
+    )
+    Admin::UserAccessControl.create!(
+      app_type: @report_user.app_type,
+      user: @report_user,
+      access: :read,
+      resource_type: :report,
+      resource_name: :_all_reports_,
+      current_admin: @setup_admin
+    )
+  end
+
+  before(:each) do
+    make_an_admin
+    login_as(@admin, scope: :admin)
+  end
+
+  # The alt_resource_name prefix for the User Access Overview reports.
+  def report_url(short_name, params = {})
+    # Build the URL with params sorted alphabetically to match Rails url_for output.
+    sorted = params.sort_by { |k, _| k.to_s }
+    qs = sorted.map { |k, v| "search_attrs%5B#{k}%5D=#{CGI.escape(v.to_s)}" }.join('&')
+    base = "/reports/admin_user_access_overview__#{short_name}"
+    qs.empty? ? base : "#{base}?#{qs}"
+  end
+
+  # Capybara's default visibility filter is too strict for the admin index
+  # pages where some rows/cells are hidden until expanded. These helpers
+  # check link presence across all DOM links regardless of CSS visibility.
+  def expect_link_with_href_including(text, expected_href)
+    matching = page.all(:link, text, visible: :all).map { |l| l[:href] }
+    expect(matching).to(
+      include(a_string_including(expected_href)),
+      "expected a link '#{text}' with href including '#{expected_href}'. Found: #{matching.inspect}"
+    )
+  end
+
+  def expect_no_link_with_href_including(text, expected_href)
+    matching = page.all(:link, text, visible: :all).map { |l| l[:href] }
+    expect(matching).not_to include(a_string_including(expected_href))
+  end
+
+  describe 'Usernames and Passwords admin page (manage_users)' do
+    it 'shows a User Access Overview link for each user' do
+      visit '/admin/manage_users'
+
+      expected = report_url('user_access_overview_by_role', user: @drill_user.id)
+      expect_link_with_href_including('access overview', expected)
+    end
+  end
+
+  describe 'User Roles admin page' do
+    it 'shows drill-down links to User Access Overview using user, role, and app type' do
+      visit "/admin/user_roles?filter%5Buser_id%5D=#{@drill_user.id}"
+
+      user_role_link = report_url('user_access_overview_by_role',
+                                  user: @drill_user.id,
+                                  app_type_id: @app_type.id,
+                                  role_name: @role.role_name)
+      role_users_link = report_url('user_access_overview_users_with_role',
+                                   app_type_id: @app_type.id,
+                                   role_name: @role.role_name)
+
+      expect_link_with_href_including('access overview', user_role_link)
+      expect_link_with_href_including('users with role', role_users_link)
+    end
+  end
+
+  describe 'User Access Controls admin page' do
+    it 'shows a user-scoped overview link for direct (user-specific) UACs' do
+      visit "/admin/user_access_controls?filter%5Buser_id%5D=#{@drill_user.id}"
+
+      # Drill down to the user's full access view in the same app type.
+      expected = report_url('user_access_overview_by_role',
+                            user: @drill_user.id,
+                            app_type_id: @app_type.id)
+
+      expect_link_with_href_including('access overview', expected)
+    end
+
+    it 'shows a role-scoped overview link for role-based UACs' do
+      visit "/admin/user_access_controls?filter%5Brole_name%5D=#{@role.role_name}"
+
+      expected = report_url('user_access_overview_users_with_role',
+                            app_type_id: @app_type.id,
+                            role_name: @role.role_name)
+
+      expect_link_with_href_including('users with role', expected)
+    end
+
+    it 'shows a resource-scoped overview link when a resource_name is set' do
+      # The user-specific UAC is for table/player_infos. The row should
+      # provide a "resource grants" link forwarding the app_type, resource_type
+      # and resource_name to the resource-focused perspective.
+      visit "/admin/user_access_controls?filter%5Bid%5D=#{@uac_user.id}"
+
+      expected = report_url('user_access_overview_resource_by_role',
+                            app_type_id: @app_type.id,
+                            resource_type: 'table',
+                            resource_name: 'player_infos')
+
+      expect_link_with_href_including('resource grants', expected)
+    end
+
+    it 'does not show a role-scoped link when no role is set on the UAC' do
+      # The user-specific UAC has no role - the row should not include a
+      # users-with-role link for that row.
+      visit "/admin/user_access_controls?filter%5Bid%5D=#{@uac_user.id}"
+
+      role_link = report_url('user_access_overview_users_with_role',
+                             app_type_id: @app_type.id,
+                             role_name: '')
+
+      expect_no_link_with_href_including('users with role', role_link)
+    end
+  end
+
+  describe 'Cross-perspective navigation within User Access Overview reports' do
+    before(:each) do
+      # Override the admin-only login: cross-perspective tests require
+      # a regular user with view_reports access to load report pages.
+      Capybara.reset_sessions!
+      change_setting('TwoFactorAuthDisabledForUser', true)
+      login_as(@report_user, scope: :user)
+    end
+
+    it 'shows related-perspective links on each user-centric report, preserving filters' do
+      visit report_url('user_access_overview_by_role',
+                       user: @drill_user.id,
+                       app_type_id: @app_type.id,
+                       no_run: 'true')
+
+      panel = find('.uao-related-perspectives', visible: :all)
+      links_in_panel = panel.all(:link, visible: :all)
+      hrefs = links_in_panel.map { |l| [l.text, l[:href]] }
+
+      by_resource_href = report_url('user_access_overview_by_resource',
+                                    user: @drill_user.id,
+                                    app_type_id: @app_type.id)
+      resolved_href = report_url('user_access_overview_resolved',
+                                 user: @drill_user.id,
+                                 app_type_id: @app_type.id)
+
+      expect(hrefs).to(
+        include(a_collection_including(a_string_matching(/Grants by Resource/i),
+                                       a_string_including(by_resource_href))),
+        "expected a 'Grants by Resource' link in the related panel. Found: #{hrefs.inspect}"
+      )
+      expect(hrefs).to(
+        include(a_collection_including(a_string_matching(/Effective Access/i),
+                                       a_string_including(resolved_href))),
+        "expected an 'Effective Access' link in the related panel. Found: #{hrefs.inspect}"
+      )
+    end
+
+    it 'shows the related-perspective panel on the role-only and users-with-role reports' do
+      visit report_url('user_access_overview_roles_only',
+                       app_type_id: @app_type.id,
+                       no_run: 'true')
+
+      panel = find('.uao-related-perspectives', visible: :all)
+      links_in_panel = panel.all(:link, visible: :all)
+      hrefs = links_in_panel.map { |l| [l.text, l[:href]] }
+
+      users_with_role_href = report_url('user_access_overview_users_with_role',
+                                        app_type_id: @app_type.id)
+
+      expect(hrefs).to(
+        include(a_collection_including(a_string_matching(/Each Role's Users/i),
+                                       a_string_including(users_with_role_href))),
+        "expected an 'Each Role's Users' link in the related panel. Found: #{hrefs.inspect}"
+      )
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1125 (related to parent #1122; siblings #1126 / #1127).

## Summary

Adds drill-down links so admins can jump directly from the existing admin pages into the relevant User Access Overview (UAO) report perspective with the appropriate filters preselected, and adds a cross-perspective navigation panel to UAO reports so admins can switch perspective without re-entering filters.

## Changes

- **Usernames and Passwords admin page (`/admin/manage_users`)**
  - New per-row link **access overview** that opens the *By Role* UAO report filtered to the selected user.
- **User Roles admin page (`/admin/user_roles`)**
  - New per-row links **access overview** (user + role + app type → *By Role*) and **users with role** (role + app type → *Users With Role*). Each link is shown only when its required filter values are present.
- **User Access Controls admin page (`/admin/user_access_controls`)**
  - New **Drill down** column with up to three links per row:
    - **access overview** (user-scoped UACs) → *By Role*
    - **users with role** (role-scoped UACs) → *Users With Role*
    - **resource grants** (when a `resource_name` is set) → *Resource by Role*
  - Links are suppressed for rows where the required filter values are missing.
- **User Access Overview reports (`_show.html.erb`)**
  - New related-perspective panel (\"Other views with the same filters\") rendered above the criteria block. Lists the other UAO reports relevant to the current perspective and forwards the current \`search_attrs\` (\`user\`, \`app_type_id\`, \`resource_type\`, \`resource_name\`, \`role_name\`) so admins can switch perspective without re-entering filters. Hidden in embedded-report contexts.

## Implementation notes

- New helper module \`UserAccessOverviewLinksHelper\` centralizes UAO short-name mapping, path generation, and the conditional \`user_access_overview_link\` helper that returns \`nil\` when required filters are blank, keeping the per-row markup small and consistent.
- Filter forwarding strips blank values to avoid generating empty \`search_attrs[...]=\` parameters.
- All links use \`link_to\` (proper escaping); no inline scripts/styles introduced.

## Tests

Added \`spec/system/admin_user_access_overview_drill_down_spec.rb\` (8 examples, all passing) covering:

1. manage_users: user-scoped drill-down link.
2. user_roles: user + role drill-down links.
3. user_access_controls: user-scoped, role-scoped and resource-scoped drill-down links, and negative case (no role-scoped link when \`role_name\` is blank).
4. UAO reports: related-perspective panel renders the expected cross-links with filters preserved, on both user-centric and role-centric perspectives.

\`\`\`
8 examples, 0 failures
\`\`\`

Pre-existing unrelated failure in \`spec/system/admin_user_access_overview_spec.rb\` (\"returns no results when user is not selected (mandatory)\") was verified against \`develop\` and is not caused by this change.