### PR TITLE
Added SSRF guard to pull_external_data save trigger

### DIFF
--- a/app/models/save_triggers/pull_external_data.rb
+++ b/app/models/save_triggers/pull_external_data.rb
@@ -6,6 +6,10 @@ class SaveTriggers::PullExternalData < SaveTriggers::SaveTriggersBase
   BODY_METHODS = %w[put patch lock mkcol propfind proppatch unlock].freeze
   NO_BODY_METHODS = %w[head delete options trace copy move].freeze
 
+  # Re-exposed so existing callers and rescue blocks keep working after the
+  # SSRF guard was extracted into Utilities::UrlSafety.
+  UnsafeUrlError = Utilities::UrlSafety::UnsafeUrlError
+
   def self.config_def(if_extras: {}); end
 
   def initialize(config, item)
@@ -113,7 +117,7 @@ class SaveTriggers::PullExternalData < SaveTriggers::SaveTriggersBase
   end
 
   def post_form
-    uri = URI.parse(url_from_config)
+    uri = safe_uri_parse(url_from_config)
     form = @this_config[:form] || {}
     form = form.deep_transform_values { |v| FieldDefaults.calculate_default @item, v }
     @submitted_request_data = form.deep_stringify_keys
@@ -122,7 +126,7 @@ class SaveTriggers::PullExternalData < SaveTriggers::SaveTriggersBase
   end
 
   def send_body_request(method)
-    uri = URI.parse(url_from_config)
+    uri = safe_uri_parse(url_from_config)
     data = serialize_send_data
 
     request_class = Net::HTTP.const_get(method.capitalize)
@@ -135,7 +139,7 @@ class SaveTriggers::PullExternalData < SaveTriggers::SaveTriggersBase
   end
 
   def send_no_body_request(method)
-    uri = URI.parse(url_from_config)
+    uri = safe_uri_parse(url_from_config)
     request_class = Net::HTTP.const_get(method.capitalize)
     req = request_class.new(uri)
     apply_headers(req)
@@ -240,5 +244,22 @@ class SaveTriggers::PullExternalData < SaveTriggers::SaveTriggersBase
   # @param [Net::HTTPGenericRequest] req
   def apply_headers(req)
     header_config&.each { |k, v| req[k] = v }
+  end
+
+  #
+  # Parse and SSRF-validate the configured URL before opening a connection.
+  # Admin configuration and substitutions from record fields can both influence
+  # url_from_config, so every URL must be checked. Delegates to the reusable
+  # Utilities::UrlSafety validator using pull_external_data-scoped settings.
+  # @param [String] url
+  # @return [URI::Generic]
+  # @raise [UnsafeUrlError]
+  def safe_uri_parse(url)
+    Utilities::UrlSafety.safe_parse(
+      url,
+      allowed_hosts: Settings::PullExternalDataAllowedHosts,
+      allow_private: Settings::PullExternalDataAllowPrivateHosts,
+      context: 'pull_external_data'
+    )
   end
 end

