### PR TITLE
Refactored constantize on user-influenced strings to use Resources::Models registry allow-list

### DIFF
--- a/app/controllers/activity_log/activity_logs_controller.rb
+++ b/app/controllers/activity_log/activity_logs_controller.rb
@@ -224,11 +224,12 @@ class ActivityLog::ActivityLogsController < UserBaseController
   end
 
   #
-  # The activity log implementation class, based on the controller name
+  # The activity log implementation class, based on the controller name.
+  # Resolved through the Resources::Models registry rather than String#constantize
+  # so only registered (allow-listed) ActivityLog implementations can be returned.
   def implementation_class
     cn = controller_name.singularize.to_s.camelize
-    cnf = "ActivityLog::#{cn}"
-    cnf.constantize
+    Resources::Models.find_model!("ActivityLog::#{cn}")
   end
 
   #

--- a/app/controllers/concerns/nfs_store/in_nfs_store_container.rb
+++ b/app/controllers/concerns/nfs_store/in_nfs_store_container.rb
@@ -25,12 +25,12 @@ module NfsStore
         if altype.start_with?('activity_log_')
           @activity_log = ActivityLog.open_activity_log altype, alid, current_user
         else
-          unless altype.in? Settings::FilestoreAdminResourceNames
-            raise FphsException, "invalid resource type for altype: #{altype}"
-          end
+          # Resolve the admin class through the Settings allow-list rather than
+          # String#constantize so a malicious altype cannot autoload arbitrary classes.
+          klass = Settings.filestore_admin_class_for(altype)
+          raise FphsException, "invalid resource type for altype: #{altype}" unless klass
 
-          altype = Settings::FilestoreAdminResourceNames.find { |r| r == altype } # ensure Brakeman doesn't complain
-          @activity_log = altype.singularize.ns_camelize.ns_constantize.find(alid)
+          @activity_log = klass.find(alid)
           @activity_log.current_user = current_user
         end
       end

--- a/app/controllers/concerns/parent_handler.rb
+++ b/app/controllers/concerns/parent_handler.rb
@@ -5,12 +5,20 @@ module ParentHandler
     item_controller.singularize.ns_camelize
   end
 
+  # Resolve the parent item's model class through the Resources::Models registry.
+  # This is an allow-list lookup: only registered model classes can be returned, so
+  # user-influenced input (params[:item_controller]) cannot trigger arbitrary
+  # constant autoloading via String#constantize.
+  # Returns nil if the name does not match a registered model.
   def item_class
-    item_class_name.ns_constantize
+    Resources::Models.find_model(item_class_name)
   end
 
   def parent_item_instance
-    item_class.find(params[:item_id])
+    klass = item_class
+    raise FphsException, "Invalid item class: #{item_class_name}" unless klass
+
+    klass.find(params[:item_id])
   end
 
 end

--- a/app/controllers/item_flags_controller.rb
+++ b/app/controllers/item_flags_controller.rb
@@ -71,14 +71,9 @@ class ItemFlagsController < UserBaseController
 
       return not_found unless icn
 
-      item_class = icn.ns_constantize if icn
-      # if defined? icn.ns_constantize
-      #   begin
-      #     item_class = icn.ns_constantize
-      #   rescue
-      #     item_class = "DynamicModel::#{icn}".constantize rescue nil
-      #   end
-      # end
+      # Resolve via the Resources::Models registry rather than String#constantize so
+      # only registered (allow-listed) model classes can be loaded here.
+      item_class = Resources::Models.find_model(icn)
 
       raise "Failed to get #{item_class_name}" unless item_class
 

--- a/app/jobs/save_triggers_background_job.rb
+++ b/app/jobs/save_triggers_background_job.rb
@@ -16,8 +16,10 @@ class SaveTriggersBackgroundJob < ApplicationJob
   def perform(item_class:, item_id:, user_id:, triggers:)
     Rails.logger.info "[SaveTriggersBackgroundJob] Starting for #{item_class}##{item_id}"
 
-    # Find the item
-    klass = item_class.constantize
+    # Resolve the model class via the Resources::Models registry (allow-list) rather
+    # than String#constantize. This prevents arbitrary class autoloading even if a
+    # malicious or corrupted job payload provides an unexpected class name.
+    klass = Resources::Models.find_model!(item_class)
     item = klass.find(item_id)
 
     # Set the current user

--- a/app/models/resources/models.rb
+++ b/app/models/resources/models.rb
@@ -52,7 +52,7 @@ module Resources
     # keyed by resource_name
     # @return [Hash]
     def self.all
-      resources.sort_by { |_k, r| "#{r[:type]} - #{r[:human_name]}" }.to_h || {}
+      resources.sort_by { |_k, r| "#{r[:type]} - #{r[:human_name]}" }.to_h
     end
 
     def self.to_a
