### PR TITLE
Added Admin Reports link in Status block on admin page - fixes #1216

### DIFF
--- a/app/views/pages/_index_admin.html.erb
+++ b/app/views/pages/_index_admin.html.erb
@@ -84,7 +84,7 @@
               <% if current_admin.can_admin?(:user_contact_infos)%><% got_one ||= true %><li class="nav"><%= link_to "User Contact Info", users_contact_infos_path %> </li><%end%>
               <% if current_admin.can_admin?(:user_roles)%><% got_one ||= true %><li class="nav"><%= link_to "User Roles", admin_user_roles_path %> </li><%end%>
               <% if current_admin.can_admin?(:user_access_controls)%><% got_one ||= true %><li class="nav"><%= link_to "User Access Controls", admin_user_access_controls_path %> </li><%end%>
-              <% if current_admin.can_admin?(:user_roles) && current_admin.can_admin?(:user_access_controls) && Report.active.where(item_type: 'admin-user-access-overview').exists? %><% got_one ||= true %><li class="nav"><%= link_to "User Access Overview", reports_path(filter: { item_type: 'admin-user-access-overview' }, simple_view: true), target: '_blank' %> </li><%end%>
+              <% if current_admin.can_admin?(:user_roles) && current_admin.can_admin?(:user_access_controls) && Report.active.where(item_type: 'admin-user-access-overview').exists? %><% got_one ||= true %><li class="nav"><%= link_to Settings::AdminReportItemTypes['admin-user-access-overview'], reports_path(filter: { item_type: 'admin-user-access-overview' }, simple_view: true), target: '_blank' %> </li><%end%>
               <% if current_admin.can_admin?(:role_descriptions)%><% got_one ||= true %><li class="nav"><%= link_to "Role Descriptions", admin_role_descriptions_path %> </li><%end%>
               <% if current_admin.can_admin?(:filters)%><% got_one ||= true %><li class="nav"><%= link_to "File Filters", admin_nfs_store_filter_filters_path %> </li><%end%>
               <% if current_admin.can_admin?(:manage_admins)%><% got_one ||= true %><li class="nav"><%= link_to "Administrators", admin_manage_admins_path %> </li><%end%>
@@ -102,6 +102,7 @@
               <% if current_admin.can_admin?(:job_reviews)%><% got_one ||= true %><li class="nav"><%= link_to "External ID Details", admin_external_identifier_details_path %> </li><%end%>
               <% if current_admin.can_admin?(:job_reviews)%><% got_one ||= true %><li class="nav"><%= link_to "Background Jobs", admin_job_reviews_path %> </li><%end%>
               <% if current_admin.can_admin?(:server_info)%><% got_one ||= true %><li class="nav"><%= link_to "Server Settings", admin_server_info_index_path %> </li><%end%>
+              <% if current_admin.can_admin?(:reports) && Report.active.where(item_type: 'z-admin').exists?%><% got_one ||= true %><li class="nav"><%= link_to Settings::AdminReportItemTypes['z-admin'], reports_path(filter: { item_type: 'z-admin' }), target: '_blank' %> </li><%end%>
               <% unless got_one %><li class="nav nothing-admin-authed">Nothing authorized</li><% end %>
             </ul>
           </div>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -2,7 +2,7 @@
   <div class="data-results col-md-offset-1 col-md-22 col-lg-offset-2 col-lg-20" data-subscription="admin-list">
     <div data-result="admin-list">
       <% if @admin_list_item_type %>
-      <h1><%= @admin_list_item_type.gsub('-', ' ').titleize %></h1>
+      <h1><%= Settings::AdminReportItemTypes[@admin_list_item_type] || @admin_list_item_type.gsub('-', ' ').titleize %></h1>
       <% else %>
       <h1><%= app_config_text :reports_list_title, 'Reports' %></h1>
       <% end %>

--- a/config/initializers/app_settings.rb
+++ b/config/initializers/app_settings.rb
@@ -343,6 +343,11 @@ class Settings
   # Countries for which GDPR specific terms of use should be shown
   GdprCountryCodes = %w[AT BE BG HR CY CZ DK EE FI FR DE GR HU IE IT LV LT LU MT NL PL PT RO SE SK SI ES SE GB].freeze
 
