### PR TITLE
Fixed download_field_file failing for longitudinal Redcap projects with multiple instruments - fixes #1135

### DIFF
--- a/app/controllers/redcap/project_user_requests_controller.rb
+++ b/app/controllers/redcap/project_user_requests_controller.rb
@@ -51,7 +51,7 @@ class Redcap::ProjectUserRequestsController < UserBaseController
     record_id = params[:record_id]
     field_name = params[:field_name]
     resource_name = params[:id]
-    m = Resources::Models.find_by(resource_name:)
+    m = find_resource_model(resource_name)
     raise FphsException, "download_field_file resource model not found for resource_name: #{resource_name}" unless m
 
     tn = "\\.#{m.table_name}"
@@ -87,6 +87,36 @@ class Redcap::ProjectUserRequestsController < UserBaseController
 
   def permitted_params
     %i[study name server_url api_key dynamic_model_table transfer_mode frequency disabled options notes]
+  end
+
+  #
+  # Find a model in Resources::Models using the resource_name from the URL.
+  # The URL may contain one of several name formats:
+  #   - The exact plural resource_name (e.g. "dynamic_model__press_bp_measurement_rcs")
+  #   - The singular item_type_name (e.g. "dynamic_model__press_bp_measurement_rc")
+  #   - The name_with_option_type format used by longitudinal Redcap projects with multiple
+  #     data collection instruments (e.g. "dynamic_model__press_bp_measurement_rc_day_home_bp_form_upload"),
+  #     which is {item_type_name}_{option_type} - the singular name followed by underscore and option type name.
+  # @param resource_name [String] the resource_name from the URL parameter
+  # @return [Resources::Models::Item | nil]
+  def find_resource_model(resource_name)
+    return if resource_name.blank?
+
+    found = Resources::Models.find_by(resource_name:) ||
+            Resources::Models.find_by(resource_item_name: resource_name.to_sym)
+    return found if found
+
+    # Fall back to matching the longest {resource_item_name} prefix by progressively
+    # trimming trailing "_segment" suffixes (which represent the option_type).
+    # Stop once the candidate no longer contains the "__" namespace separator,
+    # to avoid matching base type registrations such as :dynamic_model.
+    candidate = resource_name.to_s
+    while candidate.include?('__') && (idx = candidate.rindex('_'))
+      candidate = candidate[0...idx]
+      match = Resources::Models.find_by(resource_item_name: candidate.to_sym)
+      return match if match
+    end
+    nil
   end
 
   #
@@ -138,16 +168,14 @@ class Redcap::ProjectUserRequestsController < UserBaseController
             request_host = uri.host.downcase
 
             @redcap__project_admin = by_project_id.find do |project_admin|
-              begin
-                stored_uri = URI.parse(project_admin.server_url.to_s)
-                stored_uri.scheme.present? &&
-                  stored_uri.host.present? &&
-                  stored_uri.scheme.downcase == request_scheme &&
-                  stored_uri.host.downcase == request_host
-              rescue URI::InvalidURIError
-                Rails.logger.warn "Invalid stored server_url for project_admin #{project_admin.id}: #{project_admin.server_url}"
-                false
-              end
+              stored_uri = URI.parse(project_admin.server_url.to_s)
+              stored_uri.scheme.present? &&
+                stored_uri.host.present? &&
+                stored_uri.scheme.downcase == request_scheme &&
+                stored_uri.host.downcase == request_host
+            rescue URI::InvalidURIError
+              Rails.logger.warn "Invalid stored server_url for project_admin #{project_admin.id}: #{project_admin.server_url}"
+              false
             end
           end
         rescue URI::InvalidURIError

--- a/spec/controllers/redcap/project_user_requests_controller_spec.rb
+++ b/spec/controllers/redcap/project_user_requests_controller_spec.rb
@@ -12,6 +12,13 @@
 #   - No match raises FphsException with project_id and server_url in message
 #   - Malformed server_url param does not cause a 500 error
 #   - project_name lookup failure includes project_name (not project_id/server_url) in message
+#
+# Also covers download_field_file action (issue #1135):
+#   - Finds model by exact plural resource_name
+#   - Finds model when resource_name is the singular item_type_name (without option type)
+#   - Finds model when resource_name is in name_with_option_type format (singular + option_type suffix)
+#     used by longitudinal projects with multiple data collection instruments
+#   - Returns 400 when resource_name is completely unknown
 
 require 'rails_helper'
 
@@ -157,6 +164,86 @@ RSpec.describe Redcap::ProjectUserRequestsController, type: :controller do
       expect(json['message']).to include('project_name: nonexistent_project_xyz')
       expect(json['message']).not_to match(/\bproject_id:/)
       expect(json['message']).not_to match(/\bserver_url:/)
