### PR TITLE
Improved NFS container error messaging and mkdir test return value - refs #1155

### DIFF
--- a/app/models/nfs_store/manage/container.rb
+++ b/app/models/nfs_store/manage/container.rb
@@ -466,8 +466,11 @@ module NfsStore
                 else
                   current_user_role_names
                 end
+
+        test_dir_ok = false
         roles.each do |role_name|
-          next unless Filesystem.test_dir role_name, self, :mkdir
+          test_dir_ok = Filesystem.test_dir role_name, self, :mkdir
+          next unless test_dir_ok
 
           res = Filesystem.create_container self, role_name
           break if res
@@ -475,6 +478,7 @@ module NfsStore
 
         unless res
           raise FsException::Action, "Could not create a container. Maybe you don't have permission to store here. " \
+                                     "Test directory access results: #{test_dir_ok}. " \
                                      "App type: #{user.app_type.name} (#{user.app_type.id}). " \
                                      "Name: #{name}. " \
                                      "Roles: #{roles.join(', ')}"

--- a/app/models/nfs_store/manage/filesystem.rb
+++ b/app/models/nfs_store/manage/filesystem.rb
@@ -181,7 +181,8 @@ module NfsStore
           # Check the path to create is actually part of the container
           container_path = container.path_for(role_name:)
           unless fs_test_path.start_with? container_path
-            Rails.logger.info 'Container path is not part of the path to be tested for mkdir'
+            Rails.logger.warn 'Container path is not part of the path to be tested for mkdir: ' \
+                              "#{container_path} not in #{fs_test_path}"
             return false
           end
 
@@ -201,11 +202,14 @@ module NfsStore
           # Although we tested up front for existence of the directory, use this as a failsafe to
           # ensure that we can not accidentally remove an existing file unexpectedly
           if File.exist? curr_path
-            raise FsException::Action, "Target directory already exists when attempting test: #{fs_test_path}"
+            raise FsException::Action, 'Target directory already exists when attempting test: ' \
+                                       "#{curr_path} in #{fs_test_path}"
           end
 
           FileUtils.touch curr_path
-          FileUtils.rm curr_path
+          res = FileUtils.rm curr_path
+          Rails.logger.warn "Failed to test mkdir for container with #{curr_path}" unless res
+          res
         elsif action == :read
           fs_test_path = nfs_store_path(role_name, container, extra_path, file_name)
           Pathname.new(fs_test_path).readable?


### PR DESCRIPTION
## Summary

Improves NFS container error reporting to make test failures easier to diagnose.

### Changes

- **`app/models/nfs_store/manage/container.rb`**: Captures the `test_dir` result and includes it in the error message when container creation fails (e.g. `Test directory access results: false`).
- **`app/models/nfs_store/manage/filesystem.rb`**: Adds more informative `warn` messages for the `:mkdir` test path, and explicitly captures and returns the result of `FileUtils.rm` to make the boolean return value unambiguous.

### Related

The root cause of the NFS directory missing issue (missing `gid600/app-type-{id}/containers` after system reboot) is fixed in [viva-consected/restructure-apps#fix-grant-aims-test-setup-1155](https://github.com/viva-consected/restructure-apps/pull/new/fix-grant-aims-test-setup-1155).

Refs #1155, #1156
