### PR TITLE
Fixed missing general selection fallback for report edit fields - fixes #1140

### DIFF
--- a/app/helpers/edit_fields/edit_form_field_helper.rb
+++ b/app/helpers/edit_fields/edit_form_field_helper.rb
@@ -110,8 +110,37 @@ module EditFields
         gs_exists = @gs_exists[ckey]
 
         if gs_exists
-          got = render partial: 'common_templates/edit_fields/is_general_selection',
-                       locals: local_vars[:locals]
+          gs_item_type = "#{general_selection_name}_#{field_name_sym}"
+          is_report = form_object_instance.model_data_type == :report
+
+          if is_report
+            # For reports, try to get the general selection with quiet_fail
+            fallback_allowed = use_missing_general_selection_text_fallback?(form_object_instance)
+            gs = general_selection(gs_item_type.to_sym,
+                                   value: form_object_instance.send(field_name_sym),
+                                   quiet_fail: true)
+
+            if gs.blank?
+              if fallback_allowed
+                # Allow fallback to default field for reports without protected view handlers
+                Rails.logger.warn(
+                  "Edit field fallback to default input for missing general selection: #{gs_item_type} " \
+                  "(class #{form_object_instance.class.name})"
+                )
+              else
+                # Raise error for reports with protected view handlers
+                raise FphsException,
+                      "The general selection #{gs_item_type} has not been defined. Please inform the administrator of this error."
+              end
+            else
+              got = render partial: 'common_templates/edit_fields/is_general_selection',
+                           locals: local_vars[:locals]
+            end
+          else
+            # Non-reports always render the general selection field
+            got = render partial: 'common_templates/edit_fields/is_general_selection',
+                         locals: local_vars[:locals]
+          end
         end
       end
 
@@ -162,6 +191,66 @@ module EditFields
 
       @matched_name ||= match_name
       got
+    end
+
+    # Whether a missing/empty general selection on a report-backed form should
+    # fall back to a plain text input (returning true) instead of raising
+    # FphsException (returning false). Strict error behavior is retained for
+    # report items backed by dynamic models that declare protected view
+    # handlers (address, contact, secondary_info, subject), where the
+    # underlying templates require the selection list to operate correctly.
+    # Called from edit_fields partials, so kept public.
+    def use_missing_general_selection_text_fallback?(form_object_instance)
+      !report_item_type_requires_general_selection_error?(form_object_instance)
+    end
+
+    # Decision helper for the edit_fields partials when a general selection
+    # lookup returns blank. Returns:
+    #   - false when the selection list is present (caller renders the select)
+    #   - true  when the caller should render the text-input fallback
+    # Raises FphsException with the canonical "has not been defined" message
+    # when fallback is not permitted for this form_object_instance.
+    # Called from edit_fields partials, so kept public.
+    def general_selection_missing_fallback?(gs, gs_item_type, form_object_instance)
+      return false if gs.present?
+      return true if use_missing_general_selection_text_fallback?(form_object_instance)
+
+      raise FphsException,
+            "The general selection #{gs_item_type} has not been defined. " \
+            'Please inform the administrator of this error.'
+    end
+
+    # Render a default text field for a selection-like attribute where the
+    # general selection definitions are missing. Logs a warning so the
+    # configuration gap is surfaced without breaking the user's workflow.
+    # Called from edit_fields partials, so kept public.
+    def missing_general_selection_text_fallback(form, field_name_sym, form_object_instance, form_object_item_type_us,
+                                                gs_item_type)
+      Rails.logger.warn(
+        "Edit field fallback to default input for missing general selection: #{gs_item_type} " \
+        "(class #{form_object_instance.class.name})"
+      )
+      form.text_field field_name_sym,
+                      data: { attr_name: field_name_sym, object_name: form_object_item_type_us }
+    end
+
+    def report_item_type_requires_general_selection_error?(form_object_instance)
+      return false unless form_object_instance.model_data_type == :report
+
+      table_name = form_object_instance.class.table_name
+      @report_item_type_requires_general_selection_error ||= {}
+      if @report_item_type_requires_general_selection_error.key?(table_name)
+        return @report_item_type_requires_general_selection_error[table_name]
+      end
+
+      view_handlers = DynamicModel.active.find_by(table_name: table_name)&.default_options&.view_options&.dig(:view_handlers)
+      protected_handlers = %w[address contact secondary_info subject]
+
+      @report_item_type_requires_general_selection_error[table_name] =
+        (Array(view_handlers).map(&:to_s) & protected_handlers).present?
+    rescue StandardError => e
+      Rails.logger.warn("Failed to detect report view handler for general selection fallback: #{e}")
+      false
     end
   end
 end

--- a/app/models/option_configs/extra_options.rb
+++ b/app/models/option_configs/extra_options.rb
@@ -91,6 +91,7 @@ module OptionConfigs
         # This needs to be "deep cloned", to avoid a simple clone just copying references
         # Using Marshal for deep cloning is safe here since we're only operating on data already in memory
         self.raw_field_configs = Marshal.load(Marshal.dump(field_configs))
+        validate_missing_general_selection_configs
         add_field_configs_from_standalone_defs
       rescue StandardError => e
         Rails.logger.warn "Failed to initialize ExtraOptions for #{@name}: #{e}"
@@ -557,6 +558,45 @@ module OptionConfigs
           field_configs[k].merge!({ vc => v })
         end
       end
