### PR TITLE
Fixed Redcap file capture desync and added manual recovery option - fixes #1137

### DIFF
--- a/app/controllers/redcap/project_admins_controller.rb
+++ b/app/controllers/redcap/project_admins_controller.rb
@@ -36,8 +36,12 @@ class Redcap::ProjectAdminsController < AdminController
 
     ignore_cache = params[:ignore_cache].to_s == 'true'
     retrieve_all = params[:retrieve_all].to_s == 'true'
+    verify_file_fields = params[:verify_file_fields].to_s == 'true'
 
-    @redcap__project_admin.dynamic_storage.request_records(ignore_cache:, retrieve_all:, request_source: :admin_ui)
+    @redcap__project_admin.dynamic_storage.request_records(ignore_cache:,
+                                                           retrieve_all:,
+                                                           verify_file_fields:,
+                                                           request_source: :admin_ui)
 
     msg = "Records requested at #{DateTime.now}"
     render json: { message: msg }, status: 200

--- a/app/controllers/redcap/project_user_requests_controller.rb
+++ b/app/controllers/redcap/project_user_requests_controller.rb
@@ -54,11 +54,16 @@ class Redcap::ProjectUserRequestsController < UserBaseController
     m = find_resource_model(resource_name)
     raise FphsException, "download_field_file resource model not found for resource_name: #{resource_name}" unless m
 
-    tn = "\\.#{m.table_name}"
+    tn = m.table_name
+    sn = m.model.respond_to?(:definition) ? m.model.definition.schema_name : nil
+    tns = sn ? [tn, "#{sn}.#{tn}"] : [tn]
 
     svp = { secure_view: params[:secure_view]&.to_unsafe_h }
 
-    project_admin = Redcap::ProjectAdmin.active.order(id: :desc).find_by('dynamic_model_table ~ ?', tn)
+    # When more than one active project admin shares the same dynamic model table,
+    # prefer one that actually pulls data (frequency != 'never') and the most recently
+    # created (highest id), to match the project that actually captures files.
+    project_admin = Redcap::ProjectAdmin.preferred_active(tns)
     if project_admin
       project_admin.current_user = current_user
       container = project_admin.file_store
@@ -73,7 +78,7 @@ class Redcap::ProjectUserRequestsController < UserBaseController
       redirect_to url
     else
       Rails.logger.warn "Download field file failed for record_id: #{record_id}, field_name: #{field_name}, " \
-                        "project_admin: #{project_admin&.id}, container: #{container&.id}, path: #{path}, tn: #{tn}"
+                        "project_admin: #{project_admin&.id}, container: #{container&.id}, path: #{path}, tns: #{tns.inspect}"
       render json: { message: 'File not found or inaccessible' }, status: 404
     end
   end

--- a/app/jobs/redcap/capture_records_job.rb
+++ b/app/jobs/redcap/capture_records_job.rb
@@ -12,8 +12,10 @@ module Redcap
     # @param [String] class_name
     # @param [Boolean] ignore_cache - force pull from REDCap, bypassing cache
     # @param [Boolean] retrieve_all - ignore export_only_updated_records setting and retrieve all records
+    # @param [Boolean] verify_file_fields - check that each file field's underlying stored file exists,
+    #                                       and retry capture for any missing files.
     # @return [Boolean] success
-    def perform(project_admin, class_name, ignore_cache: false, retrieve_all: false)
+    def perform(project_admin, class_name, ignore_cache: false, retrieve_all: false, verify_file_fields: false)
       setup_with project_admin
 
       unless project_admin&.dynamic_model_ready?
@@ -27,7 +29,9 @@ module Redcap
                              "#{project_admin.dynamic_model_table}"
       end
 
-      dr = Redcap::DataRecords.new(project_admin, class_name, is_manual_pull: true)
+      dr = Redcap::DataRecords.new(project_admin, class_name,
+                                   is_manual_pull: true,
+                                   verify_file_fields:)
       dr.retrieve_validate_store(ignore_cache:, retrieve_all:)
       project_admin.update_status(:manual_run_successful)
     rescue StandardError => e

--- a/app/models/redcap/data_records.rb
+++ b/app/models/redcap/data_records.rb
@@ -23,9 +23,10 @@ module Redcap
                   :external_id_fkey_name,
                   :retrieved_from_cache, :using_date_range_filter, :is_manual_pull,
                   :date_range_begin,
-                  :request_source
+                  :request_source,
+                  :verify_file_fields
 
