### PR TITLE
Added full_item_type_name to Admin::MasterRecord - fixes #1183

### DIFF
--- a/app/models/admin/master_record.rb
+++ b/app/models/admin/master_record.rb
@@ -140,6 +140,15 @@ class Admin::MasterRecord
     'master_id'
   end
 
+  # Returns the singularized table name for use in API helper methods such as
+  # AdminApiDefinitionsHelper#api_params_key. Dynamic definitions provide this
+  # via Dynamic::DefHandler; Admin::MasterRecord must implement it directly so
+  # that the generic admin/common/_api_panel partial works without error (#1183).
+  # @return [String] e.g. "player_info" for the "player_infos" table
+  def full_item_type_name
+    table_name.singularize
+  end
+
   # Get an estimated record count for this model.
   # @return [Integer, nil]
   def est_record_count

--- a/spec/helpers/admin_api_definitions_helper_spec.rb
+++ b/spec/helpers/admin_api_definitions_helper_spec.rb
@@ -5,7 +5,14 @@
 # Tests helper methods for generating API documentation in admin definition panels.
 # Verifies that the correct REST API endpoints, curl examples, field definitions,
 # save trigger YAML, and report-specific curl/save trigger YAML are generated for
-# dynamic models, activity logs, external identifiers, and reports.
+# dynamic models, activity logs, external identifiers, reports, and standard master
+# record models (Admin::MasterRecord - issue #1183).
+#
+# Issue #1183: clicking the API tab for a non-masters entry in /admin/master_records
+# raised "undefined method 'full_item_type_name' for an instance of Admin::MasterRecord"
+# because the generic api_panel partial (and AdminApiDefinitionsHelper#api_params_key)
+# called full_item_type_name which was missing from Admin::MasterRecord. These specs
+# verify that all helper methods work correctly with Admin::MasterRecord instances.
 
 require 'rails_helper'
 
@@ -483,6 +490,63 @@ RSpec.describe AdminApiDefinitionsHelper, type: :helper do
       key = helper.api_params_key(ei)
       expect(key).not_to include('__')
       expect(key).to eq(ei.implementation_model_name)
+    end
+
+    it 'returns the singular table name for Admin::MasterRecord (issue #1183)' do
+      record = Admin::MasterRecord.find(2) # player_infos
+      key = helper.api_params_key(record)
+      expect(key).to eq(Settings::DefaultSubjectInfoTableName.singularize)
+      expect(key).not_to include('__')
+    end
+
+    it 'does not raise an error when called with Admin::MasterRecord (issue #1183)' do
+      Admin::MasterRecord.all.each do |record|
+        expect { helper.api_params_key(record) }.not_to raise_error
+      end
+    end
+  end
+
+  describe 'Admin::MasterRecord support in API helpers (issue #1183)' do
+    let(:player_info_record) { Admin::MasterRecord.find(2) }
+
+    it 'api_base_path generates a master-nested path for player_infos' do
+      path = helper.api_base_path(player_info_record)
+      expect(path).to start_with('/masters/{{master_id}}/')
+      expect(path).to include(Settings::DefaultSubjectInfoTableName)
+    end
+
+    it 'api_endpoints generates the 4 standard endpoints for a master record model' do
+      endpoints = helper.api_endpoints(player_info_record)
+      expect(endpoints.length).to eq(4)
+      methods = endpoints.map { |e| e[:method] }
+      expect(methods).to eq(%w[GET GET POST PUT])
+    end
+
+    it 'api_fields excludes standard fields for a master record model' do
+      fields = helper.api_fields(player_info_record)
+      field_names = fields.map { |f| f[:name] }
+      expect(field_names).not_to include('id', 'created_at', 'updated_at', 'master_id')
+      expect(fields).to be_an Array
+    end
+
+    it 'api_sample_json_body does not raise an error for Admin::MasterRecord' do
+      expect { helper.api_sample_json_body(player_info_record) }.not_to raise_error
+    end
+
+    it 'api_sample_json_body wraps fields under the singular table name key' do
+      body = helper.api_sample_json_body(player_info_record)
+      key = player_info_record.table_name.singularize
+      parsed = JSON.parse(body)
+      expect(parsed.keys).to eq([key])
+    end
+
+    it 'api_save_trigger_example does not raise an error for Admin::MasterRecord' do
+      expect { helper.api_save_trigger_example(player_info_record) }.not_to raise_error
+    end
+
+    it 'api_save_trigger_example includes the correct base path for player_infos' do
+      yaml = helper.api_save_trigger_example(player_info_record)
+      expect(yaml).to include("/masters/{{master_id}}/#{Settings::DefaultSubjectInfoTableName}")
     end
   end
 

