### PR TITLE
Fixed SQL injection in AppType#associated_general_selections

### DIFF
--- a/app/models/admin/app_type.rb
+++ b/app/models/admin/app_type.rb
@@ -241,7 +241,7 @@ class Admin
         end
 
       rall = "^(#{rset.join('|')})"
-      Classification::GeneralSelection.active.where("item_type ~ '#{rall}'").order(id: :asc)
+      Classification::GeneralSelection.active.where('item_type ~ ?', rall).order(id: :asc)
     end
 
     def associated_protocols


### PR DESCRIPTION
## Summary

Fixes a potential SQL injection vulnerability in `AppType#associated_general_selections` (A03 - Injection).

## Problem

The `rall` regex string was interpolated directly into the SQL fragment:

```ruby
.where("item_type ~ '#{rall}'")
```

`rall` is constructed from `associated_table_names`, which is admin-controlled configuration. If a table name ever contained a single quote or other SQL metacharacter, this would produce unsafe SQL.

## Fix

Rewrote to use a parameterized query, passing `rall` as a bind parameter:

```ruby
.where('item_type ~ ?', rall)
```

This is functionally equivalent for all valid table names (which only contain `[a-z0-9_]`) while eliminating the injection surface.

## Changes

- `app/models/admin/app_type.rb` — use parameterized query in `associated_general_selections`