+    end
+  end
+
+  # Tests for issue #1135: download_field_file fails for longitudinal projects
+  # where the URL resource_name contains an option_type suffix (name_with_option_type format)
+  # e.g. dynamic_model__press_bp_measurement_rc_day_home_bp_form_upload instead of
+  # the actual registered resource_name dynamic_model__press_bp_measurement_rcs
+  describe 'download_field_file action resource lookup' do
+    let(:test_table_name) { 'press_bp_measurement_rcs' }
+    let(:model_resource_name) { "dynamic_model__#{test_table_name}" }
+    # item_type_name is the singular form used in name_with_option_type (item_type_name = table_name.singularize)
+    let(:item_type_name) { "dynamic_model__#{test_table_name.singularize}" }
+    let(:option_type_name) { 'day_home_bp_form_upload' }
+    # name_with_option_type is the format sent in the URL by the Handlebars template for
+    # longitudinal projects: singular item_type_name + _ + option_type
+    let(:name_with_option_type) { "#{item_type_name}_#{option_type_name}" }
+    let(:model_resource_item_name) { item_type_name }
+
+    let(:model_class) do
+      double('DynamicModel::PressBpMeasurementRc',
+             name: 'DynamicModel::PressBpMeasurementRc',
+             table_name: test_table_name)
+    end
+
+    before do
+      Resources::Models.add(
+        model_class,
+        resource_name: model_resource_name,
+        resource_item_name: model_resource_item_name
+      )
+      # Stub project admin DB query so tests focus on the resource lookup only.
+      # When no project admin is found, the controller returns 404 (file not found), which
+      # is the expected behavior for a valid resource but missing file.
+      allow(Redcap::ProjectAdmin).to receive(:active).and_return(
+        double('scope', order: double('scope2', find_by: nil))
+      )
+    end
+
+    after do
+      Resources::Models.remove(resource_name: model_resource_name)
+    end
+
+    it 'finds the model with the exact plural resource_name' do
+      get :download_field_file, params: { id: model_resource_name, field_name: 'file_field', record_id: '1' }, format: :json
+
+      # Should not raise model-not-found (400); reaches the file-not-found branch (404)
+      expect(response).not_to have_http_status(:bad_request)
+      expect(response).to have_http_status(:not_found)
+      json = JSON.parse(response.body)
+      expect(json['message']).to eq('File not found or inaccessible')
+    end
+
+    it 'finds the model when resource_name is the singular item_type_name (without option type)' do
+      get :download_field_file, params: { id: item_type_name, field_name: 'file_field', record_id: '1' }, format: :json
+
+      expect(response).not_to have_http_status(:bad_request)
+      expect(response).to have_http_status(:not_found)
+      json = JSON.parse(response.body)
+      expect(json['message']).to eq('File not found or inaccessible')
+    end
+
+    it 'finds the model when resource_name is in name_with_option_type format (issue #1135)' do
+      # This is the bug scenario: the URL contains the name_with_option_type
+      # (e.g. dynamic_model__press_bp_measurement_rc_day_home_bp_form_upload) instead of
+      # the actual resource_name (dynamic_model__press_bp_measurement_rcs)
+      get :download_field_file, params: { id: name_with_option_type, field_name: 'file_field', record_id: '1' }, format: :json
+
+      # After fix: should NOT return 400 (model not found), should return 404 (file not found)
+      expect(response).not_to have_http_status(:bad_request)
+      expect(response).to have_http_status(:not_found)
+      json = JSON.parse(response.body)
+      expect(json['message']).to eq('File not found or inaccessible')
+    end
+
+    it 'returns 400 when resource_name is completely unknown' do
+      get :download_field_file, params: { id: 'dynamic_model__completely_unknown_model', field_name: 'file_field', record_id: '1' }, format: :json
+
+      expect(response).to have_http_status(:bad_request)
+      json = JSON.parse(response.body)
+      expect(json['message']).to include('resource model not found')
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #1135 — downloading a Redcap field file failed (404, `download_field_file resource model not found`) for longitudinal Redcap projects with multiple data collection instruments.

## Root cause

`Redcap::ProjectUserRequestsController#download_field_file` looked up the model with:

```ruby
m = Resources::Models.find_by(resource_name: params[:id])
```

The `id` URL parameter is generated by the Handlebars `redcap_file` link in
`app/views/common_templates/_common_template_result_fields.html.erb`, which uses the
template-config `name` value. That value comes from
`OptionConfigs::TemplateOptionMapping` and is the singular `item_type_name`
(e.g. `dynamic_model__press_bp_measurement_rc`). For renderings that loop over option_types
(longitudinal / multi-instrument projects), it can also be in the
`name_with_option_type` format `{item_type_name}_{option_type}`
(e.g. `dynamic_model__press_bp_measurement_rc_day_home_bp_form_upload`).

Neither matches the registered model's plural `resource_name`
(`dynamic_model__press_bp_measurement_rcs`), so the lookup returned `nil` and the file
could not be downloaded.

Unlike `activity_log_type` registrations — which add a separate `Resources::Models` entry
per extra_log_type — dynamic models register a single entry without baking the option_type
into `resource_item_name`, so an equality lookup using the URL value alone cannot match.

## Fix

Introduced a private `find_resource_model` helper that resolves the URL value in three steps:

1. Exact match by `resource_name` (plural, current behavior).
2. Exact match by `resource_item_name` (singular).
3. Longest-prefix fallback: progressively trim trailing `_segment` suffixes and look each
   candidate up by `resource_item_name`. Stops when the candidate no longer contains the
   `__` namespace separator to avoid matching base type registrations such as
   `:dynamic_model`.

This makes the URL resolution deterministic (longest prefix wins) and uses the existing
`Resources::Models.find_by` API throughout.

## Tests

Added `download_field_file action resource lookup` describe block in
`spec/controllers/redcap/project_user_requests_controller_spec.rb` with 4 examples
covering:

- Exact plural `resource_name`
- Singular `item_type_name` (without option_type)
- `name_with_option_type` format (the issue #1135 case)
- Unknown resource → 400 (not matched against base `:dynamic_model`)

Regression check:

- `spec/controllers/redcap/project_user_requests_controller_spec.rb` — 11/11 pass
- `spec/controllers/redcap/` (full suite) — 37/37 pass

## Notes

- No template or front-end change. Existing cached/in-flight links continue to work.
- The controller-side resolver is the smaller-surface fix; the template chain that produces
  these URL formats remains untouched.
