### PR TITLE
Added if: conditions to attachments and after_processing in pull_emails trigger - fixes #1144

### DIFF
--- a/app/models/admin/defs/save_triggers_pull_emails_options_defs.yaml
+++ b/app/models/admin/defs/save_triggers_pull_emails_options_defs.yaml
@@ -51,6 +51,18 @@
           limit: 50                   # (optional) maximum number of emails to process per run
 
           after_processing:           # (optional) what to do with each successfully processed email
+            # The `if:` key is optional. When absent the step always runs.
+            # The condition is evaluated per-email AFTER `on_email` triggers complete,
+            # so variables set by inner triggers (e.g. via set_variables) are available.
+            # Use trigger_variables: { element: 'email.<field>', condition: '...', value: '...' }
+            # to match against email fields.
+            if:                       # (optional) only run after_processing when true
+              all:
+                this:
+                  trigger_variables:
+                    element: 'email.subject'  # dot-path into trigger_variables hash
+                    condition: '~'            # '~' = substring match, '==' = exact, '!=' = not equal
+                    value: 'Invoice'
             # Move the email out of the source. Failed emails are left in place
             # so they can be retried on the next run.
             move_to:
@@ -65,6 +77,18 @@
             # delete: true            # works for s3, filesystem and imap
 
           attachments:                # (optional) capture MIME attachments to an NfsStore container
+            # The `if:` key is optional. When absent attachments are always captured.
+            # The condition is evaluated per-email after `assign_email_trigger_variables` runs,
+            # so email fields (from, to, subject, body, etc.) are available.
+            # Use trigger_variables: { element: 'email.<field>', condition: '...', value: '...' }
+            # to conditionally capture attachments based on the email content.
+            if:                       # (optional) only capture attachments when true
+              all:
+                this:
+                  trigger_variables:
+                    element: 'email.subject'  # dot-path into trigger_variables hash
+                    condition: '~'            # '~' = substring match, '==' = exact, '!=' = not equal
+                    value: 'Invoice'
             container:
               # One of:
               from_this: model_reference   # find via ModelReference from the current item

--- a/app/models/save_triggers/pull_emails.rb
+++ b/app/models/save_triggers/pull_emails.rb
@@ -64,7 +64,7 @@ class SaveTriggers::PullEmails < SaveTriggers::SaveTriggersBase
 
       mail = parse_mime(raw_content)
       assign_email_trigger_variables(mail, raw_content, email_id)
-      capture_attachments(mail) if @config[:attachments].present?
+      capture_attachments(mail) if resolved_attachments.present? && step_applies?(resolved_attachments)
 
       attachment_failed = current_email[:status] == 'failed'
 
@@ -79,7 +79,7 @@ class SaveTriggers::PullEmails < SaveTriggers::SaveTriggersBase
       success = current_email[:status] != 'failed'
       if success
         run_on_email_complete_triggers
-        after_process(source, after_cfg, email_id)
+        after_process(source, after_cfg, email_id) if step_applies?(after_cfg)
       else
         # Re-mark failed in case attachment failed but on_email succeeded -
         # ensure we never move/delete a partially-failed email.
@@ -131,6 +131,15 @@ class SaveTriggers::PullEmails < SaveTriggers::SaveTriggersBase
 
   private
 
+  # Returns true when the step should run: either no +if:+ condition is
+  # present in +cfg+, or the condition evaluates as truthy.
+  def step_applies?(cfg)
+    return true if cfg.blank?
+
+    if_cond = cfg[:if]
+    if_cond.blank? || if_evaluates(if_cond)
+  end
+
   # Resolve {{variables.*}} (and other FieldDefaults patterns) within the
   # source configuration so that hostnames, bucket names, paths, usernames,
   # passwords, etc. can be supplied dynamically (e.g. populated by an
@@ -150,6 +159,15 @@ class SaveTriggers::PullEmails < SaveTriggers::SaveTriggersBase
 
     @resolved_after_processing ||= FieldDefaults.substitute_value_recurse(
       @item, after, allow_nil: true, ignore_missing: true
+    )
+  end
+
+  def resolved_attachments
+    attachments = @config[:attachments]
+    return attachments unless attachments.is_a?(Hash)
+
+    @resolved_attachments ||= FieldDefaults.substitute_value_recurse(
+      @item, attachments, allow_nil: true, ignore_missing: true
     )
   end
 
