### PR TITLE
Fixed 18 consistent test-suite failures across 6 areas - fixes #1228

### DIFF
--- a/app/models/classification/general_selection.rb
+++ b/app/models/classification/general_selection.rb
@@ -7,6 +7,7 @@ class Classification::GeneralSelection < ActiveRecord::Base
 
   include AdminHandler
   include SelectorCache
+
   BasicItemTypes = %i[player_infos_source
                       player_contacts_type player_contacts_source player_contacts_rank
                       addresses_type addresses_source addresses_rank].freeze
@@ -76,7 +77,7 @@ class Classification::GeneralSelection < ActiveRecord::Base
   # @param field_name [String | Symbol] field name to check
   # @return [Boolean]
   def self.exists_for?(record, field_name)
-    item_types.include?("#{prefix_name(record)}_#{field_name}".to_sym)
+    item_types.include?(:"#{prefix_name(record)}_#{field_name}")
   end
 
   #

--- a/app/models/classification/general_selection.rb
+++ b/app/models/classification/general_selection.rb
@@ -85,6 +85,12 @@ class Classification::GeneralSelection < ActiveRecord::Base
   # @param [String] attr is the attribute name
   # @return [Boolean]
   def self.use_with_attribute?(attr)
+    # Exclude fields served by dedicated template partials that source their own data
+    # and never require a general selection config:
+    #   select_record_from_* → fetches master association records by field name suffix
+    #   select_user_with_role_* → fetches users having the role derived from field name suffix
+    return false if attr.start_with?('select_record_from_', 'select_user_with_role_')
+
     !attr.in?(%w[disabled user_id created_at updated_at]) && (
       attr.start_with?('select_') ||
       attr.start_with?('multi_') ||

--- a/app/models/classification/general_selection.rb
+++ b/app/models/classification/general_selection.rb
@@ -86,12 +86,6 @@ class Classification::GeneralSelection < ActiveRecord::Base
   # @param [String] attr is the attribute name
   # @return [Boolean]
   def self.use_with_attribute?(attr)
-    # Exclude fields served by dedicated template partials that source their own data
-    # and never require a general selection config:
-    #   select_record_from_* → fetches master association records by field name suffix
-    #   select_user_with_role_* → fetches users having the role derived from field name suffix
-    return false if attr.start_with?('select_record_from_', 'select_user_with_role_')
-
     !attr.in?(%w[disabled user_id created_at updated_at]) && (
       attr.start_with?('select_') ||
       attr.start_with?('multi_') ||

--- a/app/models/classification/selection_options_handler.rb
+++ b/app/models/classification/selection_options_handler.rb
@@ -11,6 +11,40 @@ class Classification::SelectionOptionsHandler
   CacheKeySelectorWithConfigOverrides = 'selector_with_config_overrides'
 
   #
+  # The canonical list of "self-sourcing" field name prefixes.
+  #
+  # A self-sourcing field derives its own selection options at runtime from the field-name
+  # suffix - for example select_record_from_<association> (records from a master association)
+  # or select_user_with_role_<role> (users holding a role). Each is rendered by a dedicated
+  # `name_starts_with_<prefix>` edit_fields partial and never requires a persisted general
+  # selection or an edit_as override.
+  #
+  # Keep this list in sync with the `_name_starts_with_*` partials that build their options
+  # from the field name (see app/views/common_templates/edit_fields). Ordered so that, when
+  # matching, the longest/most specific prefixes are tested first.
+  SelfSourcingFieldPrefixes = %w[
+    pick_multiple_records_from_table
+    tag_select_record_from_table
+    select_record_id_from_table
+    tag_select_users_with_role
+    tag_select_record_id_from
+    select_record_from_table
+    tag_select_record_from
+    select_record_id_from
+    select_user_with_role
+    select_record_from
+  ].freeze
+
+  #
+  # Check if a field sources its own selection options at runtime, based on its name.
+  # @param [String | Symbol] field_name
+  # @return [Boolean]
+  def self.self_sourcing_field?(field_name)
+    fn = field_name.to_s
+    SelfSourcingFieldPrefixes.any? { |prefix| fn.start_with?("#{prefix}_") }
+  end
+
+  #
   # Get the selection option label for a field value in a user base object, if there is one
   # This does not benefit from memoization, so it is generally recommended to instantiate
   # the class and call #label_form(field_name, field_value)

--- a/app/models/concerns/standard_authentication.rb
+++ b/app/models/concerns/standard_authentication.rb
@@ -190,7 +190,7 @@ module StandardAuthentication
     end
 
     def clean_memos
-      @emails_by_id_memo = nil
+      @emails_by_id = nil
     end
 
     def find_active_by_email_or_id(email_or_id)

--- a/app/models/option_configs/extra_options.rb
+++ b/app/models/option_configs/extra_options.rb
@@ -590,6 +590,14 @@ module OptionConfigs
     end
 
     def field_has_selection_override?(field_name)
+      # Fields with dedicated template partials that source their own data do not
+      # require a general selection config or an edit_as override:
+      #   select_record_from_* → _name_starts_with_select_record_from.html.erb
+      #     (fetches records from the master's association by name convention)
+      #   select_user_with_role_* → _name_starts_with_select_user_with_role.html.erb
+      #     (fetches users having the role derived from the field name)
+      return true if field_name.to_s.start_with?('select_record_from_', 'select_user_with_role_')
+
       fopts = field_options[field_name.to_sym] if field_options.respond_to?(:[])
       return false unless fopts.respond_to?(:dig)
 

--- a/app/models/option_configs/extra_options.rb
+++ b/app/models/option_configs/extra_options.rb
@@ -107,14 +107,14 @@ module OptionConfigs
 
     def clean_caption_before_def
       self.caption_before ||= {}
-      self.caption_before = self.caption_before.symbolize_keys
+      self.caption_before = caption_before.symbolize_keys
 
-      self.caption_before = self.caption_before.each do |k, v|
+      self.caption_before = caption_before.each do |k, v|
         if v.is_a? String
 
           v = Formatter::Substitution.text_to_html(v).strip
 
-          self.caption_before[k] = {
+          caption_before[k] = {
             caption: v,
             edit_caption: v,
             show_caption: v,
@@ -132,7 +132,7 @@ module OptionConfigs
 
     def clean_dialog_before_def
       self.dialog_before ||= {}
-      self.dialog_before = self.dialog_before.symbolize_keys
+      self.dialog_before = dialog_before.symbolize_keys
 
       dialog_before.transform_values! { |v| v.is_a?(String) ? { name: v } : v }
       dialog_before.each do |k, v|
@@ -156,7 +156,7 @@ module OptionConfigs
     # Field labels definitions
     def clean_labels_def
       self.labels ||= {}
-      self.labels = self.labels.symbolize_keys
+      self.labels = labels.symbolize_keys
     end
 
     def clean_show_if_def
@@ -165,44 +165,44 @@ module OptionConfigs
       show_if_condition_strings&.each do |fn, val|
         # Generate a real show_if hash fs a condition string was provided
         # and show if is not already set
-        next if val.nil? || val.empty? || self.show_if[fn]
+        next if val.nil? || val.empty? || show_if[fn]
 
         begin
           bl = Redcap::DataDictionaries::BranchingLogic.new(val)
           sis = bl&.generate_show_if
-          self.show_if[fn] = sis if sis.present?
+          show_if[fn] = sis if sis.present?
         rescue StandardError => e
           Rails.logger.warn "Failed to generate real show_if (in #{@config_obj&.resource_name}) " \
                             "for #{fn}: #{val}\n#{e}"
-          self.show_if[fn] = { generate_show_if: "failed - #{e}" }
+          show_if[fn] = { generate_show_if: "failed - #{e}" }
         end
       end
 
-      self.show_if = self.show_if.symbolize_keys
+      self.show_if = show_if.symbolize_keys
     end
 
     def clean_save_action_def
       self.save_action ||= {}
-      self.save_action = self.save_action.symbolize_keys
+      self.save_action = save_action.symbolize_keys
 
       # Make save_action.on_save the default for on_create and on_update
-      os = self.save_action[:on_save]
+      os = save_action[:on_save]
       return unless os
 
-      ou = self.save_action[:on_update] || {}
-      oc = self.save_action[:on_create] || {}
-      self.save_action[:on_update] = os.merge(ou)
-      self.save_action[:on_create] = os.merge(oc)
+      ou = save_action[:on_update] || {}
+      oc = save_action[:on_create] || {}
+      save_action[:on_update] = os.merge(ou)
+      save_action[:on_create] = os.merge(oc)
     end
 
     def clean_view_options_def
       self.view_options ||= {}
-      self.view_options = self.view_options.symbolize_keys
+      self.view_options = view_options.symbolize_keys
     end
 
     def clean_db_configs_def
       self.db_configs ||= {}
-      @config_obj.db_columns ||= self.db_configs = self.db_configs.symbolize_keys if @config_obj.respond_to? :db_columns
+      @config_obj.db_columns ||= self.db_configs = db_configs.symbolize_keys if @config_obj.respond_to? :db_columns
     end
 
     #
@@ -215,10 +215,10 @@ module OptionConfigs
 
     def clean_field_options_def
       self.field_options ||= {}
-      self.field_options = self.field_options.symbolize_keys
+      self.field_options = field_options.symbolize_keys
 
       # Allow field_options.edit_as.alt_options to be an array
-      self.field_options.each do |k, v|
+      field_options.each do |k, v|
         ao = nil
         ao = v[:edit_as][:alt_options] if v && v[:edit_as]
         next unless ao.is_a? Array
@@ -227,43 +227,43 @@ module OptionConfigs
         ao.each do |aov|
           new_ao[aov.to_s.to_sym] = aov.to_s.downcase
         end
-        self.field_options[k][:edit_as][:alt_options] = new_ao
+        field_options[k][:edit_as][:alt_options] = new_ao
       end
     end
 
     def clean_filestore_def
       self.filestore ||= {}
-      self.filestore = self.filestore.symbolize_keys
+      self.filestore = filestore.symbolize_keys
     end
 
     def clean_access_if_def
       self.creatable_if ||= {}
-      self.creatable_if = self.creatable_if.symbolize_keys
+      self.creatable_if = creatable_if.symbolize_keys
 
       self.editable_if ||= {}
-      self.editable_if = self.editable_if.symbolize_keys
+      self.editable_if = editable_if.symbolize_keys
 
       self.showable_if ||= {}
-      self.showable_if = self.showable_if.symbolize_keys
+      self.showable_if = showable_if.symbolize_keys
     end
 
     def clean_valid_if_def
       self.valid_if ||= {}
-      self.valid_if = self.valid_if.symbolize_keys
+      self.valid_if = valid_if.symbolize_keys
 
-      unless self.valid_if.keys.empty? || (self.valid_if.keys - ValidValidIfTriggers).empty?
+      unless valid_if.keys.empty? || (valid_if.keys - ValidValidIfTriggers).empty?
         failed_config :valid_if,
                       "valid_if contains invalid keys #{valid_if.keys} - expected only:",
                       extra_details: ValidValidIfTriggers
       end
 
-      os = self.valid_if[:on_save]
+      os = valid_if[:on_save]
       return unless os
 
-      ou = self.valid_if[:on_update] || {}
-      oc = self.valid_if[:on_create] || {}
-      self.valid_if[:on_update] = os.merge(ou)
-      self.valid_if[:on_create] = os.merge(oc)
+      ou = valid_if[:on_update] || {}
+      oc = valid_if[:on_create] || {}
+      valid_if[:on_update] = os.merge(ou)
+      valid_if[:on_create] = os.merge(oc)
     end
 
     def clean_embed_def
@@ -410,51 +410,51 @@ module OptionConfigs
 
     def clean_save_triggers
       self.save_trigger ||= {}
-      self.save_trigger = self.save_trigger.symbolize_keys
+      self.save_trigger = save_trigger.symbolize_keys
 
-      unless self.save_trigger.keys.empty? || (self.save_trigger.keys - ValidSaveTriggerTriggers).empty?
+      unless save_trigger.keys.empty? || (save_trigger.keys - ValidSaveTriggerTriggers).empty?
         failed_config :save_trigger,
                       "save_trigger contains invalid keys #{save_trigger.keys} - expected only:",
                       extra_details: ValidSaveTriggerTriggers
       end
 
       # Make save_trigger.on_save the default for on_create and on_update
-      os = self.save_trigger[:on_save]
+      os = save_trigger[:on_save]
       if os
         os = [os] if os.is_a?(Hash)
 
-        ou = self.save_trigger[:on_update]
-        oc = self.save_trigger[:on_create]
+        ou = save_trigger[:on_update]
+        oc = save_trigger[:on_create]
         ou = [ou] if ou.is_a?(Hash)
         oc = [oc] if oc.is_a?(Hash)
 
         ou ||= []
         oc ||= []
-        self.save_trigger[:on_update] = os + ou
-        self.save_trigger[:on_create] = os + oc
+        save_trigger[:on_update] = os + ou
+        save_trigger[:on_create] = os + oc
       end
 
-      self.save_trigger[:on_upload] ||= {}
-      self.save_trigger[:on_disable] ||= {}
+      save_trigger[:on_upload] ||= {}
+      save_trigger[:on_disable] ||= {}
     end
 
     def clean_batch_triggers
       self.batch_trigger ||= {}
-      self.batch_trigger = self.batch_trigger.symbolize_keys
-      self.batch_trigger[:on_record] ||= {}
+      self.batch_trigger = batch_trigger.symbolize_keys
+      batch_trigger[:on_record] ||= {}
     end
 
     def clean_config_triggers
       self.config_trigger ||= {}
-      self.config_trigger = self.config_trigger.symbolize_keys
-      od = self.config_trigger[:on_define] ||= []
+      self.config_trigger = config_trigger.symbolize_keys
+      od = config_trigger[:on_define] ||= []
 
-      self.config_trigger[:on_define] = [od] unless od.is_a?(Array)
+      config_trigger[:on_define] = [od] unless od.is_a?(Array)
     end
 
     def clean_preset_fields
       self.preset_fields ||= {}
-      self.preset_fields = self.preset_fields.symbolize_keys
+      self.preset_fields = preset_fields.symbolize_keys
     end
 
     #
@@ -488,13 +488,13 @@ module OptionConfigs
         # 'field_configs' was explicitly set, so use it to set the appropriate configurations
         # for each of the valid_configs
         self.field_configs ||= {}
-        self.field_configs = self.field_configs.symbolize_keys
+        self.field_configs = field_configs.symbolize_keys
         failed = false
         field_configs.each do |fname, fconfig|
           unless fconfig.is_a? Hash
             failed_config :field_configs, "field '#{fname}' is not a Hash"
             failed = true
-            self.field_configs[fname] = {}
+            field_configs[fname] = {}
             next
           end
 
@@ -590,14 +590,6 @@ module OptionConfigs
     end
 
     def field_has_selection_override?(field_name)
-      # Fields with dedicated template partials that source their own data do not
-      # require a general selection config or an edit_as override:
-      #   select_record_from_* → _name_starts_with_select_record_from.html.erb
-      #     (fetches records from the master's association by name convention)
-      #   select_user_with_role_* → _name_starts_with_select_user_with_role.html.erb
-      #     (fetches users having the role derived from the field name)
-      return true if field_name.to_s.start_with?('select_record_from_', 'select_user_with_role_')
-
       fopts = field_options[field_name.to_sym] if field_options.respond_to?(:[])
       return false unless fopts.respond_to?(:dig)
 
@@ -976,7 +968,7 @@ module OptionConfigs
         raise FphsException, "incorrect action type requested in calc_valid_if #{action_type}"
       end
 
-      ci = self.valid_if[:"on_#{action_type}"]
+      ci = valid_if[:"on_#{action_type}"]
       Rails.logger.debug "Checking calc_valid_if on #{obj} with #{ci}"
       ca = ConditionalActions.new(ci, obj, return_failures:)
       ca.calc_action_if

--- a/app/models/option_configs/extra_options.rb
+++ b/app/models/option_configs/extra_options.rb
@@ -571,6 +571,9 @@ module OptionConfigs
       return if selection_fields.empty?
 
       selection_fields.each do |field_name|
+        # Fields that source their own options at runtime (records from a master
+        # association, or users holding a role) never need a general selection config.
+        next if Classification::SelectionOptionsHandler.self_sourcing_field?(field_name)
         next if general_selection_present_for_dynamic_model_field?(field_name)
         next if field_has_selection_override?(field_name)
 

--- a/spec/models/classification/general_selection_spec.rb
+++ b/spec/models/classification/general_selection_spec.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# Classification::GeneralSelection Model Spec
+#
+# Tests core general selection functionality including caching, deduplication, and
+# attribute classification.
+#
+# Regression Coverage:
+# - use_with_attribute? (GitHub #1228):
+#   This is a pure naming-convention predicate identifying selection-like attributes.
+#   It is intentionally shared (also used by Dynamic::DefHandler.item_types to build the
+#   admin general-selection dropdown registry), so it must NOT special-case self-sourcing
+#   fields. The self-sourcing exemption (select_record_from_*, select_user_with_role_*, etc.)
+#   lives in Classification::SelectionOptionsHandler.self_sourcing_field? and is exercised by
+#   spec/models/classification/selection_options_handler_self_sourcing_spec.rb.
+
 require 'rails_helper'
 
 RSpec.describe Classification::GeneralSelection, type: :model do
@@ -12,6 +26,34 @@ RSpec.describe Classification::GeneralSelection, type: :model do
 
     create_master
     create_items :list_valid_attribs
+  end
+
+  describe '.use_with_attribute?' do
+    # Selection-like attributes by naming convention
+    %w[select_status select_who select_type multi_items tag_select_labels
+       source rec_type rank outcome_selection].each do |attr|
+      it "returns true for #{attr}" do
+        expect(described_class.use_with_attribute?(attr)).to be true
+      end
+    end
+
+    # Self-sourcing fields are still selection-like by name, so use_with_attribute?
+    # returns true. They are exempted from missing-general-selection validation
+    # separately, via SelectionOptionsHandler.self_sourcing_field?.
+    %w[select_record_from_player_contact_email
+       select_record_from_addresses
+       select_user_with_role_perform_phone_screen].each do |attr|
+      it "returns true for the self-sourcing field #{attr}" do
+        expect(described_class.use_with_attribute?(attr)).to be true
+      end
+    end
+
+    # System fields that are never configurable
+    %w[disabled user_id created_at updated_at].each do |attr|
+      it "returns false for the system field #{attr}" do
+        expect(described_class.use_with_attribute?(attr)).to be false
+      end
+    end
   end
 
   it 'gets active general selection configurations' do

--- a/spec/models/classification/selection_options_handler_self_sourcing_spec.rb
+++ b/spec/models/classification/selection_options_handler_self_sourcing_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Purpose: Lock in the behaviour of Classification::SelectionOptionsHandler.self_sourcing_field?
+# (GitHub Issue #1228, Group C regression).
+#
+# "Self-sourcing" fields derive their own selection options at runtime from the field-name
+# suffix - records from a master association (select_record_from_*, select_record_id_from_*,
+# pick_multiple_records_from_table_*, with optional tag_ prefix) or users holding a role
+# (select_user_with_role_*, tag_select_users_with_role_*). They are rendered by dedicated
+# `_name_starts_with_*` edit_fields partials and never require a persisted general selection
+# or an edit_as override, so the dynamic model config validator must never flag them as
+# "missing general selection config".
+#
+# These tests verify:
+#   - Each self-sourcing prefix family is recognised (true)
+#   - The three field names that triggered the original Group C failures are recognised
+#   - General-selection-backed selection fields (select_status, source, rank, multi_*, etc.)
+#     are NOT treated as self-sourcing (false), so they remain subject to validation
+#   - A bare prefix with no suffix is not matched (a suffix is required to derive a source)
+
+require 'rails_helper'
+
+RSpec.describe Classification::SelectionOptionsHandler, type: :model do
+  describe '.self_sourcing_field?' do
+    self_sourcing_examples = %w[
+      select_record_from_addresses
+      select_record_from_table_player_contacts
+      select_record_id_from_addresses
+      select_record_id_from_table_player_contacts
+      pick_multiple_records_from_table_player_contacts
+      tag_select_record_from_addresses
+      tag_select_record_id_from_addresses
+      select_user_with_role_perform_phone_screen
+      tag_select_users_with_role_admin
+    ]
+
+    self_sourcing_examples.each do |field_name|
+      it "returns true for self-sourcing field #{field_name}" do
+        expect(described_class.self_sourcing_field?(field_name)).to be true
+      end
+    end
+
+    # Fields that source their options from general selections (or fixed config) and so
+    # must remain subject to the missing-general-selection validation.
+    general_selection_backed_examples = %w[
+      select_status
+      select_who
+      source
+      rec_type
+      rank
+      multi_choices
+      tag_select_some_values
+      some_selection
+    ]
+
+    general_selection_backed_examples.each do |field_name|
+      it "returns false for general-selection-backed field #{field_name}" do
+        expect(described_class.self_sourcing_field?(field_name)).to be false
+      end
+    end
+
+    it 'requires a suffix after the prefix' do
+      # A bare prefix cannot derive a data source, so it is not self-sourcing
+      expect(described_class.self_sourcing_field?('select_record_from')).to be false
+    end
+
+    it 'accepts symbols as well as strings' do
+      expect(described_class.self_sourcing_field?(:select_user_with_role_perform_phone_screen)).to be true
+    end
+  end
+end

--- a/spec/models/reports/user_access_overview_spec.rb
+++ b/spec/models/reports/user_access_overview_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe 'User Access Overview Reports', type: :model do
         item_type: 'admin-user-access-overview'
       )
       expect(new_report).to be_present,
-                             "Expected resource-focused report 'user_access_overview_resource_by_role' to exist"
+                            "Expected resource-focused report 'user_access_overview_resource_by_role' to exist"
     end
 
     it 'includes search_attrs with app_type_id and user for all reports' do
@@ -479,7 +479,7 @@ RSpec.describe 'User Access Overview Reports', type: :model do
         resource_name: 'admin_user_access_overview__user_access_overview_resource_by_role'
       )
       expect(resource_focus_uac).to be_present,
-                                     "Expected a UAC with resource_name 'admin_user_access_overview__user_access_overview_resource_by_role'"
+                                    "Expected a UAC with resource_name 'admin_user_access_overview__user_access_overview_resource_by_role'"
     end
   end
 

--- a/spec/models/reports/user_access_overview_spec.rb
+++ b/spec/models/reports/user_access_overview_spec.rb
@@ -1149,7 +1149,9 @@ RSpec.describe 'User Access Overview Reports', type: :model do
       template_content = File.read(template_path)
 
       # Find the line(s) that contain the User Access Overview link
-      overview_lines = template_content.lines.select { |line| line.include?('User Access Overview') }
+      # The link text uses Settings::AdminReportItemTypes['admin-user-access-overview'] rather than
+      # a hardcoded string, so match by the item_type key instead.
+      overview_lines = template_content.lines.select { |line| line.include?("Settings::AdminReportItemTypes['admin-user-access-overview']") }
       expect(overview_lines).not_to be_empty, 'Expected a User Access Overview link in the admin index'
 
       overview_line = overview_lines.first

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,6 +25,9 @@
 #   - Admin-created users when self-registration disabled
 # - Associations:
 #   - user_preference relationship with autosave and inverse_of
+# - Memoization Cache (GitHub #1228):
+#   - emails_by_id cache is cleared by clean_memos after a user save, so subsequent
+#     lookups reflect the updated email rather than a stale cached value
 
 require 'rails_helper'
 include SetupHelper
@@ -353,6 +356,37 @@ describe User do
   after :all do
     if User.method_defined? :orig_password_updated_at
       User.send :alias_method, :password_updated_at, :orig_password_updated_at
+    end
+  end
+
+  # Regression spec for GitHub #1228:
+  # StandardAuthentication#clean_memos previously cleared @emails_by_id_memo (a
+  # stale ivar name left after a RuboCop rename) instead of @emails_by_id, so the
+  # emails_by_id cache was never actually invalidated after a save.
+  describe '.emails_by_id cache invalidation (clean_memos)' do
+    it 'reflects the updated email after the user is saved' do
+      create_admin
+
+      # Warm the cache
+      original_email = @user.email
+      cache_before = User.emails_by_id
+      expect(cache_before[@user.id]).to eq original_email
+
+      # Update the email as an admin
+      new_email = "updated-#{SecureRandom.hex(4)}@example.com"
+      @user.current_admin = @admin
+      @user.email = new_email
+      @user.save!
+
+      # Cache must have been cleared and repopulated on next access
+      cache_after = User.emails_by_id
+      expect(cache_after[@user.id]).to eq new_email
+    end
+
+    it 'returns nil for the cache ivar before first access' do
+      # Ensure clean_memos sets the ivar to nil (not an incorrect name)
+      User.clean_memos
+      expect(User.instance_variable_get(:@emails_by_id)).to be_nil
     end
   end
 end

--- a/spec/support/redcap/redcap_support.rb
+++ b/spec/support/redcap/redcap_support.rb
@@ -93,6 +93,21 @@ module Redcap
       add_user_to_role Settings.admin_nfs_role, for_user: @user
       add_user_to_role 'admin', for_user: @user
 
+      # Ensure the batch user can operate in the @app_type (ref-data) context.
+      # setup_container_file_current_user (process_handler.rb #1204) normalises the
+      # file-owner's app_type_id to Settings.nfs_store_default_app_type_id before
+      # checking nfs_store group roles. When those roles are absent it falls back to
+      # the batch user via User.use_batch_user(in_app_type_id). That method calls
+      # bu.update(app_type_id: ...) which is silently rejected by the before_save
+      # :set_app_type callback if the batch user has no :app_type general access.
+      # Mirror what nfs_store_support.rb does: give the batch user access + role.
+      batch_user = User.batch_user
+      if batch_user
+        enable_user_app_access(@app_type, batch_user)
+        batch_user = User.use_batch_user(@app_type.id)
+        add_user_to_role Settings.admin_nfs_role, for_user: batch_user if batch_user
+      end
+
       @user.clear_role_names!
     end
 


### PR DESCRIPTION
## Summary

Resolves the 18 consistent test-suite failures reported in #1228, grouped into five root causes (A–E).

## Changes by group

### Group A & B — `User.emails_by_id` stale cache (6 failures)
RuboCop commit `8d0e777ae0` renamed the memoization ivar from `@emails_by_id_memo` to `@emails_by_id` but left `clean_memos` clearing the old name, so the cache was never invalidated after a user save. This surfaced as nil `user_email` during app-type export/import (Group A) and message-template email substitution (Group B).

- Fixed `StandardAuthentication#clean_memos` to clear the correct `@emails_by_id` ivar.
- Added regression spec in `spec/models/user_spec.rb` for cache invalidation after save.

### Group C — PLAY-IPA Phase 0 false config errors (3 failures)
`validate_missing_general_selection_configs` flagged self-sourcing fields (`select_record_from_*`, `select_user_with_role_*` and related families) as missing a general selection, even though they are served by dedicated `_name_starts_with_*` ERB partials that source their own data at runtime.

- Added a canonical `SelfSourcingFieldPrefixes` constant and `self_sourcing_field?` predicate in `Classification::SelectionOptionsHandler`, covering the full self-sourcing family (record-based and user-by-role).
- `validate_missing_general_selection_configs` now skips self-sourcing fields via that predicate.
- Kept `GeneralSelection.use_with_attribute?` as a pure naming-convention predicate (it is shared with `Dynamic::DefHandler.item_types`), reverting an earlier attempt that special-cased it there.
- Added regression spec `spec/models/classification/selection_options_handler_self_sourcing_spec.rb` and updated `general_selection_spec.rb`.

### Group D — Test fixes (2 failures)
- `user_access_overview_spec.rb`: updated the test to resolve the link text via `Settings::AdminReportItemTypes` rather than a hard-coded string changed by commit `40075c9e49`.
- `redcap_support.rb`: fixed batch user app access setup for the nfs_store spec.

### Group E — System/UI spec failures (5 failures)
All five resolved by the Group A `clean_memos` fix; no additional code changes required.

## Validation
- New/updated model specs pass (`selection_options_handler_self_sourcing_spec.rb`, `general_selection_spec.rb`, `user_spec.rb`).
- PLAY-IPA Phase 0 config check passes.

Detailed per-group root-cause analysis is recorded in the comments on #1228.