-    def initialize(project_admin, class_name, is_manual_pull: false, request_source: nil)
+    def initialize(project_admin, class_name, is_manual_pull: false, request_source: nil, verify_file_fields: false)
       super()
       self.project_admin = project_admin
       self.class_name = class_name
@@ -52,6 +53,9 @@ module Redcap
       self.using_date_range_filter = false
       self.is_manual_pull = is_manual_pull
       self.request_source = request_source
+      # Only honour file-field verification on manual (admin-initiated) pulls so
+      # scheduled pulls remain fast. On scheduled pulls the option is forced off.
+      self.verify_file_fields = is_manual_pull && verify_file_fields
     end
 
     #
@@ -59,16 +63,22 @@ module Redcap
     # @see Redcap::CaptureRecordsJob#perform_later
     # @param [Boolean] ignore_cache - force pull from REDCap, bypassing cache
     # @param [Boolean] retrieve_all - ignore export_only_updated_records setting and retrieve all records
-    def request_records(ignore_cache: false, retrieve_all: false)
+    # @param [Boolean] verify_file_fields - on manual pulls, treat records as changed when a file
+    #                                       field's underlying stored file is missing.
+    def request_records(ignore_cache: false, retrieve_all: false, verify_file_fields: false)
       jobclass = Redcap::CaptureRecordsJob
       jobs = ProjectAdmin.existing_jobs(jobclass, project_admin)
       return if jobs.count > 0
 
-      self.job = Redcap::CaptureRecordsJob.perform_later(project_admin, class_name, ignore_cache:, retrieve_all:)
+      self.job = Redcap::CaptureRecordsJob.perform_later(project_admin, class_name,
+                                                         ignore_cache:,
+                                                         retrieve_all:,
+                                                         verify_file_fields:)
       return if Rails.application.config.active_job.queue_adapter == :inline
 
       source_result = request_source ? { request_source => true } : {}
-      project_admin.record_job_request('setup job: store records', result: { requested: true, job: job&.job_id }.merge(source_result))
+      project_admin.record_job_request('setup job: store records',
+                                       result: { requested: true, job: job&.job_id }.merge(source_result))
     end
 
     #
@@ -524,6 +534,7 @@ module Redcap
     # @return [Integer | false | nil]
     def create_or_update(retrieved_record, keep_results: true)
       rec_ids = record_identifiers(retrieved_record)
+      attrs_for_persistence = retrieved_record.dup
       existing_record = model.where(rec_ids).first
       if existing_record
         existing_record.no_track = true if existing_record.respond_to? :no_track
@@ -546,8 +557,19 @@ module Redcap
           return
         end
 
+        # Defer file field values until the actual file has been captured.
+        # Persisting the filename string before capture_files runs leaves the
+        # row inconsistent (filename present, no stored file) if anything
+        # between the commit and capture_files raises - notably the
+        # after_commit save trigger handlers. By nulling the field here and
+        # writing the filename back via update_columns only after a successful
+        # file import, a failed pull leaves the field NULL so the next pull
+        # detects the mismatch and retries.
+        pending_file_field_values = extract_and_null_file_fields(attrs_for_persistence)
+
         existing_record.force_save!
-        if existing_record.update(retrieved_record)
+        if existing_record.update(attrs_for_persistence)
+          stash_pending_file_fields(existing_record, pending_file_field_values)
           if keep_results
             updated_ids << rec_ids
             upserted_records << existing_record
@@ -557,7 +579,11 @@ module Redcap
           errors << { id: rec_ids, errors: existing_record.errors, action: :update }
         end
       else
-        new_record = model.new(retrieved_record)
+        # See comment above on deferring file field values until capture_files
+        # has actually stored the file.
+        pending_file_field_values = extract_and_null_file_fields(attrs_for_persistence)
+
+        new_record = model.new(attrs_for_persistence)
         new_record.no_track = true if new_record.respond_to? :no_track
         if new_record.respond_to? :current_user=
           new_record.current_user = current_user
@@ -573,6 +599,7 @@ module Redcap
 
         new_record.force_save!
         if new_record.save
+          stash_pending_file_fields(new_record, pending_file_field_values)
           if keep_results
             created_ids << rec_ids
             upserted_records << new_record
@@ -586,6 +613,32 @@ module Redcap
       nil
     end
 