@@ -436,7 +454,7 @@ class SaveTriggers::PullEmails < SaveTriggers::SaveTriggersBase
   # Mirrors the file-storage approach used by SaveTriggers::GenerateDocument.
   # @param [Mail::Message] mail
   def capture_attachments(mail)
-    attachments_config = @config[:attachments]
+    attachments_config = resolved_attachments
     return if attachments_config.blank?
     return if mail.attachments.blank?
 

--- a/spec/models/save_triggers/pull_emails_spec.rb
+++ b/spec/models/save_triggers/pull_emails_spec.rb
@@ -1051,4 +1051,333 @@ RSpec.describe SaveTriggers::PullEmails, type: :model do
         .to include(:pull_emails)
     end
   end
+
+  # Issue #1144: per-email if: conditions on attachments and after_processing.
+  # When attachments.if: evaluates false the email's attachments must be skipped
+  # (without marking the email as failed). When after_processing.if: evaluates
+  # false the move/delete step must be skipped for that email.
+  describe 'if: conditions on attachments and after_processing (issue #1144)' do
+    # DSL condition that matches emails whose subject contains the word "Invoice"
+    let(:invoice_if_condition) do
+      {
+        all: {
+          this: {
+            trigger_variables: { element: 'email.subject', condition: '~', value: 'Invoice' }
+          }
+        }
+      }
+    end
+
+    describe 'attachments.if:' do
+      let(:tmp_dir) { Dir.mktmpdir(['pull_emails_if_attach', '']) }
+      let(:fake_container) { instance_double('NfsStore::Manage::Container', id: 4242, master_id: 0) }
+
+      before do
+        allow_any_instance_of(SaveTriggers::PullEmails)
+          .to receive(:resolve_attachment_container).and_return(fake_container)
+        allow_any_instance_of(SaveTriggers::PullEmails)
+          .to receive(:resolve_attachment_user).and_return(@user)
+
+        @imports = []
+        stub_sf = Struct.new(:id, :file_name, :content_type, :file_size)
+        allow(NfsStore::Import).to receive(:import_file) do |_cid, file_name, _path, _user, **opts|
+          @imports << { file_name: }
+          stub_sf.new(@imports.length, file_name, opts[:content_type], 4)
+        end
+      end
+
+      after { FileUtils.remove_entry(tmp_dir) if Dir.exist?(tmp_dir) }
+
+      it 'skips capture_attachments when the if: condition is false' do
+        # Email subject is "Monthly Newsletter" — does NOT match the Invoice condition.
+        # Expect capture_attachments to be bypassed entirely.
+        File.write(File.join(tmp_dir, 'newsletter.eml'), build_mime_email(
+                                                           from: 'news@vendor.com',
+                                                           to: 'inbox@example.org',
+                                                           subject: 'Monthly Newsletter',
+                                                           body: 'newsletter body.',
+                                                           attachments: [
+                                                             { filename: 'news.pdf',
+                                                               content: 'pdf-content',
+                                                               mime_type: 'application/pdf' }
+                                                           ]
+                                                         ))
+
+        expect_any_instance_of(SaveTriggers::PullEmails).not_to receive(:capture_attachments)
+
+        SaveTriggers::PullEmails.new(
+          {
+            source: { type: 'filesystem', path: tmp_dir },
+            attachments: { container: { id: 4242 }, path: 'emails', if: invoice_if_condition }
+          },
+          @al
+        ).perform
+      end
+
+      it 'runs capture_attachments when the if: condition is true' do
+        # Email subject is "Invoice #5678" — matches the Invoice condition.
+        # capture_attachments must run and the attachment must be imported.
+        File.write(File.join(tmp_dir, 'invoice.eml'), build_mime_email(
+                                                         from: 'billing@vendor.com',
+                                                         to: 'inbox@example.org',
+                                                         subject: 'Invoice #5678',
+                                                         body: 'invoice body.',
+                                                         attachments: [
+                                                           { filename: 'inv.pdf',
+                                                             content: 'pdf-content',
+                                                             mime_type: 'application/pdf' }
+                                                         ]
+                                                       ))
+
+        SaveTriggers::PullEmails.new(
+          {
+            source: { type: 'filesystem', path: tmp_dir },
+            attachments: { container: { id: 4242 }, path: 'emails', if: invoice_if_condition }
+          },
+          @al
+        ).perform
+
+        expect(@imports.map { |i| i[:file_name] }).to include('inv.pdf')
+      end
+
+      it 'does not mark email as failed when attachment if: is false' do
+        # Skipping attachments because the condition is false must NOT put the
+        # email into a failed state (it should remain status: ok).
+        File.write(File.join(tmp_dir, 'newsletter.eml'), build_mime_email(
+                                                           from: 'news@vendor.com',
+                                                           to: 'inbox@example.org',
+                                                           subject: 'Monthly Newsletter',
+                                                           body: 'newsletter body.',
+                                                           attachments: [
+                                                             { filename: 'news.pdf',
+                                                               content: 'pdf-content',
+                                                               mime_type: 'application/pdf' }
+                                                           ]
+                                                         ))
+
+        SaveTriggers::PullEmails.new(
+          {
+            source: { type: 'filesystem', path: tmp_dir },
+            attachments: { container: { id: 4242 }, path: 'emails', if: invoice_if_condition }
+          },
+          @al
+        ).perform
+
+        email = @al.trigger_variables[:emails].first
+        expect(email[:status]).to eq 'ok'
+        # No imports should have been triggered — the attachment step was skipped
+        expect(@imports).to be_empty
+      end
+
+      it 'runs capture_attachments when no if: is present (backward compatible)' do
+        # Attachments configured without any if: must still be imported unconditionally.
+        File.write(File.join(tmp_dir, 'any.eml'), build_mime_email(
+                                                     from: 'sender@vendor.com',
+                                                     to: 'inbox@example.org',
+                                                     subject: 'Some Email Subject',
+                                                     body: 'body content.',
+                                                     attachments: [
+                                                       { filename: 'file.pdf',
+                                                         content: 'pdf-content',
+                                                         mime_type: 'application/pdf' }
+                                                     ]
+                                                   ))
+
+        SaveTriggers::PullEmails.new(
+          {
+            source: { type: 'filesystem', path: tmp_dir },
+            attachments: { container: { id: 4242 }, path: 'emails' }
+          },
+          @al
+        ).perform
+
+        expect(@imports.map { |i| i[:file_name] }).to include('file.pdf')
+      end
+    end
+
+    describe 'after_processing.if:' do
+      let(:tmp_dir) { Dir.mktmpdir(['pull_emails_if_after', '']) }
+
+      before do
+        File.write(File.join(tmp_dir, 'invoice.eml'), build_mime_email(
+                                                         from: 'billing@vendor.com',
+                                                         to: 'inbox@example.org',
+                                                         subject: 'Invoice #5678',
+                                                         body: 'invoice email.'
+                                                       ))
+        File.write(File.join(tmp_dir, 'newsletter.eml'), build_mime_email(
+                                                            from: 'news@vendor.com',
+                                                            to: 'inbox@example.org',
+                                                            subject: 'Monthly Newsletter',
+                                                            body: 'newsletter email.'
+                                                          ))
+      end
+
+      after { FileUtils.remove_entry(tmp_dir) if Dir.exist?(tmp_dir) }
+
+      it 'skips after_processing when the if: condition is false' do
+        # after_processing delete: true — but only when the Invoice condition matches.
+        # The Newsletter email's condition is false, so it must remain on disk.
+        config = {
+          source: { type: 'filesystem', path: tmp_dir },
+          after_processing: { delete: true, if: invoice_if_condition }
+        }
+        SaveTriggers::PullEmails.new(config, @al).perform
+
+        remaining = Dir.children(tmp_dir).sort
+        expect(remaining.length).to eq 1
+        expect(remaining.first).to match(/newsletter/)
+      end
+
+      it 'runs after_processing when the if: condition is true' do
+        # The Invoice email matches the condition; it must be deleted.
+        invoice_only_dir = Dir.mktmpdir(['pull_emails_inv_only', ''])
+        begin
+          File.write(File.join(invoice_only_dir, 'invoice.eml'), build_mime_email(
+                                                                    from: 'billing@vendor.com',
+                                                                    to: 'inbox@example.org',
+                                                                    subject: 'Invoice #9999',
+                                                                    body: 'invoice.'
+                                                                  ))
+          config = {
+            source: { type: 'filesystem', path: invoice_only_dir },
+            after_processing: { delete: true, if: invoice_if_condition }
+          }
+          SaveTriggers::PullEmails.new(config, @al).perform
+
+          expect(Dir.children(invoice_only_dir)).to be_empty
+        ensure
+          FileUtils.remove_entry(invoice_only_dir) if Dir.exist?(invoice_only_dir)
+        end
+      end
+
+      it 'runs after_processing for all emails when no if: is present (backward compatible)' do
+        config = {
+          source: { type: 'filesystem', path: tmp_dir },
+          after_processing: { delete: true }
+        }
+        SaveTriggers::PullEmails.new(config, @al).perform
+
+        expect(Dir.children(tmp_dir)).to be_empty
+      end
+    end
+  end
+
+  # Issue #1144: verify that the existing ConditionalActions / if_evaluates DSL
+  # can already evaluate conditions against email fields stored in
+  # trigger_variables, using the `element:` path-traversal syntax.
+  # This underpins the planned if: support on `attachments` and `after_processing`.
+  #
+  # The mechanism relies on:
+  #   attribute_from_instance(@item, :trigger_variables)
+  #     -> falls back to instance_variable_get('@trigger_variables')
+  #     -> returns the full trigger_variables hash
+  #   non_query_expected_val_not_a_hash detects expected_val[:element]
+  #     -> traverse_element(hash, 'email.subject') navigates the nested hash
+  #     -> eval_simple_condition applies the requested condition operator
+  describe 'if_evaluates with trigger_variables element path (issue #1144)' do
+    let(:tmp_dir) { Dir.mktmpdir(['pull_emails_if_cond', '']) }
+
+    before do
+      File.write(File.join(tmp_dir, 'invoice.eml'), build_mime_email(
+                                                      from: 'billing@vendor.com',
+                                                      to: 'inbox@study.example.org',
+                                                      subject: 'Invoice #1234',
+                                                      body: 'Please find your invoice attached.'
+                                                    ))
+      File.write(File.join(tmp_dir, 'newsletter.eml'), build_mime_email(
+                                                          from: 'news@vendor.com',
+                                                          to: 'inbox@study.example.org',
+                                                          subject: 'Monthly Newsletter',
+                                                          body: 'Here is your newsletter.'
+                                                        ))
+    end
+
+    after { FileUtils.remove_entry(tmp_dir) if Dir.exist?(tmp_dir) }
+
+    it 'evaluates true when trigger_variables email subject matches the condition' do
+      # Simulate the state pull_emails sets after assign_email_trigger_variables
+      @al.trigger_variables = {
+        email: { subject: 'Invoice #1234', from: 'billing@vendor.com' }
+      }
+
+      condition = {
+        all: {
+          this: {
+            trigger_variables: { element: 'email.subject', condition: '~', value: 'Invoice' }
+          }
+        }
+      }
+      ca = ConditionalActions.new(condition, @al)
+      expect(ca.calc_action_if).to be_truthy
+    end
+
+    it 'evaluates false when trigger_variables email subject does not match' do
+      @al.trigger_variables = {
+        email: { subject: 'Monthly Newsletter', from: 'news@vendor.com' }
+      }
+
+      condition = {
+        all: {
+          this: {
+            trigger_variables: { element: 'email.subject', condition: '~', value: 'Invoice' }
+          }
+        }
+      }
+      ca = ConditionalActions.new(condition, @al)
+      expect(ca.calc_action_if).to be_falsy
+    end
+
+    it 'evaluates true for an exact equality match on email.from' do
+      @al.trigger_variables = {
+        email: { subject: 'Hello', from: 'billing@vendor.com' }
+      }
+
+      condition = {
+        all: {
+          this: {
+            trigger_variables: { element: 'email.from', condition: '==', value: 'billing@vendor.com' }
+          }
+        }
+      }
+      ca = ConditionalActions.new(condition, @al)
+      expect(ca.calc_action_if).to be_truthy
+    end
+
+    it 'evaluates false for an equality mismatch on email.from' do
+      @al.trigger_variables = {
+        email: { subject: 'Hello', from: 'other@vendor.com' }
+      }
+
+      condition = {
+        all: {
+          this: {
+            trigger_variables: { element: 'email.from', condition: '==', value: 'billing@vendor.com' }
+          }
+        }
+      }
+      ca = ConditionalActions.new(condition, @al)
+      expect(ca.calc_action_if).to be_falsy
+    end
+
+    it 'is consistent with what if_evaluates returns on the same trigger instance' do
+      @al.trigger_variables = {
+        email: { subject: 'Invoice #9999', from: 'ar@company.com' }
+      }
+
+      condition = {
+        all: {
+          this: {
+            trigger_variables: { element: 'email.subject', condition: '~', value: 'Invoice' }
+          }
+        }
+      }
+      trigger = SaveTriggers::PullEmails.new({ source: { type: 'filesystem', path: tmp_dir } }, @al)
+      expect(trigger.send(:if_evaluates, condition)).to be_truthy
+
+      @al.trigger_variables[:email][:subject] = 'Unrelated email'
+      trigger2 = SaveTriggers::PullEmails.new({ source: { type: 'filesystem', path: tmp_dir } }, @al)
+      expect(trigger2.send(:if_evaluates, condition)).to be_falsy
+    end
+  end
 end

