### PR TITLE
Split contains.resources panels into legacy single-resource and multi-resource wrapper rendering; forbid mixed AL panels - fixes #1205

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ yarn-debug.log*
 .__failed-archive__
 
 /public/handlebars*
+.playwright-cli/

--- a/app/models/option_configs/page_layout_options.rb
+++ b/app/models/option_configs/page_layout_options.rb
@@ -2,9 +2,28 @@
 
 module OptionConfigs
   class PageLayoutOptions < BaseOptions
-    def self.raise_bad_configs(_option_configs)
-      # None defined - override with real checks
-      # @todo
+    def self.raise_bad_configs(option_configs)
+      return unless option_configs.contains
+
+      resources = option_configs.contains.resources
+      return unless resources.present?
+
+      al_types = %i[activity_log activity_log_type]
+      al_count = resources.count do |r|
+        item = Resources::Models.find_by(resource_name: r)
+        item && al_types.include?(item[:type])
+      end
+
+      return if al_count.zero?
+      return if al_count == 1 && resources.length == 1
+
+      if al_count > 1
+        raise FphsException, 'Panel contains multiple activity-log resources. ' \
+                             'Activity-log resources must be in a single-resource panel.'
+      else
+        raise FphsException, 'Panel mixes activity-log resources with other resource types. ' \
+                             'Activity-log resources must be in a single-resource panel.'
+      end
     end
   end
 end

--- a/app/views/masters/_search_results_master_tabs_resources.html.erb
+++ b/app/views/masters/_search_results_master_tabs_resources.html.erb
@@ -20,40 +20,71 @@
 <% if renderable_resources.any? %>
   <%
     if default_panels.length > 0 && initial_show.nil?
-      # The "default" overrides the value set in the panel definition only if
-      # the panel definition did not specify one. Match if any of the panel's
-      # resources is in the default open panels list.
       initial_show = renderable_resources.any? { |r| r.to_s.in?(default_panels) }
     end
 
-    # Use the panel_name as the open-panels key (consistent with categories).
-    open_panel_key = panel_name
-
     extra_classes = "#{close_others ? 'tabs-close-others' : ''} #{initial_show == true ? 'on-open-click initial-show' : ''}"
 
-    # For single-resource panels, use the resource name as data-panel-tab so that
-    # spec selectors and save_action configs (which reference resource names) can find
-    # the tab directly — consistent with how standard activity log tabs work.
-    # Multi-resource panels have no single resource name, so they continue to use
-    # the panel_name.
-    panel_tab_value = renderable_resources.length == 1 ? renderable_resources.first.to_s : panel_name
-
-    # For single-resource panels, provide a data-alt-click-id alias using the hyphenated
-    # resource name so that persistent click-target links formed before PR #1182
-    # (e.g. click-target-#tab-activity-log--case-reviews) continue to resolve via the
-    # JS fallback in setup_data_toggles. Multi-resource panels have no legacy id to alias.
-    alt_click_id = renderable_resources.length == 1 ? "tab-#{renderable_resources.first.to_s.hyphenate}" : nil
+    # Use legacy AJAX tab for all single-resource panels (AL, DM, and EID alike).
+    # Multi-resource panels always use wrapper mode.
+    use_legacy = renderable_resources.length == 1
   %>