--- a/app/models/utilities/url_safety.rb
+++ b/app/models/utilities/url_safety.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'ipaddr'
+require 'resolv'
+
+module Utilities
+  #
+  # Reusable Server-Side Request Forgery (SSRF) guard for any code path that
+  # follows an admin- or user-configurable URL out to a remote HTTP service.
+  #
+  # The default blocked IP ranges and allowed schemes are defined in
+  # config/initializers/app_default_settings.rb and surfaced via
+  # Settings::BlockedExternalIpRanges and Settings::AllowedExternalUrlSchemes.
+  # Per-caller allowlists (e.g. Settings::PullExternalDataAllowedHosts) can be
+  # passed via the +allowed_hosts+ option.
+  #
+  # Example:
+  #   uri = Utilities::UrlSafety.safe_parse(
+  #     url,
+  #     allowed_hosts: Settings::PullExternalDataAllowedHosts,
+  #     allow_private: Settings::PullExternalDataAllowPrivateHosts,
+  #     context: 'pull_external_data'
+  #   )
+  #
+  class UrlSafety
+    class UnsafeUrlError < FphsException; end
+
+    class << self
+      #
+      # Parse a URL and validate it is safe to request.
+      #
+      # The URL must:
+      # - parse cleanly and use a permitted scheme
+      # - have a host
+      # - resolve (if a hostname) to addresses that are not in the configured
+      #   blocked ranges, unless an explicit allowlist matches the host or
+      #   +allow_private+ is true.
+      #
+      # Hostnames that fail to resolve are permitted to fall through to the
+      # underlying HTTP client (which will fail naturally), since refusing them
+      # here would break legitimate test stubs and intermittent DNS conditions.
+      #
+      # @param [String] url
+      # @param [Array<String>, nil] allowed_hosts host allowlist (exact match,
+      #   case-insensitive). When matched, the private-range check is skipped.
+      # @param [Boolean] allow_private if true, skip the private-range check
+      # @param [String] context label included in error messages, identifying
+      #   the calling subsystem (e.g. 'pull_external_data')
+      # @return [URI::Generic]
+      # @raise [UnsafeUrlError]
+      def safe_parse(url, allowed_hosts: nil, allow_private: false, context: 'external_url')
+        uri = URI.parse(url.to_s)
+
+        unless allowed_schemes.include?(uri.scheme)
+          raise UnsafeUrlError,
+                "#{context} refused URL with unsupported scheme: #{uri.scheme.inspect}"
+        end
+
+        host = uri.host
+        raise UnsafeUrlError, "#{context} refused URL with no host" if host.blank?
+
+        return uri if host_allowlisted?(host, allowed_hosts)
+        return uri if allow_private
+
+        resolve_addresses(host).each do |addr|
+          next unless blocked_address?(addr)
+
+          raise UnsafeUrlError,
+                "#{context} refused URL resolving to blocked address #{addr} (host=#{host})"
+        end
+
+        uri
+      rescue URI::InvalidURIError => e
+        raise UnsafeUrlError, "#{context} refused invalid URL: #{e.message}"
+      end
+
+      #
+      # Check whether an address falls within any of the configured blocked
+      # ranges. IPv4-mapped IPv6 addresses are unmapped before comparison so
+      # attackers cannot bypass IPv4 filters by encoding loopback as
+      # ::ffff:127.0.0.1.
+      # @param [IPAddr] addr
+      # @return [Boolean]
+      def blocked_address?(addr)
+        candidates = [addr]
+        candidates << addr.native if addr.ipv6? && addr.ipv4_mapped?
+        candidates.any? { |c| blocked_ip_ranges.any? { |r| r.include?(c) } }
+      end
+
+      private
+
+      def allowed_schemes
+        Settings::AllowedExternalUrlSchemes
+      end
+
+      def blocked_ip_ranges
+        Settings::BlockedExternalIpRanges
+      end
+
+      def host_allowlisted?(host, allowed_hosts)
+        return false if allowed_hosts.blank?
+
+        Array(allowed_hosts).any? { |h| h.to_s.downcase == host.downcase }
+      end
+
+      #
+      # Resolve a host (which may itself be an IP literal) to the set of
+      # addresses that a subsequent connect would reach. DNS failures are
+      # treated as "no resolved addresses".
+      # @param [String] host
+      # @return [Array<IPAddr>]
+      def resolve_addresses(host)
+        bare = host.delete_prefix('[').delete_suffix(']')
+        return [IPAddr.new(bare)] if ip_literal?(bare)
+
+        Resolv.getaddresses(host).filter_map do |a|
+          IPAddr.new(a)
+        rescue IPAddr::InvalidAddressError
+          nil
+        end
+      rescue Resolv::ResolvError, IPAddr::InvalidAddressError
+        []
+      end
+
+      def ip_literal?(str)
+        IPAddr.new(str)
+        true
+      rescue IPAddr::InvalidAddressError
+        false
+      end
+    end
+  end
+end

