### PR TITLE
Added batch user fallback for nfs_store jobs when active user has no group roles - fixes #1204

### DIFF
--- a/app/models/nfs_store/import.rb
+++ b/app/models/nfs_store/import.rb
@@ -27,7 +27,7 @@ module NfsStore
     # @return [NfsStore::Manage::StoredFile]
     def self.import_file(container_id, file_name, file_path, current_user,
                          path: nil, skip_existing: nil, replace: nil)
-      file_path = NfsStore::Manage::Filesystem.clean_path file_path
+      path = NfsStore::Manage::Filesystem.clean_path(path)
 
       transaction do
         # Set up an import object based on the file to import

--- a/app/models/nfs_store/manage/filesystem.rb
+++ b/app/models/nfs_store/manage/filesystem.rb
@@ -121,7 +121,7 @@ module NfsStore
         parts << clean_path(path) unless path.blank?
         parts << clean_path(file_name) if file_name
 
-        p = File.join(parts)
+        p = File.join(parts.compact)
 
         # Containment invariant: model fields (parent_sub_dir, directory_name
         # etc.) are not run through clean_path above; guard against any `..`

--- a/app/models/nfs_store/move_and_rename.rb
+++ b/app/models/nfs_store/move_and_rename.rb
@@ -50,9 +50,10 @@ module NfsStore
         rf = item[:retrieved_file]
         # Replace the top path with the new path, allowing relative moves of sub directories
         # Handle blank top paths carefully
