### PR TITLE
Fixed activity log item_type_exists validation to skip disabled records; cleaned up perspectives spec pollution - fixes #1235

### DIFF
--- a/app/models/activity_log.rb
+++ b/app/models/activity_log.rb
@@ -677,6 +677,8 @@ class ActivityLog < ActiveRecord::Base
 
   def item_type_exists
     return true unless errors.empty?
+    # Allow disabling a record even when the associated model is no longer accessible
+    return true if disabled?
 
     begin
       implementation_class

--- a/spec/models/activity_log_spec.rb
+++ b/spec/models/activity_log_spec.rb
@@ -3,7 +3,13 @@
 require 'rails_helper'
 
 # Use the activity log player contact phone activity log implementation,
-# since it includes the works_with concern
+# since it includes the works_with concern.
+#
+# Tests cover:
+# - Master association definitions for activity log extra log types
+# - Reconfiguration of extra log types with new steps
+# - View recreation when activity log definition changes
+# - Regression: disabling an activity log definition skips item_type_exists validation
 
 RSpec.describe 'Activity Log definition', type: :model do
   include ModelSupport
@@ -452,6 +458,42 @@ RSpec.describe 'Activity Log definition', type: :model do
 
         ActiveRecord::Base.connection.schema_cache.clear!
       end
+    end
+  end
+
+  describe 'item_type_exists validation' do
+    before :each do
+      create_user
+    end
+
+    it 'skips validation when disabling a record with an unresolvable item type' do
+      # Find an existing enabled activity log definition
+      al_def = ActivityLog.active.first
+      expect(al_def).not_to be_nil
+
+      # Directly write an invalid item_type to simulate a model that no longer exists,
+      # bypassing validations so the record is in the database with the bad value
+      al_def.update_columns(item_type: 'nonexistent_model_type')
+      al_def.reload
+
+      # Disabling the record should succeed despite the unresolvable item_type
+      al_def.current_admin = @admin
+      al_def.disabled = true
+      expect(al_def.save).to be true
+    end
+
+    it 'still validates item_type_exists for enabled records' do
+      al_def = ActivityLog.active.first
+      expect(al_def).not_to be_nil
+
+      al_def.update_columns(item_type: 'nonexistent_model_type')
+      al_def.reload
+
+      # Saving an enabled record with an unresolvable item_type should fail validation
+      al_def.current_admin = @admin
+      al_def.disabled = false
+      expect(al_def.save).to be false
+      expect(al_def.errors[:item_type]).not_to be_empty
     end
   end
 end

--- a/spec/system/activity_log/perspectives_spec.rb
+++ b/spec/system/activity_log/perspectives_spec.rb
@@ -161,6 +161,9 @@ describe 'activity log panel perspectives', js: true, driver: $browser_driver do
                            .where(app_type: @app_type, name: 'default activity log perspective')
                            .each { |ac| ac.update!(current_admin: @admin, disabled: true) }
     Admin::AppConfiguration.clear_memo!
+    # Disable the email activity log created for this spec so it doesn't contaminate
+    # subsequent specs that check supports_activity_log for player_contact items
+    @al_def&.update!(disabled: true, current_admin: @admin)
   end
 
   before(:each) do


### PR DESCRIPTION
## Summary

Fixes two related test failures caused by activity log definition validation and spec pollution.

Resolves #1235

## Changes

### `app/models/activity_log.rb`
- `item_type_exists` validation now returns early when the record is `disabled?`, allowing activity log definitions to be disabled even when their associated parent model is no longer accessible (e.g. during BHS app import setup).

### `spec/system/activity_log/perspectives_spec.rb`
- Added cleanup in `after(:all)` to disable the email activity log definition (`@al_def`) created for this spec, preventing it from leaking into subsequent specs that check `supports_activity_log` for `player_contact` items.

### `spec/models/activity_log_spec.rb`
- Added regression tests for the `item_type_exists` validation:
  - Confirms a disabled record with an unresolvable `item_type` can be saved successfully.
  - Confirms an enabled record with an unresolvable `item_type` still fails validation.

## Testing

- Model spec: `bundle exec rspec spec/models/activity_log_spec.rb -e 'item_type_exists'` — 2 examples, 0 failures