--- a/spec/models/save_triggers/pull_emails_spec.rb
+++ b/spec/models/save_triggers/pull_emails_spec.rb
@@ -1118,16 +1118,16 @@ RSpec.describe SaveTriggers::PullEmails, type: :model do
         # Email subject is "Invoice #5678" — matches the Invoice condition.
         # capture_attachments must run and the attachment must be imported.
         File.write(File.join(tmp_dir, 'invoice.eml'), build_mime_email(
-                                                         from: 'billing@vendor.com',
-                                                         to: 'inbox@example.org',
-                                                         subject: 'Invoice #5678',
-                                                         body: 'invoice body.',
-                                                         attachments: [
-                                                           { filename: 'inv.pdf',
-                                                             content: 'pdf-content',
-                                                             mime_type: 'application/pdf' }
-                                                         ]
-                                                       ))
+                                                        from: 'billing@vendor.com',
+                                                        to: 'inbox@example.org',
+                                                        subject: 'Invoice #5678',
+                                                        body: 'invoice body.',
+                                                        attachments: [
+                                                          { filename: 'inv.pdf',
+                                                            content: 'pdf-content',
+                                                            mime_type: 'application/pdf' }
+                                                        ]
+                                                      ))
 
         SaveTriggers::PullEmails.new(
           {
@@ -1172,16 +1172,16 @@ RSpec.describe SaveTriggers::PullEmails, type: :model do
       it 'runs capture_attachments when no if: is present (backward compatible)' do
         # Attachments configured without any if: must still be imported unconditionally.
         File.write(File.join(tmp_dir, 'any.eml'), build_mime_email(
-                                                     from: 'sender@vendor.com',
-                                                     to: 'inbox@example.org',
-                                                     subject: 'Some Email Subject',
-                                                     body: 'body content.',
-                                                     attachments: [
-                                                       { filename: 'file.pdf',
-                                                         content: 'pdf-content',
-                                                         mime_type: 'application/pdf' }
-                                                     ]
-                                                   ))
+                                                    from: 'sender@vendor.com',
+                                                    to: 'inbox@example.org',
+                                                    subject: 'Some Email Subject',
+                                                    body: 'body content.',
+                                                    attachments: [
+                                                      { filename: 'file.pdf',
+                                                        content: 'pdf-content',
+                                                        mime_type: 'application/pdf' }
+                                                    ]
+                                                  ))
 
         SaveTriggers::PullEmails.new(
           {
@@ -1200,17 +1200,17 @@ RSpec.describe SaveTriggers::PullEmails, type: :model do
 
       before do
         File.write(File.join(tmp_dir, 'invoice.eml'), build_mime_email(
-                                                         from: 'billing@vendor.com',
-                                                         to: 'inbox@example.org',
-                                                         subject: 'Invoice #5678',
-                                                         body: 'invoice email.'
-                                                       ))
+                                                        from: 'billing@vendor.com',
+                                                        to: 'inbox@example.org',
+                                                        subject: 'Invoice #5678',
+                                                        body: 'invoice email.'
+                                                      ))
         File.write(File.join(tmp_dir, 'newsletter.eml'), build_mime_email(
-                                                            from: 'news@vendor.com',
-                                                            to: 'inbox@example.org',
-                                                            subject: 'Monthly Newsletter',
-                                                            body: 'newsletter email.'
-                                                          ))
+                                                           from: 'news@vendor.com',
+                                                           to: 'inbox@example.org',
+                                                           subject: 'Monthly Newsletter',
+                                                           body: 'newsletter email.'
+                                                         ))
       end
 
       after { FileUtils.remove_entry(tmp_dir) if Dir.exist?(tmp_dir) }
