### PR TITLE
Fixed SQL injection vulnerability in runner.rb - resolves #1194

### DIFF
--- a/app/models/activity_log/perspectives/runner.rb
+++ b/app/models/activity_log/perspectives/runner.rb
@@ -239,10 +239,12 @@ class ActivityLog
           # Skip if no results (WHERE id IN () already returns nothing).
           return relation unless @report_ordered_ids.any?
 
-          ids_array = @report_ordered_ids.join(',')
-          return relation.reorder(
-            Arel.sql("array_position(ARRAY[#{ids_array}]::integer[], #{@al_class.quoted_table_name}.id)")
-          )
+          safe_sql = ActiveRecord::Base.sanitize_sql_array([
+            "array_position(ARRAY[?]::integer[], #{@al_class.quoted_table_name}.id)",
+            @report_ordered_ids.map(&:to_i)
+          ])
+          
+          return relation.reorder(Arel.sql(safe_sql))
         end
 
         # Non-report backends: apply action_when_attribute DESC, id DESC.


### PR DESCRIPTION
### Description
Fixed a Medium Confidence Brakeman SQL injection warning in `app/models/activity_log/perspectives/runner.rb`. Using `sanitize_sql_array` ensures parameterization of IDs injected into the SQL order clause.

### Context
This addresses the issue found during PR review for activity log panel perspectives.

Fixes #1194
