### PR TITLE
Refactored page layout resources to standardise UI panel rendering within generic blocks - fixes #1180

### DIFF
--- a/app/helpers/page_layouts_helper.rb
+++ b/app/helpers/page_layouts_helper.rb
@@ -41,6 +41,61 @@ module PageLayoutsHelper
   end
 
   #
+  # Resolve per-resource rendering metadata for a given resource name.
+  # Returns a hash with resource_name, template_name, route_path, wrapper_class, and viewable_key,
+  # or nil if the resource name cannot be resolved.
+  # @param [String] resource_name - the resource name to resolve (e.g. 'activity_log__case_reviews')
+  # @param [Symbol] context - :master_panel or :standalone_page
+  # @param [String|nil] template_prefix - explicit template prefix override (e.g. 'page-'), or nil to use
+  #   the resource-type default: activity log → '<suffix>-result-template', others → '-list-template'
+  # @return [Hash, nil]
+  def resource_render_info(resource_name, context:, template_prefix: nil)
+    model = Resources::Models.find_by(resource_name: resource_name)
+    model ||= Resources::Models.find_by(resource_item_name: resource_name.to_sym)
+
+    unless model
+      Rails.logger.warn "resource_render_info: could not resolve resource '#{resource_name}'"
+      return nil
+    end
+
+    type = model[:type]
+
+    # Handlebars templates are registered using the full, namespaced, pluralised
+    # resource name with underscores replaced by hyphens (e.g.
+    # `activity-log--case-reviews-main-result-template`, `dynamic-model--contact-infos-list-template`,
+    # `scantron-ids-list-template`). Use the resource name itself (not the
+    # stripped singular `hyphenated_name` from Resources::Models) to align with
+    # the names produced by handlebars_template_tag in the search-results partials.
+    resource_hyph = resource_name.to_s.hyphenate
+
+    template_name = if !template_prefix.nil?
+                      "#{resource_hyph}-#{template_prefix}result-template"
+                    elsif %i[activity_log activity_log_type].include?(type)
+                      # Activity logs use a context-dependent suffix:
+                      # master panels → -main-result-template; standalone pages → -page-result-template
+                      suffix = context == :master_panel ? 'main' : 'page'
+                      "#{resource_hyph}-#{suffix}-result-template"
+                    else
+                      # Dynamic models and external identifiers use the plural list template
+                      "#{resource_hyph}-list-template"
+                    end
+
+    wrapper_class = case type
+                    when :dynamic_model then 'dynamic-model-generic-block'
+                    when :external_identifier then 'external-id-generic-block'
+                    else 'activity-logs-generic-block'
+                    end
+
+    {
+      resource_name: resource_name,
+      route_path: model[:base_route_segments],
+      template_name: template_name,
+      wrapper_class: wrapper_class,
+      viewable_key: resource_name.to_sym
+    }
+  end
+
+  #
   # Format active sublist values for Handlebars template rendering.
   # Converts arrays to comma-separated strings for use with the 'in' operator.
   # @param [Array|String|nil] values - array of values, 'all' string, or nil
@@ -49,7 +104,7 @@ module PageLayoutsHelper
     return '' if values.nil?
     return 'all' if values == 'all'
     return 'none' if values.is_a?(Array) && values.empty?
-    return values.map(&:to_s).join(',') if values.is_a?(Array)
+    return values.join(',') if values.is_a?(Array)
 
     values.to_s
   end

--- a/app/models/admin/defs/page_layout_options_defs.yaml
+++ b/app/models/admin/defs/page_layout_options_defs.yaml
@@ -14,8 +14,15 @@ contains:
     - external-ids    # all available external identifiers
     - external-links  # defined external links for a master record
   resources:
-    # a single or array of named resources (model names)
-    - activity_log__player_contact_phones
+    # a single or array of named resources (model names).
+    # Three resource-name forms are supported and may be mixed within a single panel:
+    #   activity log:          activity_log__<plural_table_name>
+    #   dynamic model:         dynamic_model__<plural_table_name>
+    #   external identifier:   <plural_table_name>  (bare plural, no namespace prefix)
+    # Examples:
+    - activity_log__case_reviews        # activity log
+    - dynamic_model__contact_infos      # dynamic model
+    - scantron_ids                      # external identifier (bare plural)
     # For user_profile type, these resources may be also defined as hashes
     # allowing a resource name and tab label to be defined
     - label: Date/Time
@@ -141,8 +148,12 @@ container:
       #
       #
       resource:
-        # View a resource list (such as activity logs)
-        name: activity_log__player_contact_phone        # resource name
+        # View a resource list for any supported resource type.
+        # The same three resource-name forms accepted by contains.resources are supported here:
+        #   activity log:        activity_log__<plural_table_name>
+        #   dynamic model:       dynamic_model__<plural_table_name>
+        #   external identifier: <plural_table_name>  (bare plural, no namespace prefix)
+        name: activity_log__player_contact_phone        # resource name (any of the three forms above)
         id: 123     # optional resource id to filter the results on
                     # if missing, the URL params
                     # *filters[resource_id]* will be used (if present)

--- a/app/views/masters/_search_results_master_tabs_resources.html.erb
+++ b/app/views/masters/_search_results_master_tabs_resources.html.erb
@@ -1,32 +1,39 @@
-  <% 
-    resources.each do |resource|
-      template_postfix = ''
-      template_postfix = '-main-result-template' if resource.start_with?('activity_log__')
+<%
+  # Render a single tab for a contains.resources panel, regardless of how many
+  # resources the panel lists. The tab toggles a single outer collapse container
+  # (rendered by masters/_search_results_resources_panel) whose id is derived
+  # from the panel_name. This mirrors the contains.categories behaviour, where a
+  # single tab reveals a single panel containing one or more inner blocks.
+  #
+  # Backwards-compatibility note: existing single-resource panels (e.g. an
+  # activity log per panel) continue to function identically from the user
+  # perspective – one tab, one collapse area, one resource block inside. The
+  # configuration contract (`contains.resources: [...]`) is unchanged.
 
-      if default_panels.length > 0 && initial_show.nil?
-      # The "default" overrides the value set in the panel definition only if the panel definition was not set
-        initial_show = resource.to_s.in?(default_panels)
-      end
+  # Determine which resources are renderable for the current user. The tab is
+  # only rendered if at least one of the panel's resources resolves to render
+  # info (i.e. is known to Resources::Models and accessible).
+  renderable_resources = resources.select do |resource|
+    resource_render_info(resource, context: :master_panel)
+  end
+%>
+<% if renderable_resources.any? %>
+  <%
+    if default_panels.length > 0 && initial_show.nil?
+      # The "default" overrides the value set in the panel definition only if
+      # the panel definition did not specify one. Match if any of the panel's
+      # resources is in the default open panels list.
+      initial_show = renderable_resources.any? { |r| r.to_s.in?(default_panels) }
+    end
 