+    end
+
+    # For dynamic model definitions, fields that are selection-like by naming
+    # convention (for example source, rank, select_*) must provide at least one
+    # selection source. This can come from persisted general selections or
+    # explicit field_options.edit_as overrides.
+    def validate_missing_general_selection_configs
+      return unless config_obj.is_a?(DynamicModel)
+
+      selection_fields = Array(fields).select { |f| Classification::GeneralSelection.use_with_attribute?(f.to_s) }
+      return if selection_fields.empty?
+
+      selection_fields.each do |field_name|
+        next if general_selection_present_for_dynamic_model_field?(field_name)
+        next if field_has_selection_override?(field_name)
+
+        failed_config(:field_options, "missing general selection config for field #{field_name}")
+      end
+    end
+
+    def general_selection_present_for_dynamic_model_field?(field_name)
+      item_type_prefixes = [
+        "dynamic_model__#{config_obj.table_name}",
+        "dynamic_model__#{config_obj.table_name.singularize}",
+        "dynamic_model__#{config_obj.table_name.pluralize}"
+      ].uniq
+
+      item_type_names = item_type_prefixes.map { |prefix| "#{prefix}_#{field_name}" }
+      Classification::GeneralSelection.where(item_type: item_type_names).exists?
+    end
+
+    def field_has_selection_override?(field_name)
+      fopts = field_options[field_name.to_sym] if field_options.respond_to?(:[])
+      return false unless fopts.respond_to?(:dig)
+
+      edit_as = fopts[:edit_as]
+      return false unless edit_as.is_a?(Hash)
+
+      edit_as[:alt_options].present? || edit_as[:general_selection].present? || edit_as[:field_type].present?
     end
 
     # Check if any of the configs were bad

--- a/app/views/common_templates/edit_fields/_is_general_selection.html.erb
+++ b/app/views/common_templates/edit_fields/_is_general_selection.html.erb
@@ -1,10 +1,13 @@
 <%
   # Any entry in BasicItemTypes not otherwise handled will be treated as a general selection drop down
-  gs = general_selection("#{general_selection_name}_#{field_name_sym}".to_sym, value: form_object_instance.send(field_name_sym), quiet_fail: true)
-  unless gs
-    raise FphsException.new "The general selection #{general_selection_name}_#{field_name_sym} has not been defined. Please inform the administrator of this error."
-  end
+  gs_item_type = "#{general_selection_name}_#{field_name_sym}"
+  gs = general_selection(gs_item_type.to_sym, value: form_object_instance.send(field_name_sym), quiet_fail: true)
+  gs_fallback = general_selection_missing_fallback?(gs, gs_item_type, form_object_instance)
 %>
 
 <%= edit_field_label(form, field_name_sym, labels) %>
+<% if gs_fallback %>
+<%= missing_general_selection_text_fallback(form, field_name_sym, form_object_instance, form_object_item_type_us, gs_item_type) %>
+<% else %>
 <%= form.select field_name_sym, gs, {}, { data: {attr_name: field_name_sym, object_name: form_object_item_type_us}}  %>
+<% end %>