--- a/config/initializers/app_settings.rb
+++ b/config/initializers/app_settings.rb
@@ -253,6 +253,41 @@ class Settings
   # existing expectations around class names being broken
   CaptionAcronyms = DefaultSettings::CaptionAcronyms
 
+  # SSRF guard for admin-configurable outbound HTTP requests (Utilities::UrlSafety).
+  # AllowedExternalUrlSchemes and BlockedExternalIpRanges back the default
+  # validation rules; per-trigger settings tune the allowlist.
+  # SSRF guard defaults applied to admin-configurable outbound URLs
+  # (see Utilities::UrlSafety).
+  AllowedExternalUrlSchemes = %w[http https].freeze
+  BlockedExternalIpRanges = [
+    IPAddr.new('0.0.0.0/8'),         # "this network"
+    IPAddr.new('10.0.0.0/8'),        # RFC1918
+    IPAddr.new('100.64.0.0/10'),     # CGNAT
+    IPAddr.new('127.0.0.0/8'),       # loopback
+    IPAddr.new('169.254.0.0/16'),    # link-local (incl. cloud metadata 169.254.169.254)
+    IPAddr.new('172.16.0.0/12'),     # RFC1918
+    IPAddr.new('192.0.0.0/24'),      # IETF protocol assignments
+    IPAddr.new('192.168.0.0/16'),    # RFC1918
+    IPAddr.new('198.18.0.0/15'),     # benchmarking
+    IPAddr.new('::1/128'),           # IPv6 loopback
+    IPAddr.new('fc00::/7'),          # IPv6 unique-local
+    IPAddr.new('fe80::/10'),         # IPv6 link-local
+    IPAddr.new('::ffff:0:0/96')      # IPv4-mapped IPv6 (further checked after unmapping)
+  ].freeze
+
+  # Optional host allowlist for the pull_external_data save trigger. When set,
+  # listed hosts (exact, case-insensitive match) bypass the private-range block.
+  # Configure via FPHS_PULL_EXTERNAL_DATA_ALLOWED_HOSTS as a space-separated list.
+  PullExternalDataAllowedHosts = ENV['FPHS_PULL_EXTERNAL_DATA_ALLOWED_HOSTS'].to_s.split(/\s+/).reject(&:empty?).freeze
+  # Global override permitting pull_external_data to reach private/loopback
+  # addresses. Defaults true only in development for convenience.
+  PullExternalDataAllowPrivateHosts =
+    if ENV.key?('FPHS_PULL_EXTERNAL_DATA_ALLOW_PRIVATE_HOSTS')
+      ENV['FPHS_PULL_EXTERNAL_DATA_ALLOW_PRIVATE_HOSTS'] == 'true'
+    else
+      Rails.env.development?
+    end
+
   # Prevent versioning of dynamic definitions
   DisableVDef = ENV.key?('FPHS_DISABLE_VDEF') ? ENV['FPHS_DISABLE_VDEF'] == 'true' : Rails.env.development?
 

--- a/spec/models/save_triggers/pull_external_data_spec.rb
+++ b/spec/models/save_triggers/pull_external_data_spec.rb
@@ -637,6 +637,81 @@ RSpec.describe SaveTriggers::PullExternalData, type: :model do
     end
   end
 