+    # Remove file field values from the retrieved record hash so the row is
+    # persisted without filename strings for fields whose underlying files have
+    # not yet been captured. Returns the removed { field_name => value } hash
+    # to be replayed by #capture_files once the file is stored.
+    # @param [Hash] retrieved_record - mutated in place
+    # @return [Hash{Symbol => String}]
+    def extract_and_null_file_fields(retrieved_record)
+      pending = {}
+      file_fields.each do |field_name|
+        value = retrieved_record[field_name]
+        next if value.blank?
+
+        pending[field_name] = value
+        retrieved_record[field_name] = nil
+      end
+      pending
+    end
+
+    # Attach the deferred file field values to the persisted AR record so
+    # #capture_files can replay them after a successful file import.
+    # @param [UserBase] record
+    # @param [Hash{Symbol => String}] pending_file_field_values
+    def stash_pending_file_fields(record, pending_file_field_values)
+      record.instance_variable_set(:@_redcap_pending_file_fields, pending_file_field_values)
+    end
+
     #
     # Capture files from file fields in the requested record, which typically represents
     # an updated or created dynamic model instance.
@@ -597,8 +650,15 @@ module Redcap
     # @param [UserBase] record - the record to capture the file fields from
     def capture_files(record)
       self.done = 0
+      pending_file_field_values = record.instance_variable_get(:@_redcap_pending_file_fields) || {}
+
       file_fields.each do |field_name|
-        next if record[field_name].blank?
+        # Source the filename from the deferred values stashed before persistence,
+        # falling back to the AR attribute (e.g. for retried/legacy rows where
+        # the field already holds the filename string).
+        filename_value = pending_file_field_values[field_name]
+        filename_value = record[field_name] if filename_value.blank?
+        next if filename_value.blank?
 
         self.done += 1
         update_job_request if done % step_count == 0
@@ -623,7 +683,32 @@ module Redcap
                                              current_user,
                                              path:,
                                              replace: true)
-          imported_files << res if res
+          if res
+            imported_files << res
+            # Now that the file is stored, write the deferred filename back to
+            # the dynamic-model row. Use update_columns to skip validations and
+            # callbacks so this does not re-fire after_commit save triggers.
+            # Skip when record is not an AR instance (e.g. when capture_files
+            # is called directly with a retrieved hash in tests).
+            if record.respond_to?(:update_columns)
+              record.update_columns(field_name => filename_value)
+            else
+              record[field_name] = filename_value
+            end
+          else
+            # import_file returned nil: the file was skipped (e.g. an identical
+            # stored_file row already existed, or skip_existing matched).
+            # This can mask a missing-on-disk file when a stored_files row exists
+            # but the underlying file is not actually present, so log everything
+            # passed to import_file for diagnosis.
+            Rails.logger.warn(
+              'Redcap capture_files: NfsStore::Import.import_file returned nil (file skipped). ' \
+              "container_id: #{container.id}, file_name: #{filename}, " \
+              "file_path: #{temp_file.path}, user: #{current_user&.email}, " \
+              "path: #{path}, replace: true, record_id: #{record_id}, " \
+              "project_admin: #{project_admin.id}"
+            )
+          end
         rescue Exception => e
           # We rescue Exception rather than StandardError, since file errors inherit from Exception
           msg = "Failed to retrieve or import REDCap file for record: #{record_id} - field name: #{field_name} - with user: #{current_user.email}.\n#{e}"
@@ -677,7 +762,54 @@ module Redcap
       # This will allow the lookup of the master to run by treating it as having changed.
       res[:master_id] = true if set_master_id_using_association && existing_record['master_id'].nil?
 
+      # Optionally verify that each file field's underlying stored file is
+      # actually present in the project's filestore container. When a file is
+      # missing on disk (no nfs_store_stored_files row at the expected path /
+      # file_name) we treat the record as changed, so capture_files retries.
+      # This is only enabled when explicitly requested for a manual pull, since
+      # it adds overhead to record comparison.
+      if verify_file_fields && res.empty?
+        missing = file_fields.find do |field_name|
+          existing_value = existing_attrs[field_name]
+          next false if existing_value.blank? || existing_value == FailedFileFieldMarker
+
+          !stored_file_exists?(existing_record, field_name)
+        end
+        res[missing] = :stored_file_missing if missing
+      end
+
       res.empty?
