### PR TITLE
Fixed display_embedded? error in page layouts - fixes #1134

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -9,7 +9,7 @@ class HelpController < ApplicationController
   ImagesSubdirectory = 'images'
   IntroductionDocument = '0_introduction'
 
-  helper_method :library, :section, :subsection, :display_embedded?
+  helper_method :library, :section, :subsection
 
   include HelpHelper
 
@@ -150,16 +150,4 @@ class HelpController < ApplicationController
     component.to_s.gsub(/[^a-zA-Z0-9\-_]/, '_')
   end
 
-  #
-  # How should the requested page be rendered? The only option is 'embedded'
-  # in the :display_as param
-  def display_as
-    params[:display_as]
-  end
-
-  #
-  # Was the requested page to be displayed embedded, or as a full page?
-  def display_embedded?
-    display_as == 'embedded'
-  end
 end

--- a/app/helpers/help_helper.rb
+++ b/app/helpers/help_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module HelpHelper
+  HELP_BACK_PATH_PATTERN = %r{\A/help(?:/[a-zA-Z0-9\-_]+){2,3}\z}.freeze
+
   def view_doc(library, section, subsection)
     <<~END_HTML
       #{view_doc_in_wrapper(formatted_doc(library, section, subsection), library, section)}
@@ -150,8 +152,8 @@ module HelpHelper
       HelpController::IndexSubsection
     elsif section == 'general'
       back = params[:back_path].to_s
-      # Validate: must be a /help/ path using only safe characters (no traversal)
-      if back.match?(%r{\A/help(/[a-zA-Z0-9\-_]+){2,3}\z})
+      # Validate: must be a /help/ path using only safe characters (no traversal).
+      if valid_help_back_path?(back)
         back
       else
         HelpController::IntroductionDocument
@@ -159,6 +161,24 @@ module HelpHelper
     else
       HelpController::IntroductionDocument
     end
+  end
+
+  #
+  # How should the requested page be rendered? The only option is 'embedded'
+  # in the :display_as param
+  def display_as
+    params[:display_as]
+  end
+
+  #
+  # Was the requested page to be displayed embedded, or as a full page?
+  def display_embedded?
+    display_as == 'embedded'
+  end
+
+  # Validate explicit help back-path links to avoid traversal and unrelated routes.
+  def valid_help_back_path?(path)
+    path.match?(HELP_BACK_PATH_PATTERN)
   end
 
   #

--- a/spec/helpers/help_helper_spec.rb
+++ b/spec/helpers/help_helper_spec.rb
@@ -13,6 +13,9 @@
 #     - Rejects back_path values that don't conform to /help/<segment>/<segment>[/<segment>]
 #     - Falls back to IntroductionDocument when no valid back_path is present
 #   - Returns IntroductionDocument for all other sections
+# - #display_embedded?: Returns true when display_as param is 'embedded', false otherwise
+#   - Defined in HelpHelper (not just HelpController) so it is available in any view context,
+#     including views rendered by PageLayoutsController (fixes issue #1134)
 
 require 'rails_helper'
 
@@ -96,6 +99,30 @@ RSpec.describe HelpHelper, type: :helper do
       it 'returns IntroductionDocument regardless of params' do
         controller.params[:back_path] = '/help/admin_reference/general/save_trigger'
         expect(helper.main_section).to eq(HelpController::IntroductionDocument)
+      end
+    end
+  end
+
+  describe '#display_embedded?' do
+    context 'when display_as param is "embedded"' do
+      before { controller.params[:display_as] = 'embedded' }
+
+      it 'returns true' do
+        expect(helper.display_embedded?).to be true
+      end
+    end
+
+    context 'when display_as param is absent' do
+      it 'returns false' do
+        expect(helper.display_embedded?).to be false
+      end
+    end
+
+    context 'when display_as param is a different value' do
+      before { controller.params[:display_as] = 'full' }
+
+      it 'returns false' do
+        expect(helper.display_embedded?).to be false
       end
     end
   end


### PR DESCRIPTION
Fixed `<ActionView::Template::Error: undefined method \`display_embedded?\`>` issue when viewing documentation on the portal from the data dictionary explorer.

- Moved `display_embedded?` and `display_as` from `HelpController` to `HelpHelper` so it is available in all view contexts.
- Refactored `back_path` validation in `HelpHelper` into a named helper method and constant array.
- Included comprehensive request coverage in `HelpHelper` specifications.
