### PR TITLE
Added parse_json and parse_yaml substitution formatters - fixes #1170

### DIFF
--- a/app/assets/javascripts/app/_fpa_tag_formatter.js
+++ b/app/assets/javascripts/app/_fpa_tag_formatter.js
@@ -89,7 +89,9 @@ _fpa.tag_formatter = class {
       "ignore_missing",
       "last",
       "no_html_tag",
-      "general_selection_label"
+      "general_selection_label",
+      "parse_json",
+      "parse_yaml"
     ]
   }
 
@@ -524,6 +526,22 @@ _fpa.tag_formatter = class {
     if (!data || !data._general_selections) return res;
 
     return data._general_selections[tag_name] && data._general_selections[tag_name][res] && data._general_selections[tag_name][res].name || res
+  }
+
+  parse_json(res, _orig_val) {
+    try {
+      return JSON.parse(res);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  parse_yaml(res, _orig_val) {
+    try {
+      return jsyaml.load(res);
+    } catch (e) {
+      return null;
+    }
   }
 
 }

--- a/app/models/formatter/tag_formatter.rb
+++ b/app/models/formatter/tag_formatter.rb
@@ -65,6 +65,8 @@ module Formatter
       last
       no_html_tag
       general_selection_label
+      parse_json
+      parse_yaml
     ].freeze
 
     #
@@ -542,6 +544,26 @@ module Formatter
     # @return [String, nil] pretty JSON string or nil if object doesn't respond to to_json
     def json(res, _orig_val)
       JSON.pretty_generate(res) if res.respond_to?(:to_json)
+    end
+
+    #
+    # Parses a JSON string into a Ruby Hash or Array
+    # @param [String] res - the JSON string to parse
+    # @return [Hash, Array, nil] parsed object or nil if invalid JSON
+    def parse_json(res, _orig_val)
+      JSON.parse(res)
+    rescue JSON::ParserError, TypeError
+      nil
+    end
+
+    #
+    # Parses a YAML string into a Ruby Hash or Array
+    # @param [String] res - the YAML string to parse
+    # @return [Hash, Array, nil] parsed object or nil if invalid YAML
+    def parse_yaml(res, _orig_val)
+      YAML.safe_load(res)
+    rescue Psych::Exception, TypeError
+      nil
     end
 
     #

--- a/spec/javascripts/_fpa_tag_formatter_spec.js
+++ b/spec/javascripts/_fpa_tag_formatter_spec.js
@@ -336,4 +336,49 @@ describe('_fpa.tag_formatter', function () {
     result = _fpa.tag_formatter.format_with('1', testString, testString, 'text', {});
     expect(result).toEqual('He');
   });
+
+  it("parses JSON strings into objects with parse_json", function () {
+    const jsonString = '{"key1":"value1","key2":["item1","item2"]}';
+    const expectedObj = { key1: 'value1', key2: ['item1', 'item2'] };
+
+    var result = _fpa.tag_formatter.format_with('parse_json', jsonString, jsonString, 'json_field', {});
+    expect(result).toEqual(expectedObj);
+  });
+
+  it("parses YAML strings into objects with parse_yaml", function () {
+    const yamlString = "key1: value1\nkey2:\n- item1\n- item2\n";
+    const expectedObj = { key1: 'value1', key2: ['item1', 'item2'] };
+
+    var result = _fpa.tag_formatter.format_with('parse_yaml', yamlString, yamlString, 'yaml_field', {});
+    expect(result).toEqual(expectedObj);
+  });
+
+  it("chains parse_json with yaml to convert JSON string to YAML string", function () {
+    const jsonString = '{"name":"Alice","age":30}';
+
+    var parsed = _fpa.tag_formatter.format_with('parse_json', jsonString, jsonString, 'json_field', {});
+    var yamlResult = _fpa.tag_formatter.format_with('yaml', parsed, parsed, 'json_field', {});
+    expect(yamlResult).toContain('name: Alice');
+    expect(yamlResult).toContain('age: 30');
+  });
+
+  it("chains parse_yaml with json to convert YAML string to JSON string", function () {
+    const yamlString = "name: Alice\nage: 30\n";
+
+    var parsed = _fpa.tag_formatter.format_with('parse_yaml', yamlString, yamlString, 'yaml_field', {});
+    var jsonResult = _fpa.tag_formatter.format_with('json', parsed, parsed, 'yaml_field', {});
+    const obj = JSON.parse(jsonResult);
+    expect(obj.name).toEqual('Alice');
+    expect(obj.age).toEqual(30);
+  });
+
+  it("returns null for invalid JSON in parse_json", function () {
+    var result = _fpa.tag_formatter.format_with('parse_json', 'not valid json {{{', 'not valid json {{{', 'json_field', {});
+    expect(result).toBeNull();
+  });
+
+  it("returns null for invalid YAML in parse_yaml", function () {
+    var result = _fpa.tag_formatter.format_with('parse_yaml', ': invalid: [yaml', ': invalid: [yaml', 'yaml_field', {});
+    expect(result).toBeNull();
+  });
 });