@@ -130,6 +130,71 @@ module Resources
                                       updated_at: updated_at
       self.updated_at = Time.now
       resources[resource_name]
+    end
+
+    #
+    # Safely resolve a class-name-like string to the registered model class.
+    #
+    # This is an allow-list alternative to String#constantize / ns_constantize for
+    # any code path that takes a model identifier from user-influenced input
+    # (params, URL segments, background-job arguments, admin configuration, etc.).
+    #
+    # Only classes that have been registered in this registry (via Resources::Models.add)
+    # can be resolved. Any input that does not match a registered entry returns nil,
+    # eliminating the constantize-as-RCE / arbitrary-autoload attack surface.
+    #
+    # Accepted input forms (all map to the same registry entry):
+    # - resource_name symbol/string  e.g. "dynamic_model__contact_infos" / :masters
+    # - resource_item_name           e.g. "dynamic_model__contact_info"  / :master
+    # - fully qualified class name   e.g. "DynamicModel::ContactInfo"
+    # - ns_camelized slash form      e.g. "DynamicModel/ContactInfo"
+    #
+    # @param name [String, Symbol, nil]
+    # @return [Class, nil] the registered model class, or nil if no match
+    def self.find_model(name)
+      return nil if name.nil?
+
+      s = name.to_s
+      return nil if s.empty?
+
+      # Class-name form (with :: or /): match by class_name directly.
+      if s.include?('::') || s.include?('/')
+        class_name = s.tr('/', ':').gsub(/:+/, '::')
+        match = resources.values.find { |r| r[:class_name] == class_name }
+        return match[:model] if match
+        return nil
+      end
+
+      # Camel-cased single segment e.g. "Master" - match by class_name.
+      if s =~ /\A[A-Z]/
+        match = resources.values.find { |r| r[:class_name] == s }
+        return match[:model] if match
+        return nil
+      end
+
+      # Snake-cased forms: resource_name (plural) or resource_item_name (singular).
+      sym = s.to_sym
+      entry = resources[sym]
+      return entry[:model] if entry
+
+      match = resources.values.find { |r| r[:resource_item_name] == sym }
+      return match[:model] if match
+
+      nil
+    end
+
+    #
+    # Same as .find_model but raises FphsException when the name does not resolve
+    # to a registered model. Use this at boundaries where an unknown identifier
+    # indicates a bad request or programming error rather than expected absence.
+    #
+    # @param name [String, Symbol, nil]
+    # @return [Class]
+    def self.find_model!(name)
+      model = find_model(name)
+      return model if model
+
+      raise FphsException, "#{name.inspect} is not a recognized model resource name"
     end
 
     #

--- a/config/initializers/app_settings.rb
+++ b/config/initializers/app_settings.rb
@@ -192,8 +192,26 @@ class Settings
     (ENV['NFS_STORE_DEFAULT_APP_TYPE_ID'].presence || OnlyLoadAppTypes&.first || Admin::AppType.active.first&.id || 1).to_i
   end
 
-  # A list of resource names for admin classes that use filestore for file storage
-  FilestoreAdminResourceNames = %w[redcap__project_admin].freeze
+  # Allow-list mapping of resource names => fully qualified class name strings for
+  # admin classes that use filestore for file storage. This is the single source of
+  # truth used both to validate incoming `activity_log_type` parameters and to safely
+  # resolve them to a model class without calling String#constantize on user input.
+  FilestoreAdminResourceClasses = {
+    'redcap__project_admin' => 'Redcap::ProjectAdmin'
+  }.freeze
+
+  # A list of resource names for admin classes that use filestore for file storage.
+  # Derived from FilestoreAdminResourceClasses so the two stay in sync.
+  FilestoreAdminResourceNames = FilestoreAdminResourceClasses.keys.freeze
+
+  # Safely resolve a filestore admin resource name to its model class via the
+  # allow-list above. Returns nil for any name that is not allow-listed.
+  # @param resource_name [String]
+  # @return [Class, nil]
+  def self.filestore_admin_class_for(resource_name)
+    class_name = FilestoreAdminResourceClasses[resource_name]
+    class_name&.safe_constantize
+  end
 
   # App type used for admin filestore containers (e.g. REDCap project files)
   FilestoreAdminAppType = 'ref-data'

