### PR TITLE
Added auto name filter for admin pages with name column

### DIFF
--- a/app/controllers/concerns/admin_controller_handler.rb
+++ b/app/controllers/concerns/admin_controller_handler.rb
@@ -10,7 +10,8 @@ module AdminControllerHandler
     before_action :set_instance_from_id, only: %i[edit update destroy]
     before_action :handle_options_encoding, only: %i[create update]
 
-    helper_method :filters, :filters_on, :index_path, :index_params, :permitted_params, :object_instance,
+    helper_method :filters, :filters_on, :effective_filters, :effective_filters_on,
+                  :index_path, :index_params, :permitted_params, :object_instance,
                   :objects_instance, :human_name, :no_edit, :primary_model,
                   :view_path, :extra_field_attributes, :admin_links, :view_embedded?, :hide_app_type?,
                   :help_section, :help_subsection, :title, :sub_title, :no_create, :show_head_info, :view_folder,
@@ -139,6 +140,40 @@ module AdminControllerHandler
 
   def filters_on
     []
+  end
+
+  #
+  # Returns filters merged with an auto-detected name filter if:
+  # - the primary model has a `name` column
+  # - `name` is not already in the defined filters
+  # @return [Hash]
+  def effective_filters
+    result = filters.dup
+    return result unless result.is_a?(Hash)
+    return result if result.key?(:name)
+    return result unless primary_model.respond_to?(:attribute_names) &&
+                         primary_model.attribute_names.include?('name')
+
+    name_values = filter_values_for(:name)
+    result[:name] = name_values if name_values.present?
+    result
+  end
+
+  #
+  # Returns filters_on merged with `:name` if:
+  # - the primary model has a `name` column
+  # - `:name` is not already in filters_on
+  # - `name` is not already in the defined filters
+  # @return [Array]
+  def effective_filters_on
+    result = Array(filters_on).dup
+    return result if result.include?(:name)
+    return result if filters.is_a?(Hash) && filters.key?(:name)
+    return result unless primary_model.respond_to?(:attribute_names) &&
+                         primary_model.attribute_names.include?('name')
+
+    result << :name
+    result
   end
 
   #

--- a/app/controllers/concerns/filter_utils.rb
+++ b/app/controllers/concerns/filter_utils.rb
@@ -98,7 +98,8 @@ module FilterUtils
   def filter_params_permitted
     return @filter_params_permitted if @filter_params_permitted
 
-    fo = filters_on
+    fo = respond_to?(:effective_filters_on, true) ? effective_filters_on : filters_on
+    fo = Array(fo).dup # ensure it's a mutable array
     # Add some additional attributes to allow to be filtered on
     fo << :disabled if has_disabled_field
     fo << :id

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -72,18 +72,26 @@ module AdminHelper
                 data: { filter_on: filter_on.to_s, nothing_selected_text: 'select filter' })
   end
 
+  #
+  # Returns filters merged with an auto-detected name filter when the context
+  # provides a primary_model with a 'name' column and no explicit name filter
+  # is defined. Falls back gracefully when helper-only context lacks filter_values_for.
+  # @return [Hash]
+
   def show_filters
     return if view_embedded?
     return unless respond_to?(:filters) && filters
 
     show_disabled_filter = !respond_to?(:filters_prevent_disabled) || !filters_prevent_disabled
 
-    these_filters = filters.dup
+    these_filters = respond_to?(:effective_filters) ? effective_filters : filters.dup
 
-    fo = if filters_on.is_a? Symbol
-           [filters_on]
+    raw_filters_on = respond_to?(:effective_filters_on) ? effective_filters_on : filters_on
+
+    fo = if raw_filters_on.is_a? Symbol
+           [raw_filters_on]
          else
-           filters_on
+           raw_filters_on.dup
          end
 
     these_filters = { filters_on => these_filters } if these_filters.is_a? Array