+    end
+
+    # Check whether a stored_files row exists in the project's filestore
+    # container for the given record + file field, using a per-run memoized
+    # index to keep this O(1).
+    # @param [Dynamic::DynamicModelBase] existing_record
+    # @param [Symbol] field_name
+    # @return [Boolean]
+    def stored_file_exists?(existing_record, field_name)
+      record_id = existing_record[record_id_field]
+      return false if record_id.blank?
+
+      key = "#{project_admin.dynamic_model_table}/file-fields/#{record_id}/#{field_name}"
+      stored_file_index.include?(key)
+    end
+
+    # Memoized Set of "<path>/<file_name>" entries for every stored_files row in
+    # the project's filestore container, restricted to the file-fields path
+    # prefix used by capture_files.
+    # @return [Set<String>]
+    def stored_file_index
+      @stored_file_index ||= begin
+        container = project_admin.file_store
+        path_prefix = "#{project_admin.dynamic_model_table}/file-fields/"
+        Set.new(
+          container.stored_files
+                   .where('path LIKE ?', "#{ActiveRecord::Base.sanitize_sql_like(path_prefix)}%")
+                   .pluck(:path, :file_name)
+                   .map { |path, file_name| "#{path}/#{file_name}" }
+        )
+      end
     end
 
     #

--- a/app/models/redcap/dynamic_storage.rb
+++ b/app/models/redcap/dynamic_storage.rb
@@ -40,14 +40,16 @@ module Redcap
     # @see Redcap::CaptureRecordsJob#perform_later
     # @param [Boolean] ignore_cache - force pull from REDCap, bypassing cache
     # @param [Boolean] retrieve_all - ignore export_only_updated_records setting and retrieve all records
-    def request_records(ignore_cache: false, retrieve_all: false, request_source: nil)
+    # @param [Boolean] verify_file_fields - on manual pulls, treat records as changed when a file
+    #                                       field's underlying stored file is missing, so capture_files retries.
+    def request_records(ignore_cache: false, retrieve_all: false, verify_file_fields: false, request_source: nil)
       unless dynamic_model
         raise FphsException,
               'dynamic model has not been set up'
       end
 
       dr = Redcap::DataRecords.new(project_admin, dynamic_model_class_name, request_source:)
-      dr.request_records(ignore_cache:, retrieve_all:)
+      dr.request_records(ignore_cache:, retrieve_all:, verify_file_fields:)
     end
 
     #

--- a/app/models/redcap/project_admin.rb
+++ b/app/models/redcap/project_admin.rb
@@ -493,6 +493,18 @@ module Redcap
     end
 
     #
+    # When multiple active project admins match the same dynamic_model_table
+    # we want to pick the one that actually captures data. Prefer a project admin
+    # whose frequency is not 'never' and is the most recently created (highest id).
+    # Fall back to the most recently created match if all candidates have frequency 'never'.
+    # @param table_names [String, Array<String>] table name(s) to match
+    # @return [Redcap::ProjectAdmin, nil]
+    def self.preferred_active(table_names)
+      ordered = active.where(dynamic_model_table: table_names).order(id: :desc)
+      ordered.where.not(frequency: 'never').first || ordered.first
+    end
+
+    #
     # Create a job request record for the *action*
     # If no result is specified, default to { requested: true }
     # @param [String] action

--- a/app/views/common_templates/edit_fields/_redcap_file.html.erb
+++ b/app/views/common_templates/edit_fields/_redcap_file.html.erb
@@ -8,7 +8,10 @@
   record_id = form_object_instance.record_id
   sntn = "#{sn}.#{tn}"
   tns = [tn , sntn]
-  project_admin = Redcap::ProjectAdmin.active.find_by(dynamic_model_table: tns)
+  # When more than one active project admin shares the same dynamic model table,
+  # prefer one that actually pulls data (frequency != 'never') and the most recently
+  # created (highest id), to match the project that actually captures files.
+  project_admin = Redcap::ProjectAdmin.preferred_active(tns)
   if project_admin
     project_admin.current_user = current_user 
     container = project_admin.file_store

--- a/app/views/redcap/project_admins/_details_block.html.erb
+++ b/app/views/redcap/project_admins/_details_block.html.erb
@@ -195,6 +195,11 @@ if req&.result
                 remote: true, 
                 class: 'btn btn-warning btn-sm' %></p>
         <% end %>
+        <p><%= link_to 'retrieve & verify files', request_records_redcap_project_admin_path(id: object_instance.id, retrieve_all: true, ignore_cache: true, verify_file_fields: true), 
+              method: :post, 
+              remote: true, 
+              title: 'Retrieve all records and re-capture any file field whose stored file is missing from the filestore container',
+              class: 'btn btn-warning btn-sm' %></p>
         <p><strong>retrieve configurations</strong></p>
         <p><%= link_to 'retrieve latest redcap configuration', request_latest_rc_configs_redcap_project_admin_path(id: object_instance.id), 
               method: :post, 

