### PR TITLE
Added current app type access boolean column and filter to Usernames and Passwords admin page - resolves #1168

### DIFF
--- a/app/controllers/admin/manage_users_controller.rb
+++ b/app/controllers/admin/manage_users_controller.rb
@@ -79,6 +79,7 @@ class Admin::ManageUsersController < AdminController
   def filters
     {
       app_type_id: Admin::AppType.all_by_name,
+      current_app_access: { 'true' => 'yes', 'false' => 'no' },
       email: filter_values_for(:email),
       first_name: filter_values_for(:first_name),
       last_name: filter_values_for(:last_name)
@@ -86,7 +87,7 @@ class Admin::ManageUsersController < AdminController
   end
 
   def filters_on
-    %i[app_type_id email first_name last_name]
+    %i[app_type_id current_app_access email first_name last_name]
   end
 
   # Override regular defaults, which force the current user's app_type_id
@@ -94,8 +95,25 @@ class Admin::ManageUsersController < AdminController
     {}
   end
 
-  # Run a special filter on app_type_id, so that we don't just get the
-  # users current app, but all they have access to
+  # Override to inject current_app_access: 'true' as the default when no filter
+  # params are present in the URL, so the page opens showing only users with
+  # access to the current app type.
+  def filter_params_permitted
+    return @filter_params_permitted if @filter_params_permitted
+
+    super
+    return @filter_params_permitted if @filter_params_permitted
+
+    # No filter params in URL - inject default to show users with current app access
+    fo = filters_on + [:id, :filter_name, { ids: [] }]
+    fo << :disabled if has_disabled_field
+    @filter_params_permitted = ActionController::Parameters.new(current_app_access: 'true').permit(*fo)
+  end
+
+  # Run a special filter on app_type_id and current_app_access, so that we don't
+  # just get the users current app, but all they have access to.
+  # current_app_access is a virtual boolean filter (not a DB column) indicating
+  # whether a user has access to the admin's current app type.
   def filtered_primary_model(_ = nil)
     pm = primary_model
     a = filter_params_permitted[:app_type_id] if filter_params_permitted
@@ -108,11 +126,28 @@ class Admin::ManageUsersController < AdminController
       pm = pm.where(id: ids)
     end
 
-    # Filter on everything (except the specified app_type_id, which has beem temporarily removed)
+    # Handle current_app_access virtual filter: filter by the admin's current app type
+    caa = filter_params_permitted[:current_app_access] if filter_params_permitted
+    if caa.present?
+      # Temporarily clear so the super method doesn't attempt to filter on a non-existent column
+      filter_params_permitted[:current_app_access] = nil
+      current_app_type_id = admin_current_app_type&.id
+      if current_app_type_id
+        has_access_ids = pm.all.select { |u| current_app_type_id.in?(u.accessible_app_type_ids) }.map(&:id)
+        pm = if caa == 'true'
+               pm.where(id: has_access_ids)
+             else
+               pm.where.not(id: has_access_ids)
+             end
+      end
+    end
+
+    # Filter on everything (except the virtual filters temporarily removed above)
     res = super(pm)
 
-    # Reset the filter params so that the buttons appear correctly
+    # Reset the filter params so that the filter buttons appear correctly
     filter_params_permitted[:app_type_id] = a.to_s if a.present?
+    filter_params_permitted[:current_app_access] = caa if caa.present?
     res
   end
 
@@ -124,5 +159,11 @@ class Admin::ManageUsersController < AdminController
 
   def permitted_params
     %i[email disabled first_name last_name do_not_email expire_datetime api_access_only]
+  end
+
+  # Returns the app type currently associated with the admin session.
+  # Mirrors the admin_app_type view helper logic for use in controller filtering.
+  def admin_current_app_type
+    current_user&.app_type || current_admin.matching_user&.app_type || Admin::AppType.active.first
   end
 end

--- a/app/views/admin/manage_users/_index.html.erb
+++ b/app/views/admin/manage_users/_index.html.erb
@@ -21,6 +21,7 @@
           <th>First Name</th>
           <th>Last Name</th>
           <th>Apps</th>
+          <th>Current App</th>
           <th>Password expires in (days)</th>
           <th>Account Expiration</th>
           <th>Signed in at</th>
@@ -47,6 +48,7 @@
                 <p><span><%= a&.label %></span></p>
               <% end %>
             </td>
+            <td><%= index_list_item_boolean_field(list_item.accessible_app_type_ids.include?(admin_app_type&.id)) %></td>
             <td><%= list_item.expires_in == 0 ? '<i class="password-expired">expired</i>'.html_safe : list_item.expires_in %></td>
             <td><%= list_item.expire_datetime&.strftime('%Y-%m-%d %H:%M') %></td>
             <td><%= list_item.current_sign_in_at %></td>

--- a/spec/controllers/admin/manage_users_controller_spec.rb
+++ b/spec/controllers/admin/manage_users_controller_spec.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# Admin Manage Users Controller Spec
+#
+# Tests the Admin::ManageUsersController (Usernames and Passwords admin page).
+#
+# Covers:
+# - Standard CRUD actions for admin user management
+# - Special user actions (password reset, 2FA reset, expiration extension, unlock)
+# - Limited admin capabilities
+# - current_app_access filter: boolean column and filter for Issue #1168
+#   - filters hash includes current_app_access key with yes/no options
+#   - filters_on includes :current_app_access
+#   - Filtering by current_app_access: 'true' returns only users with access to
+#     the admin's current app type
+#   - Filtering by current_app_access: 'false' returns only users without access
+#     to the admin's current app type
+
 require 'rails_helper'
 
 RSpec.describe Admin::ManageUsersController, type: :controller do
@@ -296,6 +312,82 @@ RSpec.describe Admin::ManageUsersController, type: :controller do
     it 'never destroys the requested item' do
       create_item
       expect_to_be_bad_route(delete: "#{path_prefix}/#{object_symbol}/#{item_id}")
+    end
+  end
+
+  describe 'current_app_access filter - Issue #1168' do
+    before_each_login_admin
+
+    before :each do
+      @test_app_type = Admin::AppType.active.first
+      raise 'No active app type found for current_app_access filter tests' unless @test_app_type
+
+      # User WITH access to the current app type
+      @user_with_access = User.create!(
+        email: "caa_with_#{SecureRandom.hex(4)}@test.com",
+        current_admin: @admin
+      )
+      Admin::UserAccessControl.create!(
+        user: @user_with_access,
+        app_type: @test_app_type,
+        access: :read,
+        resource_type: :general,
+        resource_name: :app_type,
+        current_admin: @admin
+      )
+      Rails.cache.delete("all_app_type_ids_available_to::#{@user_with_access.id}")
+
+      # User WITHOUT access to any app type
+      @user_without_access = User.create!(
+        email: "caa_without_#{SecureRandom.hex(4)}@test.com",
+        current_admin: @admin
+      )
+      Rails.cache.delete("all_app_type_ids_available_to::#{@user_without_access.id}")
+    end
+
+    describe '#filter_params_permitted' do
+      it 'defaults current_app_access to true when no filter params are given' do
+        expect(controller.send(:filter_params_permitted)[:current_app_access]).to eq('true')
+      end
+    end
+
+    describe '#filters' do
+      it 'includes current_app_access key with yes/no options' do
+        get :index
+        f = controller.send(:filters)
+        expect(f).to have_key(:current_app_access)
+        expect(f[:current_app_access]).to have_key('true')
+        expect(f[:current_app_access]).to have_key('false')
+      end
+    end
+
+    describe '#filters_on' do
+      it 'includes :current_app_access' do
+        expect(controller.send(:filters_on)).to include(:current_app_access)
+      end
+    end
+
+    describe 'GET #index with current_app_access filter' do
+      it 'returns only users with current app access when no filter is set (default)' do
+        get :index
+        expect(response).to have_http_status(200)
+        expect(assigns(:users)).to include(@user_with_access)
+        expect(assigns(:users)).not_to include(@user_without_access)
+      end
+
+      it 'returns only users with current app access when filter is true' do
+        get :index, params: { filter: { current_app_access: 'true' } }
+        expect(response).to have_http_status(200)
+        expect(assigns(:users)).to include(@user_with_access)
+        expect(assigns(:users)).not_to include(@user_without_access)
+      end
+
+      it 'returns only users without current app access when filter is false' do
+        get :index, params: { filter: { current_app_access: 'false' } }
+        expect(response).to have_http_status(200)
+        expect(assigns(:users)).not_to include(@user_with_access)
+        expect(assigns(:users)).to include(@user_without_access)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Adds a **"Current App"** boolean column and filter to the admin "Usernames and Passwords" page (`Admin::ManageUsersController`), so admins can quickly see which users have access to the currently active app type and filter the list accordingly.

## Changes

### `app/controllers/admin/manage_users_controller.rb`
- Added `current_app_access` to the `filters` hash with `'true' => 'yes'` / `'false' => 'no'` options.
- Added `:current_app_access` to `filters_on`.
- Extended `filtered_primary_model` to handle the virtual `current_app_access` filter: temporarily removes it from `filter_params_permitted` so the base `FilterUtils#filtered_primary_model` doesn't attempt to query a non-existent DB column, applies the boolean filter against `accessible_app_type_ids`, then restores the param for correct UI rendering.
- Defaults to showing only users with access to the current app type when no filter is explicitly set.
- Added private `admin_current_app_type` method (mirrors the `admin_app_type` view helper logic for use inside the controller).

### `app/views/admin/manage_users/_index.html.erb`
- Added a **"Current App"** `<th>` column header.
- Added a boolean indicator cell using `index_list_item_boolean_field` showing whether each listed user has access to the admin's current app type.

### `spec/controllers/admin/manage_users_controller_spec.rb`
- Added `describe 'current_app_access filter - Issue #1168'` block covering:
  - Default behaviour: no filter param defaults to showing only users with access.
  - `filters` hash includes `current_app_access` with yes/no options.
  - `filters_on` includes `:current_app_access`.
  - `GET #index` with `current_app_access: 'true'` returns only users with current app access.
  - `GET #index` with `current_app_access: 'false'` returns only users without current app access.

## Testing

All 29 controller specs pass:

```
29 examples, 0 failures
```

Resolves #1168