--- a/spec/models/admin/master_record_spec.rb
+++ b/spec/models/admin/master_record_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Tests for Admin::MasterRecord presenter class (issue #930)
+# Tests for Admin::MasterRecord presenter class (issue #930, #1183)
 #
 # Admin::MasterRecord is a read-only presenter that wraps the masters table
 # and the standard Rails models associated with it (player_infos, pro_infos, etc.).
@@ -13,6 +13,9 @@
 # - #fields returns the column list from the underlying model class
 # - Master metadata methods (crosswalk_attrs, readonly_attrs, TemporaryMasterIds)
 #   are available for rendering the masters table details
+# - #full_item_type_name returns the singularized table name (issue #1183)
+#   so that the AdminApiDefinitionsHelper can render the API panel correctly
+#   without raising "undefined method 'full_item_type_name'"
 
 require 'rails_helper'
 
@@ -191,6 +194,31 @@ RSpec.describe Admin::MasterRecord, type: :model do
         count = record.est_record_count
         expect(count).to be_an Integer
         expect(count).to be >= 0
+      end
+    end
+  end
+
+  describe '#full_item_type_name' do
+    it 'returns the singularized table name for masters' do
+      record = Admin::MasterRecord.find(1)
+      expect(record.full_item_type_name).to eq 'master'
+    end
+
+    it 'returns the singularized table name for player_infos' do
+      record = Admin::MasterRecord.find(2)
+      expect(record.full_item_type_name).to eq Settings::DefaultSubjectInfoTableName.singularize
+    end
+
+    it 'returns the singularized table name for all standard models' do
+      Admin::MasterRecord.all.each do |record|
+        expect(record.full_item_type_name).to eq(record.table_name.singularize),
+          "Expected full_item_type_name for #{record.table_name} to be #{record.table_name.singularize}"
+      end
+    end
+
+    it 'does not include double-underscore separators (unlike dynamic model prefixed names)' do
+      Admin::MasterRecord.all.each do |record|
+        expect(record.full_item_type_name).not_to include('__')
       end
     end
   end


### PR DESCRIPTION
## Summary

Fixes the error in the admin panel master records page when clicking the API tab for any non-masters entry (Player Infos, Pro Infos, Player Contacts, Addresses, Trackers, Tracker Histories).

**Error:**
```
undefined method 'full_item_type_name' for an instance of Admin::MasterRecord
```

## Root Cause

The generic `admin/common/_api_panel` partial calls `AdminApiDefinitionsHelper#api_params_key`, which calls `object_instance.full_item_type_name`. This method exists on `DynamicModel`, `ActivityLog`, and `ExternalIdentifier` (via `Dynamic::DefHandler`) but was missing from `Admin::MasterRecord`.

## Fix

Added `#full_item_type_name` to `Admin::MasterRecord` that returns `table_name.singularize`, consistent with how `DynamicModel` computes it via `#implementation_model_name`.

## Tests

- Added 4 new examples to `spec/models/admin/master_record_spec.rb` verifying `#full_item_type_name` returns the correct singularized table name for all standard models
- Added 9 new examples to `spec/helpers/admin_api_definitions_helper_spec.rb` verifying `api_params_key`, `api_sample_json_body`, and `api_save_trigger_example` all work correctly with `Admin::MasterRecord` instances without raising errors