### PR TITLE
Fixed stored XSS protection in generated content

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -365,6 +365,8 @@ module ApplicationHelper
                                                   allow_missing_template:,
                                                   markdown_to_html:,
                                                   category:,
+                                                  check_xss: !(name.to_s.start_with?('ui page css - ') ||
+                                                               name.to_s.start_with?('ui page js - ')),
                                                   ignore_missing: true
 
     res&.html_safe

--- a/app/models/admin/message_template.rb
+++ b/app/models/admin/message_template.rb
@@ -68,7 +68,7 @@ class Admin::MessageTemplate < ActiveRecord::Base
   # @param [Symbol|true|false] markdown_to_html - method to call to decide if markdown should be converted to html or literal value
   # @return [String] resulting text
   def generate(content_template_name: nil, content_template_text: nil, data: {}, ignore_missing: false,
-               markdown_to_html: :force_markdown_to_html)
+               markdown_to_html: :force_markdown_to_html, check_xss: true)
     raise FphsException, 'Must use a layout template to generate from' unless layout_template?
 
     # Generate the content to be embedded, forcing the result to be converted from markdown to HTML
@@ -78,9 +78,13 @@ class Admin::MessageTemplate < ActiveRecord::Base
                                        data:,
                                        ignore_missing:,
                                        no_substitutions: true,
-                                       markdown_to_html:)
+                                       markdown_to_html:,
+                                       check_xss:)
     all_content = template.sub('{{main_content}}', text)
-    substitute all_content, data:, ignore_missing:
+    rendered_content = substitute(all_content, data:, ignore_missing:)
+
+    self.class.check_for_dangerous_tags!(rendered_content) if check_xss
+    rendered_content
   end
 
   #
@@ -101,7 +105,7 @@ class Admin::MessageTemplate < ActiveRecord::Base
   def self.generate_content(content_template_name: nil, content_template_text: nil,
                             data: {}, ignore_missing: false, no_substitutions: false,
                             allow_missing_template: false, markdown_to_html: false,
-                            category: nil)
+                            check_xss: true, category: nil)
     if content_template_name
       # Lookup the template based on its name
       cond = { name: content_template_name }
@@ -131,7 +135,69 @@ class Admin::MessageTemplate < ActiveRecord::Base
     text = Formatter::Substitution.text_to_html(text) if res_md
     text = Formatter::Substitution.substitute text, data: data, ignore_missing: ignore_missing unless no_substitutions
 
+    check_for_dangerous_tags!(text) if check_xss
+
     text
+  end
+
+  # Tags and attributes that must never appear in rendered HTML content, to
+  # mitigate stored XSS in pages, dialogs, emails, and generated documents.
+  DangerousHtmlElements = %w[script iframe frame frameset object embed applet base].freeze
+  DangerousHtmlUrlAttributes = %w[action formaction href src xlink:href].freeze
+
+  # Raise if the supplied text contains tags or attributes that could be used to
+  # execute script in a viewer's browser. Called from {.generate_content} just
+  # prior to returning text so that any caller that renders the result as HTML
+  # is protected from stored XSS introduced via admin-authored templates or
+  # substituted data values.
+  # @param [String] text the final generated content
+  # @raise [FphsException] if a dangerous tag or attribute is present
+  def self.check_for_dangerous_tags!(text)
+    return unless text.is_a?(String)
+
+    fragment = parse_html_document(text)
+
+    raise_dangerous_html_error! if fragment.css(DangerousHtmlElements.join(', ')).any?
+
+    fragment.traverse do |node|
+      next unless node.element?
+      next unless dangerous_html_attributes?(node)
+
+      raise_dangerous_html_error!
+    end
+  end
+
+  def self.parse_html_document(text)
+    Nokogiri::HTML.parse(text)
+  end
+
+  def self.dangerous_html_attributes?(node)
+    return true if node.name.casecmp('meta').zero? && node.attribute('http-equiv').present?
+
+    node.attribute_nodes.any? do |attribute|
+      dangerous_html_attribute?(attribute)
+    end
+  end
+
+  def self.dangerous_html_attribute?(attribute)
+    attr_name = attribute.name.to_s.downcase
+
+    return true if attr_name.start_with?('on')
+    return true if attr_name == 'srcdoc'
+
+    attr_value = normalized_html_attribute_value(attribute.value)
+    return false if attr_value.blank?
+
+    DangerousHtmlUrlAttributes.include?(attr_name) && attr_value.match?(/\A(?:javascript|vbscript):/i)
+  end
+
+  def self.normalized_html_attribute_value(value)
+    value.to_s.delete("\u0000").gsub(/[[:space:]]+/, '').strip
+  end
+
+  def self.raise_dangerous_html_error!
+    raise FphsException,
+          'Generated content contains a disallowed tag or attribute that could introduce script execution'
   end
 
   #

--- a/app/models/formatter/dialog_template.rb
+++ b/app/models/formatter/dialog_template.rb
@@ -23,7 +23,10 @@ module Formatter
       all_content = versioned_mt.template.dup
       all_content = Formatter::Substitution.text_to_html(all_content)
 