--- a/spec/controllers/admin/admin_name_filter_spec.rb
+++ b/spec/controllers/admin/admin_name_filter_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Tests for the automatic name filter feature in AdminControllerHandler - Issue #1159
+# "Any admin page that has a 'name' field should also have a filter on that field"
+#
+# Verifies that AdminControllerHandler adds two new methods:
+#   - #effective_filters  - returns #filters merged with auto-detected name filter
+#   - #effective_filters_on - returns #filters_on with :name auto-appended when needed
+#
+# Test Coverage:
+# - effective_filters auto-includes name filter for models with a name column
+# - effective_filters_on auto-includes :name for models with a name column
+# - Neither method duplicates name when it is already explicitly defined
+# - filter_params_permitted honours effective_filters_on so name params are permitted
+#
+# Uses Admin::AccuracyScoresController because:
+#   - its primary model (Classification::AccuracyScore) has a 'name' column
+#   - it defines no explicit filters or filters_on, making auto-detection unambiguous
+
+RSpec.describe Admin::AccuracyScoresController, type: :controller do
+  include ModelSupport
+  include AccuracyScoreSupport
+
+  before :all do
+    create_admin
+  end
+
+  before :each do
+    sign_in @admin
+  end
+
+  # ---------------------------------------------------------------------------
+  # effective_filters
+  # ---------------------------------------------------------------------------
+  describe '#effective_filters' do
+    context 'when the primary model has a name column and no name filter is defined' do
+      it 'auto-includes the name filter key' do
+        # AccuracyScoresController defines no filters, but Classification::AccuracyScore
+        # has a 'name' column – effective_filters should detect this automatically.
+        effective = controller.send(:effective_filters)
+
+        expect(effective).to have_key(:name)
+      end
+
+      it 'returns an Array as the name filter values' do
+        effective = controller.send(:effective_filters)
+
+        expect(effective[:name]).to be_an(Array)
+      end
+
+      it 'merges the auto-detected name filter with any pre-existing filters' do
+        allow(controller).to receive(:filters).and_return({ value: [1, 2] })
+
+        effective = controller.send(:effective_filters)
+
+        expect(effective).to have_key(:value)
+        expect(effective).to have_key(:name)
+      end
+    end
+
+    context 'when the primary model already has a name filter defined' do
+      it 'does not duplicate the name key' do
+        allow(controller).to receive(:filters).and_return({ name: %w[foo bar] })
+
+        effective = controller.send(:effective_filters)
+
+        expect(effective.keys.count { |k| k == :name }).to eq(1)
+      end
+
+      it 'preserves the existing name filter values' do
+        allow(controller).to receive(:filters).and_return({ name: %w[foo bar] })
+
+        effective = controller.send(:effective_filters)
+
+        expect(effective[:name]).to eq(%w[foo bar])
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # effective_filters_on
+  # ---------------------------------------------------------------------------
+  describe '#effective_filters_on' do
+    context 'when the primary model has a name column and :name is not in filters_on' do
+      it 'auto-appends :name to the filters_on list' do
+        # AccuracyScoresController returns [] from filters_on
+        effective_on = controller.send(:effective_filters_on)
+
+        expect(effective_on).to include(:name)
+      end
+    end
+
+    context 'when :name is already in filters_on' do
+      it 'does not duplicate :name' do
+        allow(controller).to receive(:filters_on).and_return([:name])
+
+        effective_on = controller.send(:effective_filters_on)
+
+        expect(effective_on.count(:name)).to eq(1)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Integration: filter_params_permitted honours effective_filters_on
+  # ---------------------------------------------------------------------------
+  describe 'filter_params_permitted integration' do
+    it 'permits :name when a name filter param is provided' do
+      # Set up request params as if the user navigated to the filtered index page
+      controller.params = ActionController::Parameters.new(
+        filter: { name: 'test_name_value' }
+      )
+
+      # Before implementation: filters_on returns [] → name is not in permitted params
+      # After  implementation: effective_filters_on includes :name → name IS permitted
+      permitted = controller.send(:filter_params_permitted)
+
+      expect(permitted).not_to be_nil
+      expect(permitted[:name]).to eq('test_name_value')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Integration: filtered_primary_model respects name filtering end-to-end
+  # ---------------------------------------------------------------------------
+  describe 'filtered_primary_model with name filter' do
+    before :all do
+      @score_alpha = Classification::AccuracyScore.where(name: 'zz_nf_spec_alpha').first_or_create!(
+        value: 9811,
+        current_admin: @admin
+      )
+      @score_beta = Classification::AccuracyScore.where(name: 'zz_nf_spec_beta').first_or_create!(
+        value: 9812,
+        current_admin: @admin
+      )
+    end
+
+    after :all do
+      # Disable rather than destroy to avoid FK violation from accuracy_score_history
+      Classification::AccuracyScore.where(name: %w[zz_nf_spec_alpha zz_nf_spec_beta]).update_all(disabled: true)
+    end
+
+    before :each do
+      sign_in @admin
+    end
+
+    it 'returns only records matching the name when filter params include name' do
+      # Directly set the processed filter params to simulate a permitted name filter.
+      # This tests that filtered_primary_model correctly applies a WHERE name = ... clause.
+      allow(controller).to receive(:filter_params).and_return(
+        ActionController::Parameters.new('name' => 'zz_nf_spec_alpha').permit!
+      )
+
+      pm = controller.send(:filtered_primary_model)
+      names = pm.pluck(:name)
+
+      expect(names).to include('zz_nf_spec_alpha')
+      expect(names).not_to include('zz_nf_spec_beta')
+    end
+  end
+end

