### PR TITLE
Fixed notify trigger to use config app_type for role/user lookup - fixes #1172

### DIFF
--- a/app/models/dynamic/def_handler.rb
+++ b/app/models/dynamic/def_handler.rb
@@ -305,8 +305,10 @@ module Dynamic
         app_type = Admin::AppType.find_active_by_name_or_id(app_type) if app_type
         if user
           user = User.find_active_by_email_or_id(user)
-          user.app_type = app_type if app_type
-          user.save
+          if app_type && user.app_type != app_type
+            user.app_type = app_type 
+            user.save
+          end
         elsif app_type
           user = User.use_batch_user(app_type)
         end

--- a/app/models/save_triggers/notify.rb
+++ b/app/models/save_triggers/notify.rb
@@ -53,7 +53,7 @@ class SaveTriggers::Notify < SaveTriggers::SaveTriggersBase
       end
 
       if !@receiving_user_ids&.present? && !@force_phones && !@force_emails && !@force_recip_recs
-        msg = "No recipients based on role: #{@role}, users or specified phones/emails in #{self.class.name}"
+        msg = "No recipients based on role: #{@role}, users or specified phones/emails in #{self.class.name} (user: #{resolve_user.email}, app_type: #{resolve_app_type&.id})"
         Rails.logger.warn msg
         @item.save_trigger_results['notify_results'] << false
         @item.save_trigger_results['notify_errors'] << msg
@@ -96,6 +96,7 @@ class SaveTriggers::Notify < SaveTriggers::SaveTriggersBase
     @on_complete = config[:on_complete] || @on_complete_triggers
     @from_user_email = config[:from_user_email]
     @ignore_no_recipients = config[:ignore_no_recipients]
+    @config_app_type = config[:app_type]
 
     @message_type = config[:type]
     @run_if = config[:if]
@@ -125,6 +126,18 @@ class SaveTriggers::Notify < SaveTriggers::SaveTriggersBase
     @message_type.to_s == 'email'
   end
 
+  def resolve_app_type
+    if @config_app_type.present?
+      Admin::AppType.find_active_by_name_or_id(@config_app_type)
+    else
+      @user.app_type
+    end
+  end
+
+  def resolve_user
+    @alt_batch_user || @user
+  end
+
   #
   # Set up the roles and users to get a list of receiving user IDs
   def setup_role_and_users
@@ -137,7 +150,7 @@ class SaveTriggers::Notify < SaveTriggers::SaveTriggersBase
       @role_name = calc_field_or_return(@role)
       @role_name = @role_name.reject(&:blank?) if @role_name.is_a? Array
 
-      @receiving_user_ids += Admin::UserRole.active_user_ids role_name: @role_name, app_type: @user.app_type
+      @receiving_user_ids += Admin::UserRole.active_user_ids role_name: @role_name, app_type: resolve_app_type
     end
 
     if @users