-        rf.path = "/#{rf.path}" if top_path.blank?
-        rf.path = "#{rf.path}/"
-        new_item_path = rf.path.sub(%r{^#{top_path}/}, "#{new_path}/").gsub(%r{(^/+|/+$)}, '')
+        item_path = rf.path.to_s
+        item_path = "/#{item_path}" if top_path.blank?
+        item_path = "#{item_path}/"
+        new_item_path = item_path.sub(%r{^#{top_path}/}, "#{new_path}/").gsub(%r{(^/+|/+$)}, '')
         rf.move_to new_item_path
       end
 

--- a/app/models/nfs_store/process/nfs_store_job.rb
+++ b/app/models/nfs_store/process/nfs_store_job.rb
@@ -54,7 +54,8 @@ module NfsStore
 
       #
       # Set the current_user in the supplied container_file. If the #user of the container_file
-      # is no longer active, use the Batch User instead, setting it to the in_app_type_id app
+      # is no longer active, or has no nfs_store group roles, use the Batch User instead,
+      # setting it to the in_app_type_id app.
       # @see ProcessHandler#setup_container_file_current_user
       # @param [NfsStore::Manage::ContainerFile] container_file
       # @param [Integer] in_app_type_id - id of the Admin::AppType for the Batch User if needed
@@ -80,7 +81,7 @@ module NfsStore
         return unless orig_cf_user == cf_user
         return if orig_cf_user_app_type_id == cf_user.app_type_id
 
-        cf_user.update!(app_type_id: orig_cf_user_app_type_id)
+        cf_user.app_type_id = orig_cf_user_app_type_id
       end
 
       #

--- a/app/models/nfs_store/process/process_handler.rb
+++ b/app/models/nfs_store/process/process_handler.rb
@@ -219,41 +219,74 @@ module NfsStore
         Settings.nfs_store_default_app_type_id
       end
 
-      # @see ProcessHandler#setup_container_file_current_user
+      # Convenience wrapper around the class method. NOTE: this instance method
+      # does NOT restore the user's app_type_id after the call. Use
+      # NfsStoreJob#setup_container_file_current_user (which wraps in begin/ensure)
+      # whenever a restore is required. Calling this directly is safe only when
+      # the caller takes responsibility for restoring the user's in-memory state.
+      # @see ProcessHandler.setup_container_file_current_user
       def setup_container_file_current_user(container_file)
         self.class.setup_container_file_current_user(container_file, app_type_id_for_file_user)
       end
 
       #
       # Set the current_user in the supplied container_file. If the #user of the container_file
-      # is no longer active, use the Batch User instead, setting it to the in_app_type_id app
+      # is no longer active, or has no nfs_store group roles, use the Batch User instead,
+      # setting it to the in_app_type_id app.
       # @param [NfsStore::Manage::ContainerFile] container_file
       # @param [Integer] in_app_type_id - id of the Admin::AppType for the Batch User if needed
       def self.setup_container_file_current_user(container_file, in_app_type_id)
         user = container_file.user
+        orig_user = user
+
         if user.disabled
           Rails.logger.warn "Job container file user (#{user.id}) is disabled, using batch user instead for app type: #{in_app_type_id}"
-          orig_user = user
           user = User.use_batch_user(in_app_type_id)
-          has_nfs_role = user.user_roles.pluck(:role_name).find { |r| r.start_with? 'nfs_store group ' }
-          unless has_nfs_role
+          unless user_has_nfs_group_role?(user)
             raise FsException::Action,
-                  "Job container file user (#{orig_user.id}) is disabled and batch user (#{User.batch_user}) does not have an " \
+                  "Job container file user (#{orig_user.id}) is disabled and batch user (#{User.batch_user&.email}) does not have an " \
                   "nfs_store group role in the current app: #{user.app_type_id} || #{in_app_type_id}"
           end
-        elsif user.app_type_id != default_app_type_id
-          Rails.logger.warn "ProcessHandler - setting user #{user.id} app_type_id from #{user.app_type_id} to #{default_app_type_id}"
-          user.update!(app_type_id: default_app_type_id)
+        else
+          # Normalize the user's app_type_id in-memory first, so that the subsequent role check
+          # queries roles in the correct (default) app type context. user.user_roles is scoped by
+          # user.app_type_id, so nfs_store group roles registered under default_app_type_id would
+          # be invisible if we checked before normalizing.
+          if user.app_type_id != default_app_type_id
+            Rails.logger.warn "ProcessHandler - temporarily switching user #{user.id} app_type_id from #{user.app_type_id} to #{default_app_type_id}"
+            user.app_type_id = default_app_type_id
+          end
+
+          unless user_has_nfs_group_role?(user)
+            Rails.logger.warn "Job container file user (#{orig_user.id}) has no nfs_store group roles, using batch user instead for app type: #{in_app_type_id}"
+            user = User.use_batch_user(in_app_type_id)
+            unless user_has_nfs_group_role?(user)
+              raise FsException::Action,
+                    "Job container file user (#{orig_user.id}) has no nfs_store group role and batch user (#{User.batch_user&.email}) " \
+                    "does not have an nfs_store group role in the current app: #{user.app_type_id} || #{in_app_type_id}"
+            end
+          end
         end
 
         container_file.current_user = user
+        # Clear memoized role names/group ids since the container's current_user may have changed
+        container_file.container.instance_variable_set(:@current_user_role_names, nil)
+        container_file.container.instance_variable_set(:@current_user_group_ids, nil)
         return user if container_file.current_role_name
 
         Rails.logger.info "Setting current role name for user #{user.id} in app type #{in_app_type_id}"
-        file_path, role_name = container_file.file_path_and_role_name
+        _, role_name = container_file.file_path_and_role_name
         container_file.current_role_name = role_name
         user
       end
+
+      # Check whether a user has at least one active nfs_store group role
+      # @param [User] user
+      # @return [Boolean]
+      def self.user_has_nfs_group_role?(user)
+        user.user_roles.active.pluck(:role_name).any? { |r| r.start_with? 'nfs_store group ' }
+      end
+      private_class_method :user_has_nfs_group_role?
     end
   end
 end

--- a/spec/models/nfs_store/process/dicom_deidentify_job_spec.rb
+++ b/spec/models/nfs_store/process/dicom_deidentify_job_spec.rb
@@ -255,20 +255,28 @@ RSpec.describe NfsStore::Process::DicomDeidentifyJob, type: :model do
 
     sf = reload_stored_file(sf)
 
-    # Track app_type_id changes during processing
+    # Track app_type_id changes during processing.
+    # Since app_type_id is now switched in-memory only (no DB write), we capture it from the
+    # c_user yielded by setup_container_file_current_user rather than via @user.reload (which
+    # would read the unchanged DB value).
     app_type_id_during_processing = nil
-    allow(NfsStore::Dicom::DeidentifyHandler).to receive(:deidentify_file).and_wrap_original do |method, *args|
-      app_type_id_during_processing = @user.reload.app_type_id
-      method.call(*args)
+    dij = NfsStore::Process::DicomDeidentifyJob.new
+    allow(dij).to receive(:setup_container_file_current_user).and_wrap_original do |method, *args, &block|
+      method.call(*args) do |c_user|
+        app_type_id_during_processing = c_user.app_type_id
+        block.call(c_user)
+      end
     end
 
     # Perform job with non-default app_type_id
-    dij = NfsStore::Process::DicomDeidentifyJob.new
     dij.perform(sf, app_type_2.id)
 
-    # Verify transactional app_type_id behavior
+    # Verify transactional app_type_id behavior:
+    # - during processing the user context is normalised to the default app type (in memory only)
+    # - after processing the in-memory value is restored (no DB write occurred at any point)
     expect(app_type_id_during_processing).to eq(Settings.nfs_store_default_app_type_id)
-    expect(@user.reload.app_type_id).to eq(app_type_2.id)
+    expect(@user.app_type_id).to eq(app_type_2.id)       # in-memory restore happened
+    expect(@user.reload.app_type_id).to eq(app_type_2.id) # DB was never touched
 
     # Reset user to original app_type_id for file verification
     @user.update!(app_type_id: original_app_type_id, current_admin: @admin)

--- a/spec/models/nfs_store/process/process_handler_spec.rb
+++ b/spec/models/nfs_store/process/process_handler_spec.rb
@@ -165,9 +165,8 @@ RSpec.describe NfsStore::Process::ProcessHandler, type: :model do
     sf.current_user = @user
     sfs << sf
 
-    rets = []
-    sfs.each do |h|
-      rets << {
+    rets = sfs.map do |h|
+      {
         id: h['id'].to_i,
         container_id: @container.id,
         retrieval_type: :stored_file,
@@ -273,5 +272,109 @@ RSpec.describe NfsStore::Process::ProcessHandler, type: :model do
     sf = sf.class.find(sf.id)
     expect(sf.file_metadata["Patient's Name"]).to eq "set2-#{sf.master_id}"
     expect(sf.file_metadata['Patient ID']).to eq "set2-#{sf.master.player_contacts.first.data}"
+  end
+
+  # Tests for Issue #1204: When an active user with no nfs_store group roles
+  # creates a file (e.g. via e-signature), subsequent background jobs should fall
+  # back to the batch user rather than failing with a permission denied error.
+  describe '.setup_container_file_current_user - Issue1204' do
+    context 'when the container file user is active but has no nfs_store group roles' do
+      let(:no_role_user) { create_user.first }
+
+      before do
+        # Upload a file to create a real stored file owned by @user
+        @ul = upload_file('test-no-role.txt')
+        @stored_file = @ul.stored_file
+        # Reload the stored file to get a clean instance without memoized state
+        @stored_file = NfsStore::Manage::StoredFile.find(@stored_file.id)
+
+        # Reassign the stored file to no_role_user to simulate the e-signature scenario:
+        # a user who can view files via an activity log but has no nfs_store group roles
+        @stored_file.update_column(:user_id, no_role_user.id)
+
+        # Ensure no_role_user is set to the correct app type for the role check
+        no_role_user.update!(app_type_id: @app_type.id)
+      end
+
+      it 'falls back to the batch user when the active user has no nfs_store group roles - Issue1204' do
+        result_user = NfsStore::Process::ProcessHandler.setup_container_file_current_user(
+          @stored_file,
+          @app_type.id
+        )
+
+        expect(result_user).to eq(User.batch_user),
+                               "Expected batch user but got #{result_user&.email} (id: #{result_user&.id})"
+      end
+
+      it 'sets the container file current_user to the batch user - Issue1204' do
+        NfsStore::Process::ProcessHandler.setup_container_file_current_user(
+          @stored_file,
+          @app_type.id
+        )
+
+        expect(@stored_file.current_user).to eq(User.batch_user)
+      end
+
+      it 'sets a current_role_name on the container file when falling back to batch user - Issue1204' do
+        NfsStore::Process::ProcessHandler.setup_container_file_current_user(
+          @stored_file,
+          @app_type.id
+        )
+
+        expect(@stored_file.current_role_name).not_to be_nil
+      end
+    end
+
+    context 'when neither the original user nor the batch user have nfs_store group roles' do
+      let(:no_role_user) { create_user.first }
+
+      before do
+        @ul = upload_file('test-no-role-raise.txt')
+        @stored_file = @ul.stored_file
+        @stored_file = NfsStore::Manage::StoredFile.find(@stored_file.id)
+        @stored_file.update_column(:user_id, no_role_user.id)
+        no_role_user.update!(app_type_id: @app_type.id)
+
+        # Remove nfs_store group roles from the batch user for this app type
+        batch_user = User.use_batch_user(@app_type.id)
+        batch_user.user_roles.where("role_name LIKE 'nfs_store group %'").each do |ur|
+          ur.update!(disabled: true, current_admin: @admin)
+        end
+      end
+
+      after do
+        # Restore batch user nfs_store roles so other tests are unaffected
+        batch_user = User.use_batch_user(@app_type.id)
+        batch_user.user_roles.where("role_name LIKE 'nfs_store group %'").each do |ur|
+          ur.update!(disabled: false, current_admin: @admin)
+        end
+      end
+
+      it 'raises FsException::Action when neither user has nfs_store group roles - Issue1204' do
+        expect do
+          NfsStore::Process::ProcessHandler.setup_container_file_current_user(
+            @stored_file,
+            @app_type.id
+          )
+        end.to raise_error(FsException::Action, /does not have an nfs_store group role/)
+      end
+    end
+
+    context 'when the container file user has nfs_store group roles' do
+      it 'does not replace the user with the batch user - Issue1204' do
+        ul = upload_file('test-has-role.txt')
+        stored_file = ul.stored_file
+        stored_file = NfsStore::Manage::StoredFile.find(stored_file.id)
+
+        result_user = NfsStore::Process::ProcessHandler.setup_container_file_current_user(
+          stored_file,
+          @app_type.id
+        )
+
+        expect(result_user).to eq(@user),
+                               "Expected original user but got #{result_user&.email} (id: #{result_user&.id})"
+        expect(result_user).not_to eq(User.batch_user)
+      end
+    end
   end
 end

--- a/spec/support/e_signature/e_sign_import_config.rb
+++ b/spec/support/e_signature/e_sign_import_config.rb
@@ -31,6 +31,11 @@ module ESignImportConfig
     new_app_type = Admin::AppType.where(name: 'test esign').first
     new_app_type.update! disabled: false, current_admin: @admin if new_app_type.disabled?
 
+    enable_user_app_access new_app_type, User.batch_user
+    Admin::UserRole.find_or_create_by!(role_name: 'nfs_store group 600', user: User.batch_user, app_type: new_app_type) do |ur|
+      ur.current_admin = @admin
+    end
+
     cdir = File.join(NfsStore::Manage::Filesystem.nfs_store_directory, 'gid600', "app-type-#{new_app_type.id}", 'containers')
     FileUtils.rm_rf cdir
     FileUtils.mkdir_p cdir


### PR DESCRIPTION
## Summary

Fixes #1204 - When a file is processed by a background job and the owning user has no nfs_store group roles (e.g. a user who created a file via an e-signature workflow), the job now falls back to the Batch User instead of failing with a permission error.

## Problem


## Changes

### Core fix - process_handler.rb
- Added a no-nfs_store-group-roles check in the active-user path
- Falls back to User.batch_user when the original user has no roles
- Raises FsException::Action if neither user has roles
- Changed app_type_id normalization to in-memory assignment only (no DB write)
- Clears memoized @current_user_role_names / @current_user_group_ids when current user changes

### Restore on completion - nfs_store_job.rb
- setup_container_file_current_user block wrapper restores the original user app_type_id in ensure (in-memory only, no DB write)

### Bug fixes discovered during system spec work
- import.rb: clean_path was called on file_path (absolute path) instead of the relative path keyword argument
- filesystem.rb: File.join(parts) crashed with nil entries when clean_path returns nil for blank inputs - fixed with parts.compact
- move_and_rename.rb: Was mutating rf.path directly for intermediate string building - fixed with a local item_path variable

### Test support - e_sign_import_config.rb
- Batch user given nfs_store group 600 role in the e-signature test app type

## Tests
- 4 new examples in process_handler_spec.rb covering fallback, raise, and no-replacement paths
- Updated dicom_deidentify_job_spec.rb to verify in-memory-only app_type_id normalization (no DB write at any point)
- All 7 system spec examples in filestore_operations_spec.rb pass (upload, rename, trash, multi-upload, ZIP extraction, move, download)

## Background Job Safety
The in-memory app_type_id change is safe for background jobs spawned from within the processing block. The user_roles association uses a lambda scope reading app_type_id at query time - no DB persistence needed. Each spawned background job normalises independently via its own setup_container_file_current_user call.