--- a/spec/controllers/redcap/project_user_requests_controller_spec.rb
+++ b/spec/controllers/redcap/project_user_requests_controller_spec.rb
@@ -189,16 +189,11 @@ RSpec.describe Redcap::ProjectUserRequestsController, type: :controller do
     end
 
     before do
+      setup_redcap_project_admin_configs
       Resources::Models.add(
         model_class,
         resource_name: model_resource_name,
         resource_item_name: model_resource_item_name
-      )
-      # Stub project admin DB query so tests focus on the resource lookup only.
-      # When no project admin is found, the controller returns 404 (file not found), which
-      # is the expected behavior for a valid resource but missing file.
-      allow(Redcap::ProjectAdmin).to receive(:active).and_return(
-        double('scope', order: double('scope2', find_by: nil))
       )
     end
 

--- a/spec/models/redcap/client_request_spec.rb
+++ b/spec/models/redcap/client_request_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Redcap::ClientRequest, type: :model do
   it 'saves a record for the action' do
     name = @projects.first[:name]
 
-    num = Redcap::ClientRequest.count
+    num = Redcap::ClientRequest.unscoped.count
 
     rc = Redcap::ProjectAdmin.active.find_by_name(name)
     rc.current_admin = @admin
@@ -22,8 +22,8 @@ RSpec.describe Redcap::ClientRequest, type: :model do
 
     rc.api_client.project
 
-    expect(Redcap::ClientRequest.count).to be > num
-    project_request = Redcap::ClientRequest.where(action: 'project').last
+    expect(Redcap::ClientRequest.unscoped.count).to be > num
+    project_request = Redcap::ClientRequest.unscoped.where(action: 'project').order(id: :desc).first
     expect(project_request).to be_present
     expect(project_request.action).to eq 'project'
   end

--- a/spec/models/redcap/data_records_cache_and_date_range_spec.rb
+++ b/spec/models/redcap/data_records_cache_and_date_range_spec.rb
@@ -954,15 +954,6 @@ RSpec.describe 'Redcap::DataRecords cache and date range', type: :model do
   end
 
   describe 'failed file field handling for export_only_updated_records' do
-    before :all do
-      @bad_admin, = create_admin
-      @bad_admin.update! disabled: true
-      create_admin
-      @projects = setup_redcap_project_admin_configs
-      @project = @projects.first
-      setup_file_fields
-    end
-
     before :example do
       @bad_admin, = create_admin
       @bad_admin.update! disabled: true
@@ -971,6 +962,7 @@ RSpec.describe 'Redcap::DataRecords cache and date range', type: :model do
       setup_file_store
       @projects = setup_redcap_project_admin_configs
       @project = @projects.first
+      setup_file_fields
       reset_mocks
     end
 
@@ -1189,14 +1181,21 @@ RSpec.describe 'Redcap::DataRecords cache and date range', type: :model do
         dr.retrieve
         expect(dr.records.length).to be > 0
 
+        retrieved_with_file = dr.records.find { |r| r[:file1].present? }
+        expect(retrieved_with_file).to be_present
+        target_record_id = retrieved_with_file[dr.send(:record_id_field)]
+
         # Create/update records first
         dr.records.each do |record|
           dr.send(:create_or_update, record)
         end
 
-        # Find a record with file fields
-        model_record = dr.upserted_records.find { |r| r[:file1].present? }
+        # The filename is deferred until capture_files succeeds, so locate the
+        # persisted record by record id and confirm the pending file stash.
+        model_record = dr.upserted_records.find { |r| r[dr.send(:record_id_field)] == target_record_id }
         expect(model_record).to be_present
+        pending = model_record.instance_variable_get(:@_redcap_pending_file_fields)
+        expect(pending[:file1]).to be_present
 
         dr.send(:capture_files, model_record)
 

--- a/spec/models/redcap/data_records_spec.rb
+++ b/spec/models/redcap/data_records_spec.rb
@@ -547,14 +547,25 @@ RSpec.describe Redcap::DataRecords, type: :model do
       dr.retrieve
       expect(dr.records.length).to be > 0
 
+      # Identify the retrieved record that has both file fields BEFORE
+      # create_or_update mutates the hash to NULL out file fields.
+      retrieved_with_files = dr.records.find { |r| r[:file1].present? && r[:signature].present? }
+      expect(retrieved_with_files).to be_present
+      target_record_id = retrieved_with_files[dr.send(:record_id_field)]
+
       # Create/update records first so we have ActiveRecord instances
       dr.records.each do |record|
         dr.send(:create_or_update, record)
       end
 