-      path = resource.gsub('__', '/').pluralize
-      extra_params = ''
-      using_params = ''
-      if filter_items
-        rparams = filter_items[resource.pluralize]
-        if rparams.is_a? Hash
-          rparams = rparams.to_unsafe_h if rparams.respond_to? :to_unsafe_h
-          extra_params = "&#{rparams.to_query}"
-          using_params = 'page-layout'
-        elsif rparams == 'using params'
-          using_params = 'page'
-        end
-      end
+    # Use the panel_name as the open-panels key (consistent with categories).
+    open_panel_key = panel_name
 
-      extra_classes = "#{close_others ? 'tabs-close-others' : ''} #{initial_show == true ? 'on-open-click initial-show' : ''}"
+    extra_classes = "#{close_others ? 'tabs-close-others' : ''} #{initial_show == true ? 'on-open-click initial-show' : ''}"
   %>
-  {{#if (or (not (params 'only_tabs')) (params 'only_tabs' '<%=resource.pluralize%>')) }}
-  <li role="presentation" class="<%= extra_classes %> <%= class_for_open_panels(resource, default_panels.length) %>" data-open-panels="{{open_panels}}">
-    <a id="tab-activity-log-<%= panel_name %>" href="/masters/{{id}}/<%= path %>?limit=<%=limit%><%extra_params%>&{{params_to_query 'filter' '<%=resource.pluralize%>'}}" data-using-params="<%= using_params %>" data-panel-tab="<%=resource%>" data-remote="true" data-prevent-on-collapse="true" data-toggle="collapse" data-target="#<%= resource.hyphenate %>-{{id}}" aria-expanded="false" class="scroll-to-expanded  collapsed"  data-result-target="#<%= resource.hyphenate %>-{{id}}" data-template="<%= resource.hyphenate %><%= template_postfix %>"><%= panel_label %></a>
+  {{#if (or (not (params 'only_tabs')) (params 'only_tabs' '<%= panel_name %>')) }}
+  <li role="presentation" class="<%= extra_classes %> <%= class_for_open_panels(open_panel_key, default_panels.length) %>" data-open-panels="{{open_panels}}">
+    <a id="tab-resources-<%= panel_name %>" href="#<%= panel_name %>-{{id}}" data-panel-tab="<%= panel_name %>" data-toggle="collapse" data-target="#<%= panel_name %>-{{id}}" aria-expanded="false" class="scroll-to-expanded collapsed"><%= panel_label %></a>
   </li>
   {{/if}}
-  <% end %>
+<% end %>

--- a/app/views/masters/_search_results_resources_panel.html.erb
+++ b/app/views/masters/_search_results_resources_panel.html.erb
@@ -1,34 +1,84 @@
 <%
+  # Render a single outer collapsible panel containing all resources listed in
+  # `panel.contains.resources`. Mirrors the contains.categories pattern – the
+  # tab rendered by masters/_search_results_master_tabs_resources toggles this
+  # outer collapse, and each resource produces an inner block (always visible
+  # inside the outer panel) plus a hidden loader anchor that fires the
+  # AJAX list fetch via the existing Rails UJS / Handlebars pipeline.
+  #
+  # Loader anchors are clicked the first time the outer panel is opened
+  # (handled by JS in page_layouts.js on show.bs.collapse). Initial-show
+  # panels open via the existing `on-open-click` tab auto-click in
+  # _fpa.form_utils.on_open_click, which triggers the same path.
+  #
+  # Backwards-compatibility: single-resource panels render exactly one inner
+  # resource block + one loader anchor inside the outer container, preserving
+  # the user-visible behaviour of the previous per-resource-tab design.
+
+  panel_name = panel.panel_name
+  panel_label = panel.panel_label
   resources = panel.contains.resources
-  init_visible = panel.view_options.initial_show || nil if panel.view_options
   default_expander = panel.view_options&.default_expander
   hide_sl_class = 'hide-sublist-controls' if panel.view_options&.hide_sublist_controls
   hide_al_header_class = 'hide-activity-logs-header' if panel.view_options&.hide_activity_logs_header
-  resources.each do |resource|
-    if master_viewables[resource.to_sym]
-      rs = resource.split('__', 2)
-      if rs.length == 2
-        resource_type = rs.first.hyphenate.pluralize
-      else
-        resource_type = 'details'
-      end
-      block_id = "#{resource.hyphenate}-{{id}}"
-      view_css = panel.view_css
-      outer = "##{block_id}"
-%>
-    <%= render partial: 'reports/insert_options_css', locals: {outer: outer, view_css: view_css} %>
-    <div id="<%= block_id %>" 
-         class="<%= resource_type %>-generic-block <%= resource.hyphenate %>-block collapse <%=hide_sl_class%> <%=hide_al_header_class%>"
-         data-sub-for-root="master_id"
-         data-sub-id="{{id}}"
-         data-sub-item="<%= resource %>"
-         data-template="<%= resource.hyphenate %>-main-result-template"
-         data-default-expander="<%= default_expander %>"
-    >
-        <div id="<%= resource.hyphenate %>-inner-{{id}}" class="<%= resource_type %>-inner-block">
-        </div>
-    </div>
-<%
-    end
+  view_css = panel.view_css
+  limit = (panel.view_options&.limit || 20).to_i
+
+  renderable = resources.each_with_object([]) do |resource, memo|
+    next unless master_viewables[resource.to_sym]
+
+    info = resource_render_info(resource, context: :master_panel)
+    next unless info
+
+    memo << [resource, info]
   end
 %>
+<% if renderable.any? %>
+  <% outer = "##{panel_name}-{{id}}" %>
+  <%= render partial: 'reports/insert_options_css', locals: { outer: outer, view_css: view_css } %>
+  <div id="<%= panel_name %>-{{id}}"
+       class="panel panel-default section-panel page-layout-panel contains-resources collapse <%= panel_name %>-block format-block-on-expand <%= hide_sl_class %> <%= hide_al_header_class %>">
+    <div class="is-header default-header section-panel-header">
+      <% unless hide_player_tabs? %>
+        <a href="#<%= panel_name %>-{{id}}" data-toggle="collapse" class="dropup scroll-to-master pull-right glyphicon glyphicon-remove-sign show-entity btn-close-panel" title="close panel"></a>
+      <% end %>
+      <h4 class="list-group-item-heading panel-heading--<%= panel_label.to_s.id_hyphenate %>"><%= panel_label %></h4>
+    </div>
+    <%# Hidden loader anchors – one per resource – are picked up by
+        _fpa.form_utils.on_open_click when the master record is expanded
+        (called from the search_results_template postprocessor). This is the
+        same mechanism used by the standard master_external_ids_panel to
+        lazily fetch each resource's list via Rails UJS and render it
+        through the data-template Handlebars pipeline. %>
+    <div class="on-open-click hidden">
+      <% renderable.each do |resource, render_info|
+           block_id = "#{resource.hyphenate}-{{id}}"
+           route_path = render_info[:route_path]
+           template_name = render_info[:template_name] %>
+        <a href="/masters/{{id}}/<%= route_path %>?limit=<%= limit %>"
+           data-remote="true"
+           data-result-target="#<%= block_id %>"
+           data-template="<%= template_name %>"
+           data-panel-tab="<%= resource %>"
+           class="contains-resources-loader contains-resources-loader--<%= resource.hyphenate %>"
+           aria-hidden="true"
+           tabindex="-1">load <%= resource %></a>
+      <% end %>
+    </div>
+    <% renderable.each do |resource, render_info|
+         block_id = "#{resource.hyphenate}-{{id}}"
+         inner_block_class = render_info[:wrapper_class].gsub('generic-block', 'inner-block')
+         template_name = render_info[:template_name] %>
+      <div id="<%= block_id %>"
+           class="<%= render_info[:wrapper_class] %> <%= resource.hyphenate %>-block"
+           data-sub-for-root="master_id"
+           data-sub-id="{{id}}"
+           data-sub-item="<%= resource %>"
+           data-template="<%= template_name %>"
+           data-default-expander="<%= default_expander %>">
+        <div id="<%= resource.hyphenate %>-inner-{{id}}" class="<%= inner_block_class %>">
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/page_layouts/_show_row.html.erb
+++ b/app/views/page_layouts/_show_row.html.erb
@@ -42,9 +42,11 @@
           elsif resource_def
             result_type = 'resource'
             resource = resource_def['name']
+            lookup_name = resource
             resource = resource.pluralize
             @master_id = resource_def['master_id'] || @master_id
             template_prefix = "#{resource_def['template_prefix']}-" if resource_def['template_prefix']
+            explicit_template_prefix = resource_def['template_prefix'] ? "#{resource_def['template_prefix']}-" : nil
             option_classes = resource_def['option_classes']
 
             url_parts = [
@@ -76,6 +78,7 @@
             param_parts.compact!
 
             col_url = "/#{url_parts.join("/")}?#{param_parts.join("&")}"
+            render_info = resource_render_info(lookup_name, context: :standalone_page, template_prefix: explicit_template_prefix)
           else
             # No report or resource was specified, so allow just literal header / footer text to be shown
             # without complaining about a missing resource or report
@@ -110,8 +113,8 @@
         <%if col_label.present? %><h2 class="sp-col-label"><%=col_label%></h2><% end %>
         <% if col_header.present? %><div class="sp-col-header"><%= col_header%></div><% end %>
         <div class="result-target result-target-<%=result_type%> page-template-<%=template_prefix%>prefix <%= option_classes %>">
-          <% if resource %>
-            <div id="<%= resource.hyphenate %>-<%=@master_id%>" class="no-table-results <%= template_prefix != 'page-' ? 'activity-logs-generic-block' : '' %> standalone-panel-generic-block <%= resource.hyphenate %>-block collapse" data-sub-for-root="master_id" data-sub-id="<%=@master_id%>" data-sub-item="<%= resource %>" data-template="<%= resource.hyphenate %>-<%=template_prefix%>result-template">
+          <% if resource && render_info %>
+            <div id="<%= resource.hyphenate %>-<%=@master_id%>" class="no-table-results <%= render_info[:wrapper_class] %> standalone-panel-generic-block <%= resource.hyphenate %>-block collapse" data-sub-for-root="master_id" data-sub-id="<%=@master_id%>" data-sub-item="<%= resource %>" data-template="<%= render_info[:template_name] %>">
               <div id="<%= resource.hyphenate %>-inner-<%=@master_id%>" class="standalone-panel-inner-block">
               </div>
             </div>

--- a/spec/helpers/page_layouts_helper_spec.rb
+++ b/spec/helpers/page_layouts_helper_spec.rb
@@ -2,9 +2,17 @@
 
 require 'rails_helper'
 
-# Unit tests for PageLayoutsHelper methods, specifically the format_active_values
-# helper used for configuring sublist filter button defaults.
-# Related to GitHub Issue #584.
+# Unit tests for PageLayoutsHelper methods.
+#
+# format_active_values (issue #584):
+#   Verifies correct formatting of sublist filter button defaults.
+#
+# resource_render_info (issue #1180):
+#   Verifies that the new helper correctly resolves per-resource rendering metadata
+#   (template_name, route_path, wrapper_class, viewable_key) for all three supported
+#   resource types (activity log, dynamic model, external identifier) in both
+#   :master_panel and :standalone_page contexts, and that explicit template_prefix
+#   overrides are honoured. Also verifies that an unresolvable resource name returns nil.
 
 RSpec.describe PageLayoutsHelper, type: :helper do
   describe '#format_active_values' do
@@ -38,6 +46,167 @@ RSpec.describe PageLayoutsHelper, type: :helper do
 
     it 'converts symbols to strings' do
       expect(helper.format_active_values(:active)).to eq('active')
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # resource_render_info (issue #1180)
+  # ------------------------------------------------------------------ #
+  describe '#resource_render_info' do
+    let(:activity_log_item) do
+      Resources::Models::Item.new.merge(
+        type: :activity_log,
+        resource_name: 'activity_log__case_reviews',
+        hyphenated_name: 'activity-log--case-reviews',
+        base_route_segments: 'activity_log/case_reviews'
+      )
+    end
+
+    let(:dynamic_model_item) do
+      Resources::Models::Item.new.merge(
+        type: :dynamic_model,
+        resource_name: 'dynamic_model__contact_infos',
+        hyphenated_name: 'contact-infos',
+        base_route_segments: 'dynamic_model/contact_infos'
+      )
+    end
+
+    let(:external_id_item) do
+      Resources::Models::Item.new.merge(
+        type: :external_identifier,
+        resource_name: 'scantron_ids',
+        hyphenated_name: 'scantron-ids',
+        base_route_segments: 'scantron_ids'
+      )
+    end
+
+    before do
+      allow(Resources::Models).to receive(:find_by) do |args|
+        case args[:resource_name].to_s
+        when 'activity_log__case_reviews' then activity_log_item
+        when 'dynamic_model__contact_infos' then dynamic_model_item
+        when 'scantron_ids' then external_id_item
+        else nil
+        end
+      end
+    end
+
+    context 'with an activity log resource' do
+      context 'in :master_panel context' do
+        subject(:info) { helper.resource_render_info('activity_log__case_reviews', context: :master_panel) }
+
+        it 'returns template_name with -main-result-template suffix' do
+          expect(info[:template_name]).to eq('activity-log--case-reviews-main-result-template')
+        end
+
+        it 'returns the correct route_path' do
+          expect(info[:route_path]).to eq('activity_log/case_reviews')
+        end
+
+        it 'returns the activity-logs-generic-block wrapper class' do
+          expect(info[:wrapper_class]).to eq('activity-logs-generic-block')
+        end
+
+        it 'returns the resource_name symbolised as viewable_key' do
+          expect(info[:viewable_key]).to eq(:activity_log__case_reviews)
+        end
+      end
+
+      context 'in :standalone_page context' do
+        subject(:info) { helper.resource_render_info('activity_log__case_reviews', context: :standalone_page) }
+
+        it 'returns template_name with -page-result-template suffix' do
+          expect(info[:template_name]).to eq('activity-log--case-reviews-page-result-template')
+        end
+      end
+    end
+
+    context 'with a dynamic model resource' do
+      context 'in :master_panel context' do
+        subject(:info) { helper.resource_render_info('dynamic_model__contact_infos', context: :master_panel) }
+
+        it 'returns template_name using the full namespaced hyphenated resource name with -list-template suffix' do
+          expect(info[:template_name]).to eq('dynamic-model--contact-infos-list-template')
+        end
+
+        it 'returns the correct route_path including namespace segment' do
+          expect(info[:route_path]).to eq('dynamic_model/contact_infos')
+        end
+
+        it 'returns the dynamic-model-generic-block wrapper class' do
+          expect(info[:wrapper_class]).to eq('dynamic-model-generic-block')
+        end
+
+        it 'returns the resource_name symbolised as viewable_key' do
+          expect(info[:viewable_key]).to eq(:dynamic_model__contact_infos)
+        end
+      end
+
+      context 'in :standalone_page context' do
+        subject(:info) { helper.resource_render_info('dynamic_model__contact_infos', context: :standalone_page) }
+
+        it 'returns the same -list-template regardless of context' do
+          expect(info[:template_name]).to eq('dynamic-model--contact-infos-list-template')
+        end
+      end
+    end
+
+    context 'with an external identifier resource' do
+      context 'in :master_panel context' do
+        subject(:info) { helper.resource_render_info('scantron_ids', context: :master_panel) }
+
+        it 'returns template_name with -list-template suffix' do
+          expect(info[:template_name]).to eq('scantron-ids-list-template')
+        end
+
+        it 'returns the bare table name as route_path (no namespace)' do
+          expect(info[:route_path]).to eq('scantron_ids')
+        end
+
+        it 'returns the external-id-generic-block wrapper class' do
+          expect(info[:wrapper_class]).to eq('external-id-generic-block')
+        end
+
+        it 'returns the resource_name symbolised as viewable_key' do
+          expect(info[:viewable_key]).to eq(:scantron_ids)
+        end
+      end
+
+      context 'in :standalone_page context' do
+        subject(:info) { helper.resource_render_info('scantron_ids', context: :standalone_page) }
+
+        it 'returns the same -list-template regardless of context' do
+          expect(info[:template_name]).to eq('scantron-ids-list-template')
+        end
+      end
+    end
+
+    context 'with an explicit template_prefix override' do
+      context 'dynamic model with template_prefix: "page-"' do
+        subject(:info) do
+          helper.resource_render_info('dynamic_model__contact_infos', context: :standalone_page, template_prefix: 'page-')
+        end
+
+        it 'uses the explicit prefix to build the template name' do
+          expect(info[:template_name]).to eq('dynamic-model--contact-infos-page-result-template')
+        end
+      end
+
+      context 'activity log with template_prefix: "custom-"' do
+        subject(:info) do
+          helper.resource_render_info('activity_log__case_reviews', context: :master_panel, template_prefix: 'custom-')
+        end
+
+        it 'uses the explicit prefix to build the template name overriding the context default' do
+          expect(info[:template_name]).to eq('activity-log--case-reviews-custom-result-template')
+        end
+      end
+    end
+
+    context 'with an unresolvable resource name' do
+      it 'returns nil' do
+        expect(helper.resource_render_info('nonexistent_resource', context: :master_panel)).to be_nil
+      end
     end
   end
 end

--- a/spec/system/page_layout/resource_type_rendering_spec.rb
+++ b/spec/system/page_layout/resource_type_rendering_spec.rb
@@ -1,0 +1,369 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Acceptance test for GitHub Issue #1180: Page layout resource rendering should support
+# dynamic models and external identifiers in contains.resources panels.
+#
+# Prior to the fix, `contains.resources` in a master panel page layout only correctly rendered
+# activity logs. Dynamic model and external identifier resources would produce incorrect
+# `data-template` attribute values (using the full resource name rather than the stripped
+# hyphenated name from the Resources::Models registry), causing Handlebars templates not to
+# be found and the panel content not to render.
+#
+# This spec verifies correct DOM output for each resource type after the master record is
+# expanded, specifically:
+#   AC-002: Dynamic model resource - tab link has correct data-template using the DM's
+#           hyphenated_name (stripped of namespace), content div has dynamic-model-generic-block
+#   AC-003: External identifier resource - tab link has correct data-template, content div
+#           has external-id-generic-block
+#   AC-005: Panel tab is absent when the current user has no access to the panel's resources
+#
+# Implementation changes verified:
+#   - app/helpers/page_layouts_helper.rb (resource_render_info)
+#   - app/views/masters/_search_results_master_tabs_resources.html.erb
+#   - app/views/masters/_search_results_resources_panel.html.erb
+
+describe 'page layout resource type rendering', js: true, driver: $browser_driver do
+  include ModelSupport
+  include MasterDataSupport
+  include FeatureSupport
+  include DynamicModelSupport
+
+  def set_up_feature
+    change_setting('TwoFactorAuthDisabledForUser', true)
+    change_setting('TwoFactorAuthDisabledForAdmin', true)
+    change_setting('AllowDynamicMigrations', true)
+    SetupHelper.feature_setup
+
+    @admin, @admin_password = create_admin
+
+    ms = Master.no_temporary_masters
+    if ms.count == 0 || ms.first.nil? || ms.first.id < 1
+      create_data_set_outside_tx
+    end
+
+    @master = Master.no_temporary_masters.first
+    @master_id = @master.id
+    expect(@master_id).to be > 0
+
+    @user, @good_password = create_user(create_master: true)
+    @good_email = @user.email
+    @app_type = @user.app_type
+    expect(@app_type).not_to be nil
+    expect(@user.two_factor_setup_required?).to be_falsey
+  end
+
+  # Create (or re-create) the test DynamicModel used in resource panels
+  def setup_dm_resource
+    DynamicModel.active.where(table_name: 'test_rr_dms').reload.each { |dm| dm.disable!(@admin) }
+    DynamicModel.send(:remove_const, :TestRrDm) if defined?(DynamicModel::TestRrDm)
+
+    @dm = DynamicModel.create!(
+      current_admin: @admin,
+      name: 'Test RR DM',
+      schema_name: 'dynamic_test',
+      table_name: 'test_rr_dms',
+      category: :details,
+      field_list: 'description',
+      primary_key_name: 'id',
+      foreign_key_name: 'master_id'
+    )
+
+    setup_access :dynamic_model__test_rr_dms, user: @user
+
+    # Create a record on the master so the AJAX-loaded list has visible content to assert against
+    @dm_record_text = "rr-dm-record-#{SecureRandom.hex(4)}"
+    @dm.implementation_class.create!(
+      master: @master,
+      description: @dm_record_text,
+      current_user: @user
+    )
+  end
+
+  # Create (or re-create) the test ExternalIdentifier used in resource panels
+  def setup_ei_resource
+    unless Admin::MigrationGenerator.table_exists? 'test_rr_ext_ids'
+      sql = <<~SQL
+        CREATE TABLE IF NOT EXISTS ml_app.test_rr_ext_ids (
+          id SERIAL PRIMARY KEY,
+          master_id INTEGER REFERENCES ml_app.masters(id),
+          test_rr_ext_id BIGINT NOT NULL,
+          created_at TIMESTAMP,
+          updated_at TIMESTAMP,
+          user_id INTEGER REFERENCES ml_app.users(id)
+        )
+      SQL
+      ActiveRecord::Base.connection.execute(sql)
+    end
+
+    ExternalIdentifier.active.where(name: 'test_rr_ext_ids').reload.each do |ei|
+      ei.update!(disabled: true, current_admin: @admin)
+    end
+
+    @ei = ExternalIdentifier.create!(
+      current_admin: @admin,
+      name: 'test_rr_ext_ids',
+      label: 'Test RR Ext ID',
+      external_id_attribute: 'test_rr_ext_id',
+      min_id: 1,
+      max_id: 999_999_999
+    )
+
+    setup_access :test_rr_ext_ids, resource_type: :table, user: @user
+
+    # Create a record on the master so the AJAX-loaded list has visible content to assert against.
+    # The external identifier numeric value is rendered in the list panel.
+    @ei_record_value = rand(100_000..999_999)
+    @ei.implementation_class.create!(
+      master: @master,
+      test_rr_ext_id: @ei_record_value,
+      current_user: @user
+    )
+  end
+
+  # Create a master panel page layout with contains.resources listing the given resource names.
+  # initial_show: true makes the panel auto-expand on master open and fires the AJAX list load via
+  # the `on-open-click` mechanism, so we can assert against actually rendered content.
+  def create_resource_panel(resources:, initial_show: true)
+    disable_active_panel_layout('test-rr-resources-panel')
+    resource_list = resources.map { |r| "    - #{r}" }.join("\n")
+    options_yaml = <<~YAML
+      contains:
+        resources:
+      #{resource_list}
+    YAML
+    if initial_show
+      options_yaml += "view_options:\n  initial_show: true\n"
+    end
+    Admin::PageLayout.create!(
+      current_admin: @admin,
+      app_type_id: @app_type.id,
+      layout_name: 'master',
+      panel_name: 'test-rr-resources-panel',
+      panel_label: 'RR Resources',
+      panel_position: 200,
+      options: options_yaml
+    )
+  end
+
+  # Navigate to the master record search result and expand it so tabs are rendered
+  def expand_test_master
+    visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@master_id}"
+    dismiss_modal
+    finish_page_loading
+    expect(page).to have_css("#master-#{@master_id}")
+    expect(page).not_to have_css('.alert')
+    expand_master_record(master_id: @master_id)
+    finish_page_loading
+  end
+
+  # -------------------------------------------------------------------
+  # AC-002: Dynamic model resource in contains.resources panel
+  # -------------------------------------------------------------------
+
+  describe 'dynamic model resource (AC-002)' do
+    before(:all) do
+      set_up_feature
+      setup_dm_resource
+      create_resource_panel(resources: ['dynamic_model__test_rr_dms'])
+      Rails.application.routes_reloader.reload!
+    end
+
+    after(:all) do
+      disable_active_panel_layout('test-rr-resources-panel', reload_routes: true)
+    end
+
+    before(:each) do
+      validate_setup
+      login
+    end
+
+    it 'renders a single tab keyed by the panel_name that toggles the outer panel container' do
+      expand_test_master
+
+      # The unified contract: one tab per page-layout panel, keyed by panel_name
+      # (consistent with contains.categories behaviour).
+      tab = find("a[data-panel-tab='test-rr-resources-panel']", wait: 15)
+      expect(tab['data-target']).to eq("#test-rr-resources-panel-#{@master_id}")
+
+      # Only one tab is rendered, even though the panel can contain one or more resources.
+      expect(page).to have_css("a[data-panel-tab='test-rr-resources-panel']", count: 1)
+    end
+
+    it 'renders the inner resource block with dynamic-model-generic-block class and correct data-template' do
+      expand_test_master
+
+      expected_template = 'dynamic-model--test-rr-dms-list-template'
+
+      # The inner resource block lives inside the outer panel container and is the
+      # element that self-loads its list content via the _fpa.js sub-item loader.
+      content_div = find("[data-sub-item='dynamic_model__test_rr_dms']", visible: :all, wait: 15)
+      expect(content_div[:class]).to include('dynamic-model-generic-block')
+      expect(content_div['data-template']).to eq(expected_template)
+    end
+
+    it 'loads the actual dynamic model records into the panel when the master is expanded' do
+      # With initial_show: true on the page-layout panel, opening the master record fires
+      # the on-open-click auto-click on the single resources tab, which expands the outer
+      # panel container; the inner block then loads its list via the sub-item loader.
+      expand_test_master
+
+      # Wait for Bootstrap collapse to fully open the outer resources panel
+      expect(page).to have_css("#test-rr-resources-panel-#{@master_id}.collapse.in", wait: 15)
+
+      # The dynamic model record's description field value must be rendered into the
+      # AJAX-loaded list panel for the user to see it.
+      content_div = find("[data-sub-item='dynamic_model__test_rr_dms']")
+      expect(content_div).to have_text(@dm_record_text, wait: 15)
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # AC-003: External identifier resource in contains.resources panel
+  # -------------------------------------------------------------------
+
+  describe 'external identifier resource (AC-003)' do
+    before(:all) do
+      set_up_feature
+      setup_ei_resource
+      create_resource_panel(resources: ['test_rr_ext_ids'])
+      Rails.application.routes_reloader.reload!
+    end
+
+    after(:all) do
+      disable_active_panel_layout('test-rr-resources-panel', reload_routes: true)
+    end
+
+    before(:each) do
+      validate_setup
+      login
+    end
+
+    it 'renders a single tab keyed by the panel_name for the EI panel' do
+      expand_test_master
+
+      tab = find("a[data-panel-tab='test-rr-resources-panel']", wait: 15)
+      expect(tab['data-target']).to eq("#test-rr-resources-panel-#{@master_id}")
+      expect(page).to have_css("a[data-panel-tab='test-rr-resources-panel']", count: 1)
+    end
+
+    it 'renders the inner resource block with external-id-generic-block class and correct data-template' do
+      expand_test_master
+
+      expected_template = 'test-rr-ext-ids-list-template'
+
+      content_div = find("[data-sub-item='test_rr_ext_ids']", visible: :all, wait: 15)
+      expect(content_div[:class]).to include('external-id-generic-block')
+      expect(content_div['data-template']).to eq(expected_template)
+    end
+
+    it 'loads the actual external identifier records into the panel when the master is expanded' do
+      expand_test_master
+
+      expect(page).to have_css("#test-rr-resources-panel-#{@master_id}.collapse.in", wait: 15)
+
+      content_div = find("[data-sub-item='test_rr_ext_ids']")
+      expect(content_div).to have_text(@ei_record_value.to_s, wait: 15)
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # Multiple resources in the same master panel
+  #
+  # Verifies that a single contains.resources panel listing both a dynamic
+  # model and an external identifier renders tabs and content panels for
+  # both resources, and that the AJAX-loaded list content for each resource
+  # type is rendered into its respective panel when the master is expanded.
+  # -------------------------------------------------------------------
+
+  describe 'multiple resources in the same master panel' do
+    before(:all) do
+      set_up_feature
+      setup_dm_resource
+      setup_ei_resource
+      create_resource_panel(resources: ['dynamic_model__test_rr_dms', 'test_rr_ext_ids'])
+      Rails.application.routes_reloader.reload!
+    end
+
+    after(:all) do
+      disable_active_panel_layout('test-rr-resources-panel', reload_routes: true)
+    end
+
+    before(:each) do
+      validate_setup
+      login
+    end
+
+    it 'renders a single tab and both resource blocks inside the one outer panel container' do
+      expand_test_master
+
+      # Exactly ONE tab is rendered for the panel, regardless of how many
+      # resources it contains (mirrors the contains.categories behaviour).
+      expect(page).to have_css("a[data-panel-tab='test-rr-resources-panel']", count: 1)
+      tab = find("a[data-panel-tab='test-rr-resources-panel']", wait: 15)
+      expect(tab['data-target']).to eq("#test-rr-resources-panel-#{@master_id}")
+
+      # Both resource inner blocks live inside the single outer panel container.
+      outer = find("#test-rr-resources-panel-#{@master_id}", visible: :all, wait: 15)
+      dm_content = outer.find("[data-sub-item='dynamic_model__test_rr_dms']", visible: :all)
+      ei_content = outer.find("[data-sub-item='test_rr_ext_ids']", visible: :all)
+
+      expect(dm_content[:class]).to include('dynamic-model-generic-block')
+      expect(dm_content['data-template']).to eq('dynamic-model--test-rr-dms-list-template')
+      expect(ei_content[:class]).to include('external-id-generic-block')
+      expect(ei_content['data-template']).to eq('test-rr-ext-ids-list-template')
+    end
+
+    it 'loads the actual records for both resources into their respective inner blocks' do
+      expand_test_master
+
+      # The outer panel container opens, then each inner block self-loads.
+      expect(page).to have_css("#test-rr-resources-panel-#{@master_id}.collapse.in", wait: 15)
+
+      dm_content = find("[data-sub-item='dynamic_model__test_rr_dms']")
+      ei_content = find("[data-sub-item='test_rr_ext_ids']")
+
+      expect(dm_content).to have_text(@dm_record_text, wait: 15)
+      expect(ei_content).to have_text(@ei_record_value.to_s, wait: 15)
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # AC-005: Panel tab is absent for a user with no resource access
+  # -------------------------------------------------------------------
+
+  describe 'access control - no panel tab for inaccessible resources (AC-005)' do
+    before(:all) do
+      set_up_feature
+      setup_dm_resource
+      create_resource_panel(resources: ['dynamic_model__test_rr_dms'])
+
+      # Second user with no access to the DM resource
+      @no_access_user, @no_access_password = create_user(create_master: false)
+      @no_access_email = @no_access_user.email
+
+      Rails.application.routes_reloader.reload!
+    end
+
+    after(:all) do
+      disable_active_panel_layout('test-rr-resources-panel', reload_routes: true)
+    end
+
+    before(:each) do
+      validate_setup
+    end
+
+    it 'does not render the panel tab when the user has no access to the resource' do
+      # Log in as the user without access
+      @user = @no_access_user
+      @good_email = @no_access_email
+      @good_password = @no_access_password
+      login
+
+      expand_test_master
+
+      expect(page).not_to have_css("a[data-panel-tab='test-rr-resources-panel']")
+    end
+  end
+end

--- a/spec/views/masters/_search_results_master_tabs_resources_spec.rb
+++ b/spec/views/masters/_search_results_master_tabs_resources_spec.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# View spec for masters/_search_results_master_tabs_resources partial (issue #1180).
+#
+# Unified contract (consistent with contains.categories): the partial renders a
+# SINGLE <li> tab per page-layout panel, regardless of how many resources the
+# panel lists in contains.resources. The tab toggles a single outer collapse
+# container whose id is derived from the panel_name. The actual per-resource
+# `data-template` attributes live on inner blocks rendered by the sibling
+# `_search_results_resources_panel` partial, not on the tab.
+#
+# Regression: single-resource panels (e.g. one activity log) continue to render
+# exactly one tab with the same panel_label visible to the user.
+
+RSpec.describe 'masters/_search_results_master_tabs_resources', type: :view do
+  let(:activity_log_item) do
+    Resources::Models::Item.new.merge(
+      type: :activity_log,
+      resource_name: 'activity_log__case_reviews',
+      hyphenated_name: 'activity-log--case-reviews',
+      base_route_segments: 'activity_log/case_reviews'
+    )
+  end
+
+  let(:dynamic_model_item) do
+    Resources::Models::Item.new.merge(
+      type: :dynamic_model,
+      resource_name: 'dynamic_model__contact_infos',
+      hyphenated_name: 'contact-infos',
+      base_route_segments: 'dynamic_model/contact_infos'
+    )
+  end
+
+  let(:external_id_item) do
+    Resources::Models::Item.new.merge(
+      type: :external_identifier,
+      resource_name: 'scantron_ids',
+      hyphenated_name: 'scantron-ids',
+      base_route_segments: 'scantron_ids'
+    )
+  end
+
+  before do
+    allow(Resources::Models).to receive(:find_by) do |args|
+      case args[:resource_name].to_s
+      when 'activity_log__case_reviews' then activity_log_item
+      when 'dynamic_model__contact_infos' then dynamic_model_item
+      when 'scantron_ids' then external_id_item
+      else nil
+      end
+    end
+  end
+
+  let(:base_locals) do
+    {
+      panel_name: 'test-panel',
+      panel_label: 'Test Panel',
+      default_panels: [],
+      initial_show: nil,
+      close_others: false,
+      filter_items: nil,
+      limit: 20
+    }
+  end
+
+  # --- Single resource (regression: AC-001/AC-002/AC-003) -------------
+
+  context 'with a single dynamic model resource' do
+    before do
+      render partial: 'masters/search_results_master_tabs_resources',
+             locals: base_locals.merge(resources: ['dynamic_model__contact_infos'])
+    end
+
+    it 'renders exactly one tab <li>' do
+      expect(rendered.scan(/<li\b/).length).to eq(1)
+    end
+
+    it "uses the panel_name as the tab's data-panel-tab attribute" do
+      expect(rendered).to include('data-panel-tab="test-panel"')
+    end
+
+    it "uses the panel_name as the tab's collapse target" do
+      expect(rendered).to include('data-target="#test-panel-{{id}}"')
+    end
+
+    it 'displays the panel_label as the tab text' do
+      expect(rendered).to include('Test Panel')
+    end
+
+    it 'does not place a data-template attribute on the tab itself' do
+      # data-template lives on the inner resource block, not on the tab.
+      expect(rendered).not_to include('data-template=')
+    end
+  end
+
+  context 'with a single activity log resource (regression)' do
+    before do
+      render partial: 'masters/search_results_master_tabs_resources',
+             locals: base_locals.merge(resources: ['activity_log__case_reviews'])
+    end
+
+    it 'renders exactly one tab <li>' do
+      expect(rendered.scan(/<li\b/).length).to eq(1)
+    end
+
+    it 'targets the panel_name-keyed collapse container' do
+      expect(rendered).to include('data-target="#test-panel-{{id}}"')
+    end
+  end
+
+  context 'with a single external identifier resource' do
+    before do
+      render partial: 'masters/search_results_master_tabs_resources',
+             locals: base_locals.merge(resources: ['scantron_ids'])
+    end
+
+    it 'renders exactly one tab <li>' do
+      expect(rendered.scan(/<li\b/).length).to eq(1)
+    end
+
+    it 'targets the panel_name-keyed collapse container' do
+      expect(rendered).to include('data-target="#test-panel-{{id}}"')
+    end
+  end
+
+  # --- Multiple resources in a single panel (AC-004) ------------------
+
+  context 'with multiple resources in the same panel' do
+    before do
+      render partial: 'masters/search_results_master_tabs_resources',
+             locals: base_locals.merge(
+               resources: [
+                 'activity_log__case_reviews',
+                 'dynamic_model__contact_infos',
+                 'scantron_ids'
+               ]
+             )
+    end
+
+    it 'still renders exactly one tab <li> (mirrors categories behaviour)' do
+      expect(rendered.scan(/<li\b/).length).to eq(1)
+    end
+
+    it 'uses the shared panel_name as the tab key and collapse target' do
+      expect(rendered).to include('data-panel-tab="test-panel"')
+      expect(rendered).to include('data-target="#test-panel-{{id}}"')
+    end
+  end
+
+  # --- Unresolvable / no accessible resources (AC-005/AC-007) ---------
+
+  context 'with no resolvable resources' do
+    before do
+      render partial: 'masters/search_results_master_tabs_resources',
+             locals: base_locals.merge(resources: ['nonexistent_resource'])
+    end
+
+    it 'renders no tab markup' do
+      expect(rendered).not_to include('<li')
+      expect(rendered).not_to include('<a ')
+    end
+  end
+end

--- a/spec/views/page_layouts/_show_row_spec.rb
+++ b/spec/views/page_layouts/_show_row_spec.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# View spec for page_layouts/_show_row partial (issue #1180).
+#
+# The partial renders standalone-page column resource blocks.  The key rendered
+# attributes under test are:
+#   - data-template on the inner <div>: must use the Handlebars template registered
+#     for the resource type rather than the naive "hyphenated_resource-page-result-template"
+#     pattern the current implementation produces.
+#   - CSS wrapper classes: must include the resource-type-specific generic block class
+#     (dynamic-model-generic-block, external-id-generic-block, activity-logs-generic-block)
+#     in addition to the always-present standalone-panel-generic-block.
+#
+# RED-phase contract:
+#   - Dynamic model default (no template_prefix):
+#       expected: data-template="dynamic-model--contact-infos-list-template"
+#   - External identifier default:
+#       expected: data-template="scantron-ids-list-template"
+#   - Activity log regression (AC-020): current behaviour is unchanged.
+#   - Explicit template_prefix override (AC-023): prefix takes precedence over type default.
+#
+# The partial consumes @master_id and two locals: rows and container.
+# Formatter::Substitution and markdown_to_html are stubbed to avoid DB/gem overhead.
+
+RSpec.describe 'page_layouts/_show_row', type: :view do
+  # --- shared test doubles / stubs -----------------------------------
+
+  let(:activity_log_item) do
+    Resources::Models::Item.new.merge(
+      type: :activity_log,
+      resource_name: 'activity_log__case_reviews',
+      hyphenated_name: 'activity-log--case-reviews',
+      base_route_segments: 'activity_log/case_reviews'
+    )
+  end
+
+  let(:dynamic_model_item) do
+    Resources::Models::Item.new.merge(
+      type: :dynamic_model,
+      resource_name: 'dynamic_model__contact_infos',
+      hyphenated_name: 'contact-infos',
+      base_route_segments: 'dynamic_model/contact_infos'
+    )
+  end
+
+  let(:external_id_item) do
+    Resources::Models::Item.new.merge(
+      type: :external_identifier,
+      resource_name: 'scantron_ids',
+      hyphenated_name: 'scantron-ids',
+      base_route_segments: 'scantron_ids'
+    )
+  end
+
+  before do
+    # Provide a master id so the partial can build URLs and skip the Not Found block.
+    assign(:master_id, 123)
+    assign(:master, {})
+
+    # Stub Resources::Models.find_by for the new implementation.
+    allow(Resources::Models).to receive(:find_by) do |args|
+      case args[:resource_name].to_s
+      when 'activity_log__case_reviews' then activity_log_item
+      when 'dynamic_model__contact_infos' then dynamic_model_item
+      when 'scantron_ids' then external_id_item
+      else nil
+      end
+    end
+
+    # Stub string-substitution helpers to return their input unchanged.
+    allow(view).to receive(:markdown_to_html) { |text| text.to_s.html_safe }
+    allow(Formatter::Substitution).to receive(:substitute) { |str, **_opts| str.to_s.html_safe }
+
+    # Stub the error-page partial so it never triggers in the col rendering path.
+    stub_template 'layouts/_error_page_block.erb' => ''
+  end
+
+  # Helper to build a minimal rows structure with one col containing a resource.
+  def resource_rows(resource_name, extra_resource_opts: {})
+    resource_def = { 'name' => resource_name }.merge(extra_resource_opts)
+    [{ 'cols' => [{ 'label' => 'Test Label', 'resource' => resource_def }] }]
+  end
+
+  let(:container) { double('container') }
+
+  # --- Dynamic model resource, no template_prefix (AC-021) ------------
+
+  context 'with a dynamic model resource and no template_prefix' do
+    before do
+      render partial: 'page_layouts/show_row',
+             locals: { rows: resource_rows('dynamic_model__contact_infos'), container: container }
+    end
+
+    it 'renders the inner div with data-template pointing to the stripped list template' do
+      expect(rendered).to include('data-template="dynamic-model--contact-infos-list-template"')
+    end
+
+    it 'includes the dynamic-model-generic-block wrapper class on the inner div' do
+      expect(rendered).to include('dynamic-model-generic-block')
+    end
+
+    it 'always includes the standalone-panel-generic-block wrapper class' do
+      expect(rendered).to include('standalone-panel-generic-block')
+    end
+
+    it 'sets data-url to the dynamic_model master-scoped path' do
+      expect(rendered).to match(%r{data-url=["'][^"']*masters/123/dynamic_model/contact_infos})
+    end
+  end
+
+  # --- External identifier resource, no template_prefix (AC-022) ------
+
+  context 'with an external identifier resource and no template_prefix' do
+    before do
+      render partial: 'page_layouts/show_row',
+             locals: { rows: resource_rows('scantron_ids'), container: container }
+    end
+
+    it 'renders the inner div with data-template pointing to the list template' do
+      expect(rendered).to include('data-template="scantron-ids-list-template"')
+    end
+
+    it 'includes the external-id-generic-block wrapper class on the inner div' do
+      expect(rendered).to include('external-id-generic-block')
+    end
+
+    it 'always includes the standalone-panel-generic-block wrapper class' do
+      expect(rendered).to include('standalone-panel-generic-block')
+    end
+
+    it 'sets data-url to the scantron_ids master-scoped path' do
+      expect(rendered).to match(%r{data-url=["'][^"']*masters/123/scantron_ids})
+    end
+  end
+
+  # --- Activity log resource, no template_prefix — regression (AC-020) -
+
+  context 'with an activity log resource and no template_prefix (regression)' do
+    before do
+      render partial: 'page_layouts/show_row',
+             locals: { rows: resource_rows('activity_log__case_reviews'), container: container }
+    end
+
+    it 'renders the inner div with data-template using the default page-result-template suffix' do
+      expect(rendered).to include('data-template="activity-log--case-reviews-page-result-template"')
+    end
+
+    it 'includes the activity-logs-generic-block wrapper class' do
+      expect(rendered).to include('activity-logs-generic-block')
+    end
+
+    it 'always includes the standalone-panel-generic-block wrapper class' do
+      expect(rendered).to include('standalone-panel-generic-block')
+    end
+  end
+
+  # --- Explicit template_prefix override (AC-023) ----------------------
+
+  context 'with a dynamic model resource and an explicit template_prefix' do
+    before do
+      render partial: 'page_layouts/show_row',
+             locals: {
+               rows: resource_rows('dynamic_model__contact_infos',
+                                   extra_resource_opts: { 'template_prefix' => 'page' }),
+               container: container
+             }
+    end
+
+    it 'uses the explicit prefix to build the template name overriding the type default' do
+      expect(rendered).to include('data-template="dynamic-model--contact-infos-page-result-template"')
+    end
+  end
+
+  # --- Unresolvable resource name (AC-024) ----------------------------
+
+  context 'with an unresolvable resource name' do
+    before do
+      render partial: 'page_layouts/show_row',
+             locals: { rows: resource_rows('nonexistent_resource'), container: container }
+    end
+
+    it 'renders without raising an exception' do
+      # The example itself passing without an exception satisfies this criterion.
+      expect(rendered).not_to be_nil
+    end
+
+    it 'does not include a broken data-template referencing the raw resource name' do
+      expect(rendered).not_to include('data-template="nonexistent-resource-')
+    end
+  end
+end


### PR DESCRIPTION
## Description
Resolves #1180.

Changes:
- Added `resource_render_info` helper to generalise page layout resource rendering for dynamic models and external identifiers.
- Fixed `template_name` in `resource_render_info` to use the full namespaced resource name.
- Refactored `contains.resources` panel rendering to a single tab + single outer container, matching `contains.categories`.
- Added system specs for page layout resource type rendering (DM, EI, access control, multiple resources in same master panel).

## Testing
- Extended view specs for `page_layouts_helper`.
- Added `page_layout/resource_type_rendering_spec.rb` to ensure proper DOM structures, Handlebars templates and behaviour are enforced for standard models and external identifiers.
- Categories regression suite (`initial_show_tab_spec.rb`, `master_tabs_access_control_spec.rb`, `sublist_default_filters_spec.rb`) successfully passes, untouched.