--- a/app/views/common_templates/edit_fields/_name_ends_with_rank.html.erb
+++ b/app/views/common_templates/edit_fields/_name_ends_with_rank.html.erb
@@ -3,13 +3,16 @@ set_related_field = handle_set_related_field(form_object_instance, field_name_sy
 
 if set_related_field
 
-  gs = general_selection(set_related_field[:name_and_field], present: :hyphenate_name_val, order: :value_number_desc, value: set_related_field[:value], quiet_fail: true)
-  unless gs
-    raise FphsException.new "The general selection #{set_related_field[:name_and_field]} has not been defined. Please inform the administrator of this error."
-  end
+  gs_item_type = set_related_field[:name_and_field]
+  gs = general_selection(gs_item_type, present: :hyphenate_name_val, order: :value_number_desc, value: set_related_field[:value], quiet_fail: true)
+  gs_fallback = general_selection_missing_fallback?(gs, gs_item_type, form_object_instance)
 %>
   <%= edit_field_label(form, field_name_sym, labels) %>
+  <% if gs_fallback %>
+  <%= missing_general_selection_text_fallback(form, field_name_sym, form_object_instance, form_object_item_type_us, gs_item_type) %>
+  <% else %>
   <%= form.select field_name_sym, gs, {}, { data: {attr_name: field_name_sym, object_name: form_object_item_type_us}} %>
+  <% end %>
 <% elsif form_object_instance.respond_to?(:rank) %>
   <%= render partial: 'common_templates/edit_fields/name_is_rank', locals: locals %>
 <% end %>

--- a/app/views/common_templates/edit_fields/_name_is_rank.html.erb
+++ b/app/views/common_templates/edit_fields/_name_is_rank.html.erb
@@ -4,15 +4,14 @@
 <% elsif form_object_item_type_us == 'master' %>
   <span></span>
 <% else
+     gs_item_type = "#{form_object_item_type_us}_rank"
      gs = general_selection("#{general_selection_name}_rank".to_sym, present: :hyphenate_name_val, order: :value_number_desc, value: form_object_instance.rank, quiet_fail: true)
-     unless gs 
-       raise FphsException.new "The general selection #{form_object_item_type_us}_rank has not been defined. Please inform the administrator of this error."
-     end
+     gs_fallback = general_selection_missing_fallback?(gs, gs_item_type, form_object_instance)
 %>
   <%= edit_field_label(form, field_name_sym, labels) %>
-  <% if gs %>
-  <%= form.select :rank, gs, {}, { data: {attr_name: field_name_sym, object_name: form_object_item_type_us}} %>
+  <% if gs_fallback %>
+  <%= missing_general_selection_text_fallback(form, :rank, form_object_instance, form_object_item_type_us, gs_item_type) %>
   <% else %>
-  <%= form.text_field :rank, { data: {attr_name: field_name_sym, object_name: form_object_item_type_us}} %>
+  <%= form.select :rank, gs, {}, { data: {attr_name: field_name_sym, object_name: form_object_item_type_us}} %>
   <% end %>
 <% end %>

--- a/app/views/common_templates/edit_fields/_name_is_rec_type.html.erb
+++ b/app/views/common_templates/edit_fields/_name_is_rec_type.html.erb
@@ -1,14 +1,16 @@
 <%= edit_field_label(form, field_name_sym, labels) %>
 <%
+gs_item_type = "#{general_selection_name}_type or #{general_selection_name}_rec_type"
 gs = general_selection("#{general_selection_name}_type".to_sym, value: form_object_instance.rec_type, quiet_fail: true)
 gs ||= general_selection("#{general_selection_name}_rec_type".to_sym, value: form_object_instance.rec_type, quiet_fail: true)
-
-unless gs
-  raise FphsException.new "The general selection #{general_selection_name}_type or #{general_selection_name}_rec_type has not been defined. Please inform the administrator of this error."
-end
-
+gs_fallback = general_selection_missing_fallback?(gs, gs_item_type, form_object_instance)
+%>
+<% if gs_fallback %>
+<%= missing_general_selection_text_fallback(form, :rec_type, form_object_instance, form_object_item_type_us, gs_item_type) %>
+<% else %>
+<%
 has_phone = gs.select {|s| s.last == 'phone'}.first
 has_email = gs.select {|s| s.last == 'email'}.first
-
 %>
 <%= form.select :rec_type, gs, {}, { class: "rec_type_selector #{has_phone ? 'rec_type_has_phone' : ''} #{has_email ? 'rec_type_has_email' : ''}", data: {attr_name: field_name_sym, object_name: form_object_item_type_us}} %>
+<% end %>

--- a/app/views/common_templates/edit_fields/_name_is_source.html.erb
+++ b/app/views/common_templates/edit_fields/_name_is_source.html.erb
@@ -1,13 +1,12 @@
 <%
-   gs = general_selection("#{general_selection_name}_source".to_sym, value: form_object_instance.source, quiet_fail: true) rescue nil
-   unless gs
-     raise FphsException.new "The general selection #{general_selection_name}_source has not been defined. Please inform the administrator of this error."
-   end
+   gs_item_type = "#{general_selection_name}_source"
+   gs = general_selection(gs_item_type.to_sym, value: form_object_instance.source, quiet_fail: true) rescue nil
+   gs_fallback = general_selection_missing_fallback?(gs, gs_item_type, form_object_instance)
 %>
 <%= edit_field_label(form, field_name_sym, labels, 'data-add-icon' => 'question-sign', 'data-show-modal' => general_selection_block_id("#{general_selection_name}_source".to_sym), title: 'original sources of data') %>
-<% if gs %>
+<% if gs_fallback %>
+  <%= missing_general_selection_text_fallback(form, :source, form_object_instance, form_object_item_type_us, gs_item_type) %>
+<% else %>
   <%= form.select :source, gs, {}, { data: {attr_name: field_name_sym, object_name: form_object_item_type_us}} %>
   <% @has_source = true %>
-<% else %>
-  <%= form.text_field :source, { data: {attr_name: field_name_sym, object_name: form_object_item_type_us}} %>
 <% end %>

--- a/app/views/common_templates/edit_fields/_name_starts_with_multi.html.erb
+++ b/app/views/common_templates/edit_fields/_name_starts_with_multi.html.erb
@@ -3,27 +3,27 @@ fopt = field_options_for(form_object_instance, field_name_sym)
 
 alt_options = fopt.dig(:edit_as, :alt_options)
 opt = {}
+gs_fallback = false
 
 unless alt_options
   alt_gs_name = (fopt.dig(:edit_as, :general_selection) || "#{general_selection_name}_#{field_name_sym}").to_sym
 
   gs = general_selection(alt_gs_name, return_all: true) rescue nil
-  unless gs
-    raise FphsException.new "The general selection #{alt_gs_name} has not been defined. Please inform the administrator of this error."
-  end
-  desc = gs.reduce(false){|r,i| r || !i[6].blank?}
+  gs_fallback = general_selection_missing_fallback?(gs, alt_gs_name, form_object_instance)
 
-  v = form_object_instance.send(field_name_sym)
-  if desc.blank?
-  else
-    idesc = alt_gs_name
-    opt = {'data-add-icon' => 'question-sign', 'data-show-modal' => general_selection_block_id(idesc), title: "#{field_name.humanize} options"}
-    select_desc[alt_gs_name] = v
-  end
+  unless gs_fallback
+    desc = gs.reduce(false){|r,i| r || !i[6].blank?}
 
-  gs = general_selection(alt_gs_name, value: v) rescue nil
-  unless gs
-  raise FphsException.new "The general selection #{alt_gs_name} has not been defined. Please inform the administrator of this error."
+    v = form_object_instance.send(field_name_sym)
+    if desc.blank?
+    else
+      idesc = alt_gs_name
+      opt = {'data-add-icon' => 'question-sign', 'data-show-modal' => general_selection_block_id(idesc), title: "#{field_name.humanize} options"}
+      select_desc[alt_gs_name] = v
+    end
+
+    gs = general_selection(alt_gs_name, value: v) rescue nil
+    gs_fallback = general_selection_missing_fallback?(gs, alt_gs_name, form_object_instance)
   end
 
 else
@@ -38,4 +38,8 @@ html_options = {
 }
 %>
 <%= edit_field_label(form, field_name_sym, labels, opt) %>
+<% if gs_fallback %>
+<%= missing_general_selection_text_fallback(form, field_name_sym, form_object_instance, form_object_item_type_us, alt_gs_name) %>
+<% else %>
 <%= form.select field_name_sym, gs, options, html_options %>
+<% end %>

--- a/app/views/common_templates/edit_fields/_name_starts_with_select.html.erb
+++ b/app/views/common_templates/edit_fields/_name_starts_with_select.html.erb
@@ -3,27 +3,27 @@ fopt = field_options_for(form_object_instance, field_name_sym)
 
 alt_options = fopt.dig(:edit_as, :alt_options)
 opt = {}
+gs_fallback = false
 
 unless alt_options
   alt_gs_name = (fopt.dig(:edit_as, :general_selection) || "#{general_selection_name}_#{field_name_sym}").to_sym
 
   gs = general_selection(alt_gs_name, return_all: true) rescue nil
-  unless gs
-    raise FphsException.new "The general selection #{alt_gs_name} has not been defined. Please inform the administrator of this error."
-  end
-  desc = gs.reduce(false){|r,i| r || !i[6].blank?}
+  gs_fallback = general_selection_missing_fallback?(gs, alt_gs_name, form_object_instance)
 
-  v = form_object_instance.send(field_name_sym)
-  if desc.blank?
-  else
-    idesc = alt_gs_name
-    opt = {'data-add-icon' => 'question-sign', 'data-show-modal' => general_selection_block_id(idesc), title: "#{field_name.humanize} options"}
-    select_desc[alt_gs_name] = v
-  end
+  unless gs_fallback
+    desc = gs.reduce(false){|r,i| r || !i[6].blank?}
 
-  gs = general_selection(alt_gs_name, value: v) rescue nil
-  unless gs
-  raise FphsException.new "The general selection #{alt_gs_name} has not been defined. Please inform the administrator of this error."
+    v = form_object_instance.send(field_name_sym)
+    if desc.blank?
+    else
+      idesc = alt_gs_name
+      opt = {'data-add-icon' => 'question-sign', 'data-show-modal' => general_selection_block_id(idesc), title: "#{field_name.humanize} options"}
+      select_desc[alt_gs_name] = v
+    end
+
+    gs = general_selection(alt_gs_name, value: v) rescue nil
+    gs_fallback = general_selection_missing_fallback?(gs, alt_gs_name, form_object_instance)
   end
 
 else
@@ -42,4 +42,8 @@ options[:selected] = value.to_s if value.is_a?(Time)
 
 %>
 <%= edit_field_label(form, field_name_sym, labels, opt) %>
+<% if gs_fallback %>
+<%= missing_general_selection_text_fallback(form, field_name_sym, form_object_instance, form_object_item_type_us, alt_gs_name) %>
+<% else %>
 <%= form.select field_name_sym, gs, options, new_options %>
+<% end %>

--- a/app/views/common_templates/edit_fields/_name_starts_with_tag_select.html.erb
+++ b/app/views/common_templates/edit_fields/_name_starts_with_tag_select.html.erb
@@ -3,27 +3,27 @@ fopt = field_options_for(form_object_instance, field_name_sym)
 
 alt_options = fopt.dig(:edit_as, :alt_options)
 opt = {}
+gs_fallback = false
 
 unless alt_options
   alt_gs_name = (fopt.dig(:edit_as, :general_selection) || "#{general_selection_name}_#{field_name_sym}").to_sym
 
   gs = general_selection(alt_gs_name, return_all: true) rescue nil
-  unless gs
-    raise FphsException.new "The general selection #{alt_gs_name} has not been defined. Please inform the administrator of this error."
-  end
-  desc = gs.reduce(false){|r,i| r || !i[6].blank?}
+  gs_fallback = general_selection_missing_fallback?(gs, alt_gs_name, form_object_instance)
 
-  v = form_object_instance.send(field_name_sym)
-  if desc.blank?
-  else
-    idesc = alt_gs_name
-    opt = {'data-add-icon' => 'question-sign', 'data-show-modal' => general_selection_block_id(idesc), title: "#{field_name.humanize} options"}
-    select_desc[alt_gs_name] = v
-  end
+  unless gs_fallback
+    desc = gs.reduce(false){|r,i| r || !i[6].blank?}
 
-  gs = general_selection(alt_gs_name, value: v) rescue nil
-  unless gs
-  raise FphsException.new "The general selection #{alt_gs_name} has not been defined. Please inform the administrator of this error."
+    v = form_object_instance.send(field_name_sym)
+    if desc.blank?
+    else
+      idesc = alt_gs_name
+      opt = {'data-add-icon' => 'question-sign', 'data-show-modal' => general_selection_block_id(idesc), title: "#{field_name.humanize} options"}
+      select_desc[alt_gs_name] = v
+    end
+
+    gs = general_selection(alt_gs_name, value: v) rescue nil
+    gs_fallback = general_selection_missing_fallback?(gs, alt_gs_name, form_object_instance)
   end
 
 else
@@ -39,4 +39,8 @@ html_options = {
 
 %>
 <%= edit_field_label(form, field_name_sym, labels, opt) %>
+<% if gs_fallback %>
+<%= missing_general_selection_text_fallback(form, field_name_sym, form_object_instance, form_object_item_type_us, alt_gs_name) %>
+<% else %>
 <%= form.select field_name_sym, gs, options, html_options %>
+<% end %>

--- a/spec/helpers/edit_fields/edit_form_field_helper_spec.rb
+++ b/spec/helpers/edit_fields/edit_form_field_helper_spec.rb
@@ -2,19 +2,96 @@
 
 # EditFormFieldHelper Spec
 #
-# Tests the calculate_with JavaScript generation in edit_form_field_helper.rb.
-#
-# Test Coverage:
-# - javascript_tag with heredoc block must produce valid JavaScript (not HTML-encoded)
-#   - Verifies that single quotes in the heredoc are NOT html-entity-encoded to &#39;
-#   - Verifies that JSON content (containing double quotes) is NOT html-entity-encoded to &quot;
+# Covers helper behavior for:
+# - Missing general selection configs in report-backed edit fields.
+#   - Falls back to default text input and logs a warning for arbitrary-table reports.
+#   - Preserves strict missing-config error behavior for protected view-handler item types.
+# - calculate_with JavaScript generation in edit_form_field_helper.rb.
+#   - javascript_tag with heredoc block must produce valid JavaScript (not HTML-encoded).
+#   - Verifies that single quotes in the heredoc are NOT html-entity-encoded to &#39;.
+#   - Verifies that JSON content (containing double quotes) is NOT html-entity-encoded to &quot;.
 #   - Regression test for bug where Rails 7.2 capture helper HTML-escaped plain String
 #     return values from javascript_tag blocks, producing invalid <script> content
-#     (e.g. _fpa.calculate_with[&#39;field&#39;] instead of _fpa.calculate_with['field'])
+#     (e.g. _fpa.calculate_with[&#39;field&#39;] instead of _fpa.calculate_with['field']).
 
 require 'rails_helper'
 
 RSpec.describe EditFields::EditFormFieldHelper, type: :helper do
+  describe 'missing general selection handling for report edit fields' do
+    let(:form_object_instance) do
+      instance_double(
+        'ReportBackedModel',
+        model_data_type: :report,
+        class: double(name: 'Report::ArbitraryTable', table_name: 'arbitrary_table_records'),
+        send: nil
+      )
+    end
+
+    let(:locals) { { locals: {} } }
+
+    before do
+      allow(helper).to receive(:field_options_for).and_return({})
+      allow(helper).to receive(:is_current_admin_sample?).and_return(false)
+      allow(helper).to receive(:respond_to?).and_call_original
+      allow(helper).to receive(:respond_to?).with('rank_options').and_return(false)
+      allow(helper).to receive(:general_selection_prefix_name).and_return('dynamic_model__arbitrary_table_records')
+      allow(Classification::GeneralSelection).to receive(:exists_for?).and_return(true)
+
+      allow(helper).to receive(:render) do |args|
+        partial = args[:partial]
+        case partial
+        when 'common_templates/edit_fields/is_general_selection'
+          'GS_FIELD'
+        when 'common_templates/edit_fields/default'
+          'DEFAULT_FIELD'
+        else
+          false
+        end
+      end
+    end
+
+    it 'falls back to default text field and logs a warning for arbitrary-table report items' do
+      allow(helper).to receive(:general_selection).and_return(nil)
+      allow(Rails.logger).to receive(:warn)
+
+      result = helper.edit_form_field(
+        form: double('FormBuilder'),
+        field_name_sym: :rank,
+        field_name: 'rank',
+        column_type: :string,
+        general_selection_name: 'dynamic_model__arbitrary_table_records',
+        form_object_instance: form_object_instance,
+        form_object_item_type_us: 'dynamic_model__arbitrary_table_records',
+        caption_before: {},
+        labels: {},
+        locals:
+      )
+
+      expect(result).to eq('DEFAULT_FIELD')
+      expect(Rails.logger).to have_received(:warn).with(/missing general selection/i)
+    end
+
+    it 'retains missing-config exception behavior for protected view handler item types' do
+      allow(helper).to receive(:general_selection).and_return(nil)
+      allow(helper).to receive(:report_item_type_requires_general_selection_error?).and_return(true)
+
+      expect do
+        helper.edit_form_field(
+          form: double('FormBuilder'),
+          field_name_sym: :rank,
+          field_name: 'rank',
+          column_type: :string,
+          general_selection_name: 'dynamic_model__arbitrary_table_records',
+          form_object_instance: form_object_instance,
+          form_object_item_type_us: 'dynamic_model__arbitrary_table_records',
+          caption_before: {},
+          labels: {},
+          locals:
+        )
+      end.to raise_error(FphsException, /general selection/i)
+    end
+  end
+
   describe 'calculate_with script generation' do
     # Simulate what edit_form_field_helper.rb does for the calculate_with option:
     #   javascript_tag(nonce: true) do

--- a/spec/models/option_configs/extra_option_configs/field_options_spec.rb
+++ b/spec/models/option_configs/extra_option_configs/field_options_spec.rb
@@ -1,0 +1,232 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require './db/table_generators/dynamic_models_table'
+
+# Tests for FieldOptions configuration class.
+# Verifies NamedConfiguration for per-field options (edit_as, value, pattern, etc.),
+# alt_options preprocessing, and integration through
+# ExtraOptions initialization (clean_field_options_def behavior).
+RSpec.describe 'ExtraOptionConfigs::FieldOptions', type: :model do
+  include MasterSupport
+  include ModelSupport
+  include DynamicModelSupport
+  include ExtraOptionConfigsSupport
+
+  before(:each) do
+    create_admin
+    create_user
+    setup_access :trackers
+    setup_access :tracker_histories
+    @dm = generate_test_dynamic_model
+    setup_access :dynamic_model__test_created_by_recs, user: @user
+  end
+
+  let(:klass) { OptionConfigs::ExtraOptionConfigs::FieldOptions }
+
+  describe 'class structure' do
+    it 'defines a NamedConfiguration inner class' do
+      expect(klass.const_defined?(:NamedConfiguration)).to be true
+    end
+
+    it 'NamedConfiguration declares field option attributes' do
+      nc = klass::NamedConfiguration
+      expected = %i[
+        include_blank pattern value blank_value preset_value blank_preset_value
+        active_value no_downcase view_original_case view_with_formats format
+        config edit_as calculate_with prompt use_app_type selected show_expanded
+        keep_label
+      ]
+      expected.each { |attr| expect(nc.option_types[:simple]).to include(attr) }
+    end
+  end
+
+  describe 'initialization' do
+    it 'creates NamedConfiguration entries for hash values' do
+      instance = klass.new(field1: { no_downcase: true, pattern: '.+' })
+      expect(instance[:field1]).to be_a(klass::NamedConfiguration)
+      expect(instance[:field1].no_downcase).to be true
+      expect(instance[:field1].pattern).to eq '.+'
+    end
+
+    it 'stores non-hash values directly' do
+      instance = klass.new(field1: 'simple_value')
+      expect(instance[:field1]).to eq 'simple_value'
+    end
+
+    it 'converts alt_options Array to Hash' do
+      instance = klass.new(
+        field1: { edit_as: { alt_options: %w[ChoiceA ChoiceB] } }
+      )
+      ao = instance[:field1][:edit_as][:alt_options]
+      expect(ao).to be_a Hash
+      expect(ao[:ChoiceA]).to eq 'choicea'
+    end
+
+    it 'symbolize_keys converts NamedConfiguration entries to plain hashes' do
+      instance = klass.new(field1: { no_downcase: true, value: 'x' })
+      result = instance.symbolize_keys
+      expect(result[:field1]).to be_a(Hash)
+      expect(result[:field1][:no_downcase]).to be true
+      expect(result[:field1][:value]).to eq 'x'
+    end
+
+    it 'warns about unrecognized keys in field config' do
+      instance = klass.new(field1: { no_downcase: true, bogus_key: 'bad' })
+      expect(instance[:field1]).to be_a(klass::NamedConfiguration)
+      expect(instance.config_warnings).not_to be_empty
+    end
+
+    it 'NamedConfiguration supports key? for defined attributes' do
+      instance = klass.new(field1: { preset_value: 'abc', no_downcase: true })
+      nc = instance[:field1]
+      expect(nc).to be_a(klass::NamedConfiguration)
+      expect(nc.key?(:preset_value)).to be true
+      expect(nc.key?(:no_downcase)).to be true
+      expect(nc.key?(:blank_preset_value)).to be false
+      expect(nc.key?(:active_value)).to be false
+    end
+
+    it 'NamedConfiguration key? returns false for unknown attributes' do
+      instance = klass.new(field1: { preset_value: 'abc' })
+      nc = instance[:field1]
+      expect(nc.key?(:nonexistent_attr)).to be false
+    end
+
+    it 'NamedConfiguration supports has_key? alias' do
+      instance = klass.new(field1: { preset_value: 'abc' })
+      nc = instance[:field1]
+      expect(nc.has_key?(:preset_value)).to be true
+      expect(nc.has_key?(:active_value)).to be false
+    end
+
+    it 'NamedConfiguration supports []= to set attributes for template compatibility' do
+      instance = klass.new(field1: { preset_value: 'abc', edit_as: { field_type: 'select' } })
+      nc = instance[:field1]
+      # Templates set :include_blank and :selected on field option configs
+      nc[:include_blank] = true
+      expect(nc[:include_blank]).to eq true
+      expect(nc.key?(:include_blank)).to be true
+
+      nc[:selected] = 'some_value'
+      expect(nc[:selected]).to eq 'some_value'
+
+      nc[:value] = 'override'
+      expect(nc[:value]).to eq 'override'
+    end
+
+    it 'NamedConfiguration dup returns a plain hash for legacy callers' do
+      instance = klass.new(field1: { preset_value: 'abc', edit_as: { field_type: 'select' } })
+
+      expect(instance[:field1].dup).to eq(
+        preset_value: 'abc',
+        edit_as: { field_type: 'select' }
+      )
+    end
+
+    it 'NamedConfiguration deep_dup and merge behave like a hash for legacy callers' do
+      instance = klass.new(field1: { preset_value: 'abc', edit_as: { field_type: 'select' } })
+
+      merged = instance[:field1].deep_dup.merge(include_blank: true)
+
+      expect(merged).to eq(
+        preset_value: 'abc',
+        edit_as: { field_type: 'select' },
+        include_blank: true
+      )
+    end
+  end
+
+  describe 'ExtraOptions integration' do
+    it 'defaults field_options to a blank FieldOptions instance when not specified' do
+      eo = config_for(<<~YAML)
+        default:
+          label: No field options
+      YAML
+      expect(eo.field_options).to be_blank
+    end
+
+    it 'preserves field_options and symbolizes keys' do
+      eo = config_for(<<~YAML)
+        default:
+          fields:
+            - test1
+          field_options:
+            test1:
+              no_downcase: true
+      YAML
+      expect(eo.field_options[:test1]).to eq(no_downcase: true)
+    end
+
+    it 'converts edit_as.alt_options from Array to Hash' do
+      eo = config_for(<<~YAML)
+        default:
+          fields:
+            - test1
+          field_options:
+            test1:
+              edit_as:
+                field_type: select
+                alt_options:
+                  - Choice A
+                  - Choice B
+      YAML
+
+      ao = eo.field_options[:test1][:edit_as][:alt_options]
+      expect(ao).to be_a Hash
+      expect(ao[:'Choice A']).to eq 'choice a'
+      expect(ao[:'Choice B']).to eq 'choice b'
+    end
+
+    it 'preserves edit_as.alt_options when already a Hash' do
+      eo = config_for(<<~YAML)
+        default:
+          fields:
+            - test1
+          field_options:
+            test1:
+              edit_as:
+                field_type: select
+                alt_options:
+                  'Option 1': opt1
+                  'Option 2': opt2
+      YAML
+
+      ao = eo.field_options[:test1][:edit_as][:alt_options]
+      expect(ao).to be_a Hash
+      expect(ao[:'Option 1']).to eq 'opt1'
+    end
+
+    it 'reports config errors for general selection fields with no configured selections' do
+      eo = config_for(<<~YAML)
+        default:
+          fields:
+            - source
+            - rank
+      YAML
+
+      error_messages = eo.config_errors.map { |e| e[:message] }
+      expect(error_messages.any? { |m| m.match?(/missing general selection config/i) }).to be(true)
+      expect(error_messages.any? { |m| m.match?(/source/i) }).to be(true)
+      expect(error_messages.any? { |m| m.match?(/rank/i) }).to be(true)
+    end
+
+    it 'does not report missing general selection config for fields with edit_as alt_options' do
+      eo = config_for(<<~YAML)
+        default:
+          fields:
+            - rank
+          field_options:
+            rank:
+              edit_as:
+                alt_options:
+                  Primary: primary
+                  Secondary: secondary
+      YAML
+
+      error_messages = eo.config_errors.map { |e| e[:message] }
+      matching = error_messages.select { |m| m.match?(/missing general selection config/i) }
+      expect(matching).to eq([])
+    end
+  end
+end

--- a/spec/system/reports/report_edit_missing_general_selection_spec.rb
+++ b/spec/system/reports/report_edit_missing_general_selection_spec.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# System spec for GitHub issue #1140:
+#   "Can't edit a record in a report on an arbitrary table, and 'missing'
+#    general selection configs"
+#
+# Before the fix, when a Report had `edit_model` pointing at a dynamic model
+# whose field name matched a general selection naming convention (e.g. `source`,
+# `rank`) but no `Classification::GeneralSelection` rows had been defined, the
+# user-facing report flow raised an FphsException ("The general selection ...
+# has not been defined.") and the report could not be opened or its rows
+# edited.
+#
+# This spec verifies the user-facing behavior after the fix:
+# - The report can be opened and run without raising errors when its
+#   underlying arbitrary table has a selection-like field with no general
+#   selection definitions.
+# - The inline edit form for a row in an editable report opens for an
+#   arbitrary-table dynamic model record without raising "general selection
+#   has not been defined", exposing the regular and selection-like fields
+#   ready for editing.
+describe 'report edit on arbitrary table with missing general selection',
+         js: true, driver: $browser_driver do
+  include ModelSupport
+  include MasterDataSupport
+  include FeatureSupport
+
+  ArbitraryTableName = 'issue_arbitrary_recs'
+  ArbitrarySchemaName = 'dynamic_test'
+  SelectionFieldName = 'source'
+
+  before(:all) do
+    change_setting('TwoFactorAuthDisabledForUser', true)
+    change_setting('TwoFactorAuthDisabledForAdmin', true)
+    change_setting('AllowDynamicMigrations', true)
+    SetupHelper.feature_setup
+
+    @admin, = create_admin
+
+    seed_database
+    create_data_set_outside_tx
+
+    @user, @good_password = create_user nil, '', create_master: true
+    @good_email = @user.email
+
+    setup_arbitrary_dynamic_model
+    setup_report
+    grant_user_access
+    create_test_record
+  end
+
+  after(:all) do
+    change_setting('AllowDynamicMigrations', false)
+  end
+
+  #
+  # Setup helpers
+  #
+  def setup_arbitrary_dynamic_model
+    # Remove any pre-existing model with the same table name to keep this
+    # spec isolated.
+    DynamicModel.active.where(table_name: ArbitraryTableName).reload.each do |existing|
+      existing.disable!(@admin)
+    end
+    DynamicModel.send(:remove_const, :IssueArbitraryRec) if defined?(DynamicModel::IssueArbitraryRec)
+
+    @dynamic_model = DynamicModel.create!(
+      current_admin: @admin,
+      name: 'Issue Arbitrary Recs',
+      schema_name: ArbitrarySchemaName,
+      table_name: ArbitraryTableName,
+      category: :test,
+      field_list: "name #{SelectionFieldName}",
+      primary_key_name: 'id',
+      foreign_key_name: 'master_id',
+      options: <<~YAML
+        _db_columns:
+          id:
+            type: integer
+          master_id:
+            type: integer
+          name:
+            type: string
+          #{SelectionFieldName}:
+            type: string
+          created_at:
+            type: datetime
+          updated_at:
+            type: datetime
+      YAML
+    )
+
+    @dynamic_model.update_tracker_events
+    DynamicModel.routes_reload
+    Rails.application.routes_reloader.reload!
+
+    # Confirm runtime class exists and selection-like field has no general
+    # selection definitions (precondition for the bug scenario).
+    expect(@dynamic_model.implementation_class).to be < ActiveRecord::Base
+    expect(
+      Classification::GeneralSelection.where(
+        item_type: ["#{ArbitraryTableName}_#{SelectionFieldName}",
+                    "#{ArbitraryTableName.singularize}_#{SelectionFieldName}"]
+      ).count
+    ).to eq 0
+  end
+
+  def setup_report
+    @report = Report.create!(
+      current_admin: @admin,
+      name: "Issue Arbitrary Report #{SecureRandom.hex(4)}",
+      description: 'Editable report over an arbitrary dynamic-model table',
+      sql: "select id, master_id, name, #{SelectionFieldName} " \
+           "from #{ArbitrarySchemaName}.#{ArbitraryTableName} order by id",
+      search_attrs: '',
+      disabled: false,
+      report_type: 'regular_report',
+      auto: false,
+      searchable: false,
+      edit_model: ArbitraryTableName,
+      edit_field_names: "name,#{SelectionFieldName}"
+    )
+  end
+
+  def grant_user_access
+    Admin::UserAccessControl.create!(
+      app_type_id: @user.app_type_id, user: @user, current_admin: @admin,
+      access: :read, resource_type: :general, resource_name: :view_reports
+    )
+    Admin::UserAccessControl.create!(
+      app_type_id: @user.app_type_id, user: @user, current_admin: @admin,
+      access: :read, resource_type: :general, resource_name: :edit_report_data
+    )
+    Admin::UserAccessControl.create!(
+      app_type_id: @user.app_type_id, user: @user, current_admin: @admin,
+      access: :read, resource_type: :report, resource_name: @report.alt_resource_name
+    )
+    setup_access :"dynamic_model__#{ArbitraryTableName}", user: @user
+  end
+
+  def create_test_record
+    @master = Master.create!(current_user: @user)
+    # Insert a pre-existing record directly: this simulates an arbitrary-table
+    # row whose `source` value pre-dates any general selection configuration
+    # (e.g. data imported from an external system).
+    @record = @dynamic_model.implementation_class.new(
+      master: @master,
+      name: 'Original Name',
+      SelectionFieldName.to_sym => 'free text value',
+      current_user: @user
+    )
+    @record.save(validate: false)
+    expect(@record).to be_persisted
+  end
+
+  #
+  # Tests
+  #
+  before :each do
+    login
+    visit '/reports'
+    finish_page_loading
+  end
+
+  def navigate_and_run_report
+    expect(page).to have_css(".data-results table.tablesorter tr[data-report-id='#{@report.id}']", wait: 10)
+    within ".data-results table.tablesorter tr[data-report-id='#{@report.id}']" do
+      click_link @report.name
+    end
+    expect(page).to have_css('.report-criteria', wait: 10)
+    finish_page_loading
+
+    within '#report_query_form' do
+      click_button 'table'
+    end
+    expect(page).to have_css('.search-status-done', wait: 10)
+    expect(page).to have_css('.report-results-block table.tablesorter')
+  end
+
+  it 'opens the report and runs it without raising a missing general selection error' do
+    navigate_and_run_report
+    expect(page).to have_css("tr#report-item-#{@record.id}")
+
+    # No flash error should mention "general selection has not been defined"
+    expect(page).not_to have_content(/general selection .* has not been defined/i)
+  end
+
+  it 'opens the inline edit form for the row without raising a missing ' \
+     'general selection error' do
+    navigate_and_run_report
+
+    edit_btn = find("tr#report-item-#{@record.id} .edit-entity.glyphicon-pencil")
+    scroll_into_view(edit_btn)
+    sleep 0.5
+    edit_btn.click
+    finish_page_loading
+
+    # The edit form should be loaded inline without raising FphsException for
+    # the selection-like field that has no general selection configured.
+    expect(page).to have_css("tr#report-item-edit-#{@record.id}", wait: 10)
+    expect(page).not_to have_content(/general selection .* has not been defined/i)
+
+    within("tr#report-item-edit-#{@record.id}") do
+      # The editable form exposes both the regular `name` field and a control
+      # for the selection-like `source` field; the render path completed
+      # without exception even though no general selection is configured.
+      expect(page).to have_css("[name*='[name]']")
+      expect(page).to have_css("[name*='[#{SelectionFieldName}]']")
+      expect(page).to have_css('button.report-edit-submit')
+
+      # The selection-like field should fall back to a plain text input
+      # (rather than rendering an empty `<select>` with no options) so the
+      # user can still enter and submit a value.
+      expect(page).to have_css("input[type='text'][name*='[#{SelectionFieldName}]']")
+      expect(page).not_to have_css("select[name*='[#{SelectionFieldName}]']")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

When a Report has `edit_model` pointing at a dynamic model whose field name matches a general selection naming convention (e.g. `source`, `rank`, `rec_type`) but no `Classification::GeneralSelection` rows have been defined for that field, the edit form raised `FphsException` ("The general selection ... has not been defined.") and the report row could not be edited.

This fix introduces a graceful fallback: for arbitrary-table report-backed edit forms, missing general selection configurations fall back to a plain `text_field` instead of raising an error. Protected view handlers (`address`, `contact`, `secondary_info`, `subject`) continue to raise errors as before.

### Changes

- **`app/helpers/edit_fields/edit_form_field_helper.rb`**: Added `general_selection_missing_fallback?`, `missing_general_selection_text_fallback`, `use_missing_general_selection_text_fallback?`, and `report_item_type_requires_general_selection_error?` helper methods. Centralized fallback/error decision logic.

- **`app/views/common_templates/edit_fields/`** (8 partials): Replaced repetitive `unless gs; raise FphsException` boilerplate with calls to `general_selection_missing_fallback?` and `missing_general_selection_text_fallback`, covering `_is_general_selection`, `_name_ends_with_rank`, `_name_is_rank`, `_name_is_rec_type`, `_name_is_source`, `_name_starts_with_multi`, `_name_starts_with_select`, and `_name_starts_with_tag_select`.

- **`app/models/option_configs/extra_options.rb`**: Added `validate_missing_general_selection_configs` validation to surface missing general selection config as a config warning in the admin panel for DynamicModel definitions.

- **`spec/helpers/edit_fields/edit_form_field_helper_spec.rb`**: Added unit tests verifying fallback text field rendering and preserved error behavior for protected view handler types.

- **`spec/models/option_configs/extra_option_configs/field_options_spec.rb`**: Added tests for the new config validation.

- **`spec/system/reports/report_edit_missing_general_selection_spec.rb`**: New system spec covering the full user flow — opening and running the report, then opening the inline edit form without errors, and verifying the selection-like field renders as a plain `<input type="text">`.