### PR TITLE
Added activity log panel perspectives feature - resolves #1194

### DIFF
--- a/app/assets/javascripts/app/_fpa_form_utils.js
+++ b/app/assets/javascripts/app/_fpa_form_utils.js
@@ -2275,6 +2275,56 @@ _fpa.form_utils = {
         });
       })
       .addClass('formatted-slfs');
+
+    // For each sublist-controls block: toggle filter selectors, and inject a clone of the
+    // source perspectives div (kept outside the AJAX-replaced block) so perspectives buttons
+    // appear alongside the filter selectors on every load/reload.
+    block
+      .find('.sublist-controls')
+      .not('.formatted-perspectives')
+      .each(function () {
+        var $controls = $(this);
+
+        // Toggle the filter selectors panel when the toggle button is clicked.
+        $controls.on('click', '.sublist-filter-toggle', function (ev) {
+          ev.preventDefault();
+          $controls.find('.sublist-filter-selectors').toggleClass('hidden');
+          if ($(this).hasClass('glyphicon-triangle-right')) {
+            $(this).removeClass('glyphicon-triangle-right').addClass('glyphicon-triangle-left');
+          } else {
+            $(this).removeClass('glyphicon-triangle-left').addClass('glyphicon-triangle-right');
+          }
+        });
+
+        // Clone the source perspectives div (which lives outside the AJAX-replaced resource
+        // block) and prepend it to this sublist-controls so perspectives appear alongside
+        // the filter toggle button on every load/reload.
+        var $resourceBlock = $controls.closest('[data-sub-for-root]');
+        if ($resourceBlock.length) {
+          var $source = $resourceBlock.prevAll('.activity-log-perspectives--source').first();
+          if ($source.length) {
+            $controls.find('.activity-log-perspectives--injected').remove();
+            var $clone = $source.clone(true, true)
+              .removeClass('activity-log-perspectives--source')
+              .addClass('activity-log-perspectives--injected');
+            // Restore the active button from the slug stored on the --source div.
+            var activePersp = $source.attr('data-active-perspective');
+            if (activePersp !== undefined) {
+              $clone.find('.activity-log-perspectives__btn').removeClass('active');
+              $clone.find('.activity-log-perspectives__btn[data-perspective="' + activePersp + '"]').addClass('active');
+            }
+            $controls.prepend($clone);
+          }
+        }
+
+        // If no perspectives are present, hide the filter toggle button and show the
+        // filter selectors directly (no need for a toggle when perspectives are absent).
+        if (!$controls.find('.activity-log-perspectives--injected').length) {
+          $controls.find('.sublist-filter-toggle').addClass('hidden');
+          $controls.find('.sublist-filter-selectors').removeClass('hidden');
+        }
+      })
+      .addClass('formatted-perspectives');
   },
 
   reorder_sub_list_columns: function (block) {

--- a/app/assets/javascripts/app/_fpa_loaded.js
+++ b/app/assets/javascripts/app/_fpa_loaded.js
@@ -51,6 +51,9 @@ _fpa.loaded.default = function () {
   _fpa.timed_flash_fadeout();
   _fpa.form_utils.format_block();
 
+  // Set up delegated click handler for activity log perspective buttons (all pages).
+  _fpa.page_layouts.setup_perspective_buttons($(document));
+
   // Initialize page title module and bind search tab handlers
   _fpa.page_title.init();
   _fpa.page_title.bind_search_tabs();

--- a/app/assets/javascripts/app/page_layouts.js
+++ b/app/assets/javascripts/app/page_layouts.js
@@ -1,5 +1,6 @@
 _fpa.loaded.page_layouts = function () {
   _fpa.page_layouts.load_columns()
+  _fpa.page_layouts.setup_perspective_buttons($(document))
 
   // Update page title with the page layout label
   var $page = $('#standalone-page');
@@ -77,6 +78,38 @@ _fpa.page_layouts = class {
       }, 600);
 
     }
+  }
+
+  // Bind a delegated click handler to perspective buttons (.activity-log-perspectives__btn).
+  // When a button is clicked it is marked active (siblings deactivated) and the standard
+  // data-remote Rails UJS flow handles fetching and rendering the filtered list.
+  // Uses event delegation so it works for buttons rendered dynamically from Handlebars templates.
+  //
+  // @param {jQuery} container - scope to bind within; call once with $(document).
+  static setup_perspective_buttons(container) {
+    if (container.data('perspectives-delegated')) return;
+    container.data('perspectives-delegated', true);
+
+    container.on('click', '.activity-log-perspectives__btn', function () {
+      var $btn = $(this);
+      var activePersp = $btn.data('perspective');
+
+      // Update the injected clone immediately for visual feedback.
+      $btn.closest('.activity-log-perspectives').find('.activity-log-perspectives__btn').removeClass('active');
+      $btn.addClass('active');
+
+      // Write the active perspective slug to the --source div so that when AJAX completes
+      // and setup_sub_lists re-clones from --source, it can restore the correct active button.
+      var $resourceBlock = $btn.closest('[data-sub-for-root]');
+      if ($resourceBlock.length) {
+        var $source = $resourceBlock.prevAll('.activity-log-perspectives--source').first();
+        if ($source.length) {
+          $source.attr('data-active-perspective', activePersp);
+        }
+      }
+
+      // data-remote / Rails UJS handles the AJAX request automatically.
+    });
   }
 
 }

