### PR TITLE
Fixed XSS in page layout col_header/col_footer substitution - fixes #1224

### DIFF
--- a/app/models/formatter/substitution.rb
+++ b/app/models/formatter/substitution.rb
@@ -60,7 +60,7 @@ module Formatter
     #    true - quietly ignore the missing tag
     #    false, nil - raise exception if tag is missing
     # @return [String] resulting text after substitution
-    def self.substitute(all_content, data: {}, tag_subs: nil, ignore_missing: false)
+    def self.substitute(all_content, data: {}, tag_subs: nil, ignore_missing: false, html_escape_values: false)
       return unless all_content
 
       all_content = all_content.dup
@@ -130,6 +130,7 @@ module Formatter
         end
 
         # Finally, substitute the results into the original text
+        tag_value = ERB::Util.html_escape(tag_value) if html_escape_values
         all_content.gsub!(tag_container, tag_value)
       end
 

--- a/app/views/page_layouts/_show_row.html.erb
+++ b/app/views/page_layouts/_show_row.html.erb
@@ -110,8 +110,8 @@
       col_label = Formatter::Substitution.substitute(col_label, data: sub_data, tag_subs: nil)
       col_header = markdown_to_html(col_header)
       col_footer = markdown_to_html(col_footer)
-      col_header = Formatter::Substitution.substitute(col_header, data: sub_data, tag_subs: nil).html_safe
-      col_footer = Formatter::Substitution.substitute(col_footer, data: sub_data, tag_subs: nil).html_safe
+      col_header = Formatter::Substitution.substitute(col_header, data: sub_data, tag_subs: nil, html_escape_values: true).html_safe
+      col_footer = Formatter::Substitution.substitute(col_footer, data: sub_data, tag_subs: nil, html_escape_values: true).html_safe
 
   %>
     <% if !@master_id && !col_url && !no_resource_or_report %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -310,60 +310,6 @@
       "note": ""
     },
     {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "546d379b3f4c806b5aa697f41b98e514cd1c80e6db77a59ca485450ddc7bda1b",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/page_layouts/_show_row.html.erb",
-      "line": 120,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "Formatter::Substitution.substitute(markdown_to_html((col[\"footer\"] or \"\")), :data => ((Master.find_with({ :id => params[:filters][:master_id], :type => (((active_layouts.find(params[:id]) or active_layouts.where(:panel_name => params[:id]).first).view_options.find_with or params[:filters][:master_type].hyphenate)) }, :access_by => current_user) or {})), :tag_subs => nil)",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "PageLayoutsController",
-          "method": "show",
-          "line": 28,
-          "file": "app/controllers/page_layouts_controller.rb",
-          "rendered": {
-            "name": "page_layouts/show",
-            "file": "app/views/page_layouts/show.html.erb"
-          }
-        },
-        {
-          "type": "template",
-          "name": "page_layouts/show",
-          "line": 15,
-          "file": "app/views/page_layouts/show.html.erb",
-          "rendered": {
-            "name": "page_layouts/_show_row",
-            "file": "app/views/page_layouts/_show_row.html.erb"
-          }
-        },
-        {
-          "type": "template",
-          "name": "page_layouts/_show_row",
-          "line": 103,
-          "file": "app/views/page_layouts/_show_row.html.erb",
-          "rendered": {
-            "name": "page_layouts/_show_row",
-            "file": "app/views/page_layouts/_show_row.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "page_layouts/_show_row"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "cwe_id": [
-        79
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "6d610fc02fcf061d54ad702f23cade58e38095a09cfac808a35f1cd1eef3a083",
@@ -698,15 +644,38 @@
       "note": ""
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "fcbe8cefbe5a53fefd20ecb75613ff3ae50b3b61bbd196ee2eb429d7be405e14",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/full_text_search/tsvector_writer.rb",
+      "line": 45,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ActiveRecord::Base.connection.exec_query(\"INSERT INTO #{target_table.split(\".\").map do\n ActiveRecord::Base.connection.quote_column_name(p)\n end.join(\".\")} (#{ActiveRecord::Base.connection.quote_column_name(fk_column)}, master_id, #{ActiveRecord::Base.connection.quote_column_name(target_field)}, created_at, updated_at)\\nVALUES ($1, $2, to_tsvector($4, $3), now(), now())\\nON CONFLICT (#{ActiveRecord::Base.connection.quote_column_name(fk_column)})\\nDO UPDATE SET #{ActiveRecord::Base.connection.quote_column_name(target_field)} = to_tsvector($4, $3), updated_at = now()\\n\", \"FullTextSearch::TsvectorWriter\", [bind_param(\"fk_value\", fk_value, ActiveModel::Type::Integer.new), bind_param(\"master_id\", master_id, ActiveModel::Type::Integer.new), bind_param(\"text_content\", text_content.to_s, ActiveModel::Type::String.new), bind_param(\"ts_config\", ts_config.to_s, ActiveModel::Type::String.new)])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "FullTextSearch::TsvectorWriter",
+        "method": "FullTextSearch::TsvectorWriter.write_tsvector"
+      },
+      "user_input": "target_table.split(\".\").map do\n ActiveRecord::Base.connection.quote_column_name(p)\n end.join(\".\")",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "f027ecfc9397860df7139c0e8e82c88364ae0ab2dc300fdcef882fff74fff6b9",
+      "fingerprint": "cb3759a5b14a5796fe5d5493ac66b2e75f4ca2bff9e60849cb2eb2a0990d0d8b",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/page_layouts/_show_row.html.erb",
-      "line": 111,
+      "line": 131,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "Formatter::Substitution.substitute(markdown_to_html((col[\"header\"] or \"\")), :data => ((Master.find_with({ :id => params[:filters][:master_id], :type => (((active_layouts.find(params[:id]) or active_layouts.where(:panel_name => params[:id]).first).view_options.find_with or params[:filters][:master_type].hyphenate)) }, :access_by => current_user) or {})), :tag_subs => nil)",
+      "code": "Formatter::Substitution.substitute(markdown_to_html((col[\"header\"] or \"\")), :data => ((Master.find_with({ :id => params[:filters][:master_id], :type => (((active_layouts.find(params[:id]) or active_layouts.where(:panel_name => params[:id]).first).view_options.find_with or params[:filters][:master_type].hyphenate)) }, :access_by => current_user) or ((col[\"report\"][\"defaults\"] or {}).symbolize_keys.merge((params[:filters].to_unsafe_h or params[:filters].to_h).symbolize_keys.slice(*Report.find_by_id_or_resource_name(col[\"report\"][\"id\"]).search_attributes.symbolize_keys.keys)) or {}))), :tag_subs => nil, :html_escape_values => true)",
       "render_path": [
         {
           "type": "controller",
@@ -732,7 +701,7 @@
         {
           "type": "template",
           "name": "page_layouts/_show_row",
-          "line": 103,
+          "line": 123,
           "file": "app/views/page_layouts/_show_row.html.erb",
           "rendered": {
             "name": "page_layouts/_show_row",
@@ -749,31 +718,62 @@
       "cwe_id": [
         79
       ],
-      "note": ""
+      "note": "False positive: html_escape_values: true causes Formatter::Substitution.substitute to HTML-escape all tag values via ERB::Util.html_escape before splicing into the HTML string. Verified by spec/views/page_layouts/_show_row_xss_spec.rb (issue #1224)."
     },
     {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "fcbe8cefbe5a53fefd20ecb75613ff3ae50b3b61bbd196ee2eb429d7be405e14",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/models/full_text_search/tsvector_writer.rb",
-      "line": 45,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "ActiveRecord::Base.connection.exec_query(\"INSERT INTO #{target_table.split(\".\").map do\n ActiveRecord::Base.connection.quote_column_name(p)\n end.join(\".\")} (#{ActiveRecord::Base.connection.quote_column_name(fk_column)}, master_id, #{ActiveRecord::Base.connection.quote_column_name(target_field)}, created_at, updated_at)\\nVALUES ($1, $2, to_tsvector($4, $3), now(), now())\\nON CONFLICT (#{ActiveRecord::Base.connection.quote_column_name(fk_column)})\\nDO UPDATE SET #{ActiveRecord::Base.connection.quote_column_name(target_field)} = to_tsvector($4, $3), updated_at = now()\\n\", \"FullTextSearch::TsvectorWriter\", [bind_param(\"fk_value\", fk_value, ActiveModel::Type::Integer.new), bind_param(\"master_id\", master_id, ActiveModel::Type::Integer.new), bind_param(\"text_content\", text_content.to_s, ActiveModel::Type::String.new), bind_param(\"ts_config\", ts_config.to_s, ActiveModel::Type::String.new)])",
-      "render_path": null,
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "3d7f081780d3a743085cf1c1177847a56056fa25c3f191bd6c890d88c42d1227",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/page_layouts/_show_row.html.erb",
+      "line": 140,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Formatter::Substitution.substitute(markdown_to_html((col[\"footer\"] or \"\")), :data => ((Master.find_with({ :id => params[:filters][:master_id], :type => (((active_layouts.find(params[:id]) or active_layouts.where(:panel_name => params[:id]).first).view_options.find_with or params[:filters][:master_type].hyphenate)) }, :access_by => current_user) or ((col[\"report\"][\"defaults\"] or {}).symbolize_keys.merge((params[:filters].to_unsafe_h or params[:filters].to_h).symbolize_keys.slice(*Report.find_by_id_or_resource_name(col[\"report\"][\"id\"]).search_attributes.symbolize_keys.keys)) or {}))), :tag_subs => nil, :html_escape_values => true)",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "PageLayoutsController",
+          "method": "show",
+          "line": 28,
+          "file": "app/controllers/page_layouts_controller.rb",
+          "rendered": {
+            "name": "page_layouts/show",
+            "file": "app/views/page_layouts/show.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "page_layouts/show",
+          "line": 15,
+          "file": "app/views/page_layouts/show.html.erb",
+          "rendered": {
+            "name": "page_layouts/_show_row",
+            "file": "app/views/page_layouts/_show_row.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "page_layouts/_show_row",
+          "line": 123,
+          "file": "app/views/page_layouts/_show_row.html.erb",
+          "rendered": {
+            "name": "page_layouts/_show_row",
+            "file": "app/views/page_layouts/_show_row.html.erb"
+          }
+        }
+      ],
       "location": {
-        "type": "method",
-        "class": "FullTextSearch::TsvectorWriter",
-        "method": "FullTextSearch::TsvectorWriter.write_tsvector"
+        "type": "template",
+        "template": "page_layouts/_show_row"
       },
-      "user_input": "target_table.split(\".\").map do\n ActiveRecord::Base.connection.quote_column_name(p)\n end.join(\".\")",
+      "user_input": null,
       "confidence": "Medium",
       "cwe_id": [
-        89
+        79
       ],
-      "note": ""
+      "note": "False positive: html_escape_values: true causes Formatter::Substitution.substitute to HTML-escape all tag values via ERB::Util.html_escape before splicing into the HTML string. Verified by spec/views/page_layouts/_show_row_xss_spec.rb (issue #1224)."
     }
   ],
-  "brakeman_version": "8.0.4"
+  "brakeman_version": "8.0.5"
 }

--- a/spec/views/page_layouts/_show_row_xss_spec.rb
+++ b/spec/views/page_layouts/_show_row_xss_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# View spec for XSS vulnerability in page_layouts/_show_row partial (issue #1224).
+#
+# When @master (an ActiveRecord model with user-editable fields) is used as
+# substitution data for col_header and col_footer, the substituted values are
+# NOT HTML-escaped before being spliced into the already-safe HTML string via
+# `.html_safe`. This allows stored XSS: any user-controlled field referenced by
+# a {{tag}} in a page layout column header or footer is rendered verbatim.
+#
+# The report_defaults path already escapes values with ERB::Util.html_escape,
+# but @master data bypasses that protection.
+#
+# These tests assert the SECURE behaviour (escaped output) and are expected to
+# FAIL (red) until the fix is applied.
+
+RSpec.describe 'page_layouts/_show_row XSS in col header/footer substitution', type: :view do
+  let(:xss_script_payload) { '<script>alert(1)</script>' }
+  let(:xss_img_payload) { '<img src=x onerror=alert(1)>' }
+
+  let(:container) { double('container') }
+
+  before do
+    assign(:master_id, 456)
+    # Do NOT stub Formatter::Substitution.substitute — we need real substitution
+    # to demonstrate the XSS payload flowing through unescaped.
+
+    # Stub markdown_to_html to pass through (adds <p> wrapper via Kramdown in real use,
+    # but that is orthogonal to the escaping issue).
+    allow(view).to receive(:markdown_to_html) { |text| text.to_s }
+
+    # Stub the error-page partial so it never triggers.
+    stub_template 'layouts/_error_page_block.erb' => ''
+  end
+
+  # Helper: build a rows structure with col header/footer containing substitution tags,
+  # and a simple report so col_url is generated (avoiding the "Not Found" path).
+  def rows_with_header_footer(header:, footer:, report_id: 99)
+    report_def = { 'id' => report_id }
+    [{ 'cols' => [{ 'label' => 'Test', 'header' => header, 'footer' => footer, 'report' => report_def }] }]
+  end
+
+  let(:mock_report) do
+    instance_double(Report, search_attributes: {})
+  end
+
+  before do
+    allow(Report).to receive(:find_by_id_or_resource_name).with(99).and_return(mock_report)
+  end
+
+  # ---- XSS via col_header with <script> tag ----------------------------
+
+  context 'when @master has a field containing a <script> XSS payload referenced in col_header' do
+    before do
+      assign(:master, { rank: xss_script_payload })
+
+      render partial: 'page_layouts/show_row',
+             locals: {
+               rows: rows_with_header_footer(
+                 header: 'Welcome {{rank}}',
+                 footer: ''
+               ),
+               container: container
+             }
+    end
+
+    it 'escapes the <script> tag in the rendered col_header' do
+      # The rendered output must NOT contain a literal <script> tag from user data.
+      expect(rendered).not_to include(xss_script_payload)
+    end
+
+    it 'contains the HTML-escaped version of the payload in the col_header' do
+      expect(rendered).to include('&lt;script&gt;alert(1)&lt;/script&gt;')
+    end
+  end
+
+  # ---- XSS via col_footer with <script> tag ----------------------------
+
+  context 'when @master has a field containing a <script> XSS payload referenced in col_footer' do
+    before do
+      assign(:master, { rank: xss_script_payload })
+
+      render partial: 'page_layouts/show_row',
+             locals: {
+               rows: rows_with_header_footer(
+                 header: '',
+                 footer: 'Goodbye {{rank}}'
+               ),
+               container: container
+             }
+    end
+
+    it 'escapes the <script> tag in the rendered col_footer' do
+      expect(rendered).not_to include(xss_script_payload)
+    end
+
+    it 'contains the HTML-escaped version of the payload in the col_footer' do
+      expect(rendered).to include('&lt;script&gt;alert(1)&lt;/script&gt;')
+    end
+  end
+
+  # ---- XSS via col_header with <img onerror> payload -------------------
+
+  context 'when @master has a field containing an <img onerror> XSS payload referenced in col_header' do
+    before do
+      assign(:master, { rank: xss_img_payload })
+
+      render partial: 'page_layouts/show_row',
+             locals: {
+               rows: rows_with_header_footer(
+                 header: 'Hello {{rank}}',
+                 footer: ''
+               ),
+               container: container
+             }
+    end
+
+    it 'escapes the <img> event handler in the rendered col_header' do
+      expect(rendered).not_to include(xss_img_payload)
+    end
+
+    it 'contains the HTML-escaped version of the img payload' do
+      expect(rendered).to include('&lt;img src=x onerror=alert(1)&gt;')
+    end
+  end
+
+  # ---- report_defaults path remains safe (control test) ----------------
+
+  context 'when report_defaults (not @master) contains an XSS payload' do
+    before do
+      # No @master assigned — falls through to report_defaults
+      assign(:master, nil)
+
+      render partial: 'page_layouts/show_row',
+             locals: {
+               rows: [{ 'cols' => [{
+                 'label' => 'Test',
+                 'header' => 'Value: {{first_name}}',
+                 'footer' => '',
+                 'report' => { 'id' => 99, 'defaults' => { 'first_name' => xss_script_payload } }
+               }] }],
+               container: container
+             }
+    end
+
+    it 'escapes the payload coming through report_defaults' do
+      expect(rendered).not_to include(xss_script_payload)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes a stored XSS vulnerability in page layout column header/footer rendering where user-controlled `@master` record attributes were spliced unescaped into HTML output.

Closes #1224

## Problem

The `Formatter::Substitution.substitute` method spliced tag values (including user-editable `@master` record fields) directly into HTML content without HTML-escaping. When an admin configures a page layout column header/footer with a `{{master_field}}` tag pointing at a user-editable field, a malicious user could store an XSS payload (e.g. `<script>alert(document.cookie)</script>`) in their record. That payload would then execute in every viewer's browser when the dashboard rendered.

**Attack path:** User edits record field → Admin template contains `{{field}}` → `markdown_to_html` passes raw HTML → `substitute` splices unescaped value → `.html_safe` → XSS executes.

## Solution

Added an `html_escape_values: false` keyword argument to `Formatter::Substitution.substitute`. When `true`, each tag value is passed through `ERB::Util.html_escape` before being spliced into the content string.

Updated `app/views/page_layouts/_show_row.html.erb` lines for `col_header` and `col_footer` to pass `html_escape_values: true`, escaping values at substitution time before `.html_safe` is applied.

The `col_label` line is unchanged — it relies on ERB's automatic output escaping.

## Files Changed

- `app/models/formatter/substitution.rb` — Added `html_escape_values:` parameter with conditional `ERB::Util.html_escape` applied per tag value
- `app/views/page_layouts/_show_row.html.erb` — Pass `html_escape_values: true` for `col_header` and `col_footer` substitutions
- `spec/views/page_layouts/_show_row_xss_spec.rb` — New spec: 7 examples covering `<script>` and `<img onerror>` payloads in header and footer contexts, plus a control test for `report_defaults`
- `config/brakeman.ignore` — Removed 2 obsolete entries (stale line numbers), added 2 false-positive ignores with notes explaining the escaping protection in place

## Testing

All 7 new RSpec examples pass. Tests verify:
1. Raw `<script>alert(1)</script>` payload is **not** present in rendered output
2. HTML-escaped form `&lt;script&gt;alert(1)&lt;/script&gt;` **is** present in rendered output
3. `<img src=x onerror=alert(1)>` payload is similarly escaped
4. Existing `report_defaults` path (control) continues to work correctly

Brakeman scan shows 0 active XSS warnings (the 2 flagged lines are false positives — brakeman cannot trace through the `html_escape_values: true` call path; entries documented in `brakeman.ignore` with explanatory notes).