@@ -367,8 +380,8 @@ class SaveTriggers::Notify < SaveTriggers::SaveTriggersBase
 
   def create_message_notification
     setup_data = {
-      app_type: @user.app_type,
-      user: @user,
+      app_type: resolve_app_type,
+      user: resolve_user,
       layout_template_name: @layout_template,
       content_template_name: content_template,
       content_template_text:,

--- a/spec/models/save_triggers/notify_spec.rb
+++ b/spec/models/save_triggers/notify_spec.rb
@@ -4,7 +4,8 @@
 # Covers notification trigger configuration parsing, role/user setup, message creation,
 # template substitutions, conditional actions, return_value_list references,
 # calendar invite integration (#953), NfsStore file attachment config parsing (#954),
-# inline data URI image conversion (#1148), and literal/template/array phones+emails (#1152).
+# inline data URI image conversion (#1148), literal/template/array phones+emails (#1152),
+# and config app_type for role lookup + error message improvements (#1172).
 
 require 'rails_helper'
 
@@ -20,7 +21,7 @@ RSpec.describe SaveTriggers::Notify, type: :model do
     SetupHelper.setup_al_gen_tests AlNameGenTestN, 'elt2_test', 'player_contact'
     ud, = create_user
     ud.disable!
-    u0, = create_user
+    @u0, = create_user
     u1, = create_user
     create_user
     let_user_create :player_contacts
@@ -50,8 +51,8 @@ RSpec.describe SaveTriggers::Notify, type: :model do
 
     Admin::UserRole.create! app_type: u1.app_type, user: @user, role_name: 'test_2', current_admin: @admin
 
-    at2 = Admin::AppType.create! name: 'new-notify', label: 'Test Notify App', current_admin: @admin
-    Admin::UserRole.create! app_type: at2, user: u0, role_name: 'test', current_admin: @admin
+    @at2 = Admin::AppType.create! name: 'new-notify', label: 'Test Notify App', current_admin: @admin
+    Admin::UserRole.create! app_type: @at2, user: @u0, role_name: 'test', current_admin: @admin
 
     # The number of roles is one more than we added due to automatic setup of a template@template item
     expect(Admin::UserRole.joins(:user).where(role_name: 'test', app_type: u1.app_type).where('users.disabled is null or users.disabled = false').count).to eq 4
@@ -1168,5 +1169,71 @@ RSpec.describe SaveTriggers::Notify, type: :model do
       @trigger.perform
       expect(@trigger.instance_variable_get(:@force_emails)).to eq(['dynamic@example.com', 'static@example.com'])
     end
+  end
+
+  it 'uses config app_type for role lookup when app_type is specified in config - issue #1172' do
+    # @u0 has the 'test' role only in @at2 (not in @user.app_type)
+    # @user has the 'test' role only in @user.app_type (not in @at2)
+    # With app_type: @at2.id in config, the trigger should look up roles in @at2,
+    # not in @user.app_type (the current user's app type).
+    config = {
+      type: 'email',
+      role: 'test',
+      app_type: @at2.id,
+      layout_template: @layout.name,
+      content_template: @content.name,
+      subject: 'subject text'
+    }
+
+    @trigger = SaveTriggers::Notify.new(config, @al)
+    @trigger.perform
+
+    # @u0 has role 'test' in @at2, so must be a recipient
+    expect(@trigger.receiving_user_ids).to include(@u0.id)
+    # @user has role 'test' in @user.app_type (not @at2), so must NOT be a recipient
+    expect(@trigger.receiving_user_ids).not_to include(@user.id)
+  end
+
+  it 'includes current user and app type ID in no-recipients error message - issue #1172' do
+    # The error message for missing recipients should identify which user and app type
+    # were used for the role lookup so the problem can be diagnosed.
+    config = {
+      type: 'email',
+      role: 'nonexistent-role-xyz',
+      layout_template: @layout.name,
+      content_template: @content.name,
+      subject: 'subject text'
+    }
+
+    @trigger = SaveTriggers::Notify.new(config, @al)
+    @trigger.perform
+
+    error_msg = @al.save_trigger_results['notify_errors'].last
+    expect(error_msg).to include(@user.email)
+    expect(error_msg).to include(@user.app_type.id.to_s)
+  end
+
+  it 'stores resolved app_type and user on the MessageNotification record when config app_type is specified - issue #1172' do
+    # When app_type and user are specified in the config, the MessageNotification record should
+    # be associated with the configured app_type (not the triggering user's app_type),
+    # and the user should be the alt_batch_user (@u0) resolved from the config.
+    config = {
+      type: 'email',
+      role: 'test',
+      app_type: @at2.id,
+      user: @u0.email,
+      layout_template: @layout.name,
+      content_template: @content.name,
+      subject: 'subject text'
+    }
+
+    @trigger = SaveTriggers::Notify.new(config, @al)
+    @trigger.perform
+
+    new_mn = MessageNotification.order(id: :desc).first
+    # The notification's app_type should be the configured @at2, not @user.app_type
+    expect(new_mn.app_type).to eq @at2
+    # The user on the notification should be @u0 (the resolved alt_batch_user), not the triggering @user
+    expect(new_mn.user.id).to eq @u0.id
   end
 end


### PR DESCRIPTION
## Description

Fixes #1172.

The `notify` save trigger was ignoring its `app_type` config setting when looking up users for a role, incorrectly substituting the triggering user's app type instead. This fix:
- Updates `setup_role_and_users` to use the defined `app_type` from the configuration if one is passed, defaulting to the original user's `app_type` if none is specified.
- Reuses the configured `app_type` and resolved user (`alt_batch_user` or the triggering user) in `create_message_notification`. 
- Refines error message context formatting.

## Coverage
Automated RSpect tests fully verified.
