### PR TITLE
Fixed notify on_complete array handling - fixes #1147

### DIFF
--- a/app/models/messaging/message_notification.rb
+++ b/app/models/messaging/message_notification.rb
@@ -577,8 +577,13 @@ module Messaging
     def fire_item_on_complete_triggers
       return unless for_item && on_complete_config.present?
 
-      for_item.current_user = batch_user
-      OptionConfigs::ActivityLogOptions.calc_triggers for_item, on_complete_config
+      for_item.current_user ||= user || batch_user
+      trigger_configs = on_complete_config.is_a?(Array) ? on_complete_config : [on_complete_config]
+      trigger_configs.each do |config|
+        next unless config.is_a?(Hash)
+
+        OptionConfigs::ActivityLogOptions.calc_triggers for_item, config
+      end
     end
 
     def batch_user

--- a/app/models/save_triggers/notify.rb
+++ b/app/models/save_triggers/notify.rb
@@ -93,7 +93,7 @@ class SaveTriggers::Notify < SaveTriggers::SaveTriggersBase
     @emails = config[:emails]
     @default_country_code = config[:default_country_code]
     @layout_template = config[:layout_template]
-    @on_complete = config[:on_complete]
+    @on_complete = config[:on_complete] || @on_complete_triggers
     @from_user_email = config[:from_user_email]
     @ignore_no_recipients = config[:ignore_no_recipients]
 

--- a/spec/models/save_triggers/notify_spec.rb
+++ b/spec/models/save_triggers/notify_spec.rb
@@ -273,6 +273,36 @@ RSpec.describe SaveTriggers::Notify, type: :model do
     expect(@trigger.receiving_user_ids.first).to eq @al.user_id
   end
 
+  it 'runs on_complete when notify config is an array of trigger entries - issue #1147' do
+    completion_note = 'notify on_complete array fired issue 1147'
+
+    config = {
+      type: 'email',
+      role: 'test',
+      layout_template: @layout.name,
+      content_template: @content.name,
+      subject: 'subject text',
+      on_complete: [
+        {
+          update_this: {
+            one: {
+              with: {
+                notes: completion_note
+              }
+            }
+          }
+        }
+      ]
+    }
+
+    @al.update!(notes: nil, current_user: @user)
+    @trigger = SaveTriggers::Notify.new(config, @al)
+
+    @trigger.perform
+
+    expect(@al.reload.notes).to eq(completion_note)
+  end
+
   it 'uses a simple {{template}} reference to get the users for a notification' do
     config = {
       type: 'email',


### PR DESCRIPTION
## Summary
- fix notify save trigger handling so documented array-form `on_complete` hooks execute after message delivery
- preserve extracted lifecycle hooks when notify configs are normalized before queueing the notification job
- add a regression spec covering array-form `on_complete` for notify

## Testing
- `bundle exec rspec spec/models/save_triggers/notify_spec.rb:276`
- `bundle exec rspec spec/models/save_triggers/notify_spec.rb:276 spec/models/messaging/message_notification_spec.rb:132`
- `bundle exec rspec spec/models/save_triggers/notify_spec.rb`