+  # Tests for SSRF guard against admin-configurable URLs (OWASP A10).
+  # Admins (or substituted record fields) must not be able to drive the
+  # pull_external_data save trigger to reach loopback / RFC1918 / link-local
+  # addresses, including cloud instance metadata (169.254.169.254).
+  context 'SSRF guard on configured url' do
+    let(:trigger_for_url) do
+      lambda do |url|
+        config = {
+          this1: {
+            data_field: 'notes',
+            method: 'get',
+            from: { url:, format: 'json' }
+          }
+        }
+        SaveTriggers::PullExternalData.new(config, @al)
+      end
+    end
+
+    it 'rejects loopback IPv4 literal' do
+      expect { trigger_for_url.call('http://127.0.0.1/admin').perform }
+        .to raise_error(SaveTriggers::PullExternalData::UnsafeUrlError, /blocked address/)
+    end
+
+    it 'rejects cloud instance metadata link-local address' do
+      expect { trigger_for_url.call('http://169.254.169.254/latest/meta-data/').perform }
+        .to raise_error(SaveTriggers::PullExternalData::UnsafeUrlError, /blocked address/)
+    end
+
+    it 'rejects RFC1918 private addresses' do
+      %w[http://10.0.0.5/x http://192.168.1.1/x http://172.16.0.1/x].each do |u|
+        expect { trigger_for_url.call(u).perform }
+          .to raise_error(SaveTriggers::PullExternalData::UnsafeUrlError, /blocked address/)
+      end
+    end
+
+    it 'rejects IPv6 loopback' do
+      expect { trigger_for_url.call('http://[::1]/x').perform }
+        .to raise_error(SaveTriggers::PullExternalData::UnsafeUrlError, /blocked address/)
+    end
+
+    it 'rejects IPv4-mapped IPv6 loopback (filter bypass)' do
+      expect { trigger_for_url.call('http://[::ffff:127.0.0.1]/x').perform }
+        .to raise_error(SaveTriggers::PullExternalData::UnsafeUrlError, /blocked address/)
+    end
+
+    it 'rejects unsupported schemes' do
+      expect { trigger_for_url.call('file:///etc/passwd').perform }
+        .to raise_error(SaveTriggers::PullExternalData::UnsafeUrlError, /unsupported scheme/)
+      expect { trigger_for_url.call('gopher://127.0.0.1:11211/').perform }
+        .to raise_error(SaveTriggers::PullExternalData::UnsafeUrlError, /unsupported scheme/)
+    end
+
+    it 'rejects hostnames that resolve to blocked addresses' do
+      trigger = trigger_for_url.call('http://internal.example.invalid/x')
+      allow(Resolv).to receive(:getaddresses).with('internal.example.invalid').and_return(['10.0.0.5'])
+      expect { trigger.perform }
+        .to raise_error(SaveTriggers::PullExternalData::UnsafeUrlError, /blocked address/)
+    end
+
+    it 'permits public hostnames (request reaches the HTTP client)' do
+      trigger = trigger_for_url.call('http://public.example.invalid/x')
+      allow(Resolv).to receive(:getaddresses).with('public.example.invalid').and_return(['93.184.216.34'])
+      stub_request(:get, 'http://public.example.invalid/x').to_return(status: 200, body: '{}')
+      expect { trigger.perform }.not_to raise_error
+    end
+
+    it 'honors the explicit allowlist for an otherwise blocked host' do
+      stub_const('Settings::PullExternalDataAllowedHosts', ['internal.dev.local'])
+      trigger = trigger_for_url.call('http://internal.dev.local/x')
+      allow(Resolv).to receive(:getaddresses).with('internal.dev.local').and_return(['10.0.0.5'])
+      stub_request(:get, 'http://internal.dev.local/x').to_return(status: 200, body: '{}')
+      expect { trigger.perform }.not_to raise_error
+    end
+  end
+
   # Tests for submitted request data saved to save_trigger_results (issue #950)
   context 'with submitted_request saved to save_trigger_results' do
     it 'saves submitted request data, url, and method for a POST with send_data' do


### PR DESCRIPTION
### Summary
Added SSRF (Server-Side Request Forgery) protection to the `pull_external_data` save trigger.

### Changes
- Created `Utilities::UrlSafety` to validate external URLs against prohibited private, loopback, and link-local IP blocks.
- Added `AllowedExternalUrlSchemes` and `BlockedExternalIpRanges` to global configurations in `app_settings.rb`.
- Updated `pull_external_data` save trigger to delegate URL parsing to the safety wrapper.
- Included comprehensive RSpec coverage for valid URL resolutions and blocked configurations (including IPv4-mapped IPv6 evaluation).