@@ -1234,11 +1234,11 @@ RSpec.describe SaveTriggers::PullEmails, type: :model do
         invoice_only_dir = Dir.mktmpdir(['pull_emails_inv_only', ''])
         begin
           File.write(File.join(invoice_only_dir, 'invoice.eml'), build_mime_email(
-                                                                    from: 'billing@vendor.com',
-                                                                    to: 'inbox@example.org',
-                                                                    subject: 'Invoice #9999',
-                                                                    body: 'invoice.'
-                                                                  ))
+                                                                   from: 'billing@vendor.com',
+                                                                   to: 'inbox@example.org',
+                                                                   subject: 'Invoice #9999',
+                                                                   body: 'invoice.'
+                                                                 ))
           config = {
             source: { type: 'filesystem', path: invoice_only_dir },
             after_processing: { delete: true, if: invoice_if_condition }
@@ -1286,11 +1286,11 @@ RSpec.describe SaveTriggers::PullEmails, type: :model do
                                                       body: 'Please find your invoice attached.'
                                                     ))
       File.write(File.join(tmp_dir, 'newsletter.eml'), build_mime_email(
-                                                          from: 'news@vendor.com',
-                                                          to: 'inbox@study.example.org',
-                                                          subject: 'Monthly Newsletter',
-                                                          body: 'Here is your newsletter.'
-                                                        ))
+                                                         from: 'news@vendor.com',
+                                                         to: 'inbox@study.example.org',
+                                                         subject: 'Monthly Newsletter',
+                                                         body: 'Here is your newsletter.'
+                                                       ))
     end
 
     after { FileUtils.remove_entry(tmp_dir) if Dir.exist?(tmp_dir) }