--- a/spec/helpers/admin_helper_filter_spec.rb
+++ b/spec/helpers/admin_helper_filter_spec.rb
@@ -175,5 +175,46 @@ RSpec.describe AdminHelper, type: :helper do
 
       expect(result).to include('clear filters')
     end
+
+    # -------------------------------------------------------------------------
+    # Auto name filter - Issue #1159
+    # -------------------------------------------------------------------------
+    # These tests verify that show_filters automatically includes a name filter
+    # select when the primary model has a 'name' column, without the controller
+    # having to explicitly define it in #filters / #filters_on.
+    #
+    # They will FAIL until show_filters is updated to use effective_filters and
+    # effective_filters_on instead of filters and filters_on directly.
+
+    context 'when the primary model has a name column and no name filter is explicitly defined' do
+      before do
+        # Stub the controller methods that show_filters falls back on
+        # to test that it successfully consumes them if present context responds to them.
+        helper.define_singleton_method(:filters) { {} }
+        helper.define_singleton_method(:effective_filters) { { name: %w[Alice Bob] } }
+        helper.define_singleton_method(:effective_filters_on) { [:name] }
+      end
+
+      it 'automatically renders a name filter select' do
+        result = helper.show_filters
+
+        expect(result).to include('filter-select')
+        expect(result).to include('data-filter-on="name"')
+      end
+    end
+
+    context 'when the primary model has a name column and name is already in the explicit filters' do
+      before do
+        helper.define_singleton_method(:primary_model) { Classification::AccuracyScore }
+        helper.define_singleton_method(:filters) { { name: %w[Alice Bob] } }
+        helper.define_singleton_method(:filters_on) { [:name] }
+      end
+
+      it 'renders exactly one name filter select (no duplication)' do
+        result = helper.show_filters
+
+        expect(result.scan('data-filter-on="name"').count).to eq(1)
+      end
+    end
   end
 end