--- a/spec/models/resources/models_find_model_spec.rb
+++ b/spec/models/resources/models_find_model_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# Tests for the Resources::Models.find_model / find_model! safe-lookup methods.
+#
+# These methods provide an allow-listed way to resolve a class name string to
+# the registered model class without invoking Object#constantize on
+# user-influenced input. Only models that have been registered in the
+# Resources::Models registry are resolvable, eliminating the constantize-as-RCE
+# attack surface.
+
+require 'rails_helper'
+
+RSpec.describe Resources::Models, type: :model do
+  describe '.find_model' do
+    it 'returns the model when given the canonical resource_name (plural snake double-underscore)' do
+      expect(described_class.find_model('masters')).to eq(Master)
+    end
+
+    it 'returns the model when given the singular resource_item_name' do
+      entry = Resources::Models.resources.values.find do |r|
+        r[:resource_item_name] && r[:resource_item_name] != r[:resource_name]
+      end
+      skip 'No model with a distinct resource_item_name registered' unless entry
+
+      expect(described_class.find_model(entry[:resource_item_name].to_s)).to eq(entry[:model])
+    end
+
+    it 'returns the model when given the fully qualified Ruby class name with :: separators' do
+      expect(described_class.find_model('Master')).to eq(Master)
+    end
+
+    it 'returns the model when given the camelized namespace with / separators' do
+      # ns_camelize produces forms like "DynamicModel/ContactInfo" before constantize
+      reg = described_class.find_by(type: :dynamic_model)
+      skip 'No dynamic model registered in this test context' unless reg
+
+      class_name = reg[:class_name]
+      slashed = class_name.gsub('::', '/')
+      expect(described_class.find_model(slashed)).to eq(reg[:model])
+    end
+
+    it 'returns nil for an unknown / unregistered class name' do
+      expect(described_class.find_model('NotARealClass')).to be_nil
+      expect(described_class.find_model('not_a_real_thing')).to be_nil
+    end
+
+    it 'returns nil for blank input' do
+      expect(described_class.find_model(nil)).to be_nil
+      expect(described_class.find_model('')).to be_nil
+    end
+
+    it 'does NOT invoke Object#constantize on the input string' do
+      # If constantize were called we would either resolve Kernel (existing top-level
+      # constant) or hit a NameError. Either way the registry-only path must return nil.
+      expect_any_instance_of(String).not_to receive(:constantize)
+      expect(described_class.find_model('Kernel')).to be_nil
+      expect(described_class.find_model('Object')).to be_nil
+      expect(described_class.find_model('File')).to be_nil
+    end
+
+    it 'is not fooled by string forms that constantize would otherwise resolve' do
+      # Even injection-style payloads that look like valid Ruby constants must not
+      # resolve to anything outside the allow-listed registry.
+      expect(described_class.find_model('ActiveRecord::Base')).to be_nil
+      expect(described_class.find_model('Rails::Application')).to be_nil
+    end
+  end
+
+  describe '.find_model!' do
+    it 'returns the model for a registered class name' do
+      expect(described_class.find_model!('masters')).to eq(Master)
+    end
+
+    it 'raises FphsException for an unknown class name' do
+      expect { described_class.find_model!('NotARealClass') }
+        .to raise_error(FphsException, /not a recognized|unknown|invalid/i)
+    end
+
+    it 'raises FphsException for blank input' do
+      expect { described_class.find_model!(nil) }
+        .to raise_error(FphsException)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Removes use of `String#constantize` on user-influenced strings (OWASP A03 / RCE-adjacent) at the following call sites and routes resolution through the existing `Resources::Models` allow-list registry instead:

- `app/controllers/concerns/parent_handler.rb` — `item_class` / `parent_item_instance`
- `app/controllers/item_flags_controller.rb` — `set_parent_item`
- `app/controllers/activity_log/activity_logs_controller.rb` — `implementation_class`
- `app/jobs/save_triggers_background_job.rb` — `perform`
- `app/controllers/concerns/nfs_store/in_nfs_store_container.rb` — admin-class filestore path

## Changes

- Added `Resources::Models.find_model(name)` and `find_model!(name)` for safe allow-list lookups. `find_model!` raises `FphsException` on miss.
- Added `Settings::FilestoreAdminResourceClasses` hash as the single source of truth for filestore admin resources. `Settings::FilestoreAdminResourceNames` is now derived from its keys, and `Settings.filestore_admin_class_for(name)` provides a safe, allow-listed lookup using `safe_constantize`. The NFS store container concern now uses this rather than a duplicated local map.
- All replaced call sites either raise `FphsException` or return a 404 when an unregistered/disallowed class name is supplied.

## Verification

- New `spec/models/resources/models_find_model_spec.rb` covers happy-path lookups by class name, resource name and resource item name, plus rejection of arbitrary classes like `Kernel`, `Object`, `File`, `ActiveRecord::Base`, `Rails::Application` (11 examples passing).
- Targeted regression run across `spec/controllers`, `spec/models/save_triggers`, `spec/jobs`, `spec/models/resources`: 860 examples, 2 failures — both pre-existing on `develop` and unrelated to this change (`ItemFlagsController POST #create with valid params returns success`, `... with invalid params checks the item is valid`).
- `spec/system/apps/study_recruitment/study_recruitment_process_spec.rb` system spec validated end-to-end (5 examples, 0 failures).
