### PR TITLE
Fixed Redcap job perform() keyword args causing silent failures in production with delayed_job and Ruby 3

### DIFF
--- a/app/jobs/redcap/capture_records_job.rb
+++ b/app/jobs/redcap/capture_records_job.rb
@@ -10,12 +10,21 @@ module Redcap
     # The result (number of created, updated, matched, error items) is stored to a Redcap::ClientRequest
     # @param [Redcap::ProjectAdmin] project_admin
     # @param [String] class_name
-    # @param [Boolean] ignore_cache - force pull from REDCap, bypassing cache
-    # @param [Boolean] retrieve_all - ignore export_only_updated_records setting and retrieve all records
-    # @param [Boolean] verify_file_fields - check that each file field's underlying stored file exists,
-    #                                       and retry capture for any missing files.
+    # @param [Hash] opts
+    # @option opts [Boolean] :ignore_cache - force pull from REDCap, bypassing cache
+    # @option opts [Boolean] :retrieve_all - ignore export_only_updated_records setting and retrieve all records
+    # @option opts [Boolean] :verify_file_fields - check that each file field's underlying stored file exists,
+    #                                              and retry capture for any missing files.
     # @return [Boolean] success
-    def perform(project_admin, class_name, ignore_cache: false, retrieve_all: false, verify_file_fields: false)
+    # NOTE: opts must be a plain Hash default arg (not Ruby keyword args) so that delayed_job can
+    # deserialize and splat arguments correctly in Ruby 3. Active Job serializes kwargs as a symbol-keyed
+    # Hash; when the worker calls perform(*arguments), Ruby 3 passes that hash as a positional arg and
+    # will NOT auto-convert it to keyword arguments, causing ArgumentError.
+    def perform(project_admin, class_name, opts = {})
+      ignore_cache = opts.fetch(:ignore_cache, false)
+      retrieve_all = opts.fetch(:retrieve_all, false)
+      verify_file_fields = opts.fetch(:verify_file_fields, false)
+
       setup_with project_admin
 
       unless project_admin&.dynamic_model_ready?

--- a/app/jobs/redcap/export_logs_job.rb
+++ b/app/jobs/redcap/export_logs_job.rb
@@ -7,8 +7,13 @@ module Redcap
     #
     # Download the list of data collection instruments.
     # @param [Redcap::ProjectAdmin] project_admin
+    # @param [Hash] opts
+    # @option opts [Hash] :filter
     # @return [Boolean] success
-    def perform(project_admin, filter: nil)
+    # NOTE: opts must be a plain Hash default arg (not Ruby keyword args) — see CaptureRecordsJob for explanation.
+    def perform(project_admin, opts = {})
+      filter = opts.fetch(:filter, nil)
+
       setup_with project_admin
 
       el = Redcap::ExportLogs.new(project_admin)

