### PR TITLE
Added non-blocking main template load on admin pages - fixes #1181

### DIFF
--- a/app/assets/javascripts/app/_fpa.js
+++ b/app/assets/javascripts/app/_fpa.js
@@ -1509,6 +1509,14 @@ _fpa = {
     if (current_user || current_admin) {
 
       if (current_user && current_user.app_type_id && !(controller_name == 'app_types' && action_name == 'upload')) {
+        // On admin pages the main template can be very large and slow to
+        // compile, but the admin UI does not actually depend on it. Load it
+        // in the background and immediately mark templates as loaded so the
+        // "loading..." splash guard is removed as soon as the HTML is ready.
+        // See issue #1181.
+        if (_fpa.state.is_admin_page) {
+          _fpa.status.loaded_templates = true;
+        }
         _fpa.load_template_version(_fpa.state.template_version, _fpa.state.rails_env);
 
 

--- a/app/assets/stylesheets/admin/admin.scss
+++ b/app/assets/stylesheets/admin/admin.scss
@@ -1,3 +1,5 @@
+$admin_background_well: rgb(245, 245, 245);
+
 .admin-index-page,
 .admin-user-index-page {
   border-color: silver;
@@ -23,7 +25,7 @@
 }
 
 .admin-edit-form .well {
-  background: rgb(245, 245, 245);
+  background: $admin_background_well;
 }
 
 a>.caret {
@@ -398,4 +400,15 @@ a.link-disabled {
 
 .model_generators.index .col-sm-12.admin-form__left-aligned {
   min-width: 800px;
+}
+
+.admin-components-lazy-panel {
+  .admin-components-lazy-panel__loading {
+    min-height: 500px;
+    background-color: $admin_background_well;
+    padding: 20px;
+    font-style: italic;
+    color: gray;
+    width: auto;
+  }
 }

--- a/app/views/layouts/_setup_app.html.erb
+++ b/app/views/layouts/_setup_app.html.erb
@@ -13,6 +13,12 @@
   _fpa.state.action_name = _fpa.state.action_name || '<%=action_name%>';
   _fpa.state.template_version = '<%=template_version%>';
   _fpa.state.rails_env = '<%=Rails.env%>';
+  // Indicate whether the current request is being served as an admin page
+  // (admin controller namespace, the redirect-to-admin-panel index, or any
+  // request under /admin/). The front-end uses this to avoid blocking the
+  // page with the main template "loading..." splash guard whilst the
+  // (large, slow) main template loads in the background. See issue #1181.
+  _fpa.state.is_admin_page = <%= (admin_or_user_class == 'admin_page').to_s %>;
   <% if current_user %>
   _fpa.state.app_configs = <%= Admin::AppConfiguration.all_for(current_user).to_json.html_safe %>;
   _fpa.state.current_user_roles = <%= current_user.app_type ? current_user.role_names.to_json.html_safe : [] %>;

--- a/app/views/pages/_index_admin.html.erb
+++ b/app/views/pages/_index_admin.html.erb
@@ -30,6 +30,7 @@
       <div class="col-sm-6">
         <div class="admin-components-lazy-panel"
              data-lazy-url="<%= components_panel_admin_app_types_path %>">
+             <div class="admin-components-lazy-panel__loading">loading...</div>
         </div>
       </div>
       <div class="col-sm-17 col-sm-offset-1">

--- a/spec/javascripts/_fpa_initialize_app_admin_spec.js
+++ b/spec/javascripts/_fpa_initialize_app_admin_spec.js
@@ -1,0 +1,93 @@
+//= require app/_fpa.js
+
+// _fpa.initialize_app Spec - Admin Non-Blocking Template Load (issue #1181)
+//
+// Verifies that when the page is an admin page (indicated by
+// _fpa.state.is_admin_page === true) the main template AJAX fetch does not
+// block the page with the "loading..." splash guard. The admin page should
+// be presented to the user immediately and templates loaded asynchronously
+// in the background.
+//
+// Conversely, when not on an admin page, the splash guard must remain in
+// place until templates are loaded (existing behaviour preserved).
+
+describe('_fpa.initialize_app admin non-blocking template load', function () {
+  var originalState;
+  var ajaxDeferred;
+
+  beforeEach(function () {
+    originalState = _fpa.state;
+    _fpa.state = {
+      caption_before: {},
+      dialog_before: {},
+      template_config: {},
+      template_config_versions: {},
+      controller_name: 'admin',
+      action_name: 'index',
+      template_version: 'v1',
+      rails_env: 'test',
+      current_user: { id: 1, app_type_id: 1 },
+      current_admin: { id: 1 }
+    };
+    _fpa.status = _fpa.status || {};
+    _fpa.status.one_time_setup_run = false;
+    _fpa.status.loaded_templates = false;
+    _fpa.status.html_ready = false;
+    _fpa.status.pending_template_retrieves = 0;
+
+    $('body').removeClass('status-compiling status-compiled initial-compiling status-failed-compilation');
+    $('body').addClass('initial-compiling');
+
+    // Stub helpers that initialize_app calls so the test is hermetic.
+    spyOn(_fpa.loaded, 'preload');
+    spyOn(_fpa, 'handle_remotes');
+    spyOn(_fpa, 'one_time_setup').and.callThrough();
+
+    // Stub the AJAX get used in load_template_version so it does not actually
+    // resolve unless we explicitly resolve the deferred in the test. This lets
+    // us check what happens BEFORE templates have been loaded.
+    ajaxDeferred = $.Deferred();
+    spyOn($, 'get').and.returnValue(ajaxDeferred.promise());
+  });
+
+  afterEach(function () {
+    _fpa.state = originalState;
+    $('body').removeClass('status-compiling status-compiled initial-compiling status-failed-compilation');
+  });
+
+  describe('when is_admin_page is true', function () {
+    beforeEach(function () {
+      _fpa.state.is_admin_page = true;
+    });
+
+    it('marks templates as loaded immediately so the splash guard can be removed without waiting for the AJAX response', function () {
+      _fpa.initialize_app();
+
+      expect(_fpa.status.loaded_templates).toBe(true);
+    });
+
+    it('still initiates the background template load AJAX request', function () {
+      _fpa.initialize_app();
+
+      expect($.get).toHaveBeenCalled();
+    });
+  });
+
+  describe('when is_admin_page is falsy (regular user page)', function () {
+    beforeEach(function () {
+      _fpa.state.is_admin_page = false;
+    });
+
+    it('does NOT mark templates as loaded before the AJAX response completes', function () {
+      _fpa.initialize_app();
+
+      expect(_fpa.status.loaded_templates).toBe(false);
+    });
+
+    it('initiates the template load AJAX request', function () {
+      _fpa.initialize_app();
+
+      expect($.get).toHaveBeenCalled();
+    });
+  });
+});

--- a/spec/system/admin/admin_non_blocking_template_load_spec.rb
+++ b/spec/system/admin/admin_non_blocking_template_load_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression coverage for issue #1181 — when navigating an admin page, the
+# main template should be loaded in the background and the admin UI must not
+# be blocked by the "loading..." splash guard. The Javascript state must
+# expose `_fpa.state.is_admin_page === true` for admin controllers so the
+# front-end can take the non-blocking code path.
+
+describe 'admin pages do not block on main template load', js: true, driver: $browser_driver do
+  include ModelSupport
+  include AdminActionsSetup
+  include FeatureSupport
+
+  before(:all) do
+    SetupHelper.feature_setup
+    ENV['FPHS_ADMIN_SETUP'] = 'yes'
+    Admin.transaction do
+      make_an_admin
+    end
+  end
+
+  it 'exposes _fpa.state.is_admin_page = true and reaches status-compiled on the admin index' do
+    admin_sign_in_with_2fa
+
+    visit '/admin/app_types'
+
+    using_wait_time(30) { expect(page).to have_css('body.status-compiled') }
+
+    is_admin_page = page.evaluate_script('window._fpa && _fpa.state && _fpa.state.is_admin_page === true')
+    expect(is_admin_page).to be true
+  end
+
+  it 'exposes _fpa.state.is_admin_page = true on the admin landing page (pages#index via admin layout)' do
+    admin_sign_in_with_2fa
+
+    # After sign-in, the admin lands on `pages#index` rendered with the
+    # admin_application layout. This is not an `Admin::*` controller, so
+    # detection must rely on the admin-page indicator rather than the
+    # controller namespace alone.
+    visit '/'
+
+    using_wait_time(30) { expect(page).to have_css('body.status-compiled') }
+
+    is_admin_page = page.evaluate_script('window._fpa && _fpa.state && _fpa.state.is_admin_page === true')
+    expect(is_admin_page).to be true
+  end
+end


### PR DESCRIPTION
Fixes #1181

Added non-blocking main template load on admin pages to prevent the splash guard from freezing the UI.
- Identified admin pages via `admin_or_user_class`
- Appended a skeleton loader placeholder to the components panel until rendering finishes.
- Verified test coverage with integration and Javascript unit tests.
