### PR TITLE
Added `same_site` lax to session cookie - fixes #1184

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,4 @@
-# Be sure to restart your server when you modify this file.
-
-# Rails.application.config.session_store :cookie_store, key: "_fpa1_session_#{Rails.env}", secure: Rails.env.production?
-
-Rails.application.config.session_store :active_record_store
+# Set same_site to :lax to allow the session cookie to be sent in cross-site requests,
+# which is necessary for certain authentication flows and third-party integrations.
+# This setting helps mitigate CSRF attacks while still allowing necessary cross-site interactions.
+Rails.application.config.session_store :active_record_store, same_site: :lax


### PR DESCRIPTION
## Summary

Sets the `same_site: :lax` option on the `active_record_store` session cookie configuration.

## Changes

- `config/initializers/session_store.rb`: Added `same_site: :lax` to the session store configuration, replacing commented-out legacy cookie store config.

## Why

Setting `same_site: :lax` allows the session cookie to be sent in cross-site top-level navigations (e.g. following links from third-party sites), which is necessary for certain authentication flows and third-party integrations. It also helps mitigate CSRF attacks by preventing the cookie from being sent in cross-site POST requests or embedded iframes.

Fixes #1184