-      # Find a record that has both file1 and signature fields
-      model_record = dr.upserted_records.find { |r| r[:file1].present? && r[:signature].present? }
+      # Find the AR record corresponding to the retrieved record that had both
+      # file fields. After create_or_update the column values are NULL, so we
+      # locate it by record_id and verify via the stashed pending values.
+      model_record = dr.upserted_records.find { |r| r[dr.send(:record_id_field)] == target_record_id }
       expect(model_record).to be_present
+      pending = model_record.instance_variable_get(:@_redcap_pending_file_fields)
+      expect(pending[:file1]).to be_present
+      expect(pending[:signature]).to be_present
 
       dr.send(:capture_files, model_record)
 
@@ -570,6 +581,210 @@ RSpec.describe Redcap::DataRecords, type: :model do
       model_record.reload
       expect(model_record.file1).to eq Redcap::DataRecords::FailedFileFieldMarker
       expect(model_record.signature).to be_present
+    end
+
+    # The following specs verify that file field filenames are not persisted to
+    # the dynamic-model row until the underlying file has actually been imported
+    # to the NfsStore container. This avoids leaving the row in an inconsistent
+    # state ("filename present, no file stored") if anything between the row
+    # commit and capture_files raises - notably an after_commit save trigger.
+    it 'defers persisting file field values until after the file has been captured' do
+      setup_file_fields
+      rc = @project_admin
+      rc.current_admin = @admin
+      setup_file_store rc.job_admin
+      setup_file_store
+
+      clean_file_fields_filesystem rc.file_store
+      mock_file_field_requests
+
+      dr = Redcap::DataRecords.new(rc, 'TestFileFieldRec')
+      dr.retrieve
+      expect(dr.records.length).to be > 0
+
+      # Find a retrieved record that has both file fields populated by REDCap
+      retrieved = dr.records.find { |r| r[:file1].present? && r[:signature].present? }
+      expect(retrieved).to be_present
+
+      # Keep a copy of the original retrieved values. create_or_update now
+      # persists from a dup hash, so the caller's retrieved hash remains
+      # unchanged while file field values are deferred on persistence.
+      pre_file1_value = retrieved[:file1]
+      pre_signature_value = retrieved[:signature]
+
+      dr.send(:create_or_update, retrieved)
+
+      # After create_or_update but before capture_files, the row must have NULL
+      # in each file field column, and the captured values must be stashed on
+      # the AR instance for replay by capture_files.
+      model_record = dr.upserted_records.last
+      expect(model_record).to be_present
+
+      model_record.reload
+      expect(model_record.file1).to be_blank
+      expect(model_record.signature).to be_blank
+
+      pending = model_record.instance_variable_get(:@_redcap_pending_file_fields)
+      expect(pending).to eq(file1: pre_file1_value, signature: pre_signature_value)
+
+      # The retrieved hash remains unchanged (we only null on the persistence
+      # copy), while the DB row itself stores NULL until capture_files runs.
+      expect(retrieved[:file1]).to eq pre_file1_value
+      expect(retrieved[:signature]).to eq pre_signature_value
+
+      # Now run capture_files. The file is imported and the filename is written
+      # back to the column via update_columns (no callbacks, no after_commit).
+      dr.send(:capture_files, model_record)
+      expect(dr.errors).not_to be_present
+      expect(dr.imported_files.count).to eq 2
+
+      model_record.reload
+      expect(model_record.file1).to eq pre_file1_value
+      expect(model_record.signature).to eq pre_signature_value
+    end
+
+    it 'leaves the file field NULL when capture_files is not invoked (simulating an after_commit failure)' do
+      setup_file_fields
+      rc = @project_admin
+      rc.current_admin = @admin
+      setup_file_store rc.job_admin
+      setup_file_store
+
+      clean_file_fields_filesystem rc.file_store
+      mock_file_field_requests
+
+      dr = Redcap::DataRecords.new(rc, 'TestFileFieldRec')
+      dr.retrieve
+
+      retrieved = dr.records.find { |r| r[:file1].present? && r[:signature].present? }
+      original_file1 = retrieved[:file1]
+      original_signature = retrieved[:signature]
+
+      dr.send(:create_or_update, retrieved)
+      model_record = dr.upserted_records.last
+      expect(model_record).to be_present
+
+      # Simulate the failure mode where an after_commit save trigger raises
+      # after the row is committed but before capture_files runs for this record.
+      # capture_files is intentionally NOT invoked here.
+
+      model_record.reload
+      expect(model_record.file1).to be_blank
+      expect(model_record.signature).to be_blank
+
+      # On the next pull, REDCap returns the original filename strings; because
+      # the DB row has NULL, record_matches_retrieved returns false and the
+      # record is reprocessed, allowing capture_files to retry the import.
+      Rails.cache.clear
+      mock_file_field_requests
+      dr2 = Redcap::DataRecords.new(rc, 'TestFileFieldRec')
+      dr2.retrieve
+      retrieved2 = dr2.records.find { |r| r[:file1] == original_file1 && r[:signature] == original_signature }
+      expect(retrieved2).to be_present
+
+      dr2.send(:create_or_update, retrieved2)
+      model_record2 = dr2.upserted_records.last
+      expect(model_record2).to be_present
+      expect(model_record2.id).to eq model_record.id
+
+      dr2.send(:capture_files, model_record2)
+      expect(dr2.errors).not_to be_present
+      expect(dr2.imported_files.count).to eq 2
+
+      model_record2.reload
+      expect(model_record2.file1).to eq original_file1
+      expect(model_record2.signature).to eq original_signature
+    end
+
+    # When the admin requests a manual pull with verify_file_fields: true, any
+    # record whose dynamic-model row has a non-blank file field value but no
+    # corresponding stored_files entry in the project's filestore container
+    # should be treated as changed, so capture_files retries the file import.
+    # This is a recovery option for legacy desynced rows; the option is
+    # forced off for scheduled (non-manual) pulls to keep them fast.
+    it 'verify_file_fields retries capture when a stored file is missing from the container' do
+      setup_file_fields
+      rc = @project_admin
+      rc.current_admin = @admin
+      setup_file_store rc.job_admin
+      setup_file_store
+
+      clean_file_fields_filesystem rc.file_store
+      mock_file_field_requests
+
+      # First, pull normally so file fields are captured and the dynamic-model
+      # row has the filenames and the container has the stored_files rows.
+      dr = Redcap::DataRecords.new(rc, 'TestFileFieldRec')
+      dr.retrieve
+      retrieved = dr.records.find { |r| r[:file1].present? && r[:signature].present? }
+      original_file1 = retrieved[:file1]
+      original_signature = retrieved[:signature]
+      dr.send(:create_or_update, retrieved)
+      model_record = dr.upserted_records.last
+      dr.send(:capture_files, model_record)
+      expect(dr.errors).not_to be_present
+
+      model_record.reload
+      expect(model_record.file1).to eq original_file1
+      expect(model_record.signature).to eq original_signature
+
+      # Simulate the production symptom: delete the stored_files row(s) for
+      # this record so the container no longer knows about the file. The
+      # dynamic-model row still holds the filename.
+      sf_path = "#{rc.dynamic_model_table}/file-fields/#{model_record[dr.send(:record_id_field)]}"
+      sf_ids = rc.file_store.stored_files.where(path: sf_path).pluck(:id)
+      ActiveRecord::Base.connection.execute(
+        "DELETE FROM nfs_store_stored_file_history WHERE nfs_store_stored_file_id IN (#{sf_ids.join(',')})"
+      )
+      rc.file_store.stored_files.where(id: sf_ids).delete_all
+
+      # Without verify_file_fields the next pull treats this record as
+      # unchanged (filename matches between REDCap and DB), so the missing
+      # file is not noticed and capture_files is not run.
+      Rails.cache.clear
+      mock_file_field_requests
+      dr_default = Redcap::DataRecords.new(rc, 'TestFileFieldRec', is_manual_pull: true)
+      dr_default.retrieve
+      retrieved_default = dr_default.records.find { |r| r[:file1] == original_file1 && r[:signature] == original_signature }
+      expect(retrieved_default).to be_present
+      dr_default.send(:create_or_update, retrieved_default)
+      expect(dr_default.upserted_records).to be_empty
+      expect(dr_default.unchanged_ids).not_to be_empty
+
+      # With verify_file_fields enabled, the missing stored file is detected
+      # and the record flows through to capture_files. We assert the
+      # detection-and-upsert behaviour here (the actual re-import side
+      # effects are covered by other specs).
+      Rails.cache.clear
+      mock_file_field_requests
+      dr_verify = Redcap::DataRecords.new(rc, 'TestFileFieldRec',
+                                          is_manual_pull: true,
+                                          verify_file_fields: true)
+      dr_verify.retrieve
+      retrieved_verify = dr_verify.records.find { |r| r[:file1] == original_file1 && r[:signature] == original_signature }
+      expect(retrieved_verify).to be_present
+      dr_verify.send(:create_or_update, retrieved_verify)
+      expect(dr_verify.upserted_records).not_to be_empty
+      reupserted = dr_verify.upserted_records.find { |r| r.id == model_record.id }
+      expect(reupserted).to be_present
+    end
+
+    it 'verify_file_fields is forced off for scheduled (non-manual) pulls' do
+      setup_file_fields
+      rc = @project_admin
+      rc.current_admin = @admin
+      setup_file_store rc.job_admin
+      setup_file_store
+
+      dr_scheduled = Redcap::DataRecords.new(rc, 'TestFileFieldRec',
+                                             is_manual_pull: false,
+                                             verify_file_fields: true)
+      expect(dr_scheduled.verify_file_fields).to be false
+
+      dr_manual = Redcap::DataRecords.new(rc, 'TestFileFieldRec',
+                                          is_manual_pull: true,
+                                          verify_file_fields: true)
+      expect(dr_manual.verify_file_fields).to be true
     end
 
     it 'downloads files in background' do

