### PR TITLE
Added inline data URI image embedding in notification emails - resolves #1148

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -3,6 +3,21 @@
 #
 # Perform mailing to valid users and non-user email addresses
 class NotificationMailer < ActionMailer::Base
+  MIME_EXT_MAP = {
+    'image/png' => 'png',
+    'image/jpeg' => 'jpg',
+    'image/gif' => 'gif',
+    'image/svg+xml' => 'svg',
+    'image/webp' => 'webp',
+    'image/tiff' => 'tiff',
+    'image/bmp' => 'bmp'
+  }.freeze
+
+  DATA_URI_IMG_REGEX = /(<img\b[^>]*?\s)src=(['"])(data:(image\/[^;'"]+);base64,([A-Za-z0-9+\/=\s]+?))\2([^>]*?>)/im.freeze
+
+  # Maximum decoded size (bytes) for an inline data-URI image. Images exceeding this
+  # limit are skipped and left as-is to prevent memory exhaustion.
+  MAX_DATA_URI_IMAGE_BYTES = (10 * 1024 * 1024).freeze
   #
   # Send a message notification
   # Filter out any emails that are either invalid (no fully qualified domain name specified)
@@ -72,8 +87,10 @@ class NotificationMailer < ActionMailer::Base
       }
     end
 
+    html = Settings::ProcessInlineDataUriImages ? embed_inline_data_uri_images(notify.generated_text) : notify.generated_text
+
     mail(options) do |format|
-      format.html { render html: notify.generated_text.html_safe }
+      format.html { render html: html.html_safe }
     end
   end
 
@@ -86,5 +103,45 @@ class NotificationMailer < ActionMailer::Base
   def fully_qualified_domain_name?(email)
     domain = email.split('@', 2)
     domain.last&.include?('.')
+  end
+
+  private
+
+  #
+  # Replace <img src="data:<mime>;base64,..."> tags with MIME inline attachments.
+  # Each matching data URI is decoded, attached as a MIME inline part, and the src
+  # attribute is rewritten to the corresponding cid: reference.
+  # Images larger than MAX_DATA_URI_IMAGE_BYTES (decoded) are skipped with a warning.
+  # @param [String] html
+  # @return [String]
+  def embed_inline_data_uri_images(html)
+    return html unless Settings::ProcessInlineDataUriImages
+
+    n = 0
+    html.gsub(DATA_URI_IMG_REGEX) do
+      leading_attrs = Regexp.last_match(1)
+      quote = Regexp.last_match(2)
+      mime_type = Regexp.last_match(4)
+      payload = Regexp.last_match(5)
+      trailing_attrs = Regexp.last_match(6)
+
+      begin
+        decoded_bytes = Base64.strict_decode64(payload.gsub(/\s/, ''))
+
+        if decoded_bytes.bytesize > MAX_DATA_URI_IMAGE_BYTES
+          Rails.logger.warn "embed_inline_data_uri_images: skipping oversized image for #{mime_type} (#{decoded_bytes.bytesize} bytes)"
+          next Regexp.last_match(0)
+        end
+
+        ext = MIME_EXT_MAP.fetch(mime_type, 'bin')
+        n += 1
+        filename = "inline-#{n}-#{SecureRandom.hex(4)}.#{ext}"
+        attachments.inline[filename] = { mime_type: mime_type, content: decoded_bytes }
+        "#{leading_attrs}src=#{quote}#{attachments[filename].url}#{quote}#{trailing_attrs}"
+      rescue ArgumentError => e
+        Rails.logger.warn "embed_inline_data_uri_images: skipping malformed base64 for #{mime_type}: #{e.message}"
+        Regexp.last_match(0)
+      end
+    end
   end
 end

--- a/config/initializers/app_settings.rb
+++ b/config/initializers/app_settings.rb
@@ -229,6 +229,9 @@ class Settings
   # Dynamic models create their own migrations during configuration, if this is set
   AllowDynamicMigrations = ENV['FPHS_ALLOW_DYN_MIGRATIONS'] == 'true' || Rails.env.development?
 
+  # Convert inline data URI images in email bodies to MIME inline attachments
+  ProcessInlineDataUriImages = ENV.key?('FPHS_PROCESS_INLINE_DATA_URI_IMAGES') ? ENV['FPHS_PROCESS_INLINE_DATA_URI_IMAGES'] == 'true' : true
+
   # Redcap records request options - additional request parameters to add / override the payload
   # to a records request.
   # Hash of options are:
@@ -303,7 +306,7 @@ class Settings
     DefaultShortLinkS3Bucket DefaultShortLinkLogS3Bucket LogBucketPrefix ShortcodeLength
     DefaultSubjectInfoTableName DefaultSecondaryInfoTableName DefaultContactInfoTableName DefaultAddressInfoTableName
     ScriptedJobDirectory
-    DisableVDef AllowDynamicMigrations
+    DisableVDef AllowDynamicMigrations ProcessInlineDataUriImages
     AllowUsersToRegister DefaultUserTemplateEmail RegistrationAdminEmail AllowAdminsToManageAdmins NotifyOnRegistration
     InvitationCode ReCaptchaSiteKey ReCaptchaMinScore
     CountryCodesForTimezones DefaultUserTimezone

--- a/docs/admin_reference/general/save_trigger_notify.md
+++ b/docs/admin_reference/general/save_trigger_notify.md
@@ -6,3 +6,12 @@ Send a notification (email, SMS, etc.) using a configured message template when 
 ```yaml
 !defs(save_triggers_notify_options_defs.yaml)
 ```
+
+## Inline Image Handling
+
+Email bodies can contain `<img src="data:image/...;base64,...">` tags. When such tags are
+present, they are automatically converted to proper MIME inline attachments (CID references)
+so that email clients such as Gmail and Outlook display them correctly.
+
+This behaviour is controlled by the `ProcessInlineDataUriImages` setting (default: enabled).
+Set the environment variable `FPHS_PROCESS_INLINE_DATA_URI_IMAGES=false` to disable it.

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -1,0 +1,332 @@
+# frozen_string_literal: true
+
+# Tests for NotificationMailer#embed_inline_data_uri_images (issue #1148)
+# Covers the private helper that converts <img src="data:image/...;base64,..."/> tags
+# in the generated HTML into proper MIME inline attachments referenced by cid: URLs.
+# Also covers the Settings::ProcessInlineDataUriImages setting (default true) that
+# controls whether the transformation is applied.
+# Includes MIME structure validation tests that confirm the generated email
+# serialises to a well-formed RFC-2387 multipart/related message with matching
+# Content-ID headers, mirroring the structure of tmp/agent-tmp/inline_image_example.eml.
+
+require 'rails_helper'
+
+RSpec.describe NotificationMailer, type: :mailer do
+  include MasterSupport
+  include ModelSupport
+  include PlayerContactSupport
+
+  # Minimal valid 1x1 red pixel PNG encoded in base64
+  PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=='
+
+  def setup_mailer_test
+    create_admin
+    @rec_user, = create_user
+    create_user
+    seed_database
+    ActivityLog.define_models
+    setup_access :player_contacts
+    create_item(data: rand(10_000_000_000_000_000), rank: 10)
+    @player_contact.master.current_user = @user
+    expect(@player_contact.master).to be_a Master
+
+    setup_access :activity_log__player_contact_phones
+    setup_access :activity_log__player_contact_phone__primary, resource_type: :activity_log_type
+    setup_access :activity_log__player_contact_phone__blank_log, resource_type: :activity_log_type
+    setup_access :activity_log__player_contact_phones, user: @user
+    setup_access :activity_log__player_contact_phone__primary, resource_type: :activity_log_type, user: @user
+    setup_access :activity_log__player_contact_phone__blank_log, resource_type: :activity_log_type, user: @user
+    @activity_log = @player_contact.activity_log__player_contact_phones.create!(
+      select_call_direction: 'from player', select_who: 'user', master: @player_contact.master
+    )
+
+    t = '<html><head></head><body>{{main_content}}</body></html>'
+    @layout = Admin::MessageTemplate.create!(
+      name: 'test mailer layout', message_type: :email, template_type: :layout, template: t, current_admin: @admin
+    )
+  end
+
+  # Build a MessageNotification whose content template is the given HTML string.
+  # Calls mn.generate before returning so generated_text is set.
+  def create_notification_with_content(content_html)
+    content = Admin::MessageTemplate.create!(
+      name: "test content #{SecureRandom.hex(4)}",
+      message_type: :email,
+      template_type: :content,
+      template: content_html,
+      current_admin: @admin
+    )
+    mn = Messaging::MessageNotification.create!(
+      app_type: @user.app_type,
+      user: @user,
+      recipient_user_ids: [@rec_user],
+      layout_template_name: @layout.name,
+      content_template_name: content.name,
+      item_type: @activity_log.class.name,
+      item_id: @activity_log.id,
+      master: @activity_log.master,
+      message_type: :email
+    )
+    mn.generate
+    mn
+  end
+
+  # Extract the HTML body from a mail that may be single-part or multipart/related
+  def html_body(mail)
+    (mail.html_part || mail).body.decoded
+  end
+
+  describe 'embed_inline_data_uri_images data URI conversion (issue #1148)' do
+    before :example do
+      setup_mailer_test
+      change_setting('TestMail', true)
+      change_setting('ProcessInlineDataUriImages', true)
+    end
+
+    after :example do
+      change_setting('TestMail', false)
+      change_setting('ProcessInlineDataUriImages', nil)
+    end
+
+    it 'converts a single PNG data URI image to an inline attachment with a cid: reference in the body' do
+      content_html = %(<p>Look at this:</p><img src="data:image/png;base64,#{PNG_BASE64}" alt="test"/>)
+      mn = create_notification_with_content(content_html)
+
+      mail = NotificationMailer.send_message_notification(mn)
+
+      inline_attachments = mail.attachments.select(&:inline?)
+      expect(inline_attachments.size).to eq(1)
+
+      # The decoded bytes of the attachment must match the original base64 data
+      expect(Base64.strict_encode64(inline_attachments.first.body.decoded)).to eq(PNG_BASE64)
+
+      body = html_body(mail)
+      expect(body).to include('src="cid:')
+      expect(body).not_to include('src="data:')
+    end
+
+    it 'converts multiple data URI images to distinct inline attachments each with a unique cid' do
+      img1 = %(<img src="data:image/png;base64,#{PNG_BASE64}" alt="img1"/>)
+      img2 = %(<img src="data:image/png;base64,#{PNG_BASE64}" alt="img2"/>)
+      content_html = "<p>Two images: #{img1} #{img2}</p>"
+      mn = create_notification_with_content(content_html)
+
+      mail = NotificationMailer.send_message_notification(mn)
+
+      inline_attachments = mail.attachments.select(&:inline?)
+      expect(inline_attachments.size).to eq(2)
+
+      # Each attachment must have a unique Content-ID
+      cids = inline_attachments.map(&:content_id)
+      expect(cids.uniq.size).to eq(2)
+
+      # Both img tags must be rewritten with cid: references
+      expect(html_body(mail).scan('src="cid:').size).to eq(2)
+    end
+
+    it 'rewrites only the data URI image and leaves the https image src unchanged' do
+      data_img = %(<img src="data:image/png;base64,#{PNG_BASE64}" alt="data"/>)
+      https_img = '<img src="https://example.com/img.png" alt="remote"/>'
+      content_html = "<p>#{data_img}#{https_img}</p>"
+      mn = create_notification_with_content(content_html)
+
+      mail = NotificationMailer.send_message_notification(mn)
+
+      body = html_body(mail)
+      expect(body).to include('src="https://example.com/img.png"')
+      expect(body).not_to include('src="data:')
+
+      inline_attachments = mail.attachments.select(&:inline?)
+      expect(inline_attachments.size).to eq(1)
+    end
+
+    it 'assigns the correct file extension to the inline attachment filename based on MIME type' do
+      [
+        ['image/jpeg', '.jpg'],
+        ['image/gif', '.gif'],
+        ['image/svg+xml', '.svg']
+      ].each do |mime_type, expected_ext|
+        content_html = %(<p><img src="data:#{mime_type};base64,#{PNG_BASE64}" alt="test"/></p>)
+        mn = create_notification_with_content(content_html)
+
+        mail = NotificationMailer.send_message_notification(mn)
+
+        inline_attachments = mail.attachments.select(&:inline?)
+        expect(inline_attachments.size).to eq(1), "Expected 1 inline attachment for MIME type #{mime_type}"
+        expect(inline_attachments.first.filename).to end_with(expected_ext),
+          "Expected filename to end with #{expected_ext} for MIME type #{mime_type}"
+      end
+    end
+
+    it 'leaves a malformed base64 data URI unchanged and does not raise an exception or add an attachment' do
+      malformed = '<img src="data:image/png;base64,!!!INVALID!!!" alt="broken"/>'
+      content_html = "<p>Bad image: #{malformed}</p>"
+      mn = create_notification_with_content(content_html)
+
+      expect do
+        mail = NotificationMailer.send_message_notification(mn)
+        expect(html_body(mail)).to include('data:image/png;base64,!!!INVALID!!!')
+        expect(mail.attachments.select(&:inline?).size).to eq(0)
+      end.not_to raise_error
+    end
+
+    it 'performs no transformation when Settings::ProcessInlineDataUriImages is false' do
+      change_setting('ProcessInlineDataUriImages', false)
+
+      content_html = %(<p><img src="data:image/png;base64,#{PNG_BASE64}" alt="test"/></p>)
+      mn = create_notification_with_content(content_html)
+
+      mail = NotificationMailer.send_message_notification(mn)
+
+      body = html_body(mail)
+      expect(body).to include('src="data:image/png;base64,')
+      expect(body).not_to include('src="cid:')
+      expect(mail.attachments.select(&:inline?).size).to eq(0)
+    end
+
+    it 'includes both a .ics calendar attachment and an inline image attachment in the same email' do
+      calendar_data = {
+        'method' => 'REQUEST',
+        'summary' => 'Test Meeting',
+        'dtstart' => '2026-05-01 10:00:00',
+        'dtend' => '2026-05-01 11:00:00',
+        'organizer' => 'org@example.com'
+      }
+      content_html = %(<p><img src="data:image/png;base64,#{PNG_BASE64}" alt="test"/></p>)
+      content = Admin::MessageTemplate.create!(
+        name: "cal test content #{SecureRandom.hex(4)}",
+        message_type: :email,
+        template_type: :content,
+        template: content_html,
+        current_admin: @admin
+      )
+      mn = Messaging::MessageNotification.create!(
+        app_type: @user.app_type,
+        user: @user,
+        recipient_user_ids: [@rec_user],
+        layout_template_name: @layout.name,
+        content_template_name: content.name,
+        item_type: @activity_log.class.name,
+        item_id: @activity_log.id,
+        master: @activity_log.master,
+        message_type: :email,
+        extra_substitutions: { calendar_invite: calendar_data }
+      )
+      mn.generate
+      mn.resolve_attachments
+
+      mail = NotificationMailer.send_message_notification(mn)
+
+      ics_attachment = mail.attachments['calendar.ics']
+      expect(ics_attachment).not_to be_nil
+      expect(ics_attachment.content_type).to include('text/calendar')
+      expect(ics_attachment.inline?).to be false
+
+      inline_attachments = mail.attachments.select(&:inline?)
+      expect(inline_attachments.size).to eq(1)
+      expect(inline_attachments.first.inline?).to be true
+    end
+  end
+
+  describe 'MIME structure validation (issue #1148)' do
+    before :example do
+      setup_mailer_test
+      change_setting('TestMail', true)
+      change_setting('ProcessInlineDataUriImages', true)
+    end
+
+    after :example do
+      change_setting('TestMail', false)
+      change_setting('ProcessInlineDataUriImages', nil)
+    end
+
+    it 'produces a multipart/related part in the serialised message so that cid: references resolve' do
+      content_html = %(<p><img src="data:image/png;base64,#{PNG_BASE64}" alt="test"/></p>)
+      mn = create_notification_with_content(content_html)
+
+      mail = NotificationMailer.send_message_notification(mn)
+
+      # The mail must be multipart
+      expect(mail.multipart?).to be true
+
+      # The serialised message must declare multipart/related — the Mail gem only
+      # emits this in to_s, not directly via mail.parts at the runtime object level.
+      expect(mail.to_s).to match(/Content-Type:\s*multipart\/related/i),
+        'Expected multipart/related in the serialised MIME message for CID image resolution'
+
+      # Additionally, the inline attachment must be present and the HTML must reference it
+      inline_att = mail.attachments.find(&:inline?)
+      expect(inline_att).not_to be_nil
+      bare_cid = inline_att.content_id.delete('<>').strip
+      expect(html_body(mail)).to include("cid:#{bare_cid}")
+    end
+
+    it 'sets Content-Disposition: inline on the image attachment' do
+      content_html = %(<p><img src="data:image/png;base64,#{PNG_BASE64}" alt="test"/></p>)
+      mn = create_notification_with_content(content_html)
+
+      mail = NotificationMailer.send_message_notification(mn)
+
+      inline_att = mail.attachments.find(&:inline?)
+      expect(inline_att).not_to be_nil
+      expect(inline_att.content_disposition).to match(/\Ainline/i)
+    end
+
+    it 'has a Content-ID on the inline attachment that matches the cid: reference in the HTML body' do
+      content_html = %(<p><img src="data:image/png;base64,#{PNG_BASE64}" alt="test"/></p>)
+      mn = create_notification_with_content(content_html)
+
+      mail = NotificationMailer.send_message_notification(mn)
+
+      inline_att = mail.attachments.find(&:inline?)
+      expect(inline_att).not_to be_nil
+
+      # Mail gem stores Content-ID as "<id@host>"; strip angle brackets to get bare cid
+      raw_cid = inline_att.content_id                          # e.g. "<abc123@host>"
+      bare_cid = raw_cid.delete('<>').strip                    # e.g. "abc123@host"
+
+      body = html_body(mail)
+      expect(body).to include("src=\"cid:#{bare_cid}\""),
+        "Expected HTML body to contain src=\"cid:#{bare_cid}\" but got:\n#{body}"
+    end
+
+    it 'round-trips the image bytes correctly through base64 encode/decode' do
+      original_bytes = Base64.strict_decode64(PNG_BASE64)
+      content_html = %(<p><img src="data:image/png;base64,#{PNG_BASE64}" alt="test"/></p>)
+      mn = create_notification_with_content(content_html)
+
+      mail = NotificationMailer.send_message_notification(mn)
+
+      inline_att = mail.attachments.find(&:inline?)
+      expect(inline_att).not_to be_nil
+      expect(inline_att.body.decoded).to eq(original_bytes),
+        'Decoded attachment bytes must match the original decoded base64 payload'
+    end
+
+    it 'serialises to a valid RFC-compliant .eml string with multipart/related and cid: reference' do
+      content_html = %(<p><img src="data:image/png;base64,#{PNG_BASE64}" alt="test"/></p>)
+      mn = create_notification_with_content(content_html)
+
+      mail = NotificationMailer.send_message_notification(mn)
+      eml_string = mail.to_s
+
+      # The serialised message must declare the related content-type
+      expect(eml_string).to match(/Content-Type:\s*multipart\/related/i)
+
+      # The serialised message must carry a Content-ID header for the inline part
+      expect(eml_string).to match(/Content-ID:/i)
+
+      # The HTML part in the serialised message must reference that CID
+      inline_att = mail.attachments.find(&:inline?)
+      bare_cid = inline_att.content_id.delete('<>').strip
+      expect(eml_string).to include("cid:#{bare_cid}")
+
+      # The original data: URI must NOT appear in the serialised message
+      expect(eml_string).not_to include('src="data:')
+      expect(eml_string).not_to include("src='data:")
+
+      # Content-Disposition header must say inline for the image part
+      expect(eml_string).to match(/Content-Disposition:\s*inline/i)
+    end
+  end
+end

--- a/spec/models/save_triggers/notify_spec.rb
+++ b/spec/models/save_triggers/notify_spec.rb
@@ -1014,4 +1014,56 @@ RSpec.describe SaveTriggers::Notify, type: :model do
       end
     end
   end
+
+  context 'with data URI inline images in content (issue #1148)' do
+    # Minimal valid 1x1 red pixel PNG in base64
+    PNG_BASE64_NOTIFY = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=='
+
+    before :example do
+      change_setting('TestMail', true)
+      change_setting('ProcessInlineDataUriImages', true)
+    end
+
+    after :example do
+      change_setting('TestMail', false)
+      change_setting('ProcessInlineDataUriImages', nil)
+    end
+
+    it 'converts data URI images to inline attachments when sending notification email triggered by notify' do
+      # Content template embeds a data URI image
+      data_img = %(<img src="data:image/png;base64,#{PNG_BASE64_NOTIFY}" alt="embedded"/>)
+      t = "<p>Here is an image: #{data_img}</p>"
+      content_with_image = Admin::MessageTemplate.create!(
+        name: 'test email content with image',
+        message_type: :email,
+        template_type: :content,
+        template: t,
+        current_admin: @admin
+      )
+
+      config = {
+        type: 'email',
+        role: 'test',
+        layout_template: @layout.name,
+        content_template: content_with_image.name,
+        subject: 'Image Notification'
+      }
+
+      @trigger = SaveTriggers::Notify.new(config, @al)
+      @trigger.perform
+
+      new_mn = MessageNotification.order(id: :desc).first
+      new_mn.generate
+
+      mail = NotificationMailer.send_message_notification(new_mn)
+
+      # The data URI must have been replaced with an inline cid: attachment
+      inline_attachments = mail.attachments.select(&:inline?)
+      expect(inline_attachments.size).to eq(1)
+
+      body = (mail.html_part || mail).body.decoded
+      expect(body).to include('src="cid:')
+      expect(body).not_to include('src="data:')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Converts inline `data:image/*;base64,...` URIs in email bodies into proper MIME inline attachments referenced by `cid:` URLs, so that email clients (Gmail, Outlook web) that strip `data:` URIs display the images correctly.

Resolves #1148.

## Changes

### `app/mailers/notification_mailer.rb`
- Added `MIME_EXT_MAP` constant mapping image MIME types to file extensions (`png`, `jpg`, `gif`, `svg`, `webp`, `tiff`, `bmp`).
- Added `DATA_URI_IMG_REGEX` constant for matching `<img src="data:image/...;base64,...">` tags (case-insensitive, single/double quotes, other attributes preserved).
- Added `MAX_DATA_URI_IMAGE_BYTES = 10MB` size cap to prevent memory exhaustion from oversized payloads.
- Added private `embed_inline_data_uri_images(html)` helper that:
  - Decodes each data URI payload with `Base64.strict_decode64`
  - Registers each image as `attachments.inline[filename]` (Mail gem assigns `Content-Disposition: inline` and a `Content-ID` automatically)
  - Replaces `src="data:..."` with `src="cid:..."` in the HTML
  - Skips malformed base64 (logs warning, tag left intact)
  - Skips images over 10 MB (logs warning, tag left intact)
  - Returns HTML unchanged if `Settings::ProcessInlineDataUriImages` is falsy
- Updated `send_message_notification` to call the helper before rendering.

### `config/initializers/app_settings.rb`
- Added `ProcessInlineDataUriImages` setting (default: `true`, controlled via `FPHS_PROCESS_INLINE_DATA_URI_IMAGES` env var).
- Added to `AppSettingsVars` for admin server info display.

### `docs/admin_reference/general/save_trigger_notify.md`
- Added `## Inline Image Handling` section describing the automatic conversion and the `FPHS_PROCESS_INLINE_DATA_URI_IMAGES` environment variable.

## Tests

### `spec/mailers/notification_mailer_spec.rb` (new file — 12 tests)
**Functional tests:**
- Single PNG data URI → one inline attachment, `cid:` reference in body, bytes round-trip
- Multiple data URI images → multiple distinct inline attachments with unique Content-IDs
- Mixed `data:` + `https:` images → only the data URI is rewritten
- MIME type → correct extension (`.jpg`, `.gif`, `.svg`)
- Malformed base64 → tag unchanged, no exception, no attachment
- `ProcessInlineDataUriImages = false` → no transformation

**MIME structure tests:**
- `multipart/related` present in serialised `mail.to_s`
- `Content-Disposition: inline` on the image attachment
- `Content-ID` header matches the `cid:` reference in the HTML body
- Decoded attachment bytes match the original base64 payload
- Full RFC-compliant `.eml` serialisation validates all the above together
- `.ics` calendar attachment (issue #953) coexists correctly with inline images

### `spec/models/save_triggers/notify_spec.rb`
- Added `context 'with data URI inline images in content (issue #1148)'` — end-to-end integration test through the notify save trigger.

## Decisions
- Transformation applied in the mailer (not in `MessageNotification#generate`) so the persisted `generated_content` retains the original `data:` URIs for admin preview.
- Default enabled — current emails with data URIs are already broken in Gmail.