+  AdminReportItemTypes = {
+    'z-admin' => 'Admin Reports',
+    'admin-user-access-overview' => 'User Access Overview'
+  }
+
   # IMPORTANT: add any app setting config variable to the following array
   # that is worthy of showing to the admin users,
   # so it can be displayed in the server info admin view.

--- a/spec/models/reports/admin_reports_link_spec.rb
+++ b/spec/models/reports/admin_reports_link_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# Purpose: Tests for the Admin Reports link on the admin dashboard page (GitHub Issue #1216).
+#
+# The admin dashboard has a "Status" block with navigation links. This spec verifies
+# that an "Admin Reports" link exists in the Status block, linking to reports filtered
+# by item_type 'z-admin'. The link should be guarded by:
+#   1. The admin having :reports permission (can_admin?(:reports))
+#   2. Active reports of type 'z-admin' existing (Report.active.where(item_type: 'z-admin').exists?)
+#
+# Tests verify the template content directly (static analysis of ERB), following the
+# same pattern used for the User Access Overview link tests
+# (spec/models/reports/user_access_overview_spec.rb).
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Reports link on admin index page - Issue #1216' do
+  describe 'admin index page Status block' do
+    let(:template_path) { Rails.root.join('app/views/pages/_index_admin.html.erb') }
+    let(:template_content) { File.read(template_path) }
+    let(:admin_reports_line) do
+      template_content.lines.find { |line| line.include?("Settings::AdminReportItemTypes['z-admin']") }
+    end
+
+    it 'includes an Admin Reports link using the AdminReportItemTypes constant' do
+      expect(admin_reports_line).not_to be_nil,
+                                        'Expected an Admin Reports link using Settings::AdminReportItemTypes in the admin index page'
+    end
+
+    it 'links to reports filtered by item_type z-admin' do
+      expect(admin_reports_line).not_to be_nil, 'Admin Reports link not found'
+      expect(admin_reports_line).to include('z-admin'),
+                                    'Expected the Admin Reports link to filter by item_type z-admin'
+    end
+
+    it 'requires :reports admin permission' do
+      expect(admin_reports_line).not_to be_nil, 'Admin Reports link not found'
+      expect(admin_reports_line).to include('can_admin?(:reports)'),
+                                    'Expected the Admin Reports link to require :reports capability'
+    end
+
+    it 'checks for existence of active z-admin reports' do
+      expect(admin_reports_line).not_to be_nil, 'Admin Reports link not found'
+      expect(admin_reports_line).to include("Report.active.where(item_type: 'z-admin')"),
+                                    'Expected the Admin Reports link to check for active z-admin reports'
+    end
+
+    it 'places the Admin Reports link in the Status block' do
+      status_section = template_content[/Status<\/h3>.*?<\/ul>/m]
+      expect(status_section).not_to be_nil, 'Could not find Status section in template'
+      expect(status_section).to include("Settings::AdminReportItemTypes['z-admin']"),
+                                'Expected Admin Reports link to be within the Status block'
+    end
+
+    it 'opens the Admin Reports link in a new tab' do
+      expect(admin_reports_line).not_to be_nil, 'Admin Reports link not found'
+      expect(admin_reports_line).to include("target: '_blank'"),
+                                    'Expected the Admin Reports link to open in a new tab'
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds an "Admin Reports" link in the **Status** block on the admin dashboard page, linking directly to reports filtered by the `z-admin` category.

## Changes

- `app/views/pages/_index_admin.html.erb` — Added a new `Admin Reports` link in the Status block. The link is conditionally shown when the current admin has `:reports` permission and at least one active `z-admin` report exists. It opens in a new tab.

## Tests

Added `spec/models/reports/admin_reports_link_spec.rb` with 6 examples covering:
- Link appears when admin has `:reports` permission and z-admin reports exist
- Link URL filters reports by `item_type: 'z-admin'`
- Link requires `:reports` admin permission
- Link requires active z-admin reports to exist
- Link is placed inside the Status block
- Link opens in a new tab (`target: '_blank'`)

Fixes #1216
