### PR TITLE
Fixed contains.resources panel HTML IDs and data-panel-tab for single-resource panels - fixes #1200

### DIFF
--- a/app/assets/javascripts/app/_fpa_form_utils.js
+++ b/app/assets/javascripts/app/_fpa_form_utils.js
@@ -1144,6 +1144,14 @@ _fpa.form_utils = {
           if ($pos.length) $target = $pos;
         }
 
+        // Fallback: if no direct id match was found, look for an element carrying
+        // a data-alt-click-id alias (used by contains.resources panels to maintain
+        // backwards-compat with pre-PR-#1182 resource-based tab ids).
+        if (!$target.length && target[0] === '#') {
+          const altId = target.replace('#', '');
+          $target = $(`[data-alt-click-id="${altId}"]`);
+        }
+
         if (last) $target = $target.last();
 
         $target.click();

--- a/app/assets/javascripts/app/activity_logs/save_action.js
+++ b/app/assets/javascripts/app/activity_logs/save_action.js
@@ -84,15 +84,32 @@ _fpa.activity_logs.save_action = class {
     var res = $(sel).not('[disabled]').first().click();
   }
 
+  // Find the nav tab anchor for the given panel value within this master panel.
+  // Primary lookup uses data-panel-tab:
+  //   - Single-resource contains.resources panels: data-panel-tab = resource name
+  //     (e.g. 'activity_log__play_ipa_assignments'), consistent with standard AL tabs.
+  //   - Multi-resource contains.resources panels: data-panel-tab = panel_name
+  //     (e.g. 'play-ipa-tracker').
+  // Fallback uses data-alt-click-id to support legacy panel_name-based save_action configs
+  // and old click-target links that reference the resource-hyphenated tab id.
+  find_panel_tab() {
+    var master_scope = '.master-panel[data-master-id="' + this.master_id + '"] ';
+    var tab = $(master_scope + 'a[data-panel-tab="' + this.action_value + '"]');
+    if (!tab.length) {
+      tab = $(master_scope + 'a[data-alt-click-id="tab-' + this.action_value.replace(/__/g, '--').replace(/_/g, '-') + '"]');
+    }
+    return tab;
+  }
+
   show_panel() {
-    var tab = $('.master-panel[data-master-id="' + this.master_id + '"] a[data-panel-tab="' + this.action_value + '"]').click();
+    var tab = this.find_panel_tab().click();
     window.setTimeout(function () {
       $(tab.attr('data-target')).collapse('show');
     }, 500);
   }
 
   hide_panel() {
-    var tab2 = $('.master-panel[data-master-id="' + this.master_id + '"] a[data-panel-tab="' + this.action_value + '"]');
+    var tab2 = this.find_panel_tab();
     window.setTimeout(function () {
       $(tab2.attr('data-target')).collapse('hide');
     }, 500);
@@ -100,7 +117,7 @@ _fpa.activity_logs.save_action = class {
 
 
   refresh_panel() {
-    var tab3 = $('.master-panel[data-master-id="' + this.master_id + '"] a[data-panel-tab="' + this.action_value + '"]');
+    var tab3 = this.find_panel_tab();
     var exp = tab3.attr('aria-expanded') == 'true';
     tab3.click();
 

--- a/app/views/masters/_search_results_master_tabs_resources.html.erb
+++ b/app/views/masters/_search_results_master_tabs_resources.html.erb
@@ -30,10 +30,30 @@
     open_panel_key = panel_name
 
     extra_classes = "#{close_others ? 'tabs-close-others' : ''} #{initial_show == true ? 'on-open-click initial-show' : ''}"
+
+    # For single-resource panels, use the resource name as data-panel-tab so that
+    # spec selectors and save_action configs (which reference resource names) can find
+    # the tab directly — consistent with how standard activity log tabs work.
+    # Multi-resource panels have no single resource name, so they continue to use
+    # the panel_name.
+    panel_tab_value = renderable_resources.length == 1 ? renderable_resources.first.to_s : panel_name
+
+    # For single-resource panels, provide a data-alt-click-id alias using the hyphenated
+    # resource name so that persistent click-target links formed before PR #1182
+    # (e.g. click-target-#tab-activity-log--case-reviews) continue to resolve via the
+    # JS fallback in setup_data_toggles. Multi-resource panels have no legacy id to alias.
+    alt_click_id = renderable_resources.length == 1 ? "tab-#{renderable_resources.first.to_s.hyphenate}" : nil
   %>
   {{#if (or (not (params 'only_tabs')) (params 'only_tabs' '<%= panel_name %>')) }}
   <li role="presentation" class="<%= extra_classes %> <%= class_for_open_panels(open_panel_key, default_panels.length) %>" data-open-panels="{{open_panels}}">
-    <a id="tab-resources-<%= panel_name %>" href="#<%= panel_name %>-{{id}}" data-panel-tab="<%= panel_name %>" data-toggle="collapse" data-target="#<%= panel_name %>-{{id}}" aria-expanded="false" class="scroll-to-expanded collapsed"><%= panel_label %></a>
+    <a id="tab-resources-<%= panel_name.id_hyphenate %>"
+       href="#<%= panel_name.id_hyphenate %>-{{id}}"
+       data-panel-tab="<%= panel_tab_value %>"
+       data-toggle="collapse"
+       data-target="#<%= panel_name.id_hyphenate %>-{{id}}"
+       aria-expanded="false"
+       class="scroll-to-expanded collapsed"<% if alt_click_id %>
+       data-alt-click-id="<%= alt_click_id %>"<% end %>><%= panel_label %></a>
   </li>
   {{/if}}
 <% end %>

--- a/app/views/masters/_search_results_resources_panel.html.erb
+++ b/app/views/masters/_search_results_resources_panel.html.erb
@@ -34,13 +34,13 @@
   end
 %>
 <% if renderable.any? %>
-  <% outer = "##{panel_name}-{{id}}" %>
+  <% outer = "##{panel_name.id_hyphenate}-{{id}}" %>
   <%= render partial: 'reports/insert_options_css', locals: { outer: outer, view_css: view_css } %>
-  <div id="<%= panel_name %>-{{id}}"
-       class="panel panel-default section-panel page-layout-panel contains-resources collapse <%= panel_name %>-block format-block-on-expand <%= hide_sl_class %> <%= hide_al_header_class %>">
+  <div id="<%= panel_name.id_hyphenate %>-{{id}}"
+       class="panel panel-default section-panel page-layout-panel contains-resources collapse <%= panel_name.id_hyphenate %>-block format-block-on-expand <%= hide_sl_class %> <%= hide_al_header_class %>">
     <div class="is-header default-header section-panel-header">
       <% unless hide_player_tabs? %>
-        <a href="#<%= panel_name %>-{{id}}" data-toggle="collapse" class="dropup scroll-to-master pull-right glyphicon glyphicon-remove-sign show-entity btn-close-panel" title="close panel"></a>
+        <a href="#<%= panel_name.id_hyphenate %>-{{id}}" data-toggle="collapse" class="dropup scroll-to-master pull-right glyphicon glyphicon-remove-sign show-entity btn-close-panel" title="close panel"></a>
       <% end %>
       <h4 class="list-group-item-heading panel-heading--<%= panel_label.to_s.id_hyphenate %>"><%= panel_label %></h4>
     </div>
@@ -59,7 +59,7 @@
            data-remote="true"
            data-result-target="#<%= block_id %>"
            data-template="<%= template_name %>"
-           data-panel-tab="<%= resource %>"
+           data-resource-name="<%= resource %>"
            class="contains-resources-loader contains-resources-loader--<%= resource.hyphenate %>"
            aria-hidden="true"
            tabindex="-1">load <%= resource %></a>

--- a/docs/admin_reference/page_layouts/master_panels.md
+++ b/docs/admin_reference/page_layouts/master_panels.md
@@ -91,3 +91,19 @@ These view options are used by standalone page layouts:
                                           # (crosswalk or external id) 
                                           # to search for the master record
                                           # with for standalone pages
+
+## Linking to Expand Tabs
+
+You can create HTML links within your configuration (such as in `caption_before` texts) that automatically expand specific panels when clicked. This is useful for guiding users to the next steps in a workflow within the same master record.
+
+To do this, use a URL hash formatted with `#click-target-[tab-id]`.
+
+- **For standard Activity Log tabs:**
+  Use `#click-target-tab-activity-log--[item-type]` where the item type is singular.
+  *(Example: `[Open Data Requests](#click-target-tab-activity-log--data-request)`)*
+
+- **For configured `contains.resources` panels (including multi-resource panels):**
+  Use `#click-target-tab-resources-[panel-name]` where the panel name is hyphenated with spaces replaced by hyphens.
+  *(Example: for a panel named "My Custom Panel", use `[Open Custom Panel](#click-target-tab-resources-my-custom-panel)`)*
+  
+*Note: For `contains.resources` panels containing only a single resource, the older `#click-target-tab-[resource-name-hyphenated]` format acts as an alias (e.g. `#click-target-tab-activity-log--case-reviews`), but the `tab-resources-[panel-name]` format is preferred.*

--- a/spec/system/activity_log/versioned_phone_log_templates_spec.rb
+++ b/spec/system/activity_log/versioned_phone_log_templates_spec.rb
@@ -38,10 +38,26 @@ describe 'Versioned phone log templates', driver: $browser_driver do
 
   def search_for_player(player)
     click_link 'Research'
+    finish_page_loading
+    finish_form_formatting
+
     within '#master-search-simple-form' do
       fill_in 'Last name', with: player.last_name
       fill_in 'First or nick name', with: player.first_name
-      click_button 'search'
+      finish_page_loading
+      finish_form_formatting
+
+      search_button = find_button('search', wait: 5)
+      scroll_into_view(search_button)
+      begin
+        search_button.click
+      rescue Selenium::WebDriver::Error::ElementClickInterceptedError
+        finish_page_loading
+        finish_form_formatting
+        search_button = find_button('search', wait: 5)
+        scroll_into_view(search_button)
+        search_button.click
+      end
     end
 
     dismiss_modal

--- a/spec/views/masters/_search_results_master_tabs_resources_spec.rb
+++ b/spec/views/masters/_search_results_master_tabs_resources_spec.rb
@@ -11,6 +11,11 @@ require 'rails_helper'
 # `data-template` attributes live on inner blocks rendered by the sibling
 # `_search_results_resources_panel` partial, not on the tab.
 #
+# data-panel-tab contract (consistent with standard activity-log tabs):
+#   - Single-resource panels: data-panel-tab = resource name (e.g. 'activity_log__case_reviews')
+#     so that spec selectors and save_action configs referencing resource names find the tab.
+#   - Multi-resource panels: data-panel-tab = panel_name (no single resource name to use).
+#
 # Regression: single-resource panels (e.g. one activity log) continue to render
 # exactly one tab with the same panel_label visible to the user.
 
@@ -77,8 +82,9 @@ RSpec.describe 'masters/_search_results_master_tabs_resources', type: :view do
       expect(rendered.scan(/<li\b/).length).to eq(1)
     end
 
-    it "uses the panel_name as the tab's data-panel-tab attribute" do
-      expect(rendered).to include('data-panel-tab="test-panel"')
+    it "uses the resource name as the tab's data-panel-tab attribute (single-resource panel)" do
+      expect(rendered).to include('data-panel-tab="dynamic_model__contact_infos"')
+      expect(rendered).not_to include('data-panel-tab="test-panel"')
     end
 
     it "uses the panel_name as the tab's collapse target" do
@@ -160,6 +166,81 @@ RSpec.describe 'masters/_search_results_master_tabs_resources', type: :view do
     it 'renders no tab markup' do
       expect(rendered).not_to include('<li')
       expect(rendered).not_to include('<a ')
+    end
+  end
+
+  # --- Panel name with spaces (regression: panel IDs must be valid CSS) ---
+
+  context 'with a panel_name that contains spaces (e.g. "phone log")' do
+    before do
+      render partial: 'masters/search_results_master_tabs_resources',
+             locals: base_locals.merge(
+               panel_name: 'phone log',
+               panel_label: 'Phone Log',
+               resources: ['activity_log__case_reviews']
+             )
+    end
+
+    it 'uses a hyphenated id on the tab anchor (no spaces in id attribute)' do
+      expect(rendered).to include('id="tab-resources-phone-log"')
+      expect(rendered).not_to include('id="tab-resources-phone log"')
+    end
+
+    it 'uses a hyphenated fragment in href (valid CSS selector)' do
+      expect(rendered).to include('href="#phone-log-{{id}}"')
+      expect(rendered).not_to include('href="#phone log-')
+    end
+
+    it 'uses a hyphenated fragment in data-target (valid CSS selector)' do
+      expect(rendered).to include('data-target="#phone-log-{{id}}"')
+      expect(rendered).not_to include('data-target="#phone log-')
+    end
+
+    it 'uses the resource name as data-panel-tab for a single-resource panel (even when panel_name has spaces)' do
+      expect(rendered).to include('data-panel-tab="activity_log__case_reviews"')
+      expect(rendered).not_to include('data-panel-tab="phone log"')
+    end
+  end
+
+  # --- data-alt-click-id backwards-compat alias (issue #1200) ---------
+  #
+  # Single-resource panels must carry data-alt-click-id="tab-{resource.hyphenate}"
+  # so that persistent click-target links using the pre-PR-#1182 resource-based
+  # tab id continue to resolve via the JS fallback in setup_data_toggles.
+  # Multi-resource panels have no legacy single-resource id to alias.
+
+  context 'with a single activity log resource (data-alt-click-id alias)' do
+    before do
+      render partial: 'masters/search_results_master_tabs_resources',
+             locals: base_locals.merge(resources: ['activity_log__case_reviews'])
+    end
+
+    it 'renders data-alt-click-id with the hyphenated resource name' do
+      expect(rendered).to include('data-alt-click-id="tab-activity-log--case-reviews"')
+    end
+  end
+
+  context 'with a single dynamic model resource (data-alt-click-id alias)' do
+    before do
+      render partial: 'masters/search_results_master_tabs_resources',
+             locals: base_locals.merge(resources: ['dynamic_model__contact_infos'])
+    end
+
+    it 'renders data-alt-click-id with the hyphenated resource name' do
+      expect(rendered).to include('data-alt-click-id="tab-dynamic-model--contact-infos"')
+    end
+  end
+
+  context 'with multiple resources in a panel (no data-alt-click-id alias)' do
+    before do
+      render partial: 'masters/search_results_master_tabs_resources',
+             locals: base_locals.merge(
+               resources: ['activity_log__case_reviews', 'dynamic_model__contact_infos']
+             )
+    end
+
+    it 'does not render a data-alt-click-id attribute' do
+      expect(rendered).not_to include('data-alt-click-id=')
     end
   end
 end

--- a/spec/views/masters/_search_results_resources_panel_spec.rb
+++ b/spec/views/masters/_search_results_resources_panel_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# View spec for masters/_search_results_resources_panel partial.
+#
+# The partial renders the outer collapsible container for a contains.resources
+# page-layout panel.  The outer container `id`, its close-button `href`, and its
+# CSS class suffix are all derived from `panel_name`.
+#
+# Regression (issue #1200): when `panel_name` contains spaces the generated
+# `id` and `href` attributes were invalid HTML / broken CSS selectors, preventing
+# Bootstrap collapse from firing.  The fix applies `.id_hyphenate` to every
+# place `panel_name` is used as an HTML id or CSS selector target.  The
+# `data-panel-tab` attribute on individual resource loader anchors is NOT
+# hyphenated – it is compared as a value, not used as a selector.
+
+RSpec.describe 'masters/_search_results_resources_panel', type: :view do
+  # --- shared doubles -------------------------------------------------
+
+  let(:activity_log_item) do
+    Resources::Models::Item.new.merge(
+      type: :activity_log,
+      resource_name: 'activity_log__case_reviews',
+      hyphenated_name: 'activity-log--case-reviews',
+      base_route_segments: 'activity_log/case_reviews'
+    )
+  end
+
+  let(:render_info_for_case_reviews) do
+    {
+      resource_name: 'activity_log__case_reviews',
+      route_path: 'activity_log/case_reviews',
+      template_name: 'activity-log--case-reviews-main-result-template',
+      wrapper_class: 'activity-logs-generic-block',
+      viewable_key: :activity_log__case_reviews
+    }
+  end
+
+  def make_panel(panel_name:, panel_label: 'Test Panel', resources: ['activity_log__case_reviews'])
+    contains_double = double('contains', resources: resources)
+    view_options_double = double('view_options',
+                                 default_expander: nil,
+                                 hide_sublist_controls: false,
+                                 hide_activity_logs_header: false,
+                                 limit: 20)
+    double('panel',
+           panel_name: panel_name,
+           panel_label: panel_label,
+           contains: contains_double,
+           view_options: view_options_double,
+           view_css: nil)
+  end
+
+  before do
+    allow(Resources::Models).to receive(:find_by) do |args|
+      case args[:resource_name].to_s
+      when 'activity_log__case_reviews' then activity_log_item
+      else nil
+      end
+    end
+
+    allow(view).to receive(:master_viewables).and_return(activity_log__case_reviews: true)
+    allow(view).to receive(:resource_render_info).and_return(render_info_for_case_reviews)
+    allow(view).to receive(:hide_player_tabs?).and_return(false)
+
+    stub_template 'reports/_insert_options_css.html.erb' => ''
+  end
+
+  # --- Standard panel_name (no spaces) --------------------------------
+
+  context 'with a simple hyphenated panel_name (e.g. "test-panel")' do
+    before do
+      render partial: 'masters/search_results_resources_panel',
+             locals: { panel: make_panel(panel_name: 'test-panel', panel_label: 'Test Panel') }
+    end
+
+    it 'sets the outer div id from the panel_name' do
+      expect(rendered).to include('id="test-panel-{{id}}"')
+    end
+
+    it 'sets the close-button href from the panel_name' do
+      expect(rendered).to include('href="#test-panel-{{id}}"')
+    end
+
+    it 'includes the panel_name CSS block class' do
+      expect(rendered).to include('test-panel-block')
+    end
+  end
+
+  # --- Panel name with spaces (regression: panel IDs must be valid CSS) ---
+
+  context 'with a panel_name that contains spaces (e.g. "phone log")' do
+    before do
+      render partial: 'masters/search_results_resources_panel',
+             locals: { panel: make_panel(panel_name: 'phone log', panel_label: 'Phone Log') }
+    end
+
+    it 'uses a hyphenated id on the outer collapse div (no spaces in id attribute)' do
+      expect(rendered).to include('id="phone-log-{{id}}"')
+      expect(rendered).not_to include('id="phone log-')
+    end
+
+    it 'uses a hyphenated fragment in the close-button href (valid CSS selector)' do
+      expect(rendered).to include('href="#phone-log-{{id}}"')
+      expect(rendered).not_to include('href="#phone log-')
+    end
+
+    it 'uses a hyphenated CSS block class (no spaces in class attribute)' do
+      expect(rendered).to include('phone-log-block')
+      expect(rendered).not_to include('phone log-block')
+    end
+
+    it 'renders the resource loader anchor with the route path' do
+      expect(rendered).to include('activity_log/case_reviews')
+    end
+
+    it 'renders the on-open-click hidden loader div' do
+      expect(rendered).to include('on-open-click hidden')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes two related bugs in `contains.resources` panel rendering — invalid HTML IDs from panel names with spaces, and incorrect `data-panel-tab` values that broke tab navigation for single-resource panels.

## Changes

### `app/views/masters/_search_results_resources_panel.html.erb`
- Used `id_hyphenate` on `panel_name` for the outer collapse `div#` and `href` / `data-target` attributes, preventing invalid HTML IDs when `panel_name` contains spaces.
- Changed `data-panel-tab` on hidden loader anchors to `data-resource-name` — `data-panel-tab` on hidden loaders was unused by any JS and caused ambiguous matches with `find("a[data-panel-tab='...']", visible: :all)`.

### `app/views/masters/_search_results_master_tabs_resources.html.erb`
- Single-resource `contains.resources` panels now use the **resource name** (e.g. `activity_log__play_ipa_assignments`) as `data-panel-tab`, consistent with standard activity-log tabs. Multi-resource panels continue to use `panel_name`.
- Added `data-alt-click-id="tab-<resource-hyphenated>"` alias on single-resource panels for backwards-compatible `#click-target-tab-*` hash links.
- `open_panel_key` (used for auto-open via `open_panels` config) still uses `panel_name` — unaffected.

### `app/assets/javascripts/app/activity_logs/save_action.js`
- `find_panel_tab()` fallback to `data-alt-click-id` supports legacy `save_action` configs that reference resource names or panel names.
- Comment updated to document the two-step lookup strategy.

## Tests

- New view spec `spec/views/masters/_search_results_resources_panel_spec.rb` (8 examples).
- Updated `spec/views/masters/_search_results_master_tabs_resources_spec.rb` (27 examples, 0 failures).
- PLAY-IPA system spec (`spec/system/apps/play_ipa/`): Phases 1–6 all pass. Phase 0 failure is pre-existing (unrelated config issues).

Fixes #1200