### PR DESCRIPTION
## Summary

Adds support for per-email `if:` conditions on the `attachments` and `after_processing` configuration blocks in the `pull_emails` save trigger.

## Changes

### New behaviour
- `attachments.if:` — when present, evaluates the condition per email (after `assign_email_trigger_variables` populates `trigger_variables[:email]`). If false, the attachment capture step is skipped for that email without marking it as failed.
- `after_processing.if:` — when present, evaluates the condition per email (after `on_email` inner triggers complete, so variables they set are also available). If false, the move/delete step is skipped for that email.
- Both conditions use the standard `trigger_variables: { element: 'email.<field>', condition: '...', value: '...' }` DSL already used by `if_evaluates`.
- Fully backward-compatible: omitting `if:` leaves existing behaviour unchanged.

### Bug fix
- Fixed asymmetric `{{variables.*}}` substitution: `@config[:attachments]` was never passed through `FieldDefaults.substitute_value_recurse`, so secrets/variables in the attachments config (including in `attachments.if:` value strings) were not expanded. Added `resolved_attachments` memoized method mirroring the existing `resolved_after_processing` and `resolved_source` pattern.

### Documentation
- Updated `save_triggers_pull_emails_options_defs.yaml` admin panel definition with YAML examples and explanatory comments for both new `if:` keys.

Closes #1144