--- a/app/assets/stylesheets/app/activity_log.css.scss
+++ b/app/assets/stylesheets/app/activity_log.css.scss
@@ -1,5 +1,75 @@
+@use "../app_vars" as *;
+
 .activity-logs-item-block {
   padding: 0em;
+}
+
+// Perspective filter buttons injected into .sublist-controls alongside the filter selectors.
+// Uses BEM: block = .activity-log-perspectives, element = __btn, modifier = --active (via Bootstrap .active)
+
+// Source div hidden in its original DOM position; only the JS-injected clone is shown.
+.activity-log-perspectives--source {
+  display: none !important;
+}
+
+.activity-log-perspectives {
+  display: inline;
+  padding-right: 10px;
+
+  &__btn {
+    box-shadow: none;
+    background: $switch_bg_off;
+    color: rgb(255, 255, 255);
+    text-shadow: none;
+    border-radius: 30px;
+    padding: 3px 5px;
+    font-size: 90%;
+    font-weight: normal;
+    margin-right: 2px;
+    border: 1px solid transparent;
+
+    &.active {
+      background-color: $switch_bg_on;
+      box-shadow: none;
+      color: rgb(127, 90, 9);
+      border-color: rgb(199, 181, 142);
+
+      &:hover {
+        background: $switch_bg_on;
+      }
+    }
+
+    &:hover {
+      background-position: 0;
+      border-color: rgb(204, 204, 204);
+      outline: none !important;
+      text-shadow: none;
+      background: $switch_bg_off;
+      color: white;
+    }
+  }
+}
+
+// Allow filter selectors to flow inline alongside toggle and perspectives buttons.
+// Uses !important to override search_results.scss which is loaded later (alphabetically).
+.sublist-controls .sublist-filter-selectors {
+  width: auto !important;
+  line-height: normal !important;
+}
+
+// Match the responsive size increase applied to .filter-switch at wider breakpoints.
+@media only screen and (min-width: 1400px) {
+  .activity-log-list .sublist-controls .activity-log-perspectives__btn {
+    font-size: 12px;
+    padding: 5px 10px;
+  }
+}
+
+@media only screen and (min-width: 1600px) {
+  .sublist-controls .activity-log-perspectives__btn {
+    font-size: 12px;
+    padding: 5px 10px;
+  }
 }
 
 .activity-logs-generic-block {

--- a/app/assets/stylesheets/app/search_results.scss
+++ b/app/assets/stylesheets/app/search_results.scss
@@ -960,7 +960,7 @@ li.list-group-item.is_external_id_item {
     }
 
     .filter-switch.active {
-      background-color: rgb(230, 213, 176);
+      background-color: $switch_bg_on;
       box-shadow: none;
       color: rgb(127, 90, 9);
       text-shadow: 1px 1px 1px white;
@@ -984,7 +984,7 @@ li.list-group-item.is_external_id_item {
     }
 
     .order-switch.active, .expander-switch.active {
-      background-color: rgb(230, 213, 176);
+      background-color: $switch_bg_on;
       box-shadow: none;
       color: rgb(127, 90, 9);
       text-shadow: 1px 1px 1px white;
@@ -1008,7 +1008,7 @@ li.list-group-item.is_external_id_item {
     }
 
     .layout-switch.active {
-      background-color: rgb(230, 213, 176);
+      background-color: $switch_bg_on;
       box-shadow: none;
       color: rgb(127, 90, 9);
       border-color: rgb(199, 181, 142);

--- a/app/controllers/activity_log/activity_logs_controller.rb
+++ b/app/controllers/activity_log/activity_logs_controller.rb
@@ -12,6 +12,7 @@ class ActivityLog::ActivityLogsController < UserBaseController
   # e.g. a player contact
   # Not called for new or edit, since these are call elsewhere
   before_action :set_item, only: %i[index create update destroy]
+  before_action :apply_perspective, only: :index
   after_action :check_authentication_still_valid
 
   def template_config
@@ -280,5 +281,75 @@ class ActivityLog::ActivityLogsController < UserBaseController
 
     et = params[:extra_type]
     params[pname] = { extra_log_type: et }
+  end
+
+  #
+  # Apply a named perspective to @master_objects when params[:perspective] is present,
+  # or when a default perspective is configured in the app configuration for the current
+  # user and resource. Looks up the panel by params[:panel_name] and the current user's
+  # app type, then resolves the matching perspective config and runs the backend runner.
+  def apply_perspective
+    panel_name = params[:panel_name].presence
+    return unless panel_name && @implementation_class && @master
+
+    perspective_name = params[:perspective].presence
+    resource_name    = @implementation_class.resource_name.to_s
+
+    # When no explicit perspective param, check the app config for a per-user default
+    if perspective_name.blank?
+      defaults = Admin::AppConfiguration.hash_for(:default_activity_log_perspective, current_user)
+      raw_default = defaults[resource_name.to_sym].presence || defaults[resource_name].presence
+      if raw_default.present?
+        resolved = if raw_default.is_a?(String) && raw_default.include?('{{')
+                     Formatter::Substitution.substitute(raw_default, data: current_user, tag_subs: nil,
+                                                                     ignore_missing: true)&.strip
+                   else
+                     raw_default
+                   end
+        perspective_name = resolved.presence
+      end
+    end
+
+    return unless perspective_name
+
+    # Any missing or invalid configuration raises FphsException so the error surfaces
+    # immediately rather than silently showing unfiltered results.
+
+    panel = Admin::PageLayout.active
+                             .where(app_type_id: current_user.app_type_id, panel_name:)
+                             .first
+
+    unless panel
+      raise FphsException, "apply_perspective: no active panel found for panel_name=#{panel_name.inspect} app_type_id=#{current_user.app_type_id}"
+    end
+
+    all_perspectives = panel.view_options&.perspectives
+
+    unless all_perspectives.present?
+      raise FphsException, "apply_perspective: panel #{panel.id} has no perspectives configured"
+    end
+
+    perspectives_for_resource = (all_perspectives.with_indifferent_access[resource_name] || [])
+    config = perspectives_for_resource.find { |p| p.with_indifferent_access[:name].to_s == perspective_name }
+
+    unless config
+      raise FphsException, "apply_perspective: no perspective named #{perspective_name.inspect} found for resource #{resource_name.inspect}; available keys: #{all_perspectives.keys.inspect}"
+    end
+
+    # Wrap only the runner so unexpected runtime errors are logged with context
+    # before being re-raised. The validation guards above propagate directly.
+    begin
+      result = ActivityLog::Perspectives::Runner.new(
+        config, @implementation_class, current_user, master: @master
+      ).run
+    rescue StandardError => e
+      msg = "apply_perspective: runner failed for perspective #{perspective_name.inspect} on #{resource_name.inspect}: #{e.message}"
+      Rails.logger.error msg
+      Rails.logger.error e.short_string_backtrace
+      raise FphsException, msg
+    end
+
+    Rails.logger.debug { "apply_perspective: runner result=#{result.nil? ? 'nil (no matching records)' : result.to_sql}" }
+    @master_objects = @master_objects.merge(result) if result
   end
 end

--- a/app/models/activity_log/perspectives/runner.rb
+++ b/app/models/activity_log/perspectives/runner.rb
@@ -1,0 +1,271 @@
+# frozen_string_literal: true
+
+class ActivityLog
+  module Perspectives
+    # Execute a single named perspective for an activity log panel, returning an
+    # ActiveRecord::Relation scoped to the caller's master record.
+    #
+    # Supported backends (mutually exclusive — first match wins):
+    #   :report                  — runs a named Report, optionally with {{table_name}} substitution
+    #   :where                   — direct AR conditions hash, column-name whitelisted
+    #   :conditional_calculation — runs a ConditionalActions calculation using return_all_results
+    #
+    # Additional modifiers applied on top of the backend result:
+    #   :order    — { column: "asc"|"desc" }, whitelisted against class columns
+    #   :limit    — integer max records
+    #
+    # Usage:
+    #   relation = ActivityLog::Perspectives::Runner.new(
+    #     config, ActivityLog::CaseReview, current_user, master: @master
+    #   ).run
+    class Runner
+      # Allowed ORDER directions
+      VALID_DIRECTIONS = %w[asc desc].freeze
+
+      # @param config [Hash] a single perspective definition hash from page_layout
+      #   view_options.perspectives[<resource_name>][idx]
+      # @param al_class [Class] the activity log implementation class
+      # @param current_user [User]
+      # @param master [Master]
+      def initialize(config, al_class, current_user, master:)
+        @config = config.with_indifferent_access
+        @al_class = al_class
+        @current_user = current_user
+        @master = master
+      end
+
+      # Run the perspective and return an ActiveRecord::Relation.
+      # Returns nil only when a backend legitimately produces no results (e.g. a
+      # conditional_calculation where no records match). Raises on configuration
+      # errors so the caller can surface the problem rather than silently bypassing
+      # the filter and showing unfiltered records.
+      # @return [ActiveRecord::Relation, nil]
+      def run
+        Rails.logger.debug { "ActivityLog::Perspectives::Runner#run – al_class=#{@al_class}, master=#{@master&.id}, config=#{@config.to_h}" }
+        base = run_backend
+        base = apply_order(base)
+        base = apply_limit(base)
+        Rails.logger.debug { "ActivityLog::Perspectives::Runner#run – result SQL: #{base&.to_sql}" }
+        base
+      end
+
+      private
+
+      def run_backend
+        if @config[:report].present?
+          run_report_backend
+        elsif @config[:where].present?
+          run_where_backend
+        elsif @config[:conditional_calculation].present?
+          run_conditional_calculation_backend
+        else
+          # No backend — return all records for this master (acts as an "all" perspective reset)
+          @al_class.where(master_id: @master.id)
+        end
+      end
+
+      # Run a Report-based perspective.
+      # The report SQL may use {{table_name}}/{{schema_name}} substitutions.
+      def run_report_backend
+        resource_name = @config.dig(:report, :resource_name)
+        Rails.logger.debug { "ActivityLog::Perspectives::Runner#run_report_backend – resource_name=#{resource_name.inspect}" }
+        report = Report.find_by_id_or_resource_name(resource_name)
+        raise FphsException, "Perspective report not found: #{resource_name}" unless report
+
+        Rails.logger.debug { "ActivityLog::Perspectives::Runner#run_report_backend – report found id=#{report.id} (#{report.alt_resource_name})" }
+
+        # Perspectives are configured by admins in page layouts that users already have access to,
+        # and results are always scoped to @master.id via the final where() clause below.
+        # We therefore skip per-report UAC and require only that the report is active (already
+        # ensured by find_by_id_or_resource_name which scopes to Report.active).
+
+        report.current_user = @current_user
+        runner = report.runner
+
+        if report.uses_table_subs?
+          schema_name = Admin::MigrationGenerator.table_schema_hash[@al_class.table_name]
+          runner.data_reference.init(
+            table_name: @al_class.table_name,
+            schema_name: schema_name
+          )
+        end
+
+        # Only inject master_id into the report params when the report's search_attrs
+        # explicitly defines it. Reports::Runner#search_attrs_prep slices the params hash
+        # down to only the keys present in search_attrs, so injecting master_id when it
+        # is not declared there would cause sanitize_sql_for_conditions to raise
+        # PreparedStatementInvalid (unrecognised named bind variable :master_id). The
+        # final scope below always restricts results to @master regardless, so the
+        # SQL-level filter is an optimisation only.
+        report_attr_keys = report.search_attributes.symbolize_keys.keys
+        master_id_param  = report_attr_keys.include?(:master_id) ? { master_id: @master.id } : {}
+        defaults = (@config.dig(:report, :defaults) || {}).merge(master_id_param)
+        Rails.logger.debug { "ActivityLog::Perspectives::Runner#run_report_backend – running report with defaults=#{defaults.inspect}" }
+        raw_results = runner.run(defaults)
+
+        # Extract IDs from raw PG result set and scope back through the correct
+        # al_class + master_id so that records from other resources or masters
+        # that happen to share an ID cannot leak into the result.
+        ids = raw_results.map { |r| r['id'].to_i }.compact
+        Rails.logger.debug { "ActivityLog::Perspectives::Runner#run_report_backend – report returned #{ids.length} ids: #{ids.first(10).inspect}" }
+        # Remember the ordered IDs so apply_order can preserve SQL row order when no
+        # explicit order: is configured on this perspective.
+        @report_ordered_ids = ids
+        @al_class.where(master_id: @master.id, id: ids)
+      end
+
+      # Run a simple where-hash perspective.
+      # Column names are validated against the class's actual columns to prevent injection.
+      def run_where_backend
+        @al_class.where(master_id: @master.id).where(sanitized_where_conditions)
+      end
+
+      # Run a ConditionalActions-based perspective using return_all_results.
+      #
+      # The config value is the inner CalcActions condition hash.  It should target the
+      # activity log table using simple field conditions plus a `return: return_all_results`
+      # directive at the table level.  Example:
+      #
+      #   conditional_calculation:
+      #     activity_log__case_reviews:
+      #       status: active
+      #       return: return_all_results
+      #
+      # `no_masters: {}` is injected automatically so ConditionalActions queries the activity
+      # log class directly rather than joining through the masters table.  This is required
+      # for return_all_results to produce activity log record IDs rather than master IDs.
+      # If `no_masters` is already present in the supplied config it is left unchanged.
+      #
+      # Returns nil if no value is set by the calculation (e.g. no results match, or
+      # return_all_results is not used in the config).
+      def run_conditional_calculation_backend
+        # Deep-dup and coerce to indifferent access before modifying
+        calc_config = @config[:conditional_calculation].deep_dup.with_indifferent_access
+
+        # Perspectives query the activity log class directly (not joined through masters).
+        # Inject no_masters: {} so CalcActions uses the AL class as the base scope;
+        # without this, return_all_results would pluck master IDs instead of AL record IDs.
+        calc_config[:no_masters] ||= {}
+
+        ca = ConditionalActions.new(calc_config, context_instance)
+        ca.get_this_val
+
+        return nil unless ca.this_val_set?
+
+        result = ca.this_val
+        return nil unless result.present?
+
+        # Re-scope through al_class + master_id to prevent cross-resource or cross-master
+        # leakage regardless of what the calculation returns.
+        ids = result.is_a?(ActiveRecord::Relation) ? result.pluck(:id) : Array(result).map(&:id)
+        @al_class.where(master_id: @master.id, id: ids)
+      end
+
+      # Validate each key in the where config against the class's column names.
+      # String values may contain {{field_defaults}} substitutions which are resolved
+      # against the current user/master context before the condition is applied.
+      # Returns a clean hash safe to pass to AR's where().
+      # Raises FphsException on unknown columns or unresolved template references so
+      # admin misconfiguration is surfaced immediately rather than silently ignored.
+      def sanitized_where_conditions
+        allowed_columns = @al_class.column_names.map(&:to_s)
+        @config[:where].each_with_object({}) do |(k, v), h|
+          col = k.to_s
+          unless allowed_columns.include?(col)
+            raise FphsException,
+                  "Perspectives::Runner – where: key #{col.inspect} is not a valid column on #{@al_class}"
+          end
+
+          if v.is_a?(String)
+            result = FieldDefaults.calculate_default(context_instance, v, ignore_missing: true)
+            if result.blank? && v.include?('{{')
+              raise FphsException,
+                    "Perspectives::Runner – where: value #{v.inspect} for column #{col.inspect} resolved to blank; " \
+                    'check field reference in template'
+            end
+
+            h[col] = result
+          else
+            h[col] = v
+          end
+        end
+      end
+
+      # A lightweight unsaved instance of the activity log class used as the substitution
+      # context for FieldDefaults and ConditionalActions.  Memoized so all backends share
+      # the same object within a single #run call.
+      def context_instance
+        @context_instance ||= begin
+          inst = @al_class.new(master_id: @master.id)
+          inst.current_user = @current_user
+          inst
+        end
+      end
+
+      # Apply ordering to the relation.
+      #
+      # Priority:
+      #   1. Explicit `order:` in perspective config — always wins (column-name whitelisted).
+      #   2. Report backend with no explicit order — preserve the SQL row order returned by
+      #      the report using array_position so the caller's ORDER BY is honoured.
+      #   3. All other backends with no explicit order — order chronologically by
+      #      action_when_attribute DESC, id DESC (mirrors the Master has_many scope).
+      def apply_order(relation)
+        return relation if relation.nil?
+
+        if @config[:order].present?
+          # Explicit order: always wins. Raise on any invalid column or direction so the
+          # admin knows the config is wrong rather than silently falling back to default order.
+          allowed_columns = @al_class.column_names.map(&:to_s)
+          order_clauses = @config[:order].each_with_object({}) do |(col, dir), h|
+            col_s = col.to_s
+            dir_s = dir.to_s.downcase
+            unless allowed_columns.include?(col_s)
+              raise FphsException,
+                    "Perspectives::Runner – order: column #{col_s.inspect} is not a valid column on #{@al_class}"
+            end
+            unless VALID_DIRECTIONS.include?(dir_s)
+              raise FphsException,
+                    "Perspectives::Runner – order: direction #{dir.inspect} for column #{col_s.inspect} is not valid; use 'asc' or 'desc'"
+            end
+
+            h[col_s] = dir_s
+          end
+          return relation.reorder(order_clauses)
+        end
+
+        if @report_ordered_ids
+          # Report backend: preserve the SQL row order using array_position.
+          # Skip if no results (WHERE id IN () already returns nothing).
+          return relation unless @report_ordered_ids.any?
+
+          ids_array = @report_ordered_ids.join(',')
+          return relation.reorder(
+            Arel.sql("array_position(ARRAY[#{ids_array}]::integer[], #{@al_class.quoted_table_name}.id)")
+          )
+        end
+
+        # Non-report backends: apply action_when_attribute DESC, id DESC.
+        # This mirrors the ordering used on the Master has_many association scope.
+        # Use created_at when action_when_attribute is :alt_order (a pseudo-attribute).
+        awa = @al_class.action_when_attribute
+        awa = :created_at if awa == :alt_order
+        relation.reorder(awa => :desc, id: :desc)
+      end
+
+      # Apply a LIMIT from config.
+      # Raises FphsException when a limit: value is present but not a positive integer.
+      def apply_limit(relation)
+        return relation unless @config[:limit].present?
+
+        limit = @config[:limit].to_i
+        unless limit.positive?
+          raise FphsException,
+                "Perspectives::Runner – limit: #{@config[:limit].inspect} is not a positive integer"
+        end
+
+        relation.limit(limit)
+      end
+    end
+  end
+end

--- a/app/models/admin/defs/app_configuration_defs.yaml
+++ b/app/models/admin/defs/app_configuration_defs.yaml
@@ -180,4 +180,22 @@ default options dynamic model: |
       options: |
         _configurations:
           use_current_version: true
-          
+default activity log perspective: |
+  Default perspective to activate for each activity log panel, keyed by resource name.
+  When set, the named perspective will be selected automatically when the panel first loads,
+  overriding the panel-level default_perspective setting in page_layout view_options.
+  Provide a YAML hash where each key is the activity log resource name and the value is the
+  perspective slug to activate. The value may use \{\{#if}} and \{\{#is}} substitutions to
+  conditionally set the default perspective based on the current context. For example:
+
+      activity_log__case_reviews: recent_active
+      activity_log__data_requests: my_open
+
+  With conditional substitutions (values evaluated against the current user):
+
+      activity_log__case_reviews: |
+        \{\{#is role_name '===' 'coordinator'}}
+          coordinator_view
+        \{\{else is role_name '===' 'reviewer'}}
+          reviewer_view
+        \{\{/is}}

--- a/app/models/admin/defs/page_layout_options_defs.yaml
+++ b/app/models/admin/defs/page_layout_options_defs.yaml
@@ -63,6 +63,32 @@ view_options:
                                       # Example:
                                       #   player_contacts: desc
                                       #   addresses: asc
+  perspectives:                       # hash of resource names to array of perspective definitions for activity log panels
+                                      # Each perspective filters/orders the activity log list server-side
+                                      # Example:
+                                      #   activity_log__case_reviews:
+                                      #     - name: recent_active    # slug used in request params
+                                      #       label: Recent Active   # button label shown to user
+                                      #       report:                # Report backend (use report alt_resource_name)
+                                      #         resource_name: al_recent_active_report
+                                      #         defaults:            # criteria hash passed to report runner
+                                      #           status: active
+                                      #       order:                 # whitelisted sort (column: asc|desc)
+                                      #         created_at: desc     # omit to use action_when_attribute desc
+                                      #                              # (report backend preserves SQL row order)
+                                      #       limit: 10              # max records to return
+                                      #     - name: my_open          # ConditionalActions backend
+                                      #       label: My Open
+                                      #       conditional_calculation:  # CalcActions condition hash;
+                                      #         activity_log__case_reviews: # use field: value for equality
+                                      #           status: active            # and return: return_all_results
+                                      #           return: return_all_results # no_masters is auto-injected
+                                      #     - name: all
+                                      #       label: All             # 'all' with no backend = reset to unfiltered
+  default_perspective:                # slug of the perspective to activate by default for this panel
+                                      # May be overridden per-user via the 'default activity log perspective'
+                                      # Admin::AppConfiguration entry (keyed by resource_name).
+                                      # Example: recent_active
 
 list_options:
   hide_in_list: false (default) | true

--- a/app/models/admin/page_layout.rb
+++ b/app/models/admin/page_layout.rb
@@ -75,7 +75,8 @@ class Admin::PageLayout < Admin::AdminBase
             with: %i[initial_show orientation add_item_label limit find_with hide_sublist_controls default_expander
                      hide_activity_logs_header close_others
                      show_for_single_master_only show_for_multi_master_only filter_items
-                     active_sublist_values sort_sublists]
+                     active_sublist_values sort_sublists
+                     perspectives default_perspective]
 
   # List options for dashboards list
   configure :list_options, with: %i[hide_in_list]

--- a/app/models/formatter/substitution.rb
+++ b/app/models/formatter/substitution.rb
@@ -37,7 +37,7 @@ module Formatter
 
     NoAutoTitleizeTags = %w[resource_name item_type_name default_embed_resource_name
                             definition_resource_name definition_item_type_name table_name schema_name
-                            default_schema_name redcap_event_name].freeze
+                            default_schema_name redcap_event_name role_name].freeze
     #
     # Perform substitutions on the text, using either a Hash of data or an object item.
     # Provide a tag substitution to be used to enclose the substituted items
@@ -518,6 +518,11 @@ module Formatter
         sym = rn.id_underscore.to_sym
         cur[sym] = rn
       end
+
+      # Make the user's first role available as {{role_name}} for {{#is role_name '===' 'xxx'}} patterns.
+      # Uses ||= to avoid overwriting an existing role_name attribute on the primary data object
+      # (e.g. when processing Admin::UserRole records that have their own role_name column).
+      data[:role_name] ||= cu.role_names.first&.to_s || ''
     end
 
     #

--- a/app/views/masters/_search_results_parts.html.erb
+++ b/app/views/masters/_search_results_parts.html.erb
@@ -165,7 +165,8 @@
 <%= handlebars_template_tag('sublist_controls', css_class: 'hidden handlebars-partial') do %>
   <div class="sublist-controls">
     {{#if filter_attr}}
-    <div class="sublist-filter-selectors">
+    <button class="btn btn-clear btn-sm sublist-filter-toggle glyphicon glyphicon-triangle-right" title="show/hide filters"></button>
+    <div class="sublist-filter-selectors hidden">
       {{#if filter_all}}
       <button class="btn btn-default btn-sm filter-switch-all glyphicon glyphicon-minus" data-filter-all="true"></button>
       {{/if}}

--- a/app/views/masters/_search_results_resources_panel.html.erb
+++ b/app/views/masters/_search_results_resources_panel.html.erb
@@ -27,6 +27,19 @@
   view_css = panel.view_css
   limit = (panel.view_options&.limit || 20).to_i
 
+  # Perspectives: hash keyed by resource name → array of perspective definitions
+  all_perspectives = (panel.view_options&.perspectives || {}).with_indifferent_access
+  # Panel-level default perspective slug (overridden per-user via AppConfiguration)
+  panel_default_perspective = panel.view_options&.default_perspective
+  # User / role / app-type specific default perspectives hash keyed by resource name.
+  # Values may contain {{#is}} / {{#if}} substitution blocks evaluated against the current user.
+  user_default_perspectives = Admin::AppConfiguration.hash_for(:default_activity_log_perspective, current_user)
+                                                     .transform_values do |v|
+    next v unless v.is_a?(String) && v.include?('{{')
+
+    Formatter::Substitution.substitute(v, data: current_user, tag_subs: nil, ignore_missing: true)&.strip
+  end
+
   renderable = resources.each_with_object([]) do |resource, memo|
     next unless master_viewables[resource.to_sym]
 
@@ -42,7 +55,41 @@
   <% resource, render_info = renderable.first
      block_id = "#{resource.hyphenate}-{{id}}"
      inner_block_class = render_info[:wrapper_class].gsub('generic-block', 'inner-block')
-     template_name = render_info[:template_name] %>
+     template_name = render_info[:template_name]
+     resource_perspectives = all_perspectives[resource.to_s]
+     eff_default = user_default_perspectives[resource.to_sym].presence ||
+                   user_default_perspectives[resource.to_s].presence ||
+                   panel_default_perspective %>
+  <%# Perspectives button bar (if configured). Rendered as a preceding sibling
+      of the resource block so the JS `prevAll('.activity-log-perspectives--source')`
+      lookup works the same way as in WRAPPER mode. %>
+  <% if resource_perspectives.present? %>
+    <div class="activity-log-perspectives activity-log-perspectives--source"
+         data-resource="<%= resource %>"
+         data-panel-name="<%= panel_name %>">
+      <a href="/masters/{{id}}/<%= render_info[:route_path] %>?limit=<%= limit %>&panel_name=<%= panel_name %>"
+         data-remote="true"
+         data-result-target="#<%= block_id %>"
+         data-template="<%= template_name %>"
+         data-panel-tab="<%= resource %>"
+         data-perspective=""
+         class="btn btn-default btn-sm activity-log-perspectives__btn<%= ' active' if eff_default.blank? %>"
+         ><%= t('activity_log.perspectives.all_label', default: 'All') %></a>
+      <% resource_perspectives.each do |persp|
+           pname  = persp.is_a?(Hash) ? (persp[:name] || persp['name']).to_s : ''
+           plabel = persp.is_a?(Hash) ? (persp[:label] || persp['label']).to_s : pname
+           next if pname.blank? %>
+        <a href="/masters/{{id}}/<%= render_info[:route_path] %>?limit=<%= limit %>&panel_name=<%= panel_name %>&perspective=<%= ERB::Util.url_encode(pname) %>"
+           data-remote="true"
+           data-result-target="#<%= block_id %>"
+           data-template="<%= template_name %>"
+           data-panel-tab="<%= resource %>"
+           data-perspective="<%= pname %>"
+           class="btn btn-default btn-sm activity-log-perspectives__btn<%= ' active' if eff_default.to_s == pname %>"
+           ><%= plabel %></a>
+      <% end %>
+    </div>
+  <% end %>
   <div id="<%= block_id %>"
        class="<%= render_info[:wrapper_class] %> <%= resource.hyphenate %>-block collapse"
        data-sub-for-root="master_id"
@@ -74,8 +121,13 @@
       <% renderable.each do |resource, render_info|
            block_id = "#{resource.hyphenate}-{{id}}"
            route_path = render_info[:route_path]
-           template_name = render_info[:template_name] %>
-        <a href="/masters/{{id}}/<%= route_path %>?limit=<%= limit %>"
+           template_name = render_info[:template_name]
+           # Resolve effective default perspective for this resource
+           eff_default = user_default_perspectives[resource.to_sym].presence ||
+                         user_default_perspectives[resource.to_s].presence ||
+                         panel_default_perspective
+           default_param = eff_default.present? ? "&perspective=#{ERB::Util.url_encode(eff_default)}" : '' %>
+        <a href="/masters/{{id}}/<%= route_path %>?limit=<%= limit %>&panel_name=<%= panel_name %><%= default_param %>"
            data-remote="true"
            data-result-target="#<%= block_id %>"
            data-template="<%= template_name %>"
@@ -88,7 +140,39 @@
     <% renderable.each do |resource, render_info|
          block_id = "#{resource.hyphenate}-{{id}}"
          inner_block_class = render_info[:wrapper_class].gsub('generic-block', 'inner-block')
-         template_name = render_info[:template_name] %>
+         template_name = render_info[:template_name]
+         resource_perspectives = all_perspectives[resource.to_s]
+         eff_default = user_default_perspectives[resource.to_sym].presence ||
+                       user_default_perspectives[resource.to_s].presence ||
+                       panel_default_perspective %>
+      <% if resource_perspectives.present? %>
+        <div class="activity-log-perspectives activity-log-perspectives--source"
+             data-resource="<%= resource %>"
+             data-panel-name="<%= panel_name %>">
+          <%# "All" reset button — no perspective param %>
+          <a href="/masters/{{id}}/<%= render_info[:route_path] %>?limit=<%= limit %>&panel_name=<%= panel_name %>"
+             data-remote="true"
+             data-result-target="#<%= block_id %>"
+             data-template="<%= template_name %>"
+             data-panel-tab="<%= resource %>"
+             data-perspective=""
+             class="btn btn-default btn-sm activity-log-perspectives__btn<%= ' active' if eff_default.blank? %>"
+             ><%= t('activity_log.perspectives.all_label', default: 'All') %></a>
+          <% resource_perspectives.each do |persp|
+               pname  = persp.is_a?(Hash) ? (persp[:name] || persp['name']).to_s : ''
+               plabel = persp.is_a?(Hash) ? (persp[:label] || persp['label']).to_s : pname
+               next if pname.blank? %>
+            <a href="/masters/{{id}}/<%= render_info[:route_path] %>?limit=<%= limit %>&panel_name=<%= panel_name %>&perspective=<%= ERB::Util.url_encode(pname) %>"
+               data-remote="true"
+               data-result-target="#<%= block_id %>"
+               data-template="<%= template_name %>"
+               data-panel-tab="<%= resource %>"
+               data-perspective="<%= pname %>"
+               class="btn btn-default btn-sm activity-log-perspectives__btn<%= ' active' if eff_default.to_s == pname %>"
+               ><%= plabel %></a>
+          <% end %>
+        </div>
+      <% end %>
       <div id="<%= block_id %>"
            class="<%= render_info[:wrapper_class] %> <%= resource.hyphenate %>-block"
            data-sub-for-root="master_id"

--- a/docs/admin_reference/page_layouts/0_introduction.md
+++ b/docs/admin_reference/page_layouts/0_introduction.md
@@ -7,6 +7,7 @@
 The components that can be configured are:
 
 - [Master Panels](master_panels.md)
+- [Activity Log Panel Perspectives](perspectives.md)
 - [User Profile](user_profile.md)
 - [Navigations](navigations.md)
 - [Dashboards](dashboards.md)
@@ -27,3 +28,4 @@ available to all *app types*.
 ## Contents
 
 - [Detailed Options](detailed_options.md)
+- [Activity Log Panel Perspectives](perspectives.md)

--- a/docs/admin_reference/page_layouts/master_panels.md
+++ b/docs/admin_reference/page_layouts/master_panels.md
@@ -107,3 +107,10 @@ To do this, use a URL hash formatted with `#click-target-[tab-id]`.
   *(Example: for a panel named "My Custom Panel", use `[Open Custom Panel](#click-target-tab-resources-my-custom-panel)`)*
   
 *Note: For `contains.resources` panels containing only a single resource, the older `#click-target-tab-[resource-name-hyphenated]` format acts as an alias (e.g. `#click-target-tab-activity-log--case-reviews`), but the `tab-resources-[panel-name]` format is preferred.*
+
+## Activity Log Perspectives
+
+Filter buttons can be added above an activity log content block to let users switch between
+server-side filtered views of the list.
+
+See [perspectives.md](perspectives.md) for the full configuration reference.

--- a/docs/admin_reference/page_layouts/perspectives.md
+++ b/docs/admin_reference/page_layouts/perspectives.md
@@ -1,0 +1,288 @@
+# Activity Log Panel Perspectives
+
+**Perspectives** add a row of filter buttons above an activity log content block within a master
+panel.  Clicking a button reloads the list server-side with the configured filter applied.
+Clicking the **All** button restores the unfiltered list.
+
+Perspectives are configured entirely through the *Page Layout* admin panel — no code changes are
+required.
+
+---
+
+## Overview
+
+When perspectives are enabled for a resource inside a panel, the UI renders a `btn-group` bar
+directly above the activity log list:
+
+```
+[ All ]  [ Recent Active ]  [ My Open ]  [ Closed ]
+```
+
+The active button is highlighted.  Clicking any button triggers an AJAX reload of the list using
+the perspective's backend (a `where:` filter, a Report, or both with an optional `order:` and
+`limit:`).
+
+---
+
+## Configuration
+
+Perspectives are defined inside `view_options` of a **Master Panel** page layout.
+
+### Minimal example — `where:` backend
+
+```yaml
+contains:
+  resources:
+    - activity_log__case_reviews
+view_options:
+  initial_show: true
+  perspectives:
+    activity_log__case_reviews:
+      - name: recent_active
+        label: Recent Active
+        where:
+          status: active
+        order:
+          created_at: desc
+        limit: 20
+      - name: my_closed
+        label: My Closed
+        where:
+          status: closed
+      - name: assigned_to_me
+        label: Mine
+        where:
+          assigned_to: '{{current_user_email}}'   # resolved to the logged-in user's email
+  default_perspective: recent_active
+```
+
+### Example using a Report backend
+
+```yaml
+view_options:
+  perspectives:
+    activity_log__data_requests:
+      - name: my_open
+        label: My Open
+        report:
+          resource_name: dr_my_open_report
+          defaults:
+            status: open
+        limit: 50
+```
+
+### Example using a Conditional Calculation backend
+
+```yaml
+view_options:
+  perspectives:
+    activity_log__case_reviews:
+      - name: active_mine
+        label: My Active
+        conditional_calculation:
+          activity_log__case_reviews:
+            status: active
+            return: return_all_results
+        order:
+          created_at: desc
+        limit: 25
+```
+
+---
+
+## `perspectives` key
+
+The value is a **hash keyed by resource name** (the activity log's resource name, e.g.
+`activity_log__case_reviews`).  Each value is an **array of perspective definitions**.
+
+```yaml
+perspectives:
+  <activity_log_resource_name>:
+    - name: <slug>          # (required) identifier used in request params
+      label: <text>         # (required) button label shown to the user
+      where:                # (optional) AR conditions hash — column names are
+        <column>: <value>   #   whitelisted against the model's actual columns.
+                            #   String values support {{field_defaults}} substitutions
+                            #   evaluated against the current user/master context
+                            #   (e.g. current_user_email, current_user).
+      report:               # (optional, mutually exclusive with where: and conditional_calculation:)
+        resource_name: <alt_resource_name>   # report's alt_resource_name
+        defaults:                            # (optional) criteria hash passed
+          <key>: <value>                     #   to the report runner;
+                                             #   supports {{table_name}} and
+                                             #   {{schema_name}} substitutions
+      conditional_calculation:  # (optional, mutually exclusive with where: and report:)
+        <resource_name>:        # CalcActions condition hash; use field: value for equality,
+          <field>: <value>      #   or a condition hash for other operators.
+          return: return_all_results  # required return directive
+      order:                # (optional) whitelisted sort order
+        <column>: asc|desc  #   only valid column names are applied
+      limit: <integer>      # (optional) max records returned for this perspective
+```
+
+### Perspective definition keys
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `name` | ✅ | Slug used in request parameters and in `default_perspective` references.  Use `all` with no backend to create an explicit "All" reset button (one is always added automatically). |
+| `label` | ✅ | Button label displayed to the user. |
+| `where` | — | Hash of `{ column: value }` conditions applied as an ActiveRecord `where`.  Column names are validated against the model's columns.  String values support `{{field_defaults}}` substitutions evaluated against the current user/master context (e.g. `current_user_email`, `current_user`).  Mutually exclusive with `report` and `conditional_calculation`. |
+| `report` | — | Report-based backend.  Specify the report's `alt_resource_name` and optional `defaults` criteria.  Mutually exclusive with `where` and `conditional_calculation`. |
+| `conditional_calculation` | — | [ConditionalActions](../../dev_reference/main/architecture_overview.md) condition hash targeting the activity log's own resource name.  Use `field: value` pairs for equality conditions and `return: return_all_results` as the return-mode directive.  `no_masters: {}` is injected automatically.  Mutually exclusive with `where` and `report`. |
+| `order` | — | Hash of `{ column: "asc" \| "desc" }`.  Column names are validated against the model's columns.  When omitted, a default ordering is applied automatically (see **Ordering** below). |
+| `limit` | — | Integer maximum number of records returned.  Overrides the panel-level `limit` view option for this perspective. |
+
+> **Note:** If none of `where`, `report`, or `conditional_calculation` is provided, clicking the button returns the full
+> unfiltered list (equivalent to the built-in **All** button).
+
+---
+
+## Ordering
+
+The ordering applied to a perspective result follows this priority (highest wins):
+
+| Priority | Condition | Ordering applied |
+|----------|-----------|------------------|
+| 1 | `order:` is present in the perspective config | The specified columns/directions.  Column names are whitelisted; invalid names are silently ignored. |
+| 2 | `report:` backend, no `order:` | The row order returned by the report SQL is preserved using `array_position`.  Write `ORDER BY` in your report SQL to control it. |
+| 3 | Any other backend, no `order:` | `action_when_attribute DESC, id DESC` — matching the chronological ordering used on the master panel (mirrors the activity log's `Master` has_many scope). |
+
+**`action_when_attribute`** is the field configured on the activity log definition (e.g. `called_when`, `completed_when`).  If it is set to `alt_order`, `created_at` is used instead.
+
+Report perspectives intentionally do **not** fall back to `action_when_attribute` because the report author controls the ordering via the SQL `ORDER BY` clause.  Add an explicit `order:` to override it.
+
+---
+
+## `default_perspective` key
+
+Set at the panel level inside `view_options` to specify which perspective button should be active
+when the panel first loads.
+
+```yaml
+view_options:
+  perspectives:
+    activity_log__case_reviews:
+      - name: recent_active
+        label: Recent Active
+        where:
+          status: active
+  default_perspective: recent_active   # slug of the perspective to activate by default
+```
+
+If `default_perspective` is omitted, the **All** button is active by default.
+
+---
+
+## Per-user default via App Configuration
+
+The panel-level `default_perspective` can be overridden on a per-user (or per-role) basis using
+the **`default activity log perspective`** `Admin::AppConfiguration` entry.
+
+The configuration value is a YAML hash where each key is an activity log resource name and the
+value is the perspective slug to activate:
+
+```yaml
+activity_log__case_reviews: recent_active
+activity_log__data_requests: my_open
+```
+
+Conditional substitutions (evaluated against the current user) are supported:
+
+```yaml
+activity_log__case_reviews: |
+  {{#is role_name '===' 'coordinator'}}
+    coordinator_view
+  {{else is role_name '===' 'reviewer'}}
+    reviewer_view
+  {{/is}}
+```
+
+**Precedence** (highest to lowest):
+
+1. `default activity log perspective` app configuration (per user / role)
+2. Panel-level `default_perspective` in `view_options`
+3. Built-in **All** (no filter)
+
+---
+
+## Complete example
+
+```yaml
+contains:
+  resources:
+    - activity_log__case_reviews
+view_options:
+  initial_show: true
+  limit: 25
+  perspectives:
+    activity_log__case_reviews:
+      - name: recent_active
+        label: Recent Active
+        where:
+          status: active
+        order:
+          created_at: desc
+        limit: 20
+      - name: my_closed
+        label: My Closed
+        where:
+          status: closed
+      - name: high_priority
+        label: High Priority
+        report:
+          resource_name: case_review_high_priority_report
+          defaults:
+            schema_name: "{{schema_name}}"
+        order:
+          priority_rank: asc
+        limit: 50
+  default_perspective: recent_active
+```
+
+---
+
+## HTML structure
+
+The perspectives bar is rendered as a Bootstrap `btn-group` above the activity log list:
+
+```html
+<div class="activity-log-perspectives btn-group"
+     data-resource="activity_log__case_reviews"
+     data-panel-name="my-panel-name">
+
+  <a class="btn btn-default btn-xs activity-log-perspectives__btn active"
+     data-perspective=""
+     data-remote="true">All</a>
+
+  <a class="btn btn-default btn-xs activity-log-perspectives__btn"
+     data-perspective="recent_active"
+     data-remote="true">Recent Active</a>
+
+  <!-- … additional perspective buttons … -->
+</div>
+```
+
+The `active` CSS class is toggled on the clicked button by the JavaScript handler in
+`app/assets/javascripts/app/page_layouts.js`.
+
+---
+
+## Notes
+
+- Perspectives only appear when the `perspectives` key is present in `view_options` for the
+  resource.  If the key is absent the button bar is not rendered.
+- Column names in `where:` and `order:` are whitelisted against the model's actual database
+  columns.  Invalid column names are silently ignored.
+- When `order:` is omitted, results are ordered by `action_when_attribute DESC, id DESC` for
+  `where:`, `conditional_calculation:`, and no-backend perspectives.  For `report:` perspectives,
+  the SQL row order from the report is preserved; use `ORDER BY` in the report SQL to control it.
+- Access control is respected: if a user does not have access to the underlying Report resource,
+  the perspective returns `nil` and the full unfiltered list is shown instead.
+- The `conditional_calculation` backend uses `ConditionalActions` with `no_masters: {}` injected
+  automatically so the query runs directly against the activity log table (not joined through
+  `masters`).  Use `return: return_all_results` as a field-level directive to collect matching
+  records.  If the calculation returns no results the full unfiltered list is shown instead.
+  Results are always re-scoped through the activity log class and master record to prevent
+  cross-resource or cross-master leakage.
+- The `limit` on an individual perspective overrides the panel-level `limit` view option only for
+  that perspective.

--- a/spec/models/activity_log/perspectives/runner_spec.rb
+++ b/spec/models/activity_log/perspectives/runner_spec.rb
@@ -1,0 +1,379 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Tests for ActivityLog::Perspectives::Runner.
+#
+# Verifies that the runner correctly applies each backend type (where, report,
+# conditional_calculation), enforces column-name whitelisting on the where backend
+# and on order/limit clauses, raises on configuration errors (so the caller surfaces
+# the problem rather than silently showing unfiltered records), and returns nil only
+# when a backend legitimately produces no results.
+#
+# NOTE: report-backend perspectives intentionally bypass per-report UAC because
+# the perspective is admin-gated via the page layout and results are always
+# re-scoped to @master.id by the final where() clause. A missing UAC entry on the
+# backing report must NOT silently bypass the filter.
+
+RSpec.describe ActivityLog::Perspectives::Runner, type: :model do
+  include ModelSupport
+  include PlayerContactSupport
+
+  before :each do
+    create_user
+    setup_access :player_contacts
+    let_user_create_player_contacts
+    create_item(data: rand(10_000_000_000_000_000), rank: 10)
+    @master = @player_contact.master
+    @master.current_user = @user
+
+    # Set up access for activity log and create two records for filtering tests
+    al_class = ActivityLog::PlayerContactPhone
+    setup_access :activity_log__player_contact_phones, resource_type: :table, access: :create, user: @user
+    setup_access :activity_log__player_contact_phone__primary, resource_type: :activity_log_type, access: :create, user: @user
+
+    @al1 = @player_contact.activity_log__player_contact_phones.create!(
+      select_call_direction: 'to player', select_who: 'user', extra_log_type: 'primary', master: @master
+    )
+    @al2 = @player_contact.activity_log__player_contact_phones.create!(
+      select_call_direction: 'to staff', select_who: 'user', extra_log_type: 'primary', master: @master
+    )
+    @al_class = al_class
+  end
+
+  # Helper to build a runner with the given config hash
+  def build_runner(config)
+    ActivityLog::Perspectives::Runner.new(config, @al_class, @user, master: @master)
+  end
+
+  describe 'where backend' do
+    it 'returns records matching a valid where condition' do
+      config = { where: { select_call_direction: 'to player' } }
+      result = build_runner(config).run
+      expect(result).to be_a ActiveRecord::Relation
+      ids = result.pluck(:id)
+      expect(ids).to include @al1.id
+      expect(ids).not_to include @al2.id
+    end
+
+    it 'raises FphsException for where keys that are not valid column names' do
+      config = { where: { 'drop table masters;--' => 'x', select_call_direction: 'to staff' } }
+      expect { build_runner(config).run }.to raise_error(FphsException, /not a valid column/)
+    end
+
+    it 'returns all master records when where hash is empty' do
+      config = { where: {} }
+      result = build_runner(config).run
+      expect(result.pluck(:id)).to include @al1.id, @al2.id
+    end
+
+    it 'resolves {{current_user_email}} substitution in a where value' do
+      # Store the current user's email on one of the records so a substitution-based
+      # where filter can match it.
+      @al1.update_column(:select_who, @user.email)
+      config = { where: { select_who: '{{current_user_email}}' } }
+      result = build_runner(config).run
+      expect(result).to be_a ActiveRecord::Relation
+      ids = result.pluck(:id)
+      expect(ids).to include @al1.id
+      expect(ids).not_to include @al2.id
+    end
+  end
+
+  describe 'no-backend (all) perspective' do
+    it 'returns all records for the master when no backend is specified' do
+      config = {}
+      result = build_runner(config).run
+      expect(result).to be_a ActiveRecord::Relation
+      expect(result.pluck(:id)).to include @al1.id, @al2.id
+    end
+  end
+
+  describe 'order modifier' do
+    it 'applies a valid order clause' do
+      config = { order: { id: 'desc' } }
+      result = build_runner(config).run
+      ids = result.pluck(:id)
+      expect(ids).to eq ids.sort.reverse
+    end
+
+    it 'raises FphsException for invalid column names in the order clause' do
+      config = { where: {}, order: { 'invalid_column' => 'asc' } }
+      expect { build_runner(config).run }.to raise_error(FphsException, /not a valid column/)
+    end
+
+    it 'raises FphsException for invalid directions in the order clause' do
+      config = { where: {}, order: { id: 'RANDOM()' } }
+      expect { build_runner(config).run }.to raise_error(FphsException, /not valid.*use 'asc' or 'desc'/)
+    end
+  end
+
+  describe 'default ordering (action_when_attribute)' do
+    # Make @al1 (smaller id) more recent than @al2 so that action_when_attribute DESC
+    # puts al1 first — deliberately opposing the class default_scope "id DESC" (which
+    # would put al2 first).  This lets us distinguish the two orderings.
+    before :each do
+      awa = @al_class.action_when_attribute
+      @al1.update_column(awa, 1.day.ago)
+      @al2.update_column(awa, 2.days.ago)
+    end
+
+    it 'orders by action_when_attribute desc when no order: is configured on a where backend' do
+      config = { where: {} }
+      result = build_runner(config).run
+      ordered_ids = result.pluck(:id)
+      # al1 has more-recent action_when_attribute so should appear before al2
+      expect(ordered_ids.index(@al1.id)).to be < ordered_ids.index(@al2.id)
+    end
+
+    it 'orders by action_when_attribute desc when no order: is configured on the no-backend (all) perspective' do
+      config = {}
+      result = build_runner(config).run
+      ordered_ids = result.pluck(:id)
+      expect(ordered_ids.index(@al1.id)).to be < ordered_ids.index(@al2.id)
+    end
+
+    it 'orders by action_when_attribute desc when no order: is configured on a conditional_calculation backend' do
+      # Both records have select_who: 'user' so this returns both and lets us check ordering.
+      calc_conf = {
+        @al_class.resource_name.to_s => {
+          select_who: 'user',
+          return: 'return_all_results'
+        }
+      }
+      config = { conditional_calculation: calc_conf }
+      result = build_runner(config).run
+      ordered_ids = result.pluck(:id)
+      expect(ordered_ids.index(@al1.id)).to be < ordered_ids.index(@al2.id)
+    end
+
+    it 'respects an explicit order: that overrides the action_when_attribute default' do
+      # order by id ASC — al1 (smaller id, more recent awa) should come first by id too,
+      # so use id DESC here to conflict with awa DESC and prove explicit order wins
+      config = { where: {}, order: { id: 'desc' } }
+      result = build_runner(config).run
+      ordered_ids = result.pluck(:id)
+      expect(ordered_ids.first).to eq [@al1.id, @al2.id].max
+    end
+  end
+
+  describe 'limit modifier' do
+    it 'applies a positive limit' do
+      config = { limit: 1 }
+      result = build_runner(config).run
+      expect(result.count).to eq 1
+    end
+
+    it 'raises FphsException for a zero or non-positive limit' do
+      config = { limit: 0 }
+      expect { build_runner(config).run }.to raise_error(FphsException, /not a positive integer/)
+    end
+  end
+
+  describe 'report backend' do
+    before :each do
+      create_admin
+      # Create a report that selects IDs from the activity log table for this master.
+      # No UAC grant is needed — perspective runner bypasses per-report access checks.
+      al_table = @al_class.table_name
+      @al_report_sql = "SELECT id FROM #{al_table} WHERE master_id = :master_id AND select_call_direction = 'to player'"
+      @al_report = Report.create!(
+        current_admin: @admin,
+        name: "Perspective test report #{SecureRandom.hex}",
+        sql: @al_report_sql,
+        search_attrs: "master_id:\n  integer:\n",
+        disabled: false,
+        report_type: 'regular_report',
+        auto: false,
+        searchable: false
+      )
+    end
+
+    it 'returns records identified by a report that the user can access' do
+      config = { report: { resource_name: @al_report.alt_resource_name } }
+      result = build_runner(config).run
+      expect(result).to be_a ActiveRecord::Relation
+      expect(result.pluck(:id)).to include @al1.id
+      expect(result.pluck(:id)).not_to include @al2.id
+    end
+
+    it 'returns filtered records when the report SQL has no named params and search_attrs is empty' do
+      # This covers the case where the admin writes a plain SQL report (no :master_id bind
+      # variable, no search_attrs definition). Previously, run_report_backend always merged
+      # master_id: @master.id into defaults, which search_attrs_prep would silently strip
+      # (since master_id is not declared), potentially leaving :master_id unbound and causing
+      # sanitize_sql_for_conditions to raise PreparedStatementInvalid → the filter was skipped.
+      # With the fix, master_id is only injected when search_attrs declares it; the final
+      # @al_class.where(master_id:, id:) scope always restricts to the correct master.
+      al_table = @al_class.table_name
+      plain_sql = "SELECT id FROM #{al_table} WHERE select_call_direction = 'to player'"
+      plain_report = Report.create!(
+        current_admin: @admin,
+        name: "Plain perspective report #{SecureRandom.hex}",
+        sql: plain_sql,
+        search_attrs: '',
+        disabled: false,
+        report_type: 'regular_report',
+        auto: false,
+        searchable: false
+      )
+      config = { report: { resource_name: plain_report.alt_resource_name } }
+      result = build_runner(config).run
+      expect(result).to be_a ActiveRecord::Relation
+      expect(result.pluck(:id)).to include @al1.id
+      expect(result.pluck(:id)).not_to include @al2.id
+    end
+
+    it 'raises when the report does not exist' do
+      config = { report: { resource_name: 'nonexistent_perspective_report' } }
+      expect { build_runner(config).run }.to raise_error(FphsException)
+    end
+
+    it 'still runs successfully even when the user has no explicit UAC grant on the report' do
+      # Perspectives bypass per-report access checks: the perspective itself is
+      # admin-gated via the page layout and results are always re-scoped to @master.id.
+      # A missing UAC entry must NOT silently bypass the filter.
+      config = { report: { resource_name: @al_report.alt_resource_name } }
+      result = build_runner(config).run
+      expect(result).to be_a ActiveRecord::Relation
+      expect(result.pluck(:id)).to include @al1.id
+    end
+
+    it 'preserves the SQL row order from the report when no order: is configured' do
+      # Write a report that returns records ORDER BY id ASC.
+      # @al1.id < @al2.id, so ASC order puts al1 first.
+      # The class default_scope is "id DESC" (al2 first), so if the runner applies
+      # the report's order, al1 must appear before al2.
+      al_table = @al_class.table_name
+      ordered_sql = "SELECT id FROM #{al_table} WHERE master_id = :master_id ORDER BY id ASC"
+      ordered_report = Report.create!(
+        current_admin: @admin,
+        name: "Ordered perspective report #{SecureRandom.hex}",
+        sql: ordered_sql,
+        search_attrs: "master_id:\n  integer:\n",
+        disabled: false,
+        report_type: 'regular_report',
+        auto: false,
+        searchable: false
+      )
+      config = { report: { resource_name: ordered_report.alt_resource_name } }
+      result = build_runner(config).run
+      ordered_ids = result.pluck(:id)
+      expect(ordered_ids.index(@al1.id)).to be < ordered_ids.index(@al2.id)
+    end
+
+    it 'explicit order: overrides the report SQL ordering' do
+      al_table = @al_class.table_name
+      asc_sql = "SELECT id FROM #{al_table} WHERE master_id = :master_id ORDER BY id ASC"
+      asc_report = Report.create!(
+        current_admin: @admin,
+        name: "Asc perspective report #{SecureRandom.hex}",
+        sql: asc_sql,
+        search_attrs: "master_id:\n  integer:\n",
+        disabled: false,
+        report_type: 'regular_report',
+        auto: false,
+        searchable: false
+      )
+      # Explicit order: DESC should override the report's ASC
+      config = { report: { resource_name: asc_report.alt_resource_name }, order: { id: 'desc' } }
+      result = build_runner(config).run
+      ordered_ids = result.pluck(:id)
+      expect(ordered_ids.index(@al2.id)).to be < ordered_ids.index(@al1.id)
+    end
+
+    it 'excludes IDs returned by the report that belong to a different master' do
+      # Save the original master before create_item overwrites @player_contact / @master
+      original_master = @master
+
+      # Create a second master + player contact and an activity log record on it
+      create_item(data: rand(10_000_000_000_000_000), rank: 10)
+      other_master = @player_contact.master
+      other_master.current_user = @user
+      al_other = @player_contact.activity_log__player_contact_phones.create!(
+        select_call_direction: 'to player', select_who: 'user', extra_log_type: 'primary', master: other_master
+      )
+
+      # Build a report that returns all "to player" records regardless of master
+      al_table = @al_class.table_name
+      broad_sql = "SELECT id FROM #{al_table} WHERE select_call_direction = 'to player'"
+      broad_report = Report.create!(
+        current_admin: @admin,
+        name: "Broad perspective test report #{SecureRandom.hex}",
+        sql: broad_sql,
+        search_attrs: '',
+        disabled: false,
+        report_type: 'regular_report',
+        auto: false,
+        searchable: false
+      )
+      config = { report: { resource_name: broad_report.alt_resource_name } }
+      # Run against the original master — only @al1 should be returned
+      result = ActivityLog::Perspectives::Runner.new(config, @al_class, @user, master: original_master).run
+      # @al1 is on @master — should be included
+      expect(result.pluck(:id)).to include @al1.id
+      # al_other is on a different master — must NOT be included
+      expect(result.pluck(:id)).not_to include al_other.id
+    end
+  end
+
+  describe 'conditional_calculation backend' do
+    # Build a ConditionalActions-compatible config that uses return_all_results
+    # to return activity log records where select_call_direction matches direction.
+    # Uses the field: value (simple equality) format with return: 'return_all_results'
+    # as the return-mode directive at the table level.
+    def calc_config_for(direction)
+      {
+        @al_class.resource_name.to_s => {
+          select_call_direction: direction,
+          return: 'return_all_results'
+        }
+      }
+    end
+
+    it 'returns records matching the conditional calculation' do
+      config = { conditional_calculation: calc_config_for('to player') }
+      result = build_runner(config).run
+      expect(result).to be_a ActiveRecord::Relation
+      expect(result.pluck(:id)).to include @al1.id
+      expect(result.pluck(:id)).not_to include @al2.id
+    end
+
+    it 'returns only the other record when condition matches the other direction' do
+      config = { conditional_calculation: calc_config_for('to staff') }
+      result = build_runner(config).run
+      expect(result.pluck(:id)).to include @al2.id
+      expect(result.pluck(:id)).not_to include @al1.id
+    end
+
+    it 'returns nil when no records match (this_val not set)' do
+      config = { conditional_calculation: calc_config_for('no such direction') }
+      result = build_runner(config).run
+      expect(result).to be_nil
+    end
+
+    it 'raises on a malformed config' do
+      # Pass something that ConditionalActions will fail on without a valid condition
+      config = { conditional_calculation: { completely_invalid_table!: { id: { not_a_condition: true } } } }
+      expect { build_runner(config).run }.to raise_error(StandardError)
+    end
+
+    it 'excludes records belonging to a different master' do
+      original_master = @master
+
+      # Create a second master and activity log record on it
+      create_item(data: rand(10_000_000_000_000_000), rank: 10)
+      other_master = @player_contact.master
+      other_master.current_user = @user
+      al_other = @player_contact.activity_log__player_contact_phones.create!(
+        select_call_direction: 'to player', select_who: 'user', extra_log_type: 'primary', master: other_master
+      )
+
+      # Condition matches 'to player' on any master, but runner must scope to original_master
+      config = { conditional_calculation: calc_config_for('to player') }
+      result = ActivityLog::Perspectives::Runner.new(config, @al_class, @user, master: original_master).run
+      expect(result.pluck(:id)).to include @al1.id
+      expect(result.pluck(:id)).not_to include al_other.id
+    end
+  end
+end

--- a/spec/requests/activity_log/perspectives_spec.rb
+++ b/spec/requests/activity_log/perspectives_spec.rb
@@ -1,0 +1,497 @@
+# frozen_string_literal: true
+
+# Tests for the activity log perspectives feature (issue #1194).
+# Covers:
+# - Perspective filtering intersected with User Access Control
+# - report: backend perspectives through the full HTTP controller stack, including:
+#   - reports that use :master_id named params with matching search_attrs
+#   - plain-SQL reports with empty search_attrs (previously failed silently due to
+#     master_id being stripped by search_attrs_prep before SQL sanitization)
+# - default activity log perspective app config with plain slugs
+# - default activity log perspective app config with {{#is}} substitution blocks
+#   evaluated against the current user (role-based conditional defaults)
+
+require 'rails_helper'
+
+RSpec.describe 'ActivityLog Perspectives', type: :request do
+  include MasterSupport
+  include ModelSupport
+  include ActivityLogSupport
+
+  before(:all) do
+    change_setting('AllowDynamicMigrations', true)
+  end
+
+  after(:all) do
+    change_setting('AllowDynamicMigrations', false)
+  end
+
+  before(:each) do
+    @admin = create_admin.first
+    @user = create_user.first
+    @master = create_master(@user)
+    
+    @al_def = generate_test_activity_log
+    
+    @implementation_class = ActivityLog::PlayerContactEmail
+
+    # Set up basic user access to the specific resources
+    setup_access :player_contacts, user: @user
+    setup_access :activity_log__player_contact_email__primary, resource_type: :activity_log_type, user: @user
+    setup_access :activity_log__player_contact_email__blank_log, resource_type: :activity_log_type, user: @user
+  end
+
+  def login_user(user = nil)
+    user ||= @user || create_user.first
+    sign_out :user
+    user.confirmed_at ||= Time.now
+    user.current_admin ||= @admin
+    user.save
+    get '/users/sign_in'
+    expect(response.status).to eq 200
+    
+    # We must actually sign in via Devise or Warden
+    sign_in user
+  end
+
+  describe 'perspectives with User Access Controls' do
+    before(:each) do
+      # Create a player contact so the activity log has an item
+      @player_contact = PlayerContact.create!(current_user: @user, master: @master, data: 'test@example.com', rec_type: 'email', rank: 10 )
+
+      # Create some logs
+      @al1 = @player_contact.activity_log__player_contact_emails.new(select_who: 'subject', extra_log_type: 'primary')
+      @al1.master = @master
+      @al1.current_user = @user
+      @al1.save!
+      
+      @al2 = @player_contact.activity_log__player_contact_emails.new(select_who: 'agent', extra_log_type: 'primary')
+      @al2.master = @master
+      @al2.current_user = @user
+      @al2.save!
+      
+      # We create a third one that belongs to an extra log type or something that falls out of UAC
+      @al3 = @player_contact.activity_log__player_contact_emails.new(select_who: 'agent', extra_log_type: 'blank_log')
+      @al3.master = @master
+      @al3.current_user = @user
+      @al3.save!
+
+      # A panel layout configuration for perspectives
+      options_yaml = <<~YAML
+        view_options:
+          perspectives:
+            activity_log__player_contact_emails:
+              - name: who_is_agent
+                label: Is Agent
+                where: 
+                  select_who: agent
+      YAML
+
+      @panel = Admin::PageLayout.create!(
+        app_type: @user.app_type,
+        layout_name: 'test_layout',
+        panel_name: 'test_panel',
+        panel_label: 'Test Panel',
+        current_admin: @admin,
+        options: options_yaml
+      )
+
+      ActionController::Base.allow_forgery_protection = true
+      login_user(@user)
+    end
+
+    after(:each) do
+      ActionController::Base.allow_forgery_protection = false
+    end
+
+    it 'intersects perspective filters with User Access Control constraints' do
+      # When no perspective is applied, they see all 3 items via standard UAC
+      get "/masters/#{@master.id}/activity_log/player_contact_emails.json"
+      expect(response).to have_http_status(:success)
+      
+      json = JSON.parse(response.body)
+      ids = json['activity_log__player_contact_emails'].map { |i| i['id'] }
+      expect(ids).to include(@al1.id, @al2.id, @al3.id)
+      
+      # With perspective applied, they only see matching items
+      get "/masters/#{@master.id}/activity_log/player_contact_emails.json", params: { perspective: 'who_is_agent', panel_name: 'test_panel' }
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      ids = json['activity_log__player_contact_emails'].map { |i| i['id'] }
+      expect(ids).not_to include(@al1.id) # 'subject'
+      expect(ids).to include(@al2.id, @al3.id) # Both 'agent'
+      
+      # Now, we change the user's UAC for this specific action to exclude 'extra_log_type: blank_log'
+      Admin::UserAccessControl.where(resource_name: 'activity_log__player_contact_email__primary', app_type: @user.app_type).update_all(disabled: true)
+      Admin::UserAccessControl.where(resource_name: 'activity_log__player_contact_email__blank_log', app_type: @user.app_type).update_all(disabled: true)
+      
+      setup_access :activity_log__player_contact_email__primary, resource_type: :activity_log_type, access: :read, user: @user
+      uac = Admin::UserAccessControl.last
+      uac.update!(
+        current_admin: @admin,
+        options: {
+          filter_if_condition: { # We will remove this and just let the missing 'blank_log' access block it, since it's an extra log type
+            note: 'we do not need it now'
+          }
+        }
+      )
+      
+      # Reload the index
+      get "/masters/#{@master.id}/activity_log/player_contact_emails.json"
+      json = JSON.parse(response.body)
+      ids = json['activity_log__player_contact_emails'].map { |i| i['id'] }
+      
+      # UAC alone means @al3 should be missing because it lacks access to extra_log_type 'blank_log'
+      expect(ids).to include(@al1.id, @al2.id)
+      expect(ids).not_to include(@al3.id)
+      
+      # FINALLY assert the intersection:
+      # Applying perspective AND the filtered UAC
+      get "/masters/#{@master.id}/activity_log/player_contact_emails.json", params: { perspective: 'who_is_agent', panel_name: 'test_panel' }
+      json = JSON.parse(response.body)
+      ids = json['activity_log__player_contact_emails'].map { |i| i['id'] }
+      
+      # Should ONLY contain @al2 ('agent' AND 'extra_log_type: primary')
+      expect(ids).not_to include(@al1.id) # Fails perspective ('subject')
+      expect(ids).to include(@al2.id)     # Passes both
+      expect(ids).not_to include(@al3.id) # Fails UAC ('blank_log')
+    end
+  end
+
+  describe 'default activity log perspective app config with {{#is}} substitutions' do
+    before(:each) do
+      @player_contact = PlayerContact.create!(
+        current_user: @user, master: @master,
+        data: 'sub@example.com', rec_type: 'email', rank: 10
+      )
+
+      @al_subject = @player_contact.activity_log__player_contact_emails.new(
+        select_who: 'subject', extra_log_type: 'primary'
+      )
+      @al_subject.master = @master
+      @al_subject.current_user = @user
+      @al_subject.save!
+
+      @al_agent = @player_contact.activity_log__player_contact_emails.new(
+        select_who: 'agent', extra_log_type: 'primary'
+      )
+      @al_agent.master = @master
+      @al_agent.current_user = @user
+      @al_agent.save!
+
+      # Panel with two named perspectives
+      options_yaml = <<~YAML
+        view_options:
+          perspectives:
+            activity_log__player_contact_emails:
+              - name: only_subject
+                label: Subject Only
+                where:
+                  select_who: subject
+              - name: only_agent
+                label: Agent Only
+                where:
+                  select_who: agent
+      YAML
+
+      @panel = Admin::PageLayout.create!(
+        app_type: @user.app_type,
+        layout_name: 'test_layout',
+        panel_name: 'role_perspective_panel',
+        panel_label: 'Role Perspective Panel',
+        current_admin: @admin,
+        options: options_yaml
+      )
+
+      ActionController::Base.allow_forgery_protection = true
+    end
+
+    after(:each) do
+      ActionController::Base.allow_forgery_protection = false
+      Admin::AppConfiguration.remove_default_config @user.app_type, 'default activity log perspective', @admin
+    end
+
+    it 'applies a plain slug default perspective from app config' do
+      add_app_config @user.app_type, 'default activity log perspective',
+                     "activity_log__player_contact_emails: only_agent\n"
+
+      login_user(@user)
+      get "/masters/#{@master.id}/activity_log/player_contact_emails.json",
+          params: { panel_name: 'role_perspective_panel' }
+      expect(response).to have_http_status(:success)
+
+      ids = JSON.parse(response.body)['activity_log__player_contact_emails'].map { |i| i['id'] }
+      expect(ids).not_to include(@al_subject.id)
+      expect(ids).to include(@al_agent.id)
+    end
+
+    it 'resolves an {{#is}} conditional default perspective against the current user role' do
+      # Two users with different roles get different default perspectives
+      @user_coordinator = create_user.first
+      @user_reviewer    = create_user.first
+      create_user_role 'coordinator', user: @user_coordinator
+      create_user_role 'reviewer',    user: @user_reviewer
+
+      setup_access :player_contacts,                                          user: @user_coordinator
+      setup_access :activity_log__player_contact_emails,                     user: @user_coordinator
+      setup_access :activity_log__player_contact_email__primary,
+                   resource_type: :activity_log_type, user: @user_coordinator
+      setup_access :player_contacts,                                          user: @user_reviewer
+      setup_access :activity_log__player_contact_emails,                     user: @user_reviewer
+      setup_access :activity_log__player_contact_email__primary,
+                   resource_type: :activity_log_type, user: @user_reviewer
+
+      conditional_value = <<~YAML
+        {{#is role_name '===' 'coordinator'}}only_subject{{else is role_name '===' 'reviewer'}}only_agent{{/is}}
+      YAML
+
+      add_app_config @user_coordinator.app_type, 'default activity log perspective',
+                     "activity_log__player_contact_emails: |\n  #{conditional_value.strip}\n"
+
+      # Coordinator → only_subject perspective
+      login_user(@user_coordinator)
+      get "/masters/#{@master.id}/activity_log/player_contact_emails.json",
+          params: { panel_name: 'role_perspective_panel' }
+      expect(response).to have_http_status(:success)
+      ids = JSON.parse(response.body)['activity_log__player_contact_emails'].map { |i| i['id'] }
+      expect(ids).to include(@al_subject.id)
+      expect(ids).not_to include(@al_agent.id)
+
+      # Reviewer → only_agent perspective
+      login_user(@user_reviewer)
+      get "/masters/#{@master.id}/activity_log/player_contact_emails.json",
+          params: { panel_name: 'role_perspective_panel' }
+      expect(response).to have_http_status(:success)
+      ids = JSON.parse(response.body)['activity_log__player_contact_emails'].map { |i| i['id'] }
+      expect(ids).to include(@al_agent.id)
+      expect(ids).not_to include(@al_subject.id)
+    end
+
+    it 'falls back to the full list when no {{#is}} branch matches' do
+      unmatched_value = "{{#is role_name '===' 'coordinator'}}only_subject{{/is}}"
+
+      add_app_config @user.app_type, 'default activity log perspective',
+                     "activity_log__player_contact_emails: |\n  #{unmatched_value}\n"
+
+      # @user has no roles, so no branch matches → blank slug → full list
+      login_user(@user)
+      get "/masters/#{@master.id}/activity_log/player_contact_emails.json",
+          params: { panel_name: 'role_perspective_panel' }
+      expect(response).to have_http_status(:success)
+      ids = JSON.parse(response.body)['activity_log__player_contact_emails'].map { |i| i['id'] }
+      expect(ids).to include(@al_subject.id, @al_agent.id)
+    end
+  end
+
+  describe 'report backend perspective via HTTP' do
+    # Tests that a perspective configured with `report:` backend correctly filters
+    # the activity log index response through the full controller stack.
+    # Covers both the case where the report SQL uses a :master_id named parameter
+    # (with master_id declared in search_attrs) and the case where it does not
+    # (plain SQL, empty search_attrs), which previously failed silently.
+    before(:each) do
+      @player_contact = PlayerContact.create!(
+        current_user: @user, master: @master,
+        data: 'rpt@example.com', rec_type: 'email', rank: 10
+      )
+
+      @al_subject = @player_contact.activity_log__player_contact_emails.new(
+        select_who: 'subject', extra_log_type: 'primary'
+      )
+      @al_subject.master = @master
+      @al_subject.current_user = @user
+      @al_subject.save!
+
+      @al_agent = @player_contact.activity_log__player_contact_emails.new(
+        select_who: 'agent', extra_log_type: 'primary'
+      )
+      @al_agent.master = @master
+      @al_agent.current_user = @user
+      @al_agent.save!
+
+      al_table = ActivityLog::PlayerContactEmail.table_name
+
+      # Report A: uses :master_id named param + matching search_attrs
+      @report_with_master_id = Report.create!(
+        current_admin: @admin,
+        name: "Persp request test master_id #{SecureRandom.hex}",
+        sql: "SELECT id FROM #{al_table} WHERE master_id = :master_id AND select_who = 'agent'",
+        search_attrs: "master_id:\n  integer:\n",
+        disabled: false,
+        report_type: 'regular_report',
+        auto: false,
+        searchable: false
+      )
+      Admin::UserAccessControl.create!(
+        app_type: @user.app_type, access: :read, resource_type: :report,
+        resource_name: @report_with_master_id.alt_resource_name, current_admin: @admin
+      )
+
+      # Report B: plain SQL, no named params, empty search_attrs
+      @report_plain_sql = Report.create!(
+        current_admin: @admin,
+        name: "Persp request test plain_sql #{SecureRandom.hex}",
+        sql: "SELECT id FROM #{al_table} WHERE select_who = 'agent'",
+        search_attrs: '',
+        disabled: false,
+        report_type: 'regular_report',
+        auto: false,
+        searchable: false
+      )
+      Admin::UserAccessControl.create!(
+        app_type: @user.app_type, access: :read, resource_type: :report,
+        resource_name: @report_plain_sql.alt_resource_name, current_admin: @admin
+      )
+
+      ActionController::Base.allow_forgery_protection = true
+      login_user(@user)
+    end
+
+    after(:each) do
+      ActionController::Base.allow_forgery_protection = false
+    end
+
+    shared_examples 'filters to agent records via report backend' do |panel_name_key|
+      it 'returns only records matching the report filter' do
+        options_yaml = <<~YAML
+          view_options:
+            perspectives:
+              activity_log__player_contact_emails:
+                - name: only_agent
+                  label: Agent Only
+                  report:
+                    resource_name: #{report_resource_name}
+        YAML
+        panel = Admin::PageLayout.create!(
+          app_type: @user.app_type,
+          layout_name: 'test_layout',
+          panel_name: panel_name_key,
+          panel_label: 'Report Perspective Panel',
+          current_admin: @admin,
+          options: options_yaml
+        )
+
+        get "/masters/#{@master.id}/activity_log/player_contact_emails.json",
+            params: { perspective: 'only_agent', panel_name: panel_name_key }
+        expect(response).to have_http_status(:success)
+
+        ids = JSON.parse(response.body)['activity_log__player_contact_emails'].map { |i| i['id'] }
+        expect(ids).to include(@al_agent.id)
+        expect(ids).not_to include(@al_subject.id)
+      ensure
+        panel&.update!(current_admin: @admin, disabled: true)
+      end
+    end
+
+    context 'with a report that uses :master_id named param (search_attrs defines master_id)' do
+      let(:report_resource_name) { @report_with_master_id.alt_resource_name }
+
+      include_examples 'filters to agent records via report backend', 'report_persp_panel_named'
+    end
+
+    context 'with a plain-SQL report (no named params, empty search_attrs)' do
+      let(:report_resource_name) { @report_plain_sql.alt_resource_name }
+
+      include_examples 'filters to agent records via report backend', 'report_persp_panel_plain'
+    end
+  end
+
+  describe 'showable_if filtering applied to where: perspective results' do
+    # Verifies that records returned by a where: perspective that are hidden by
+    # showable_if in the extra log type config are excluded from the final response.
+    # The where: backend may return records that pass the column filter but should
+    # not be visible — showable_if must still be enforced on perspective results.
+
+    before(:each) do
+      @player_contact = PlayerContact.create!(
+        current_user: @user, master: @master,
+        data: 'showable@example.com', rec_type: 'email', rank: 10
+      )
+
+      # Both records pass the where: filter (extra_log_type: primary).
+      # showable_if will hide the 'agent' one; only the 'subject' one should appear.
+      @al_visible = @player_contact.activity_log__player_contact_emails.new(
+        select_who: 'subject', extra_log_type: 'primary'
+      )
+      @al_visible.master = @master
+      @al_visible.current_user = @user
+      @al_visible.save!
+
+      @al_hidden = @player_contact.activity_log__player_contact_emails.new(
+        select_who: 'agent', extra_log_type: 'primary'
+      )
+      @al_hidden.master = @master
+      @al_hidden.current_user = @user
+      @al_hidden.save!
+
+      # Configure showable_if on the 'primary' extra log type to hide records
+      # where select_who != 'subject'.
+      @al_def.extra_log_types = <<~YAML
+        primary:
+          label: Primary
+          fields:
+            - select_who
+          showable_if:
+            all:
+              this:
+                select_who: subject
+        blank_log:
+          label: Blank Log
+          fields:
+            - select_who
+      YAML
+      @al_def.current_admin = @admin
+      @al_def.updated_at = DateTime.now
+      @al_def.save!
+
+      @panel = Admin::PageLayout.create!(
+        app_type: @user.app_type,
+        layout_name: 'test_layout',
+        panel_name: 'showable_panel',
+        panel_label: 'Showable Panel',
+        current_admin: @admin,
+        options: <<~YAML
+          view_options:
+            perspectives:
+              activity_log__player_contact_emails:
+                - name: all_primary
+                  label: All Primary
+                  where:
+                    extra_log_type: primary
+        YAML
+      )
+
+      ActionController::Base.allow_forgery_protection = true
+      login_user(@user)
+    end
+
+    after(:each) do
+      ActionController::Base.allow_forgery_protection = false
+    end
+
+    it 'excludes records hidden by showable_if even when they pass the where: filter' do
+      get "/masters/#{@master.id}/activity_log/player_contact_emails.json",
+          params: { perspective: 'all_primary', panel_name: 'showable_panel' }
+
+      expect(response).to have_http_status(:success)
+      ids = JSON.parse(response.body)['activity_log__player_contact_emails'].map { |i| i['id'] }
+
+      # @al_visible passes both the where: filter and showable_if → present
+      expect(ids).to include(@al_visible.id)
+      # @al_hidden passes the where: filter but is blocked by showable_if → absent
+      expect(ids).not_to include(@al_hidden.id)
+    end
+
+    it 'returns only showable records without a perspective (behaviour is consistent)' do
+      # Without a perspective the normal index also applies showable_if, confirming
+      # the behaviour is consistent regardless of whether a perspective is active.
+      get "/masters/#{@master.id}/activity_log/player_contact_emails.json"
+
+      expect(response).to have_http_status(:success)
+      ids = JSON.parse(response.body)['activity_log__player_contact_emails'].map { |i| i['id'] }
+
+      expect(ids).to include(@al_visible.id)
+      expect(ids).not_to include(@al_hidden.id)
+    end
+  end
+end

--- a/spec/system/activity_log/perspectives_spec.rb
+++ b/spec/system/activity_log/perspectives_spec.rb
@@ -1,0 +1,321 @@
+# frozen_string_literal: true
+
+# System spec for GitHub Issue #1194: Activity Log filter activities (perspectives)
+#
+# Tests the activity log panel perspectives feature from a UI/browser perspective:
+# - Perspective buttons appear alongside the activity log content block when configured
+#   via Admin::PageLayout view_options.perspectives
+# - The "All" button is active by default when no default perspective is configured
+# - The panel-level view_options.default_perspective marks that named button active on
+#   initial render
+# - Admin::AppConfiguration 'default activity log perspective' (user-scoped) marks
+#   the configured perspective button active on initial render
+# - Clicking a perspective button toggles active class and triggers AJAX refresh
+# - The refreshed block shows only records matching the perspective's where: filter
+# - Clicking "All" restores the full unfiltered list
+# - When no perspectives are configured, the perspective button bar is absent
+#
+# Issue: https://github.com/consected/restructure/issues/1194
+# PR:    https://github.com/consected/restructure/pull/1197
+
+require 'rails_helper'
+
+describe 'activity log panel perspectives', js: true, driver: $browser_driver do
+  include ModelSupport
+  include MasterDataSupport
+  include ActivityLogSupport
+  include FeatureSupport
+
+  PERSP_PANEL_NAME = 'al-perspectives-test-panel'
+  PERSP_RESOURCE   = 'activity_log__player_contact_emails'
+  PERSP_SLUG       = 'who_is_agent'
+  PERSP_LABEL      = 'Is Agent'
+
+  def base_panel_options_yaml(perspectives: true, default_perspective: nil)
+    persp_yaml = if perspectives
+                   <<~PERSP
+                     perspectives:
+                       #{PERSP_RESOURCE}:
+                         - name: #{PERSP_SLUG}
+                           label: #{PERSP_LABEL}
+                           where:
+                             select_who: agent
+                   PERSP
+                 else
+                   ''
+                 end
+
+    default_yaml = default_perspective ? "    default_perspective: #{default_perspective}\n" : ''
+
+    persp_indented = persp_yaml.present? ? persp_yaml.lines.map { |l| "    #{l}" }.join : ''
+
+    <<~YAML
+      contains:
+        resources:
+          - #{PERSP_RESOURCE}
+      view_options:
+        initial_show: true
+    #{persp_indented}#{default_yaml}
+    YAML
+  end
+
+  def update_panel_options(options_yaml)
+    @panel_layout.orig_config_text = nil
+    @panel_layout.update!(current_admin: @admin, options: options_yaml)
+    Rails.cache.delete('server_cache_version')
+    Admin::AppConfiguration.clear_memo!
+  end
+
+  def navigate_and_expand
+    visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@master.id}"
+    dismiss_modal
+    finish_page_loading
+    expect(page).to have_css("#master-#{@master.id}", wait: 15)
+    expand_master_record(master_id: @master.id)
+    finish_page_loading
+    # In LEGACY mode (single-resource panel) the block id is resource-keyed,
+    # not panel_name-keyed. Wait for the resource block to expand.
+    resource_block_id = PERSP_RESOURCE.hyphenate
+    expect(page).to have_css("##{resource_block_id}-#{@master.id}.collapse.in", wait: 20)
+    finish_page_loading
+  end
+
+  def perspectives_bar
+    find(".activity-log-perspectives[data-resource='#{PERSP_RESOURCE}']", wait: 15)
+  end
+
+  def al_content_block
+    find("[data-sub-item='#{PERSP_RESOURCE}']", wait: 15)
+  end
+
+  def click_perspective_btn(data_perspective)
+    btn = find(".activity-log-perspectives__btn[data-perspective='#{data_perspective}']", wait: 15)
+    scroll_into_view(btn)
+    sleep 0.3
+    btn.click
+    finish_page_loading
+    sleep 0.5 # Allow time for JavaScript active-class toggle
+  end
+
+  before(:all) do
+    change_setting('TwoFactorAuthDisabledForUser', true)
+    change_setting('TwoFactorAuthDisabledForAdmin', true)
+    change_setting('AllowDynamicMigrations', true)
+    SetupHelper.feature_setup
+
+    @admin, @admin_password = create_admin
+    create_data_set_outside_tx
+
+    @user, @good_password = create_user
+    @good_email = @user.email
+    @app_type = @user.app_type
+
+    # generate_test_activity_log creates AL definition and sets @master
+    @al_def = generate_test_activity_log
+
+    setup_access :player_contacts, user: @user
+
+    @player_contact = @master.player_contacts.create!(
+      data: 'perspectives@example.com',
+      rec_type: 'email',
+      rank: 10,
+      current_user: @user
+    )
+
+    @al_subject = @player_contact.activity_log__player_contact_emails.new(
+      select_who: 'subject',
+      extra_log_type: 'primary'
+    )
+    @al_subject.master = @master
+    @al_subject.current_user = @user
+    @al_subject.save!
+
+    @al_agent = @player_contact.activity_log__player_contact_emails.new(
+      select_who: 'agent',
+      extra_log_type: 'primary'
+    )
+    @al_agent.master = @master
+    @al_agent.current_user = @user
+    @al_agent.save!
+
+    disable_active_panel_layout(PERSP_PANEL_NAME)
+
+    @panel_layout = Admin::PageLayout.create!(
+      current_admin: @admin,
+      app_type: @app_type,
+      layout_name: 'master',
+      panel_name: PERSP_PANEL_NAME,
+      panel_label: 'Al Perspectives Test Panel',
+      panel_position: 200,
+      options: base_panel_options_yaml
+    )
+
+    ActivityLog.define_models
+    Rails.application.routes_reloader.reload!
+  end
+
+  after(:all) do
+    change_setting('AllowDynamicMigrations', false)
+    disable_active_panel_layout(PERSP_PANEL_NAME)
+    Admin::AppConfiguration.active
+                           .where(app_type: @app_type, name: 'default activity log perspective')
+                           .each { |ac| ac.update!(current_admin: @admin, disabled: true) }
+    Admin::AppConfiguration.clear_memo!
+  end
+
+  before(:each) do
+    update_panel_options(base_panel_options_yaml)
+    Admin::AppConfiguration.clear_memo!
+    login
+  end
+
+  # ---------------------------------------------------------------------------
+  # Perspectives buttons rendering
+  # ---------------------------------------------------------------------------
+
+  it 'renders the perspectives button bar when perspectives are configured' do
+    navigate_and_expand
+
+    expect(page).to have_css(".activity-log-perspectives[data-resource='#{PERSP_RESOURCE}']", wait: 15)
+    within perspectives_bar do
+      expect(page).to have_css(".activity-log-perspectives__btn[data-perspective='']")
+      expect(page).to have_css(".activity-log-perspectives__btn[data-perspective='#{PERSP_SLUG}']")
+      expect(page).to have_text('All')
+      expect(page).to have_text(PERSP_LABEL)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Default active state — no default configured
+  # ---------------------------------------------------------------------------
+
+  it 'marks the "All" button active by default when no default perspective is configured' do
+    navigate_and_expand
+
+    within perspectives_bar do
+      all_btn   = find(".activity-log-perspectives__btn[data-perspective='']")
+      named_btn = find(".activity-log-perspectives__btn[data-perspective='#{PERSP_SLUG}']")
+
+      expect(all_btn[:class]).to include('active'),
+                                 '"All" button should be active when no default is configured'
+      expect(named_btn[:class]).not_to include('active')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Default active state — panel-level default_perspective
+  # ---------------------------------------------------------------------------
+
+  it 'marks the configured default_perspective button active on initial render' do
+    update_panel_options(base_panel_options_yaml(default_perspective: PERSP_SLUG))
+
+    navigate_and_expand
+
+    within perspectives_bar do
+      named_btn = find(".activity-log-perspectives__btn[data-perspective='#{PERSP_SLUG}']")
+      all_btn   = find(".activity-log-perspectives__btn[data-perspective='']")
+
+      expect(named_btn[:class]).to include('active'),
+                                   'Named perspective should be active when default_perspective is set'
+      expect(all_btn[:class]).not_to include('active')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Default active state — Admin::AppConfiguration user default
+  # ---------------------------------------------------------------------------
+
+  it 'marks the app-config default perspective button active for the configured user' do
+    add_app_config(
+      @app_type,
+      'default activity log perspective',
+      "#{PERSP_RESOURCE}: #{PERSP_SLUG}",
+      user: @user
+    )
+    Admin::AppConfiguration.clear_memo!
+
+    navigate_and_expand
+
+    within perspectives_bar do
+      named_btn = find(".activity-log-perspectives__btn[data-perspective='#{PERSP_SLUG}']")
+      expect(named_btn[:class]).to include('active'),
+                                   'App-config default should be reflected as active button'
+    end
+  ensure
+    Admin::AppConfiguration.active
+                           .where(app_type: @app_type, name: 'default activity log perspective')
+                           .each { |ac| ac.update!(current_admin: @admin, disabled: true) }
+    Admin::AppConfiguration.clear_memo!
+  end
+
+  # ---------------------------------------------------------------------------
+  # Button click toggles active class
+  # ---------------------------------------------------------------------------
+
+  it 'toggles active class when a perspective button is clicked and restores it on "All"' do
+    navigate_and_expand
+
+    # Verify buttons exist
+    bar = perspectives_bar
+    expect(bar).to have_css(".activity-log-perspectives__btn[data-perspective='']")
+    expect(bar).to have_css(".activity-log-perspectives__btn[data-perspective='#{PERSP_SLUG}']")
+
+    # Click the named perspective button
+    click_perspective_btn(PERSP_SLUG)
+    sleep 1  # Allow JavaScript and AJAX to complete
+
+    # Verify the named button is now active
+    all_btn = find(".activity-log-perspectives__btn[data-perspective='']")
+    named_btn = find(".activity-log-perspectives__btn[data-perspective='#{PERSP_SLUG}']")
+
+    # Check class attributes with retry via Capybara
+    expect(page).to have_css(".activity-log-perspectives__btn[data-perspective='#{PERSP_SLUG}'].active", wait: 10)
+    expect(all_btn[:class]).not_to include('active')
+
+    # Click All button to reset
+    click_perspective_btn('')
+    sleep 1
+
+    # Verify All is active again
+    expect(page).to have_css(".activity-log-perspectives__btn[data-perspective=''].active", wait: 10)
+    named_btn = find(".activity-log-perspectives__btn[data-perspective='#{PERSP_SLUG}']")
+    expect(named_btn[:class]).not_to include('active')
+  end
+
+  # ---------------------------------------------------------------------------
+  # AJAX content filtering
+  # ---------------------------------------------------------------------------
+
+  it 'loads only matching records when a perspective is applied, and restores all on "All"' do
+    navigate_and_expand
+
+    # Both records should be visible in the initial unfiltered list
+    block = al_content_block
+    expect(block).to have_css("ul[data-item-id='#{@al_agent.id}']", wait: 20)
+    expect(block).to have_css("ul[data-item-id='#{@al_subject.id}']", wait: 20)
+
+    click_perspective_btn(PERSP_SLUG)
+
+    block = al_content_block
+    expect(block).to have_css("ul[data-item-id='#{@al_agent.id}']", wait: 20)
+    expect(block).not_to have_css("ul[data-item-id='#{@al_subject.id}']")
+
+    click_perspective_btn('')
+
+    block = al_content_block
+    expect(block).to have_css("ul[data-item-id='#{@al_agent.id}']", wait: 20)
+    expect(block).to have_css("ul[data-item-id='#{@al_subject.id}']", wait: 20)
+  end
+
+  # ---------------------------------------------------------------------------
+  # No perspectives configured — bar absent
+  # ---------------------------------------------------------------------------
+
+  it 'does not render the perspective button bar when no perspectives are configured' do
+    update_panel_options(base_panel_options_yaml(perspectives: false))
+
+    navigate_and_expand
+
+    expect(page).not_to have_css(".activity-log-perspectives[data-resource='#{PERSP_RESOURCE}']")
+  end
+end


### PR DESCRIPTION
## Summary

Adds an **Activity Log Panel Perspectives** feature to `contains.resources` panels. Perspectives let admins define named filter buttons that appear above an activity log content block, allowing users to switch between server-side filtered views of the list without leaving the page.

Resolves #1194

## What changed

### Core feature
- `ActivityLog::Perspectives::Runner` — new service that intercepts activity log index requests and applies a named perspective's `where:` clause from the panel's `view_options.perspectives` config. Supports `FieldDefaults` substitution in `where:` values (e.g. `{{current_user_id}}`).
- `Admin::PageLayout` YAML config now accepts `view_options.perspectives` (array of `{name, label, where}` hashes) and an optional `view_options.default_perspective` slug.
- `Admin::AppConfiguration` key `default_activity_log_perspective` allows per-user/role/app-type default perspective overrides with Handlebars substitution support.
- Perspectives respect `action_when_attribute` ordering and preserve report SQL ordering priority.

### View changes
- `_search_results_resources_panel.html.erb` — perspectives button bar rendered as a preceding sibling of the resource block div in both LEGACY mode (single resource) and WRAPPER mode (multi-resource).
- The front-end JS (`_fpa_form_utils.js`) clones the `--source` bar into `.sublist-controls` on every AJAX load; no JS changes required.

### Documentation
- `docs/admin_reference/page_layouts/perspectives.md` — full configuration reference with examples.
- `docs/admin_reference/page_layouts/master_panels.md` — added link to perspectives docs.
- Admin reference index updated.

### Specs
- `spec/system/activity_log/perspectives_spec.rb` — 7 system spec examples covering button rendering, perspective filtering, "All" reset, default perspective, and user-configured default.
- `spec/requests/activity_log/perspectives_spec.rb` — request-level specs for Runner integration.
- `spec/models/activity_log/perspectives/runner_spec.rb` — unit specs for Runner, including bad-config error handling and FieldDefaults substitution.
- `spec/models/option_configs/page_layout_options_spec.rb` — page layout option parsing specs.
- `spec/views/masters/_search_results_resources_panel_spec.rb` — view specs confirming perspectives bar rendering in both LEGACY and WRAPPER modes.

## Notes

- Perspectives only apply to `contains.resources` panels; `contains.categories` panels use a separate rendering path and are unaffected.
- A bad/missing perspective configuration raises `FphsException` rather than silently returning unfiltered results.