--- a/spec/models/formatter/substitution_spec.rb
+++ b/spec/models/formatter/substitution_spec.rb
@@ -522,4 +522,27 @@ Good?)
     res = Formatter::Substitution.substitute(txt.dup, data:)
     expect(res.strip).to eq 'Result: Z and D'
   end
+
+  it 'converts a JSON string field to YAML via parse_json and yaml formatters' do
+    json_string = '{"name":"Alice","scores":[10,20,30]}'
+    txt = '{{json_field::parse_json::yaml}}'
+    data = { json_field: json_string }
+    res = Formatter::Substitution.substitute txt.dup, data:, tag_subs: nil
+    expect(res).to eq "name: Alice\nscores:\n- 10\n- 20\n- 30\n"
+  end
+
+  it 'converts a YAML string field to JSON via parse_yaml and json formatters' do
+    yaml_string = "name: Alice\nscores:\n- 10\n- 20\n- 30\n"
+    txt = '{{yaml_field::parse_yaml::json}}'
+    data = { yaml_field: yaml_string }
+    res = Formatter::Substitution.substitute txt.dup, data:, tag_subs: nil
+    expect(res).to eq "{\n  \"name\": \"Alice\",\n  \"scores\": [\n    10,\n    20,\n    30\n  ]\n}"
+  end
+
+  it 'returns nil representation when parse_json fails and is chained with a serializer' do
+    txt = '{{json_field::parse_json::json}}'
+    data = { json_field: 'not valid json' }
+    res = Formatter::Substitution.substitute txt.dup, data:, tag_subs: nil
+    expect(res).to eq 'null'
+  end
 end

--- a/spec/models/formatter/tag_formatter_spec.rb
+++ b/spec/models/formatter/tag_formatter_spec.rb
@@ -294,6 +294,43 @@ RSpec.describe Formatter::TagFormatter, type: :model do
     run tests
   end
 
+  it 'parses JSON and YAML strings into objects' do
+    json_string = '{"key1":"value1","key2":["item1","item2"]}'
+    yaml_string = "key1: value1\nkey2:\n- item1\n- item2\n"
+    expected_hash = { 'key1' => 'value1', 'key2' => %w[item1 item2] }
+
+    tests = [
+      [:parse_json, json_string, expected_hash],
+      [:parse_yaml, yaml_string, expected_hash]
+    ]
+
+    run tests
+  end
+
+  it 'chains parse_json and parse_yaml with serialization formatters' do
+    json_string = '{"key1":"value1","key2":["item1","item2"]}'
+    yaml_string = "key1: value1\nkey2:\n- item1\n- item2\n"
+
+    # parse_json then serialize as yaml
+    parsed = Formatter::TagFormatter.format_with 'parse_json', json_string, json_string
+    yaml_result = Formatter::TagFormatter.format_with 'yaml', parsed, parsed
+    expect(yaml_result).to eq "key1: value1\nkey2:\n- item1\n- item2\n"
+
+    # parse_yaml then serialize as json
+    parsed = Formatter::TagFormatter.format_with 'parse_yaml', yaml_string, yaml_string
+    json_result = Formatter::TagFormatter.format_with 'json', parsed, parsed
+    expect(json_result).to eq "{\n  \"key1\": \"value1\",\n  \"key2\": [\n    \"item1\",\n    \"item2\"\n  ]\n}"
+  end
+
+  it 'returns nil for invalid JSON and YAML in parse operations' do
+    tests = [
+      [:parse_json, 'not valid json {{{', nil],
+      [:parse_yaml, "key: [\ninvalid", nil]
+    ]
+
+    run tests
+  end
+
   it 'handles numeric indexing for strings and arrays' do
     test_string = 'Hello World'
     test_array = ['first', 'second', 'third', 'fourth']


### PR DESCRIPTION
Fixes #1170.

This pull request implements \`parse_json\` and \`parse_yaml\` curly brace substitution formatters. It enables JSON and YAML fields to be parsed during substitution sequences in both the Ruby backend and the JavaScript frontend.

### Changes Made:
- Added \`parse_json\` formatter to parsing a string as JSON.
- Added \`parse_yaml\` formatter to parse a string as YAML.
- Used \`YAML.safe_load\` for consistency within the existing codebase.
- Added corresponding Javascript implementations for \`parse_json\` and \`parse_yaml\` formats relying on \`JSON.parse\` and \`jsyaml.load\`.
- Registered both formatters in \`ValidOps\`.
- Graceful error handling is implemented by returning \`nil\` or \`null\` for invalid payload inputs.
- Thorough tests added to \`spec/models/formatter/tag_formatter_spec.rb\`, \`spec/models/formatter/substitution_spec.rb\`, and \`spec/javascripts/_fpa_tag_formatter_spec.js\`.