--- a/spec/system/admin/admin_name_filter_spec.rb
+++ b/spec/system/admin/admin_name_filter_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+# Admin Name Filter System Spec - Issue #1159
+#
+# Tests that the Reports admin panel automatically includes a name filter
+# dropdown (using chosen.js) when the primary model has a 'name' column,
+# without the controller needing to explicitly define it.
+#
+# Verifies:
+# - A name filter select is rendered with data-filter-on="name"
+# - The filter is wrapped in a chosen-container (typeahead UI)
+# - Selecting a name value navigates to the filtered index
+# - Only records matching the selected name are shown after filtering
+
+require 'rails_helper'
+
+describe 'admin name filter - Issue #1159', js: true, driver: $browser_driver do
+  include ModelSupport
+  include AdminActionsSetup
+  include FeatureSupport
+
+  before(:all) do
+    change_setting('TwoFactorAuthDisabledForUser', true)
+    SetupHelper.feature_setup
+    ENV['FPHS_ADMIN_SETUP'] = 'yes'
+    make_an_admin
+
+    @report_alpha = Report.create!(
+      current_admin: @admin,
+      name: "Alpha Name Filter Test #{SecureRandom.hex(4)}",
+      description: 'First report for name filter test',
+      sql: 'select 1',
+      search_attrs: '',
+      disabled: false,
+      report_type: 'regular_report',
+      auto: false,
+      searchable: false
+    )
+
+    @report_beta = Report.create!(
+      current_admin: @admin,
+      name: "Beta Name Filter Test #{SecureRandom.hex(4)}",
+      description: 'Second report for name filter test',
+      sql: 'select 1',
+      search_attrs: '',
+      disabled: false,
+      report_type: 'regular_report',
+      auto: false,
+      searchable: false
+    )
+  end
+
+  after(:all) do
+    @report_alpha&.update(disabled: true, current_admin: @admin) if @report_alpha&.persisted?
+    @report_beta&.update(disabled: true, current_admin: @admin) if @report_beta&.persisted?
+  end
+
+  before(:each) do
+    admin_sign_in_with_2fa
+  end
+
+  it 'renders a name filter select on the reports admin page' do
+    visit '/admin/reports'
+    finish_page_loading
+
+    within '#filter-selects' do
+      name_select = find('select.filter-select[data-filter-on="name"]', visible: :all)
+      expect(name_select).to be_present
+
+      # chosen.js wraps the hidden select in a div.chosen-container
+      expect(page).to have_css('.chosen-container', minimum: 1)
+    end
+  end
+
+  it 'shows a label for the name filter' do
+    visit '/admin/reports'
+    finish_page_loading
+
+    within '#filter-selects' do
+      expect(page).to have_css('.filter-select-label', text: /name/i, visible: true)
+    end
+  end
+
+  it 'populates the name filter options with existing report names' do
+    visit '/admin/reports'
+    finish_page_loading
+
+    name_select = find('select.filter-select[data-filter-on="name"]', visible: :all)
+    option_values = name_select.all('option', visible: :all).map(&:value)
+
+    expect(option_values).to include(@report_alpha.name)
+    expect(option_values).to include(@report_beta.name)
+  end
+
+  it 'filters the report list when a name is selected' do
+    visit '/admin/reports'
+    finish_page_loading
+
+    # Open the chosen dropdown for the name filter.
+    # Chosen.js inserts the div.chosen-container immediately after the hidden select,
+    # both within the same span.filter-select-group. Navigate via the visible label.
+    name_label = find('.filter-select-label', exact_text: 'Name:', visible: true)
+    name_filter_group = name_label.find(:xpath, '..')
+    name_filter_group.find('.chosen-container').click
+
+    results_selector = 'body > .chosen-container.chosen-with-drop .chosen-results li.active-result'
+    expect(page).to have_css(results_selector, wait: 5)
+
+    results = all(results_selector)
+    target = results.find { |r| r.text == @report_alpha.name }
+    unless target
+      raise "Could not find '#{@report_alpha.name}' in name filter dropdown. " \
+            "Available: #{results.map(&:text).inspect}"
+    end
+
+    target.click
+    finish_page_loading
+
+    # After filtering, only the matching report should appear
+    within '.data-results' do
+      expect(page).to have_css("#admin-item-#{@report_alpha.id}", wait: 10)
+      expect(page).not_to have_css("#admin-item-#{@report_beta.id}")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds an automatic `name` filter to any admin panel whose primary model has a `name` database column, without requiring individual controllers to explicitly configure it. This satisfies the requirement from Issue #1159 that "any admin page that has a 'name' field should also have a filter on that field."

## Changes

### `app/controllers/concerns/admin_controller_handler.rb`
- Added `effective_filters` — returns `filters` merged with an auto-detected name filter when the primary model has a `name` column and no explicit name filter is defined.
- Added `effective_filters_on` — returns `filters_on` with `:name` auto-appended under the same conditions.
- Both methods exposed as `helper_method` so views can use them transparently.

### `app/controllers/concerns/filter_utils.rb`
- `filter_params_permitted` now calls `effective_filters_on` when available (via `respond_to?` check), falling back to `filters_on` for controllers that don't include `AdminControllerHandler`. This ensures `:name` is in the permitted params when a name filter is active.

### `app/helpers/admin_helper.rb`
- `show_filters` delegates to `effective_filters` / `effective_filters_on` when the context responds to them, with a safe fallback to the original `filters` / `filters_on` for non-admin contexts.

## Tests

| File | Coverage |
|---|---|
| `spec/controllers/admin/admin_name_filter_spec.rb` | Unit tests for `effective_filters`, `effective_filters_on`, `filter_params_permitted`, and end-to-end `filtered_primary_model` with a name param |
| `spec/helpers/admin_helper_filter_spec.rb` | Updated to verify `show_filters` renders a `data-filter-on="name"` select when `effective_filters` returns name values, and does not duplicate when name is already explicit |
| `spec/system/admin/admin_name_filter_spec.rb` | Capybara system spec: verifies the name filter select renders, populates with existing report names, and correctly filters the results list after a Chosen.js selection |

## Notes

- No changes to admin page templates or YAML configs are needed.
- Controllers that already define an explicit `:name` key in `filters` are unaffected (the auto-detection guards on `filters.key?(:name)`).
- Standard user-facing controllers that include `FilterUtils` but not `AdminControllerHandler` are unaffected (guarded by `respond_to?`).

Closes #1159