--- a/spec/models/redcap/project_admin_spec.rb
+++ b/spec/models/redcap/project_admin_spec.rb
@@ -239,6 +239,40 @@ RSpec.describe Redcap::ProjectAdmin, type: :model do
     end
   end
 
+  describe '.preferred_active' do
+    it 'prefers the most recent non-never project among matching table names' do
+      matching = Redcap::ProjectAdmin.active.order(:id).limit(3).to_a
+      expect(matching.length).to eq 3
+
+      table_names = ['pref_table', 'redcap_test.pref_table']
+      matching[0].update_columns(dynamic_model_table: table_names[0], frequency: 'never')
+      matching[1].update_columns(dynamic_model_table: table_names[1], frequency: '15 minutes')
+      matching[2].update_columns(dynamic_model_table: table_names[0], frequency: '1 hour')
+
+      result = Redcap::ProjectAdmin.preferred_active(table_names)
+      expect(result).to be_present
+      expect(result.id).to eq matching[2].id
+    end
+
+    it 'falls back to the most recent match when all candidates are frequency never' do
+      matching = Redcap::ProjectAdmin.active.order(:id).limit(2).to_a
+      expect(matching.length).to eq 2
+
+      table_name = 'redcap_test.all_never_table'
+      matching[0].update_columns(dynamic_model_table: table_name, frequency: 'never')
+      matching[1].update_columns(dynamic_model_table: table_name, frequency: 'never')
+
+      result = Redcap::ProjectAdmin.preferred_active(table_name)
+      expect(result).to be_present
+      expect(result.id).to eq matching[1].id
+    end
+
+    it 'returns nil when no active project matches' do
+      result = Redcap::ProjectAdmin.preferred_active(['missing_table', 'redcap_test.missing_table'])
+      expect(result).to be_nil
+    end
+  end
+
   describe 'transfer mode "none" enforcement' do
     it 'sets frequency to nil when transfer_mode is set to "none"' do
       rc = Redcap::ProjectAdmin.active.first