-  {{#if (or (not (params 'only_tabs')) (params 'only_tabs' '<%= panel_name %>')) }}
-  <li role="presentation" class="<%= extra_classes %> <%= class_for_open_panels(open_panel_key, default_panels.length) %>" data-open-panels="{{open_panels}}">
-    <a id="tab-resources-<%= panel_name.id_hyphenate %>"
-       href="#<%= panel_name.id_hyphenate %>-{{id}}"
-       data-panel-tab="<%= panel_tab_value %>"
-       data-toggle="collapse"
-       data-target="#<%= panel_name.id_hyphenate %>-{{id}}"
-       aria-expanded="false"
-       class="scroll-to-expanded collapsed"<% if alt_click_id %>
-       data-alt-click-id="<%= alt_click_id %>"<% end %>><%= panel_label %></a>
-  </li>
-  {{/if}}
+  <% if use_legacy %>
+    <%
+      resource = renderable_resources.first.to_s
+      render_info = resource_render_info(resource, context: :master_panel)
+      route_path = render_info[:route_path]
+      block_id = "#{resource.hyphenate}-{{id}}"
+
+      extra_params = ''
+      using_params = ''
+      if filter_items
+        rparams = filter_items[resource.pluralize]
+        if rparams.is_a?(Hash)
+          rparams = rparams.to_unsafe_h if rparams.respond_to?(:to_unsafe_h)
+          extra_params = "&#{rparams.to_query}"
+          using_params = 'page-layout'
+        elsif rparams == 'using params'
+          using_params = 'page'
+        end
+      end
+    %>
+    {{#if (or (not (params 'only_tabs')) (params 'only_tabs' '<%= resource.pluralize %>')) }}
+    <li role="presentation" class="<%= extra_classes %> <%= class_for_open_panels(resource, default_panels.length) %>" data-open-panels="{{open_panels}}">
+      <a id="tab-activity-log-<%= panel_name.id_hyphenate %>"
+         href="/masters/{{id}}/<%= route_path %>?limit=<%= limit %><%= extra_params %>&{{params_to_query 'filter' '<%= resource.pluralize %>'}}"
+         data-using-params="<%= using_params %>"
+         data-panel-tab="<%= resource %>"
+         data-remote="true"
+         data-prevent-on-collapse="true"
+         data-toggle="collapse"
+         data-target="#<%= block_id %>"
+         aria-expanded="false"
+         class="scroll-to-expanded collapsed"
+         data-result-target="#<%= block_id %>"
+         data-alt-click-id="tab-<%= resource.hyphenate %>"
+         data-template="<%= render_info[:template_name] %>"><%= panel_label %></a>
+    </li>
+    {{/if}}
+  <% else %>
+    <%
+      open_panel_key = panel_name
+
+      panel_tab_value = renderable_resources.length == 1 ? renderable_resources.first.to_s : panel_name
+
+      alt_click_id = renderable_resources.length == 1 ? "tab-#{renderable_resources.first.to_s.hyphenate}" : nil
+    %>
+    {{#if (or (not (params 'only_tabs')) (params 'only_tabs' '<%= panel_name %>')) }}
+    <li role="presentation" class="<%= extra_classes %> <%= class_for_open_panels(open_panel_key, default_panels.length) %>" data-open-panels="{{open_panels}}">
+      <a id="tab-resources-<%= panel_name.id_hyphenate %>"
+         href="#<%= panel_name.id_hyphenate %>-{{id}}"
+         data-panel-tab="<%= panel_tab_value %>"
+         data-toggle="collapse"
+         data-target="#<%= panel_name.id_hyphenate %>-{{id}}"
+         aria-expanded="false"
+         class="scroll-to-expanded collapsed"<% if alt_click_id %>
+         data-alt-click-id="<%= alt_click_id %>"<% end %>><%= panel_label %></a>
+    </li>
+    {{/if}}
+  <% end %>
 <% end %>

--- a/app/views/masters/_search_results_resources_panel.html.erb
+++ b/app/views/masters/_search_results_resources_panel.html.erb
@@ -1,19 +1,22 @@
 <%
-  # Render a single outer collapsible panel containing all resources listed in
-  # `panel.contains.resources`. Mirrors the contains.categories pattern – the
-  # tab rendered by masters/_search_results_master_tabs_resources toggles this
-  # outer collapse, and each resource produces an inner block (always visible
-  # inside the outer panel) plus a hidden loader anchor that fires the
-  # AJAX list fetch via the existing Rails UJS / Handlebars pipeline.
+  # Render the collapsible block(s) for a contains.resources panel.
   #
-  # Loader anchors are clicked the first time the outer panel is opened
-  # (handled by JS in page_layouts.js on show.bs.collapse). Initial-show
-  # panels open via the existing `on-open-click` tab auto-click in
-  # _fpa.form_utils.on_open_click, which triggers the same path.
+  # TWO MODES – chosen by the number of renderable resources:
   #
-  # Backwards-compatibility: single-resource panels render exactly one inner
-  # resource block + one loader anchor inside the outer container, preserving
-  # the user-visible behaviour of the previous per-resource-tab design.
+  # LEGACY mode (exactly one resource):
+  #   Renders the resource block directly, without an outer wrapper or heading.
+  #   The companion tab in _search_results_master_tabs_resources acts as an AJAX
+  #   trigger whose href is the resource URL and whose data-target/data-result-target
+  #   point at the resource-keyed collapse id (e.g. `activity-log--case-reviews-{{id}}`).
+  #   Applies to all single-resource panels regardless of resource type (AL, DM, EID)
+  #   or whether the panel_name contains spaces.
+  #
+  # WRAPPER mode (two or more resources):
+  #   Renders an outer collapsible panel (panel_name-keyed id) with a heading,
+  #   hidden loader anchors (one per resource), and inner resource blocks inside.
+  #   The tab toggles the outer container; loader anchors fire individual AJAX
+  #   fetches when the outer panel first opens (via on-open-click).
+  #   Activity logs may NOT be mixed with other resource types in wrapper mode.
 
   panel_name = panel.panel_name
   panel_label = panel.panel_label
@@ -33,7 +36,27 @@
     memo << [resource, info]
   end
 %>
-<% if renderable.any? %>
+<% if renderable.length == 1 %>
+  <%# LEGACY single-resource mode: render the resource block directly, without
+      the outer panel wrapper or heading. The tab partial drives the AJAX fetch. %>
+  <% resource, render_info = renderable.first
+     block_id = "#{resource.hyphenate}-{{id}}"
+     inner_block_class = render_info[:wrapper_class].gsub('generic-block', 'inner-block')
+     template_name = render_info[:template_name] %>
+  <div id="<%= block_id %>"
+       class="<%= render_info[:wrapper_class] %> <%= resource.hyphenate %>-block collapse"
+       data-sub-for-root="master_id"
+       data-sub-id="{{id}}"
+       data-sub-item="<%= resource %>"
+       data-template="<%= template_name %>"
+       data-route-path="<%= render_info[:route_path] %>"
+       data-default-expander="<%= default_expander %>">
+    <div id="<%= resource.hyphenate %>-inner-{{id}}" class="<%= inner_block_class %>">
+    </div>
+  </div>
+<% elsif renderable.length >= 2 %>
+  <%# WRAPPER mode: outer panel container with heading and hidden loader anchors.
+      Used for multi-resource panels (no activity-log mixing allowed). %>
   <% outer = "##{panel_name.id_hyphenate}-{{id}}" %>
   <%= render partial: 'reports/insert_options_css', locals: { outer: outer, view_css: view_css } %>
   <div id="<%= panel_name.id_hyphenate %>-{{id}}"
@@ -46,10 +69,7 @@
     </div>
     <%# Hidden loader anchors – one per resource – are picked up by
         _fpa.form_utils.on_open_click when the master record is expanded
-        (called from the search_results_template postprocessor). This is the
-        same mechanism used by the standard master_external_ids_panel to
-        lazily fetch each resource's list via Rails UJS and render it
-        through the data-template Handlebars pipeline. %>
+        (called from the search_results_template postprocessor). %>
     <div class="on-open-click hidden">
       <% renderable.each do |resource, render_info|
            block_id = "#{resource.hyphenate}-{{id}}"

--- a/spec/models/option_configs/page_layout_options_spec.rb
+++ b/spec/models/option_configs/page_layout_options_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Spec for OptionConfigs::PageLayoutOptions.raise_bad_configs (issue #1205).
+#
+# Validates that the raise_bad_configs class method correctly enforces the
+# panel resource composition rules:
+#
+#   - A panel with a single resource of any type is always valid.
+#   - A panel with 2+ resources that are all non-activity-log types is valid.
+#   - A panel that mixes activity-log resources with other resource types raises FphsException.
+#   - A panel with 2+ activity-log resources raises FphsException.
+#   - Panels with no contains.resources key are skipped (no exception).
+#   - An unresolvable resource name is treated as a non-AL type (no crash).
+#
+# These are RED-phase tests: the invalid cases currently do NOT raise because
+# raise_bad_configs is a stub. They will pass once the implementation is added.
+
+RSpec.describe OptionConfigs::PageLayoutOptions, type: :model do
+  let(:al_item) { { type: :activity_log, resource_name: 'activity_log__case_reviews' } }
+  let(:al2_item) { { type: :activity_log, resource_name: 'activity_log__contact_logs' } }
+  let(:dm_item) { { type: :dynamic_model, resource_name: 'dynamic_model__contact_infos' } }
+  let(:eid_item) { { type: :external_identifier, resource_name: 'scantron_ids' } }
+
+  before do
+    allow(Resources::Models).to receive(:find_by) do |args|
+      case args[:resource_name].to_s
+      when 'activity_log__case_reviews' then al_item
+      when 'activity_log__contact_logs' then al2_item
+      when 'dynamic_model__contact_infos' then dm_item
+      when 'scantron_ids' then eid_item
+      end
+    end
+  end
+
+  # Build a duck-type option_configs double with contains.resources returning the given array.
+  def make_option_configs(resources)
+    contains = double('contains', resources: resources)
+    double('option_configs', contains: contains)
+  end
+
+  def make_option_configs_nil_resources
+    contains = double('contains', resources: nil)
+    double('option_configs', contains: contains)
+  end
+
+  def make_option_configs_nil_contains
+    double('option_configs', contains: nil)
+  end
+
+  describe '.raise_bad_configs' do
+    context 'with a single activity log resource' do
+      it 'does not raise an exception' do
+        expect do
+          described_class.raise_bad_configs(make_option_configs(['activity_log__case_reviews']))
+        end.not_to raise_error
+      end
+    end
+
+    context 'with a single dynamic model resource' do
+      it 'does not raise an exception' do
+        expect do
+          described_class.raise_bad_configs(make_option_configs(['dynamic_model__contact_infos']))
+        end.not_to raise_error
+      end
+    end
+
+    context 'with a single external identifier resource' do
+      it 'does not raise an exception' do
+        expect do
+          described_class.raise_bad_configs(make_option_configs(['scantron_ids']))
+        end.not_to raise_error
+      end
+    end
+
+    context 'with 2+ non-activity-log resources (DM + EID)' do
+      it 'does not raise an exception' do
+        expect do
+          described_class.raise_bad_configs(
+            make_option_configs(['dynamic_model__contact_infos', 'scantron_ids'])
+          )
+        end.not_to raise_error
+      end
+    end
+
+    context 'with 1 activity log + 1 dynamic model (mixed types)' do
+      it 'raises FphsException (mixing AL with other types is forbidden)' do
+        expect do
+          described_class.raise_bad_configs(
+            make_option_configs(['activity_log__case_reviews', 'dynamic_model__contact_infos'])
+          )
+        end.to raise_error(FphsException)
+      end
+    end
+
+    context 'with 1 activity log + 1 external identifier (mixed types)' do
+      it 'raises FphsException (mixing AL with other types is forbidden)' do
+        expect do
+          described_class.raise_bad_configs(
+            make_option_configs(['activity_log__case_reviews', 'scantron_ids'])
+          )
+        end.to raise_error(FphsException)
+      end
+    end
+
+    context 'with 2 activity log resources' do
+      it 'raises FphsException (multiple activity logs in one panel are forbidden)' do
+        expect do
+          described_class.raise_bad_configs(
+            make_option_configs(['activity_log__case_reviews', 'activity_log__contact_logs'])
+          )
+        end.to raise_error(FphsException)
+      end
+    end
+
+    context 'when contains has no resources key (nil resources)' do
+      it 'does not raise an exception (no-op)' do
+        expect do
+          described_class.raise_bad_configs(make_option_configs_nil_resources)
+        end.not_to raise_error
+      end
+    end
+
+    context 'when contains is nil' do
+      it 'does not raise an exception (no-op)' do
+        expect do
+          described_class.raise_bad_configs(make_option_configs_nil_contains)
+        end.not_to raise_error
+      end
+    end
+
+    context 'with an unresolvable resource name' do
+      it 'does not raise an exception (treated as non-AL type)' do
+        expect do
+          described_class.raise_bad_configs(make_option_configs(['nonexistent_resource']))
+        end.not_to raise_error
+      end
+    end
+
+    context 'with unresolvable resource mixed with activity log' do
+      it 'raises FphsException (unresolvable treated as non-AL, so AL+other mix is forbidden)' do
+        expect do
+          described_class.raise_bad_configs(
+            make_option_configs(['activity_log__case_reviews', 'nonexistent_resource'])
+          )
+        end.to raise_error(FphsException)
+      end
+    end
+  end
+end

--- a/spec/views/masters/_search_results_master_tabs_resources_spec.rb
+++ b/spec/views/masters/_search_results_master_tabs_resources_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe 'masters/_search_results_master_tabs_resources', type: :view do
       when 'activity_log__case_reviews' then activity_log_item
       when 'dynamic_model__contact_infos' then dynamic_model_item
       when 'scantron_ids' then external_id_item
-      else nil
       end
     end
   end
@@ -70,7 +69,15 @@ RSpec.describe 'masters/_search_results_master_tabs_resources', type: :view do
     }
   end
 
-  # --- Single resource (regression: AC-001/AC-002/AC-003) -------------
+  # --- Single resource (legacy AJAX pattern) - issue #1205 regression ---
+  #
+  # Single-resource panels must revert to the pre-PR-#1182 per-resource tab
+  # behaviour: the tab <a> acts as an AJAX trigger (data-remote="true") whose
+  # href is the resource URL, and whose data-target/data-result-target point to
+  # the resource-keyed collapse id, not the panel_name-keyed id.
+  #
+  # These tests describe the CORRECT target behaviour and therefore FAIL with the
+  # current PR-#1182 implementation (Red phase of TDD).
 
   context 'with a single dynamic model resource' do
     before do
@@ -82,22 +89,39 @@ RSpec.describe 'masters/_search_results_master_tabs_resources', type: :view do
       expect(rendered.scan(/<li\b/).length).to eq(1)
     end
 
-    it "uses the resource name as the tab's data-panel-tab attribute (single-resource panel)" do
-      expect(rendered).to include('data-panel-tab="dynamic_model__contact_infos"')
-      expect(rendered).not_to include('data-panel-tab="test-panel"')
-    end
-
-    it "uses the panel_name as the tab's collapse target" do
-      expect(rendered).to include('data-target="#test-panel-{{id}}"')
-    end
-
     it 'displays the panel_label as the tab text' do
       expect(rendered).to include('Test Panel')
     end
 
-    it 'does not place a data-template attribute on the tab itself' do
-      # data-template lives on the inner resource block, not on the tab.
-      expect(rendered).not_to include('data-template=')
+    it 'uses the resource name as data-panel-tab (single-resource panel)' do
+      expect(rendered).to include('data-panel-tab="dynamic_model__contact_infos"')
+      expect(rendered).not_to include('data-panel-tab="test-panel"')
+    end
+
+    it 'uses a resource-keyed AJAX href (not a panel_name collapse anchor)' do
+      expect(rendered).to include('href="/masters/{{id}}/dynamic_model/contact_infos')
+      expect(rendered).not_to include('href="#test-panel-{{id}}"')
+    end
+
+    it 'sets data-remote="true" on the tab anchor for AJAX loading' do
+      expect(rendered).to include('data-remote="true"')
+    end
+
+    it 'sets data-result-target to the resource-keyed id' do
+      expect(rendered).to include('data-result-target="#dynamic-model--contact-infos-{{id}}"')
+    end
+
+    it 'sets data-target to the resource-keyed collapse id' do
+      expect(rendered).to include('data-target="#dynamic-model--contact-infos-{{id}}"')
+      expect(rendered).not_to include('data-target="#test-panel-{{id}}"')
+    end
+
+    it 'places data-template on the tab anchor (legacy: template is on tab, not inner block)' do
+      expect(rendered).to include('data-template="dynamic-model--contact-infos-list-template"')
+    end
+
+    it 'uses a resource-hyphenated tab id (not tab-resources-prefixed)' do
+      expect(rendered).not_to include('id="tab-resources-test-panel"')
     end
   end
 
@@ -111,8 +135,31 @@ RSpec.describe 'masters/_search_results_master_tabs_resources', type: :view do
       expect(rendered.scan(/<li\b/).length).to eq(1)
     end
 
-    it 'targets the panel_name-keyed collapse container' do
-      expect(rendered).to include('data-target="#test-panel-{{id}}"')
+    it 'uses a resource-keyed AJAX href (not a panel_name collapse anchor)' do
+      expect(rendered).to include('href="/masters/{{id}}/activity_log/case_reviews')
+      expect(rendered).not_to include('href="#test-panel-{{id}}"')
+    end
+
+    it 'sets data-remote="true" on the tab anchor for AJAX loading' do
+      expect(rendered).to include('data-remote="true"')
+    end
+
+    it 'sets data-result-target to the resource-keyed id' do
+      expect(rendered).to include('data-result-target="#activity-log--case-reviews-{{id}}"')
+    end
+
+    it 'sets data-target to the resource-keyed collapse id (not panel_name-keyed)' do
+      expect(rendered).to include('data-target="#activity-log--case-reviews-{{id}}"')
+      expect(rendered).not_to include('data-target="#test-panel-{{id}}"')
+    end
+
+    it 'places data-template on the tab anchor for the AL main-result-template' do
+      expect(rendered).to include('data-template="activity-log--case-reviews-main-result-template"')
+    end
+
+    it 'uses the legacy activity-log tab id prefix (not tab-resources-prefixed)' do
+      expect(rendered).to include('id="tab-activity-log-test-panel"')
+      expect(rendered).not_to include('id="tab-resources-test-panel"')
     end
   end
 
@@ -126,8 +173,35 @@ RSpec.describe 'masters/_search_results_master_tabs_resources', type: :view do
       expect(rendered.scan(/<li\b/).length).to eq(1)
     end
 
-    it 'targets the panel_name-keyed collapse container' do
-      expect(rendered).to include('data-target="#test-panel-{{id}}"')
+    it 'uses a resource-keyed AJAX href (not a panel_name collapse anchor)' do
+      expect(rendered).to include('href="/masters/{{id}}/scantron_ids')
+      expect(rendered).not_to include('href="#test-panel-{{id}}"')
+    end
+
+    it 'sets data-remote="true" on the tab anchor for AJAX loading' do
+      expect(rendered).to include('data-remote="true"')
+    end
+
+    it 'sets data-result-target to the resource-keyed id' do
+      expect(rendered).to include('data-result-target="#scantron-ids-{{id}}"')
+    end
+
+    it 'sets data-target to the resource-keyed collapse id (not panel_name-keyed)' do
+      expect(rendered).to include('data-target="#scantron-ids-{{id}}"')
+      expect(rendered).not_to include('data-target="#test-panel-{{id}}"')
+    end
+
+    it 'places data-template on the tab anchor for the EID list template' do
+      expect(rendered).to include('data-template="scantron-ids-list-template"')
+    end
+
+    it 'uses the legacy activity-log tab id prefix' do
+      expect(rendered).to include('id="tab-activity-log-test-panel"')
+      expect(rendered).not_to include('id="tab-resources-test-panel"')
+    end
+
+    it 'renders data-alt-click-id with the hyphenated resource name' do
+      expect(rendered).to include('data-alt-click-id="tab-scantron-ids"')
     end
   end
 
@@ -181,19 +255,26 @@ RSpec.describe 'masters/_search_results_master_tabs_resources', type: :view do
              )
     end
 
-    it 'uses a hyphenated id on the tab anchor (no spaces in id attribute)' do
-      expect(rendered).to include('id="tab-resources-phone-log"')
-      expect(rendered).not_to include('id="tab-resources-phone log"')
+    it 'uses a hyphenated legacy tab id (no spaces, no tab-resources- prefix)' do
+      expect(rendered).to include('id="tab-activity-log-phone-log"')
+      expect(rendered).not_to include('id="tab-resources-phone-log"')
+      expect(rendered).not_to include('id="tab-activity-log-phone log"')
     end
 
-    it 'uses a hyphenated fragment in href (valid CSS selector)' do
-      expect(rendered).to include('href="#phone-log-{{id}}"')
+    it 'uses a resource-keyed AJAX href (not a panel_name collapse anchor)' do
+      expect(rendered).to include('href="/masters/{{id}}/activity_log/case_reviews')
+      expect(rendered).not_to include('href="#phone-log-{{id}}"')
       expect(rendered).not_to include('href="#phone log-')
     end
 
-    it 'uses a hyphenated fragment in data-target (valid CSS selector)' do
-      expect(rendered).to include('data-target="#phone-log-{{id}}"')
+    it 'sets data-target to the resource-keyed collapse id (not panel_name-keyed)' do
+      expect(rendered).to include('data-target="#activity-log--case-reviews-{{id}}"')
+      expect(rendered).not_to include('data-target="#phone-log-{{id}}"')
       expect(rendered).not_to include('data-target="#phone log-')
+    end
+
+    it 'sets data-remote="true" on the tab anchor for AJAX loading' do
+      expect(rendered).to include('data-remote="true"')
     end
 
     it 'uses the resource name as data-panel-tab for a single-resource panel (even when panel_name has spaces)' do

--- a/spec/views/masters/_search_results_resources_panel_spec.rb
+++ b/spec/views/masters/_search_results_resources_panel_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe 'masters/_search_results_resources_panel', type: :view do
     allow(Resources::Models).to receive(:find_by) do |args|
       case args[:resource_name].to_s
       when 'activity_log__case_reviews' then activity_log_item
-      else nil
       end
     end
 
@@ -67,56 +66,152 @@ RSpec.describe 'masters/_search_results_resources_panel', type: :view do
     stub_template 'reports/_insert_options_css.html.erb' => ''
   end
 
-  # --- Standard panel_name (no spaces) --------------------------------
+  # --- Single activity-log resource: legacy mode (issue #1205) --------
+  #
+  # Single-resource panels must render WITHOUT the outer collapsible wrapper
+  # introduced by PR #1182. The resource block is rendered directly with its
+  # own resource-keyed id, not a panel_name-keyed id.
 
-  context 'with a simple hyphenated panel_name (e.g. "test-panel")' do
+  context 'with a simple hyphenated panel_name (e.g. "test-panel") — single AL resource legacy mode' do
     before do
       render partial: 'masters/search_results_resources_panel',
              locals: { panel: make_panel(panel_name: 'test-panel', panel_label: 'Test Panel') }
     end
 
-    it 'sets the outer div id from the panel_name' do
-      expect(rendered).to include('id="test-panel-{{id}}"')
+    it 'does NOT render the outer panel-default wrapper div (legacy mode: no outer wrapper)' do
+      expect(rendered).not_to include('class="panel panel-default section-panel')
     end
 
-    it 'sets the close-button href from the panel_name' do
-      expect(rendered).to include('href="#test-panel-{{id}}"')
+    it 'does NOT render an <h4> heading (AL has its own heading)' do
+      expect(rendered).not_to include('<h4')
     end
 
-    it 'includes the panel_name CSS block class' do
-      expect(rendered).to include('test-panel-block')
+    it 'does NOT render the on-open-click hidden loader div (no deferred loader in legacy mode)' do
+      expect(rendered).not_to include('on-open-click hidden')
+    end
+
+    it 'renders the resource block with a resource-keyed id (not panel_name-keyed)' do
+      expect(rendered).to include('id="activity-log--case-reviews-{{id}}"')
+      expect(rendered).not_to include('id="test-panel-{{id}}"')
+    end
+
+    it 'renders the resource block with the legacy wrapper + resource-hyphenated class' do
+      expect(rendered).to include('activity-logs-generic-block activity-log--case-reviews-block')
+    end
+
+    it 'renders data-sub-item with the resource name' do
+      expect(rendered).to include('data-sub-item="activity_log__case_reviews"')
+    end
+
+    it 'renders data-template directly on the resource block (not on a separate loader anchor)' do
+      expect(rendered).to include('data-template="activity-log--case-reviews-main-result-template"')
+    end
+
+    it 'renders the inner block with a resource-keyed id' do
+      expect(rendered).to include('id="activity-log--case-reviews-inner-{{id}}"')
     end
   end
 
-  # --- Panel name with spaces (regression: panel IDs must be valid CSS) ---
+  # --- Single AL resource with spaces in panel_name: still resource-keyed ---
 
-  context 'with a panel_name that contains spaces (e.g. "phone log")' do
+  context 'with a panel_name that contains spaces (e.g. "phone log") — single AL resource legacy mode' do
     before do
       render partial: 'masters/search_results_resources_panel',
              locals: { panel: make_panel(panel_name: 'phone log', panel_label: 'Phone Log') }
     end
 
-    it 'uses a hyphenated id on the outer collapse div (no spaces in id attribute)' do
-      expect(rendered).to include('id="phone-log-{{id}}"')
+    it 'does NOT render the outer panel-default wrapper div' do
+      expect(rendered).not_to include('class="panel panel-default section-panel')
+    end
+
+    it 'does NOT render an <h4> heading' do
+      expect(rendered).not_to include('<h4')
+    end
+
+    it 'does NOT render the on-open-click hidden loader div' do
+      expect(rendered).not_to include('on-open-click hidden')
+    end
+
+    it 'renders the resource block with a resource-keyed id (panel_name not in the id)' do
+      expect(rendered).to include('id="activity-log--case-reviews-{{id}}"')
+      expect(rendered).not_to include('id="phone-log-{{id}}"')
       expect(rendered).not_to include('id="phone log-')
     end
 
-    it 'uses a hyphenated fragment in the close-button href (valid CSS selector)' do
-      expect(rendered).to include('href="#phone-log-{{id}}"')
-      expect(rendered).not_to include('href="#phone log-')
-    end
-
-    it 'uses a hyphenated CSS block class (no spaces in class attribute)' do
-      expect(rendered).to include('phone-log-block')
-      expect(rendered).not_to include('phone log-block')
-    end
-
-    it 'renders the resource loader anchor with the route path' do
+    it 'renders the resource loader route path' do
       expect(rendered).to include('activity_log/case_reviews')
     end
+  end
 
-    it 'renders the on-open-click hidden loader div' do
-      expect(rendered).to include('on-open-click hidden')
+  # --- Single dynamic model resource: legacy mode (issue #1205) --------
+
+  context 'with a single dynamic model resource — legacy mode' do
+    let(:dynamic_model_item) do
+      Resources::Models::Item.new.merge(
+        type: :dynamic_model,
+        resource_name: 'dynamic_model__contact_infos',
+        hyphenated_name: 'dynamic-model--contact-infos',
+        base_route_segments: 'dynamic_model/contact_infos'
+      )
+    end
+
+    let(:render_info_for_contact_infos) do
+      {
+        resource_name: 'dynamic_model__contact_infos',
+        route_path: 'dynamic_model/contact_infos',
+        template_name: 'dynamic-model--contact-infos-list-template',
+        wrapper_class: 'dynamic-model-generic-block',
+        viewable_key: :dynamic_model__contact_infos
+      }
+    end
+
+    before do
+      allow(Resources::Models).to receive(:find_by) do |args|
+        case args[:resource_name].to_s
+        when 'dynamic_model__contact_infos' then dynamic_model_item
+        end
+      end
+
+      allow(view).to receive(:master_viewables).and_return(dynamic_model__contact_infos: true)
+      allow(view).to receive(:resource_render_info).and_return(render_info_for_contact_infos)
+
+      render partial: 'masters/search_results_resources_panel',
+             locals: { panel: make_panel(panel_name: 'contacts-panel',
+                                         panel_label: 'Contacts',
+                                         resources: ['dynamic_model__contact_infos']) }
+    end
+
+    it 'does NOT render the outer panel-default wrapper div (legacy mode: no outer wrapper)' do
+      expect(rendered).not_to include('class="panel panel-default section-panel')
+    end
+
+    it 'does NOT render an <h4> heading' do
+      expect(rendered).not_to include('<h4')
+    end
+
+    it 'does NOT render the on-open-click hidden loader div' do
+      expect(rendered).not_to include('on-open-click hidden')
+    end
+
+    it 'renders the resource block with a resource-keyed id (not panel_name-keyed)' do
+      expect(rendered).to include('id="dynamic-model--contact-infos-{{id}}"')
+      expect(rendered).not_to include('id="contacts-panel-{{id}}"')
+    end
+
+    it 'renders the resource block with the DM wrapper + resource-hyphenated class' do
+      expect(rendered).to include('dynamic-model-generic-block dynamic-model--contact-infos-block')
+    end
+
+    it 'renders data-sub-item with the DM resource name' do
+      expect(rendered).to include('data-sub-item="dynamic_model__contact_infos"')
+    end
+
+    it 'renders data-template with the DM list template directly on the resource block' do
+      expect(rendered).to include('data-template="dynamic-model--contact-infos-list-template"')
+    end
+
+    it 'renders the inner block with a resource-keyed id' do
+      expect(rendered).to include('id="dynamic-model--contact-infos-inner-{{id}}"')
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes regression introduced by PR #1182, which applied the new outer-wrapper rendering (`panel panel-default section-panel` + `<h4>` heading) to **all** `contains.resources` page-layout panels, including single activity-log panels that already have their own heading. This caused duplicate headings and broke JavaScript DOM ids.

Closes #1205

## Changes

### Two-mode rendering split

**Single-resource panels** (`renderable.length == 1`) → **legacy mode**:
- Panel partial renders the resource block directly with a resource-keyed `id="<resource.hyphenate>-{{id}}"` — no outer wrapper, no `<h4>`, no hidden loader div
- Tab partial renders an AJAX-trigger tab (`data-remote`, `data-result-target`, `data-target` all resource-keyed) — same as pre-PR-#1182 behaviour

**Multi-resource panels** (`renderable.length >= 2`) → **wrapper mode** (PR #1182 behaviour, unchanged):
- Outer `panel panel-default section-panel` container with `<h4>` heading
- Hidden `.on-open-click` loader anchors
- Inner resource blocks

### Config validation

`OptionConfigs::PageLayoutOptions.raise_bad_configs` now raises `FphsException` when any panel mixes activity-log resources with other resource types, or contains more than one activity-log resource. This prevents creating configurations that could never render correctly in wrapper mode.

### Also

Added `.playwright-cli/` to `.gitignore` (was inadvertently untracked).

## Files Changed

| File | Change |
|---|---|
| `app/models/option_configs/page_layout_options.rb` | Implemented `raise_bad_configs` AL-singleton validation |
| `app/views/masters/_search_results_resources_panel.html.erb` | Two-mode branch: legacy (1 resource) vs wrapper (2+) |
| `app/views/masters/_search_results_master_tabs_resources.html.erb` | Two-mode branch: AJAX tab (1 resource) vs collapse tab (2+) |
| `spec/models/option_configs/page_layout_options_spec.rb` | **New** — 11 examples for `raise_bad_configs` |
| `spec/views/masters/_search_results_resources_panel_spec.rb` | Updated for legacy mode assertions |
| `spec/views/masters/_search_results_master_tabs_resources_spec.rb` | Updated single-resource and EID contexts for legacy AJAX tab |

## Test Results

- 93 unit/view specs — 0 failures
- `spec/system/apps/play_ipa/play_ipa_process_spec.rb` (Phase 5) — 0 failures
- `spec/system/apps/study_recruitment/study_recruitment_process_spec.rb` (all phases) — 5 examples, 0 failures