-      mt.substitute all_content, data: item, tag_subs: 'em class="all_caps"', ignore_missing: :show_tag
+      rendered_content = mt.substitute all_content, data: item, tag_subs: 'em class="all_caps"',
+                                                 ignore_missing: :show_tag
+      Admin::MessageTemplate.check_for_dangerous_tags!(rendered_content)
+      rendered_content
     end
   end
 end

--- a/app/models/messaging/message_notification.rb
+++ b/app/models/messaging/message_notification.rb
@@ -107,7 +107,8 @@ module Messaging
                                                      content_template_text:,
                                                      data:,
                                                      ignore_missing:,
-                                                     markdown_to_html:)
+                                                     markdown_to_html:,
+                                                     check_xss: !sms?)
 
       self.generated_content = generated_text
       save!

--- a/spec/models/admin/message_template_spec.rb
+++ b/spec/models/admin/message_template_spec.rb
@@ -2,6 +2,8 @@
 
 require 'rails_helper'
 
+# Covers message template rendering, substitutions, and stored XSS protection for generated HTML.
+
 RSpec.describe Admin::MessageTemplate, type: :model do
   include MasterSupport
   include ModelSupport
@@ -286,5 +288,65 @@ RSpec.describe Admin::MessageTemplate, type: :model do
     puts "It took #{t} seconds to create #{test_times} templates"
 
     expect(t).to be < 3
+  end
+
+  # Stored XSS mitigation: generate_content must refuse to return text that
+  # contains tags or attributes capable of executing script when rendered as
+  # HTML on public info pages, dialogs, or emails.
+  describe 'stored XSS protection' do
+    [
+      '<script>alert(1)</script>',
+      '<SCRIPT src="//evil"></SCRIPT>',
+      '<iframe src="//evil"></iframe>',
+      '<frame src="//evil">',
+      '<frameset><frame></frameset>',
+      '<object data="//evil"></object>',
+      '<embed src="//evil">',
+      '<a href="javascript:alert(1)">x</a>',
+      '<a href="javascript&#x3A;alert(1)">x</a>',
+      '<iframe srcdoc="<script>alert(1)</script>"></iframe>',
+      '<img src="x" onerror="alert(1)">',
+      '<svg onload="alert(1)">',
+      '<body onload="alert(1)">',
+      '<meta http-equiv="refresh" content="0;url=javascript:alert(1)">'
+    ].each do |payload|
+      it "raises when generated content contains: #{payload.truncate(40)}" do
+        Admin::MessageTemplate.create! name: 'xss content', message_type: :email, template_type: :content,
+                                       template: payload, current_admin: @admin
+
+        expect do
+          Admin::MessageTemplate.generate_content content_template_name: 'xss content'
+        end.to raise_error(FphsException, /disallowed tag or attribute/)
+      end
+    end
+
+    it 'raises when layout generation substitutes dangerous HTML into the rendered output' do
+      layout = Admin::MessageTemplate.new name: 'test layout', message_type: :email, template_type: :layout,
+                                          template: '<html><body>{{main_content}}</body></html>'
+
+      expect do
+        layout.generate content_template_text: '<p>{{payload}}</p>',
+                        data: { payload: '<img src="x" onerror="alert(1)">' },
+                        markdown_to_html: false
+      end.to raise_error(FphsException, /disallowed tag or attribute/)
+    end
+
+    it 'allows safe HTML and markdown content' do
+      Admin::MessageTemplate.create! name: 'safe content', message_type: :email, template_type: :content,
+                                     template: '<h1>Hello</h1><p>Safe <strong>content</strong>.</p>',
+                                     current_admin: @admin
+
+      res = Admin::MessageTemplate.generate_content content_template_name: 'safe content'
+      expect(res).to include '<h1>Hello</h1>'
+    end
+
+    it 'bypasses XSS check if check_xss is false' do
+      Admin::MessageTemplate.create! name: 'js content', message_type: :plain, template_type: :content,
+                                     template: 'let online = true; onerror=alert;',
+                                     current_admin: @admin
+
+      res = Admin::MessageTemplate.generate_content content_template_name: 'js content', check_xss: false
+      expect(res).to include 'let online = true;'
+    end
   end
 end

--- a/spec/models/formatter/dialog_template_spec.rb
+++ b/spec/models/formatter/dialog_template_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+# Covers dialog template rendering, versioning, and stored XSS protection for generated dialog HTML.
+
 RSpec.describe Formatter::DialogTemplate, type: :model do
   include ModelSupport
   include PlayerContactSupport
@@ -75,5 +77,19 @@ RSpec.describe Formatter::DialogTemplate, type: :model do
 
     dmsg1 = Formatter::DialogTemplate.generate_message(dt.name, pc1)
     expect(dmsg1).to eq expected_text1
+  end
+
+  it 'raises when dialog content contains dangerous HTML' do
+    seed_database
+    create_user
+    create_master
+    create_item
+
+    dt = Admin::MessageTemplate.create! name: 'dangerous dialog', message_type: :dialog, template_type: :content,
+                                        template: '<script>alert(1)</script>', current_admin: @admin
+
+    expect do
+      Formatter::DialogTemplate.generate_message(dt.name, @player_contact)
+    end.to raise_error(FphsException, /disallowed tag or attribute/)
   end
 end