### PR DESCRIPTION
This PR fixes issue #1137 where REDCap file capture could leave a desynced state (filename stored in the dynamic model row without a corresponding stored file), and adds a manual recovery path for admins.

## What changed

1. Deferred file-field persistence during record upsert:
- File field values are removed from the persistence payload during create/update.
- Filenames are written back only after a successful file import in capture_files.
- On import failure, fields are marked with FailedFileFieldMarker for retry visibility.

2. Added opt-in manual recovery verification:
- Added verify_file_fields option for manual pulls.
- Added a new admin action button: "retrieve & verify files" to force a full pull and re-capture files when stored-file rows are missing.
- Scheduled pulls keep verification disabled for performance.

3. Deterministic ProjectAdmin selection:
- Added Redcap::ProjectAdmin.preferred_active(table_names) to consistently select the most relevant active config (prefer non-"never" frequency, newest id fallback).
- Updated both file download lookup paths to use this shared selection behavior.

4. Logging improvement:
- Added warning logs when NfsStore::Import.import_file returns nil so skipped imports are diagnosable.

5. Test and regression updates:
- Added/updated model specs for deferred persistence and verify_file_fields behavior.
- Updated client request counting spec to use unscoped count (model default scope limits records).
- Fixed cache/date-range setup isolation to avoid duplicate fixture collisions.
- Updated controller lookup specs to use realistic fixtures rather than stubbing query chains.
- Added explicit preferred_active selection-priority model tests.

## Why this solves the issue

The desync happened when filename values could be persisted before file import completed, and subsequent failures skipped capture_files. By deferring filename persistence until after successful import, we avoid the inconsistent state. The manual verify_file_fields path adds a recovery option for legacy desynced records.