--- a/spec/jobs/redcap/capture_records_job_spec.rb
+++ b/spec/jobs/redcap/capture_records_job_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Tests for Redcap::CaptureRecordsJob focusing on delayed_job serialization
+# compatibility in Ruby 3.
+#
+# Root cause (issue #1137): When a job is queued via delayed_job in production,
+# Active Job serializes keyword arguments as a plain symbol-keyed Hash. Ruby 3
+# does NOT automatically convert a splatted positional Hash to keyword arguments,
+# so `perform(*arguments)` with a Hash as the last element raises
+# `ArgumentError: wrong number of arguments` for any method using Ruby keyword args.
+# The fix is for perform() to use a plain optional Hash arg (opts = {}) instead
+# of keyword arguments, which correctly accepts the splatted deserialized Hash.
+RSpec.describe Redcap::CaptureRecordsJob, type: :job do
+  include ModelSupport
+  include Redcap::RedcapSupport
+
+  describe '#perform signature - delayed_job / Ruby 3 compatibility' do
+    it 'has an optional third positional argument, not Ruby keyword arguments' do
+      # Verify the signature accepts a plain hash as the 3rd positional arg.
+      # `parameters` returns :opt for optional positional, :key/:keyreq for kwargs.
+      params = described_class.instance_method(:perform).parameters
+      first_two_types = params[0..1].map(&:first)
+      third_param_type = params[2]&.first
+
+      expect(first_two_types).to all(eq(:req))
+      expect(third_param_type).to eq(:opt), \
+        'perform() must use `opts = {}` not keyword args to survive delayed_job deserialization in Ruby 3'
+      expect(params.none? { |type, _| %i[key keyreq].include?(type) }).to be true
+    end
+
+    it 'raises ArgumentError (regression proof) when a method uses keyword args and receives a splatted Hash' do
+      # Demonstrate that the old keyword-arg signature would fail in exactly this way.
+      # Note: procs are lenient with kwargs in Ruby 3; lambdas (and defs) are strict.
+      # Use a lambda to simulate the strict method behavior.
+      old_signature = lambda { |_pa, _cn, ignore_cache: false, retrieve_all: false, verify_file_fields: false| nil }
+      args_from_delayed_job = ['pa', 'cn', { ignore_cache: true, retrieve_all: true, verify_file_fields: true }]
+
+      expect { old_signature.call(*args_from_delayed_job) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe 'Active Job serialization roundtrip for opts' do
+    before :all do
+      create_admin
+      @rc_project_configs = setup_redcap_project_admin_configs
+      @project_admin = Redcap::ProjectAdmin.active.first
+      @project_admin.current_admin = @admin
+    end
+
+    it 'preserves all opts values through serialize/deserialize (as delayed_job does)' do
+      # Simulate what delayed_job does: serialize then deserialize job arguments.
+      opts = { ignore_cache: true, retrieve_all: true, verify_file_fields: true }
+      serialized = ActiveJob::Arguments.serialize([@project_admin, 'SomeClass', opts])
+      deserialized = ActiveJob::Arguments.deserialize(serialized)
+
+      deserialized_opts = deserialized.last
+      expect(deserialized_opts).to be_a(Hash)
+      expect(deserialized_opts[:ignore_cache]).to be true
+      expect(deserialized_opts[:retrieve_all]).to be true
+      expect(deserialized_opts[:verify_file_fields]).to be true
+    end
+
+    it 'does NOT raise ArgumentError when called with a splatted symbol-keyed Hash (simulates delayed_job roundtrip)' do
+      # Active Job serializes kwargs into a symbol-keyed Hash stored in the arguments array.
+      # The delayed_job worker later calls `perform(*arguments)`. In Ruby 3 this passes the
+      # Hash as a positional arg - NOT as keyword args. This must not raise ArgumentError.
+      # Note: the job body will raise FphsException (no DM configured for this project),
+      # proving that argument unpacking succeeded - we are only checking for ArgumentError here.
+      # The `not_to raise_error(ArgumentError)` pattern is intentional: we want to distinguish
+      # ArgumentError (broken argument parsing) from FphsException (expected job-logic error).
+      deserialized_opts = { ignore_cache: true, retrieve_all: true, verify_file_fields: false }
+      job = described_class.new
+
+      RSpec::Expectations.configuration.on_potential_false_positives = :nothing
+      expect do
+        job.perform(@project_admin, 'SomeClass', deserialized_opts)
+      end.not_to raise_error(ArgumentError)
+      RSpec::Expectations.configuration.on_potential_false_positives = :warn
+    end
+
+    it 'does not raise ArgumentError when splatting deserialized arguments into perform (full roundtrip)' do
+      # Full roundtrip: serialize opts → deserialize → splat into perform().
+      # This is exactly what delayed_job does in production.
+      # Note: the job body will raise FphsException (no DM configured for this project),
+      # proving that argument unpacking succeeded - we are only checking for ArgumentError here.
+      # The `not_to raise_error(ArgumentError)` pattern is intentional: we want to distinguish
+      # ArgumentError (broken argument parsing) from FphsException (expected job-logic error).
+      opts = { ignore_cache: false, retrieve_all: true, verify_file_fields: true }
+      serialized = ActiveJob::Arguments.serialize([@project_admin, 'SomeClass', opts])
+      deserialized = ActiveJob::Arguments.deserialize(serialized)
+
+      job = described_class.new
+      RSpec::Expectations.configuration.on_potential_false_positives = :nothing
+      expect do
+        job.perform(*deserialized)
+      end.not_to raise_error(ArgumentError)
+      RSpec::Expectations.configuration.on_potential_false_positives = :warn
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`CaptureRecordsJob#perform` and `ExportLogsJob#perform` used Ruby keyword arguments in their signatures. In production, `delayed_job` serializes Active Job arguments to the database and deserializes them when running the job. 

Active Job's `Arguments.serialize` converts `{ignore_cache: true}` to `{"ignore_cache" => true, "_aj_symbol_keys" => ["ignore_cache", ...]}`. On deserialization this is restored as a plain symbol-keyed Hash. When `delayed_job` calls `perform(*arguments)`, Ruby 3 passes this Hash as a **positional argument** — not as keyword arguments — causing:

```
ArgumentError: wrong number of arguments (given 3, expected 2)
```

This error is swallowed silently in production (captured by the `rescue StandardError => e` block and stored as a failure record), so no files are ever retrieved.

**The bug is invisible in development and test** because:
- Development uses `:inline` adapter (no serialization)
- Test environment sets `Delayed::Worker.delay_jobs = false` (synchronous, no serialization roundtrip)

## Fix

Changed both job `perform` methods to use `opts = {}` (a plain optional hash argument) instead of Ruby keyword arguments. The splatted deserialized hash is correctly accepted as `opts` in Ruby 3.

```ruby
# Before (broken in production with delayed_job + Ruby 3):
def perform(project_admin, class_name, ignore_cache: false, retrieve_all: false, verify_file_fields: false)

# After (fixed):
def perform(project_admin, class_name, opts = {})
  ignore_cache = opts.fetch(:ignore_cache, false)
  retrieve_all = opts.fetch(:retrieve_all, false)
  verify_file_fields = opts.fetch(:verify_file_fields, false)
```

## Files changed

- `app/jobs/redcap/capture_records_job.rb` — changed `perform` to use `opts = {}`
- `app/jobs/redcap/export_logs_job.rb` — changed `perform` to use `opts = {}`
- `spec/jobs/redcap/capture_records_job_spec.rb` — new spec proving the fix and providing a regression test

## Tests

5 new Rspec examples in `spec/jobs/redcap/capture_records_job_spec.rb`:
1. Verifies `perform` has an optional third positional argument (not kwargs)
2. Regression proof: a method with keyword arg signature raises `ArgumentError` when called with a splatted Hash
3. Verifies opts values survive Active Job serialize → deserialize roundtrip
4. Verifies no `ArgumentError` when calling `perform` with a splatted symbol-keyed Hash (as delayed_job does)
5. Full serialize → deserialize → `perform(*deserialized)` roundtrip with no `ArgumentError`

Fixes #1137