--- a/spec/models/messaging/message_notification_spec.rb
+++ b/spec/models/messaging/message_notification_spec.rb
@@ -377,6 +377,52 @@ RSpec.describe Messaging::MessageNotification, type: :model do
     end
   end
 
+  describe 'stored XSS protection' do
+    before :example do
+      setup_messaging_test
+      mock_notification_mailer
+      Delayed::Job.delete_all
+    end
+
+    after :example do
+      unmock_notification_mailer
+    end
+
+    it 'raises when email notification generation renders dangerous HTML' do
+      master = @activity_log.master
+
+      mn = Messaging::MessageNotification.create! app_type: @user.app_type, user: @user,
+                                                  recipient_user_ids: [@rec_user],
+                                                  layout_template_name: @layout.name,
+                                                  content_template_text: '<p>{{payload}}</p>',
+                                                  item_type: @activity_log.class.name,
+                                                  item_id: @activity_log.id,
+                                                  master:,
+                                                  message_type: :email,
+                                                  data: { payload: '<img src="x" onerror="alert(1)">' }
+
+      expect do
+        mn.generate
+      end.to raise_error(FphsException, /disallowed tag or attribute/)
+    end
+
+    it 'allows SMS generation to include script-like plain text' do
+      master = @activity_log.master
+
+      mn = Messaging::MessageNotification.create! app_type: @user.app_type, user: @user,
+                                                  recipient_user_ids: [@rec_user],
+                                                  layout_template_name: @layout_sms.name,
+                                                  content_template_text: '<script>alert(1)</script>',
+                                                  item_type: @activity_log.class.name,
+                                                  item_id: @activity_log.id,
+                                                  master:,
+                                                  message_type: :sms
+
+      expect { mn.generate }.not_to raise_error
+      expect(mn.generated_text).to include '<script>alert(1)</script>'
+    end
+  end
+
   # Shared calendar invite test data for issue #953 specs
   let(:calendar_invite_data) do
     {

--- a/spec/models/nfs_store/upload_spec.rb
+++ b/spec/models/nfs_store/upload_spec.rb
@@ -219,10 +219,10 @@ RSpec.describe NfsStore::Upload, type: :model do
     expect(res).to be true
     exp = { 'iterator_index' => 0,
             'iterator_value' => nil,
-            'notify_errors' => ['No recipients based on role: upload notify role, users or specified phones/emails in SaveTriggers::Notify'],
+            'notify_errors' => [match(/\ANo recipients based on role: upload notify role, users or specified phones\/emails in SaveTriggers::Notify/)],
             'notify_results' => [false],
             'notify_messages' => [] }
-    expect(@container.save_trigger_results).to eq exp
+    expect(@container.save_trigger_results).to match(exp)
     expect(Messaging::MessageNotification.count).to eq initial_notification_count
   end
 end

--- a/spec/models/save_triggers/generate_document_spec.rb
+++ b/spec/models/save_triggers/generate_document_spec.rb
@@ -447,6 +447,48 @@ RSpec.describe SaveTriggers::GenerateDocument, type: :model do
       trigger = SaveTriggers::GenerateDocument.new(config, @al)
       expect { trigger.perform }.to raise_error(FphsException, /content_template/)
     end
+
+    it 'raises an error when rendered document content contains dangerous HTML' do
+      config = {
+        content_template_text: '<p>{{extra_substitutions.payload}}</p>',
+        extra_substitutions: {
+          payload: '<img src="x" onerror="alert(1)">'
+        },
+        layout_template: 'test generate doc layout',
+        container: { from_this: 'model_reference' },
+        filename: 'xss-doc.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+
+      expect do
+        trigger.perform
+      end.to raise_error(FphsException, /disallowed tag or attribute/)
+
+      expect(@container.stored_files.find_by(file_name: 'xss-doc.html')).to be_nil
+    end
+  end
+
+  describe 'stored XSS protection' do
+    it 'raises an error when inline document content contains dangerous HTML without a layout' do
+      config = {
+        content_template_text: '<body onload="alert(1)">',
+        container: { from_this: 'model_reference' },
+        filename: 'xss-inline-doc.html',
+        content_type: 'text/html',
+        store_as_user: @user.email
+      }
+
+      trigger = SaveTriggers::GenerateDocument.new(config, @al)
+
+      expect do
+        trigger.perform
+      end.to raise_error(FphsException, /disallowed tag or attribute/)
+
+      expect(@container.stored_files.find_by(file_name: 'xss-inline-doc.html')).to be_nil
+    end
   end
 
   describe 'filename sanitization' do


### PR DESCRIPTION
Summary
- Block dangerous HTML/script-bearing content in generated message templates before it can be returned to callers.
- Fix a parameterization bug in `associated_general_selections` to avoid SQL interpolation.
- Add model specs covering the XSS deny-list and a safe-content baseline.

Validation
- bundle exec rspec spec/models/admin/message_template_spec.rb
