### PR TITLE
Fixed embedded DM show mode for versioned definitions

### DIFF
--- a/app/views/activity_logs/_common_search_results_template.html.erb
+++ b/app/views/activity_logs/_common_search_results_template.html.erb
@@ -103,205 +103,37 @@
 %>
   <%= render partial: 'common_templates/search_results_template', locals: mapped_vars %>
 <% end %>
-<%= handlebars_template_tag("sub_list_#{item_type_name}_result-partial", css_class: 'hidden handlebars-partial') do %>
-  {{#was _created}}<div class="panel index-{{_created}} sub-list-item activity-log--<%=item_type_name_hyphenated%>-type" id="activity-log-<%=item_type_name_hyphenated%>-sub-list-{{master_id}}-{{id}}" data-template="sub-list-<%=item_type_name_hyphenated%>-result-template" data-sub-item="<%=item_type%>" data-sub-id="{{id}}" data-sort-desc="data-item-rank" data-preprocessor="<%=item_type%>_edit_form">{{/was}}
-  
-    <ul class="list-group" data-item-id="{{id}}" data-item-rank="{{rank}}">
-      <li class="list-group-item sub-list-data">
-        <i class="glyphicon glyphicon-phone"></i>
-        <a data-on-click-call="activity_logs.selected_parent" data-on-click-show="activity_logs_<%=item_type_name%>_actions_block@#activity-log-{{master_id}}-initial-action" data-master-id="{{master_id}}" data-item-id="{{id}}" data-item-data="{{data}}" data-rec-type="{{rec_type}}">{{pretty_string data return_string="true"}}</a>
-        <a data-toggle="scrollto-result" data-target-force="true" data-target="#activity-log-<%=item_type_name_hyphenated%>-sub-list-{{master_id}}-{{id}}" title="edit" class="edit-entity edit-activity-log-<%=item_type_name_hyphenated%> pull-right glyphicon glyphicon-edit small" href="/masters/{{master_id}}/<%=item_type.pluralize%>/{{id}}/edit" data-remote="true" data-<%=item_type_hyphenated%>-id="{{id}}" data-result-target=""></a>
-        <span class="pull-right label label-info general-rank-{{rank}} <%=item_type_hyphenated%>-{{rank}} rank-label--spaced">{{#has 'rank'}}{{#if rank}}{{rank}} - {{rank_name}}{{else}}(no rank){{/if}}{{/has}}</span>
-      </li>
-      <li class="list-group-item activity-log-actions-holder activity-log-initial-action">
-          {{> activity_logs_<%=item_type_name%>_actions item_id=id}}
-      </li>
-    </ul>
-  
-  {{#was _created}}</div>{{/was}}
-<% end %>
-<%= handlebars_template_tag("sub-list-#{item_type_name_hyphenated}-result-template") do %>
-  {{#with <%=item_type%>}}
-      {{>sub_list_<%=item_type_name%>_result}}
-  {{/with}}
-<% end %>
-<%= handlebars_template_tag("activity_logs_#{item_type_name}_actions_block") do %>
-  {{> activity_logs_<%=item_type_name%>_actions item_id=item_id}}
-<% end %>
-<%= handlebars_template_tag("activity_logs_#{item_type_name}_actions-partial", css_class: 'hidden handlebars-partial handlebars-template') do %>
-  <% unless prevent_create  || !current_user.has_access_to?(:create, :activity_log_type, current_definition.option_type_config_for(:primary).resource_name)%>
-  <span id="activity-log-{{master_id}}-initial-action" class="al-initial-action-container" >
-    <span class="activity-log--<%=item_type_name_hyphenated%>-actions">
-      <a href="/masters/{{master_id}}/<%=item_type.pluralize%>/{{item_id}}/activity_log/<%=item_type_name.pluralize%>/new" data-remote="true" class="btn btn-sm btn-primary add-item-button" data-extra-log-type="primary" data-toggle="unhide scrollto-result" data-target="#activity-log--<%=item_type_name_hyphenated%>-primary-{{master_id}}-"><span class="glyphicon glyphicon-plus"></span> <%= main_log_label %></a>
-    </span>
-   </span>
-   <% end %>
-<% end %>
 <%
-  # Template for page layout resource results. A plain list without activity log controls.
+  # The Handlebars template tags and postprocessor registration below are
+  # unversioned (keyed by item_type_name) and identical across all definition
+  # versions. They are extracted into a partial and rendered only for the current
+  # (live) version. Historical versions only need the versioned JS template_config
+  # emitted by the renders above (common_templates/search_results_template skips
+  # its Handlebars HTML when def_version is set); re-emitting the unversioned tags
+  # for a historical version would create duplicate template tags and DOM ids,
+  # breaking the page (issue #1238).
 %>
-<%= handlebars_template_tag("activity-log--#{item_type_name_hyphenated.pluralize}-page-result-template") do %>
-  <div id="<%=item_type_hyphenated%>-activity-logs-<%=item_type_name_hyphenated%>-type-{{item_id}}" class="panel panel-default activity-logs-item-block activity-logs-<%=item_type_name_hyphenated%>-type-block <%= hide_item_list_panel ? 'hidden-item-list-panel' : 'shown-item-list-panel' %> al-page-result-template" data-item-id="{{item_id}}" data-master-id="{{master_id}}" data-item-data="{{item_data}}">
-    <div class="col-md-24">
-        <div class="row common-template-list activity-log-list resize-children" id="activity-logs-master-{{master_id}}-" data-sub-list="<%=item_type_name%>_logs">
-          {{#each <%=full_name.pluralize%>}}
-            {{#if extra_log_type}}
-            <% all_option_configs.each do |c| %>
-              {{#is extra_log_type '===' '<%=c.name%>'}}
-                {{> common_page_template_result name='<%= full_name %>_<%=c.name%>' orig_name="<%=name.underscore%>" result_data=this _created=@index}}                
-              {{/is}}
-            <% end %>
-            {{/if}}
-          {{else}}
-          <div class="message-well">
-            <h1>Not Found</h1>
-            <p class="">
-              The requested page was not found
-            </p>
-            <p class="text-center">
-              <a href="javascript:history.back()">Go Back</a> or visit the <a href="/">Home Page</a>
-            </p>
-          </div>
-          {{/each}}
-        </div>
-      </div>
-  </div>
-<% end %>
-
-<%# Activity Log main results including controls %>
-<%= handlebars_template_tag("activity-log--#{item_type_name_hyphenated.pluralize}-main-result-template") do %>
-  <div id="<%=item_type_hyphenated%>-activity-logs-<%=item_type_name_hyphenated%>-type-{{item_id}}" class="panel panel-default activity-logs-item-block activity-logs-<%=item_type_name_hyphenated%>-type-block <%= hide_item_list_panel ? 'hidden-item-list-panel' : 'shown-item-list-panel' %> al-main-result-template" data-item-id="{{item_id}}" data-master-id="{{master_id}}" data-item-data="{{item_data}}">
-  
-    <div class="is-heading activity-logs-header">
-    <% unless hide_player_tabs? %>
-      <a data-target="#activity-log--<%=item_type_name_hyphenated.pluralize%>-{{master_id}}" data-toggle="collapse" class="show-entity pull-right glyphicon glyphicon-remove-sign no-scroll-on-collapse btn-close-panel" title="close panel"></a>
-    <% end %>
-      <h4 class="list-group-item-heading al-label-<%=item_type_name_hyphenated%>-item"><%=al_name%></h4>
-      <%= render partial: 'masters/panel_tab_caption', locals: {current_definition: current_definition} %>
-      <% if hide_item_list_panel && !prevent_create%>
-      <p class="text-center action-buttons">
-        {{#each <%=item_type.pluralize%>}}
-        <%
-        eltc = current_definition.option_type_config_for(:primary)
-        if current_user.has_access_to?(:create, :activity_log_type, eltc.resource_name)
-        %>
-          <% if rec_type.blank? %>
-            <a href="/masters/{{master_id}}/<%=item_type.pluralize%>/{{id}}/activity_log/<%=item_type_name.pluralize%>/new" data-remote="true" class="btn btn-sm btn-primary add-item-button <%= eltc.view_options[:hide_unless_creatable] ? 'hide-unless-creatable' : '' %>"  data-extra-log-type="primary" data-toggle="unhide scrollto-result" data-target="#activity-log--<%=item_type_name_hyphenated%>-primary-{{master_id}}-"><span class="glyphicon glyphicon-plus"></span> <%= main_log_label %>{{#is <%=item_type.pluralize%>.length '>' 1}} ({{data}}){{/is}}</a>
-          <% else %>
-          {{#is rec_type '===' '<%= rec_type %>'}}
-            <a href="/masters/{{master_id}}/<%=item_type.pluralize%>/{{id}}/activity_log/<%=item_type_name.pluralize%>/new" data-remote="true" class="btn btn-sm btn-primary add-item-button <%= eltc.view_options[:hide_unless_creatable] ? 'hide-unless-creatable' : '' %>"  data-extra-log-type="primary" data-toggle="unhide scrollto-result" data-target="#activity-log--<%=item_type_name_hyphenated%>-primary-{{master_id}}-"><span class="glyphicon glyphicon-plus"></span> <%= main_log_label %>{{#is <%=item_type.pluralize%>.length '>' 1}} ({{data}}){{/is}}</a>
-          {{/is}}
-          <% end %>
-        <% end %>
-        {{/each}}
-        <%
-        eltc = current_definition.option_type_config_for(:blank_log)
-        if current_user.has_access_to?(:create, :activity_log_type, eltc.resource_name)
-        %>
-        <a href="/masters/{{master_id}}/activity_log/<%=item_type_name.pluralize%>/new?extra_type=blank-log" data-remote="true" class="btn btn-sm btn-primary add-item-button <%= eltc.view_options[:hide_unless_creatable] ? 'hide-unless-creatable' : '' %>"  data-extra-log-type="blank_log" data-toggle="unhide scrollto-result" data-target="#activity-log--<%=item_type_name_hyphenated%>-blank-log-{{master_id}}-"><span class="glyphicon glyphicon-plus"></span> <%= blank_log_label %></a>
-        <% end %>
-        <% option_configs.each do |c|
-            eltc = c
-            if current_user.has_access_to? :create, :activity_log_type, c.resource_name
-        %>
-          <a href="/masters/{{master_id}}/<% if item_list.include? item_type %><%=item_type.pluralize%>/{{id}}/<% end %>activity_log/<%=item_type_name.pluralize%>/new?extra_type=<%= c.name.to_s.hyphenate %>"  data-extra-log-type="<%=c.name%>" data-remote="true" class="btn btn-sm btn-primary add-item-button <%= eltc.view_options[:hide_unless_creatable] ? 'hide-unless-creatable' : '' %>" data-toggle="unhide scrollto-result" data-target="#activity-log--<%=item_type_name_hyphenated%>-<%= c.name.to_s.hyphenate %>-{{master_id}}-"><span class="glyphicon glyphicon-plus"></span> <%= c.button_label || c.label %></a>
-        <%  end
-           end %>
-      </p>
-      <% end %>
-  
-    </div>
-    <div class="row">
-  
-      <% unless hide_item_list_panel %>
-      <div class="col-md-5 activity-log-sub-list" data-selected-id="{{item_id}}" id="activity-log-<%=item_type_name_hyphenated.pluralize%>-sub-list-{{master_id}}-" data-sub-list="<%=item_type.pluralize%>">
-  
-        {{#each <%=item_type.pluralize%>}}
-        <% if rec_type.blank? %>
-          {{>sub_list_<%=item_type_name%>_result _created=@index}}
-        <% else %>
-          {{#is rec_type '===' '<%= rec_type %>'}}
-            {{>sub_list_<%=item_type_name%>_result _created=@index}}
-          {{/is}}
-        <% end %>
-        {{/each}}
-        <div class="new-block" form-res-id="<%=item_type_hyphenated%>-{{master_id}}-" form-res-template="sub-list-<%=item_type_name_hyphenated%>-result-template" id="activity-log--<%=item_type_name_hyphenated%>-edit-form-{{master_id}}-" data-subscription="<%=item_type_hyphenated%>-edit-form-{{master_id}}-" data-preprocessor="<%=item_type%>_edit_form">
-  
-        </div>
-        <br />
-        <% unless prevent_create %>
-        <p class="help-block small">
-          Select <%=item_type_name.humanize%> above to log an activity against it. Or click <b>+ <%= blank_log_label %></b> to add an activity not tied to a specific item (such as indicating that a follow up is no longer required.)
-        </p>
-        <br />
-        <% end %>
-        <p class="text-center al-create-actions">
-          <% if current_user.has_access_to?( :create, :table, item_type.pluralize) %>
-          <a href="/masters/{{master_id}}/<%=item_type.pluralize%>/new<%= rec_type.blank? ? '' : "?#{item_type}[rec_type]=#{rec_type}"  %>" data-remote="true" class="btn btn-sm btn-default add-item-button" data-toggle="scrollto-result" data-target-force="true" data-target="#activity-log--<%=item_type_name_hyphenated%>-edit-form-{{master_id}}-" aria-label="add <%=item_type.humanize%> record"><span class="glyphicon glyphicon-plus"></span> <%= item_type.humanize%> record</a>
-          <% end %>
-          <% unless prevent_create %>
-          <% if current_user.has_access_to?(:create, :activity_log_type, current_definition.option_type_config_for(:blank_log).resource_name) %>
-          <a href="/masters/{{master_id}}/activity_log/<%=item_type_name.pluralize%>/new" data-remote="true" class="btn btn-sm btn-primary add-item-button" data-toggle="unhide scrollto-result" data-target="#activity-log--<%=item_type_name_hyphenated%>-blank-log-{{master_id}}-"><span class="glyphicon glyphicon-plus"></span> <%= blank_log_label %></a>
-          <% end %>
-            <% option_configs.each do |c|
-                if current_user.has_access_to? :create, :activity_log_type, c.resource_name
-            %>
-              <a href="/masters/{{master_id}}/<% if item_list.include? item_type %><%=item_type.pluralize%>/{{id}}/<% end %>activity_log/<%=item_type_name.pluralize%>/new?extra_type=<%= c.name.to_s.hyphenate %>" data-remote="true" class="btn btn-sm btn-primary add-item-button" data-toggle="unhide scrollto-result" data-target="#activity-log--<%=item_type_name_hyphenated%>-<%= c.name.to_s.hyphenate %>-{{master_id}}-"><span class="glyphicon glyphicon-plus"></span> <%= c.button_label || c.label %></a>
-            <%  end
-               end %>
-          <% end %>
-        </p>
-      </div>
-      <% end %>
-      <div class="col-md-<%= hide_item_list_panel ? '24' : '19' %> ">
-  
-  
-        <div class="row common-template-list activity-log-list resize-children" id="activity-logs-master-{{master_id}}-" data-sub-list="<%=item_type_name%>_logs">
-          <% unless hide_sublist_controls %>
-          {{>sublist_controls sub_list="<%=item_type_name%>_logs" sub_list_data_name="activity_log__<%=item_type_name.pluralize%>" filter_attr='extra_log_type' filter_name="human_name" filter_all=true order='asc' all_active=true layout=true}}
-          <% end %>
-          <div data-sort-desc="<%= data_action_when.hyphenate %>" <%= data_action_when.hyphenate %>="" class="new-blocks-container">
-            <div class="new-block new-after-parent alr-new-block <%=col_width_classes%> hidden" id="activity-log--<%=item_type_name_hyphenated%>-primary-{{master_id}}-" data-subscription="activity-log--<%=item_type_name_hyphenated%>-primary-edit-form-{{master_id}}-" data-preprocessor="activity_log_edit_form">
-            </div>
-            <div class="new-block new-after-parent alr-new-block <%=col_width_classes%> hidden" id="activity-log--<%=item_type_name_hyphenated%>-blank-log-{{master_id}}-" data-subscription="activity-log--<%=item_type_name_hyphenated%>-blank-log-edit-form-{{master_id}}-" data-preprocessor="activity_log_edit_form"></div>
-            <% option_configs.each do |c| 
-            
-              vos = c.view_options[:alt_width_classes]
-              cwc = if vos
-                      vos
-                    elsif c.e_sign
-                      'e-sign-doc col-md-24 col-lg-12'
-                    else
-                      col_width_classes
-                    end
-
-            %>
-              <div class="new-block new-after-parent alr-new-block <%=cwc%> hidden" id="activity-log--<%=item_type_name_hyphenated%>-<%= c.name.to_s.hyphenate %>-{{master_id}}-" data-subscription="activity-log--<%=item_type_name_hyphenated%>-<%= c.name.to_s.hyphenate %>-edit-form-{{master_id}}-" data-preprocessor="activity_log_edit_form"></div>
-            <% end %>
-          </div>
-          {{#each <%=full_name.pluralize%>}}
-            {{#if extra_log_type}}
-            <% all_option_configs.each do |c| %>
-              {{#is extra_log_type '===' '<%=c.name%>'}}
-                {{> common_template_result name='<%= full_name %>_<%=c.name%>' result_data=this _created=@index}}
-              {{/is}}
-            <% end %>
-  
-            {{/if}}
-          {{/each}}
-        </div>
-      </div>
-    </div>
-  
-  </div>
-<% end %>
-<%= javascript_tag nonce: true do %>
-  <%
-    eltcn = []
-    option_configs.each do |elt|
-      eltcn << {name: elt.name}
-    end
-  %>
-  _fpa.activity_logs.generate_postprocessors('<%=item_type_name%>', <%= eltcn.to_json.html_safe %>)
+<% unless def_version %>
+  <%= render partial: 'activity_logs/unversioned_handlebars_templates', locals: {
+    item_type_name: item_type_name,
+    item_type_name_hyphenated: item_type_name_hyphenated,
+    item_type: item_type,
+    item_type_hyphenated: item_type_hyphenated,
+    full_name: full_name,
+    name: name,
+    al_name: al_name,
+    current_definition: current_definition,
+    prevent_create: prevent_create,
+    option_configs: option_configs,
+    all_option_configs: all_option_configs,
+    main_log_label: main_log_label,
+    blank_log_label: blank_log_label,
+    hide_item_list_panel: hide_item_list_panel,
+    hide_sublist_controls: hide_sublist_controls,
+    col_width_classes: col_width_classes,
+    data_action_when: data_action_when,
+    item_list: item_list,
+    rec_type: rec_type
+  } %>
 <% end %>
 <% end %>

--- a/app/views/activity_logs/_search_results_template.html.erb
+++ b/app/views/activity_logs/_search_results_template.html.erb
@@ -2,4 +2,22 @@
   next unless m.implementation_class_defined?(::ActivityLog, fail_without_exception: true)
 %>
 <%= render partial: 'activity_logs/search_results_template_item', locals: { def_record: m } %>
+<%# Also emit JS-only template_config entries for older history versions so that
+    activity log records created before a definition version bump can still
+    resolve their vN key (issue #1238).  The common _search_results_template
+    skips Handlebars HTML-template rendering when def_version is non-nil, so this
+    only produces the lightweight JS config block. %>
+<% m.all_versions.each do |historical_version|
+     # Skip the latest history entry: it corresponds to the current live record,
+     # whose config is already emitted above with def_version=nil.
+     next if historical_version.def_version == m.all_versions.first&.def_version
+
+     # Skip versions that cannot produce a usable template: a disabled version (or
+     # one whose stored configuration no longer parses) returns nil/[] from
+     # option_configs, which would raise in the activity log common template and
+     # break the whole page render (issue #1238).
+     next if historical_version.option_configs.blank?
+%>
+  <%= render partial: 'activity_logs/search_results_template_item', locals: { def_record: historical_version } %>
+<% end %>
 <% end%>

--- a/app/views/activity_logs/_unversioned_handlebars_templates.html.erb
+++ b/app/views/activity_logs/_unversioned_handlebars_templates.html.erb
@@ -1,0 +1,214 @@
+<%#
+  Unversioned activity log Handlebars templates and postprocessor registration.
+
+  These Handlebars template tags and the generate_postprocessors call are keyed by
+  item_type_name and are identical across all definition versions, so they are
+  rendered only once (for the current/live definition version). Historical
+  definition versions must NOT re-emit them: doing so would create duplicate
+  template tags and DOM ids, breaking the page (issue #1238). The caller is
+  responsible for only rendering this partial for the current version (i.e. when
+  def_version is nil).
+
+  Locals are supplied by activity_logs/_common_search_results_template.html.erb.
+%>
+<%= handlebars_template_tag("sub_list_#{item_type_name}_result-partial", css_class: 'hidden handlebars-partial') do %>
+  {{#was _created}}<div class="panel index-{{_created}} sub-list-item activity-log--<%=item_type_name_hyphenated%>-type" id="activity-log-<%=item_type_name_hyphenated%>-sub-list-{{master_id}}-{{id}}" data-template="sub-list-<%=item_type_name_hyphenated%>-result-template" data-sub-item="<%=item_type%>" data-sub-id="{{id}}" data-sort-desc="data-item-rank" data-preprocessor="<%=item_type%>_edit_form">{{/was}}
+  
+    <ul class="list-group" data-item-id="{{id}}" data-item-rank="{{rank}}">
+      <li class="list-group-item sub-list-data">
+        <i class="glyphicon glyphicon-phone"></i>
+        <a data-on-click-call="activity_logs.selected_parent" data-on-click-show="activity_logs_<%=item_type_name%>_actions_block@#activity-log-{{master_id}}-initial-action" data-master-id="{{master_id}}" data-item-id="{{id}}" data-item-data="{{data}}" data-rec-type="{{rec_type}}">{{pretty_string data return_string="true"}}</a>
+        <a data-toggle="scrollto-result" data-target-force="true" data-target="#activity-log-<%=item_type_name_hyphenated%>-sub-list-{{master_id}}-{{id}}" title="edit" class="edit-entity edit-activity-log-<%=item_type_name_hyphenated%> pull-right glyphicon glyphicon-edit small" href="/masters/{{master_id}}/<%=item_type.pluralize%>/{{id}}/edit" data-remote="true" data-<%=item_type_hyphenated%>-id="{{id}}" data-result-target=""></a>
+        <span class="pull-right label label-info general-rank-{{rank}} <%=item_type_hyphenated%>-{{rank}} rank-label--spaced">{{#has 'rank'}}{{#if rank}}{{rank}} - {{rank_name}}{{else}}(no rank){{/if}}{{/has}}</span>
+      </li>
+      <li class="list-group-item activity-log-actions-holder activity-log-initial-action">
+          {{> activity_logs_<%=item_type_name%>_actions item_id=id}}
+      </li>
+    </ul>
+  
+  {{#was _created}}</div>{{/was}}
+<% end %>
+<%= handlebars_template_tag("sub-list-#{item_type_name_hyphenated}-result-template") do %>
+  {{#with <%=item_type%>}}
+      {{>sub_list_<%=item_type_name%>_result}}
+  {{/with}}
+<% end %>
+<%= handlebars_template_tag("activity_logs_#{item_type_name}_actions_block") do %>
+  {{> activity_logs_<%=item_type_name%>_actions item_id=item_id}}
+<% end %>
+<%= handlebars_template_tag("activity_logs_#{item_type_name}_actions-partial", css_class: 'hidden handlebars-partial handlebars-template') do %>
+  <% unless prevent_create  || !current_user.has_access_to?(:create, :activity_log_type, current_definition.option_type_config_for(:primary).resource_name)%>
+  <span id="activity-log-{{master_id}}-initial-action" class="al-initial-action-container" >
+    <span class="activity-log--<%=item_type_name_hyphenated%>-actions">
+      <a href="/masters/{{master_id}}/<%=item_type.pluralize%>/{{item_id}}/activity_log/<%=item_type_name.pluralize%>/new" data-remote="true" class="btn btn-sm btn-primary add-item-button" data-extra-log-type="primary" data-toggle="unhide scrollto-result" data-target="#activity-log--<%=item_type_name_hyphenated%>-primary-{{master_id}}-"><span class="glyphicon glyphicon-plus"></span> <%= main_log_label %></a>
+    </span>
+   </span>
+   <% end %>
+<% end %>
+<%
+  # Template for page layout resource results. A plain list without activity log controls.
+%>
+<%= handlebars_template_tag("activity-log--#{item_type_name_hyphenated.pluralize}-page-result-template") do %>
+  <div id="<%=item_type_hyphenated%>-activity-logs-<%=item_type_name_hyphenated%>-type-{{item_id}}" class="panel panel-default activity-logs-item-block activity-logs-<%=item_type_name_hyphenated%>-type-block <%= hide_item_list_panel ? 'hidden-item-list-panel' : 'shown-item-list-panel' %> al-page-result-template" data-item-id="{{item_id}}" data-master-id="{{master_id}}" data-item-data="{{item_data}}">
+    <div class="col-md-24">
+        <div class="row common-template-list activity-log-list resize-children" id="activity-logs-master-{{master_id}}-" data-sub-list="<%=item_type_name%>_logs">
+          {{#each <%=full_name.pluralize%>}}
+            {{#if extra_log_type}}
+            <% all_option_configs.each do |c| %>
+              {{#is extra_log_type '===' '<%=c.name%>'}}
+                {{> common_page_template_result name='<%= full_name %>_<%=c.name%>' orig_name="<%=name.underscore%>" result_data=this _created=@index}}                
+              {{/is}}
+            <% end %>
+            {{/if}}
+          {{else}}
+          <div class="message-well">
+            <h1>Not Found</h1>
+            <p class="">
+              The requested page was not found
+            </p>
+            <p class="text-center">
+              <a href="javascript:history.back()">Go Back</a> or visit the <a href="/">Home Page</a>
+            </p>
+          </div>
+          {{/each}}
+        </div>
+      </div>
+  </div>
+<% end %>
+
+<%# Activity Log main results including controls %>
+<%= handlebars_template_tag("activity-log--#{item_type_name_hyphenated.pluralize}-main-result-template") do %>
+  <div id="<%=item_type_hyphenated%>-activity-logs-<%=item_type_name_hyphenated%>-type-{{item_id}}" class="panel panel-default activity-logs-item-block activity-logs-<%=item_type_name_hyphenated%>-type-block <%= hide_item_list_panel ? 'hidden-item-list-panel' : 'shown-item-list-panel' %> al-main-result-template" data-item-id="{{item_id}}" data-master-id="{{master_id}}" data-item-data="{{item_data}}">
+  
+    <div class="is-heading activity-logs-header">
+    <% unless hide_player_tabs? %>
+      <a data-target="#activity-log--<%=item_type_name_hyphenated.pluralize%>-{{master_id}}" data-toggle="collapse" class="show-entity pull-right glyphicon glyphicon-remove-sign no-scroll-on-collapse btn-close-panel" title="close panel"></a>
+    <% end %>
+      <h4 class="list-group-item-heading al-label-<%=item_type_name_hyphenated%>-item"><%=al_name%></h4>
+      <%= render partial: 'masters/panel_tab_caption', locals: {current_definition: current_definition} %>
+      <% if hide_item_list_panel && !prevent_create%>
+      <p class="text-center action-buttons">
+        {{#each <%=item_type.pluralize%>}}
+        <%
+        eltc = current_definition.option_type_config_for(:primary)
+        if current_user.has_access_to?(:create, :activity_log_type, eltc.resource_name)
+        %>
+          <% if rec_type.blank? %>
+            <a href="/masters/{{master_id}}/<%=item_type.pluralize%>/{{id}}/activity_log/<%=item_type_name.pluralize%>/new" data-remote="true" class="btn btn-sm btn-primary add-item-button <%= eltc.view_options[:hide_unless_creatable] ? 'hide-unless-creatable' : '' %>"  data-extra-log-type="primary" data-toggle="unhide scrollto-result" data-target="#activity-log--<%=item_type_name_hyphenated%>-primary-{{master_id}}-"><span class="glyphicon glyphicon-plus"></span> <%= main_log_label %>{{#is <%=item_type.pluralize%>.length '>' 1}} ({{data}}){{/is}}</a>
+          <% else %>
+          {{#is rec_type '===' '<%= rec_type %>'}}
+            <a href="/masters/{{master_id}}/<%=item_type.pluralize%>/{{id}}/activity_log/<%=item_type_name.pluralize%>/new" data-remote="true" class="btn btn-sm btn-primary add-item-button <%= eltc.view_options[:hide_unless_creatable] ? 'hide-unless-creatable' : '' %>"  data-extra-log-type="primary" data-toggle="unhide scrollto-result" data-target="#activity-log--<%=item_type_name_hyphenated%>-primary-{{master_id}}-"><span class="glyphicon glyphicon-plus"></span> <%= main_log_label %>{{#is <%=item_type.pluralize%>.length '>' 1}} ({{data}}){{/is}}</a>
+          {{/is}}
+          <% end %>
+        <% end %>
+        {{/each}}
+        <%
+        eltc = current_definition.option_type_config_for(:blank_log)
+        if current_user.has_access_to?(:create, :activity_log_type, eltc.resource_name)
+        %>
+        <a href="/masters/{{master_id}}/activity_log/<%=item_type_name.pluralize%>/new?extra_type=blank-log" data-remote="true" class="btn btn-sm btn-primary add-item-button <%= eltc.view_options[:hide_unless_creatable] ? 'hide-unless-creatable' : '' %>"  data-extra-log-type="blank_log" data-toggle="unhide scrollto-result" data-target="#activity-log--<%=item_type_name_hyphenated%>-blank-log-{{master_id}}-"><span class="glyphicon glyphicon-plus"></span> <%= blank_log_label %></a>
+        <% end %>
+        <% option_configs.each do |c|
+            eltc = c
+            if current_user.has_access_to? :create, :activity_log_type, c.resource_name
+        %>
+          <a href="/masters/{{master_id}}/<% if item_list.include? item_type %><%=item_type.pluralize%>/{{id}}/<% end %>activity_log/<%=item_type_name.pluralize%>/new?extra_type=<%= c.name.to_s.hyphenate %>"  data-extra-log-type="<%=c.name%>" data-remote="true" class="btn btn-sm btn-primary add-item-button <%= eltc.view_options[:hide_unless_creatable] ? 'hide-unless-creatable' : '' %>" data-toggle="unhide scrollto-result" data-target="#activity-log--<%=item_type_name_hyphenated%>-<%= c.name.to_s.hyphenate %>-{{master_id}}-"><span class="glyphicon glyphicon-plus"></span> <%= c.button_label || c.label %></a>
+        <%  end
+           end %>
+      </p>
+      <% end %>
+  
+    </div>
+    <div class="row">
+  
+      <% unless hide_item_list_panel %>
+      <div class="col-md-5 activity-log-sub-list" data-selected-id="{{item_id}}" id="activity-log-<%=item_type_name_hyphenated.pluralize%>-sub-list-{{master_id}}-" data-sub-list="<%=item_type.pluralize%>">
+  
+        {{#each <%=item_type.pluralize%>}}
+        <% if rec_type.blank? %>
+          {{>sub_list_<%=item_type_name%>_result _created=@index}}
+        <% else %>
+          {{#is rec_type '===' '<%= rec_type %>'}}
+            {{>sub_list_<%=item_type_name%>_result _created=@index}}
+          {{/is}}
+        <% end %>
+        {{/each}}
+        <div class="new-block" form-res-id="<%=item_type_hyphenated%>-{{master_id}}-" form-res-template="sub-list-<%=item_type_name_hyphenated%>-result-template" id="activity-log--<%=item_type_name_hyphenated%>-edit-form-{{master_id}}-" data-subscription="<%=item_type_hyphenated%>-edit-form-{{master_id}}-" data-preprocessor="<%=item_type%>_edit_form">
+  
+        </div>
+        <br />
+        <% unless prevent_create %>
+        <p class="help-block small">
+          Select <%=item_type_name.humanize%> above to log an activity against it. Or click <b>+ <%= blank_log_label %></b> to add an activity not tied to a specific item (such as indicating that a follow up is no longer required.)
+        </p>
+        <br />
+        <% end %>
+        <p class="text-center al-create-actions">
+          <% if current_user.has_access_to?( :create, :table, item_type.pluralize) %>
+          <a href="/masters/{{master_id}}/<%=item_type.pluralize%>/new<%= rec_type.blank? ? '' : "?#{item_type}[rec_type]=#{rec_type}"  %>" data-remote="true" class="btn btn-sm btn-default add-item-button" data-toggle="scrollto-result" data-target-force="true" data-target="#activity-log--<%=item_type_name_hyphenated%>-edit-form-{{master_id}}-" aria-label="add <%=item_type.humanize%> record"><span class="glyphicon glyphicon-plus"></span> <%= item_type.humanize%> record</a>
+          <% end %>
+          <% unless prevent_create %>
+          <% if current_user.has_access_to?(:create, :activity_log_type, current_definition.option_type_config_for(:blank_log).resource_name) %>
+          <a href="/masters/{{master_id}}/activity_log/<%=item_type_name.pluralize%>/new" data-remote="true" class="btn btn-sm btn-primary add-item-button" data-toggle="unhide scrollto-result" data-target="#activity-log--<%=item_type_name_hyphenated%>-blank-log-{{master_id}}-"><span class="glyphicon glyphicon-plus"></span> <%= blank_log_label %></a>
+          <% end %>
+            <% option_configs.each do |c|
+                if current_user.has_access_to? :create, :activity_log_type, c.resource_name
+            %>
+              <a href="/masters/{{master_id}}/<% if item_list.include? item_type %><%=item_type.pluralize%>/{{id}}/<% end %>activity_log/<%=item_type_name.pluralize%>/new?extra_type=<%= c.name.to_s.hyphenate %>" data-remote="true" class="btn btn-sm btn-primary add-item-button" data-toggle="unhide scrollto-result" data-target="#activity-log--<%=item_type_name_hyphenated%>-<%= c.name.to_s.hyphenate %>-{{master_id}}-"><span class="glyphicon glyphicon-plus"></span> <%= c.button_label || c.label %></a>
+            <%  end
+               end %>
+          <% end %>
+        </p>
+      </div>
+      <% end %>
+      <div class="col-md-<%= hide_item_list_panel ? '24' : '19' %> ">
+  
+  
+        <div class="row common-template-list activity-log-list resize-children" id="activity-logs-master-{{master_id}}-" data-sub-list="<%=item_type_name%>_logs">
+          <% unless hide_sublist_controls %>
+          {{>sublist_controls sub_list="<%=item_type_name%>_logs" sub_list_data_name="activity_log__<%=item_type_name.pluralize%>" filter_attr='extra_log_type' filter_name="human_name" filter_all=true order='asc' all_active=true layout=true}}
+          <% end %>
+          <div data-sort-desc="<%= data_action_when.hyphenate %>" <%= data_action_when.hyphenate %>="" class="new-blocks-container">
+            <div class="new-block new-after-parent alr-new-block <%=col_width_classes%> hidden" id="activity-log--<%=item_type_name_hyphenated%>-primary-{{master_id}}-" data-subscription="activity-log--<%=item_type_name_hyphenated%>-primary-edit-form-{{master_id}}-" data-preprocessor="activity_log_edit_form">
+            </div>
+            <div class="new-block new-after-parent alr-new-block <%=col_width_classes%> hidden" id="activity-log--<%=item_type_name_hyphenated%>-blank-log-{{master_id}}-" data-subscription="activity-log--<%=item_type_name_hyphenated%>-blank-log-edit-form-{{master_id}}-" data-preprocessor="activity_log_edit_form"></div>
+            <% option_configs.each do |c| 
+            
+              vos = c.view_options[:alt_width_classes]
+              cwc = if vos
+                      vos
+                    elsif c.e_sign
+                      'e-sign-doc col-md-24 col-lg-12'
+                    else
+                      col_width_classes
+                    end
+
+            %>
+              <div class="new-block new-after-parent alr-new-block <%=cwc%> hidden" id="activity-log--<%=item_type_name_hyphenated%>-<%= c.name.to_s.hyphenate %>-{{master_id}}-" data-subscription="activity-log--<%=item_type_name_hyphenated%>-<%= c.name.to_s.hyphenate %>-edit-form-{{master_id}}-" data-preprocessor="activity_log_edit_form"></div>
+            <% end %>
+          </div>
+          {{#each <%=full_name.pluralize%>}}
+            {{#if extra_log_type}}
+            <% all_option_configs.each do |c| %>
+              {{#is extra_log_type '===' '<%=c.name%>'}}
+                {{> common_template_result name='<%= full_name %>_<%=c.name%>' result_data=this _created=@index}}
+              {{/is}}
+            <% end %>
+  
+            {{/if}}
+          {{/each}}
+        </div>
+      </div>
+    </div>
+  
+  </div>
+<% end %>
+<%= javascript_tag nonce: true do %>
+  <%
+    eltcn = []
+    option_configs.each do |elt|
+      eltcn << {name: elt.name}
+    end
+  %>
+  _fpa.activity_logs.generate_postprocessors('<%=item_type_name%>', <%= eltcn.to_json.html_safe %>)
+<% end %>

--- a/app/views/common_templates/_search_results_template.html.erb
+++ b/app/views/common_templates/_search_results_template.html.erb
@@ -387,9 +387,18 @@
   <% if full_name.to_s.start_with?('dynamic_model__') && option_type_config_name.to_s == default_option_type_name.to_s %>
   _fpa.state.caption_before.<%=name.underscore%> = _fpa.state.caption_before.<%=name_with_option_type.underscore%>;
   _fpa.state.labels_<%=name.underscore%> = _fpa.state.labels_<%=name_with_option_type.underscore%>;
-  _fpa.state.template_config.<%=resource_name%> = _fpa.state.template_config.<%=resource_name%> || _fpa.state.template_config.<%=name.underscore%>;
-  _fpa.state.template_config.<%=name.underscore.pluralize%> = _fpa.state.template_config.<%=name.underscore.pluralize%> || _fpa.state.template_config.<%=name.underscore%>;
-  _fpa.state.template_config.<%=name.underscore.sub('dynamic_model__', '')%> = _fpa.state.template_config.<%=name.underscore.sub('dynamic_model__', '')%> || _fpa.state.template_config.<%=name.underscore%>
+  <%# Alias the dynamic model's template config under its alternative resource
+      names (plural resource_name, pluralized name, and short name). The current
+      version's template object is aliased as before, but we must ALSO alias the
+      specific def_version key. Without this, when the base object already exists
+      from the initial page load (the current version), an older version's
+      template (loaded on demand via the template_config endpoint) is never linked
+      onto these alternative names, so versioned embedded items fail to render in
+      show mode (issue #1238). %>
+  <% [resource_name, name.underscore.pluralize, name.underscore.sub('dynamic_model__', '')].uniq.each do |alias_name| %>
+  _fpa.state.template_config.<%=alias_name%> = _fpa.state.template_config.<%=alias_name%> || _fpa.state.template_config.<%=name.underscore%>;
+  _fpa.state.template_config.<%=alias_name%>.v<%=def_version%> = _fpa.state.template_config.<%=alias_name%>.v<%=def_version%> || _fpa.state.template_config.<%=name.underscore%>.v<%=def_version%>;
+  <% end %>
   <% end %>
   
 <% end %>

--- a/app/views/dynamic_models/_search_results_template.html.erb
+++ b/app/views/dynamic_models/_search_results_template.html.erb
@@ -2,4 +2,15 @@
   next unless m.implementation_class_defined?(::DynamicModel, fail_without_exception: true)
 %>
   <%= render partial: 'dynamic_models/search_results_template_item', locals: { def_record: m } %>
+  <%# Also emit JS-only template_config entries for older history versions so that embedded
+      items created before a definition version bump can still resolve their vN key (issue #1238).
+      The common _search_results_template already skips Handlebars HTML-template rendering
+      when def_version is non-nil, so this only produces the lightweight JS config block. %>
+  <% m.all_versions.each do |historical_version|
+       # Skip the latest history entry: it corresponds to the current live record, whose
+       # config is already emitted above with def_version=nil.
+       next if historical_version.def_version == m.all_versions.first&.def_version
+  %>
+    <%= render partial: 'dynamic_models/search_results_template_item', locals: { def_record: historical_version } %>
+  <% end %>
 <% end %>

--- a/app/views/external_identifiers/_search_results_template.html.erb
+++ b/app/views/external_identifiers/_search_results_template.html.erb
@@ -6,6 +6,21 @@
                def_record: m,
                option_type_config: m.default_options
               } %>
+  <%# Also emit JS-only template_config entries for older history versions so that
+      external identifier records created before a definition version bump can still
+      resolve their vN key (issue #1238).  The common _search_results_template skips
+      Handlebars HTML-template rendering when def_version is non-nil, so this only
+      produces the lightweight JS config block. %>
+  <% m.all_versions.each do |historical_version|
+       # Skip the latest history entry: it corresponds to the current live record,
+       # whose config is already emitted above with def_version=nil.
+       next if historical_version.def_version == m.all_versions.first&.def_version
+  %>
+    <%= render partial: 'external_identifiers/common_search_results_template_item', 
+               locals: { 
+                 def_record: historical_version,
+                 option_type_config: historical_version.default_options
+                } %>
+  <% end %>
 <% end %>
-
 

--- a/spec/models/dynamic/versioned_field_list_spec.rb
+++ b/spec/models/dynamic/versioned_field_list_spec.rb
@@ -40,10 +40,20 @@ RSpec.describe 'Versioned field list for dynamic model instances', type: :model 
 
   before :all do
     change_setting('AllowDynamicMigrations', true)
+    # These specs only have meaning when definition-at-record-creation versioning
+    # is active. In the test environment DisableVDef already defaults to false
+    # (Rails.env.development? is false), but set it explicitly so the versioned
+    # behavior is not silently dependent on the environment default and cannot be
+    # accidentally disabled (e.g. via FPHS_DISABLE_VDEF). With versioning disabled,
+    # `versioned`/`versioned_definition` resolve to the current definition and the
+    # "old fields only" assertions below would no longer be exercised.
+    @prev_disable_vdef = Settings::DisableVDef
+    change_setting('DisableVDef', false)
   end
 
   after :all do
     change_setting('AllowDynamicMigrations', false)
+    change_setting('DisableVDef', @prev_disable_vdef)
   end
 
   before :example do
@@ -118,8 +128,8 @@ RSpec.describe 'Versioned field list for dynamic model instances', type: :model 
     expect(v1_version.field_list_array).to include('test1')
     expect(v1_version.field_list_array).to include('test2')
     expect(v1_version.field_list_array).not_to include(new_field),
-      "Expected v1 versioned definition field_list_array NOT to include '#{new_field}', " \
-      "but got: #{v1_version.field_list_array}"
+                                               "Expected v1 versioned definition field_list_array NOT to include '#{new_field}', " \
+                                               "but got: #{v1_version.field_list_array}"
   end
 
   it 'returns only old fields from versioned option_type_config when a new field is added' do
@@ -159,8 +169,8 @@ RSpec.describe 'Versioned field list for dynamic model instances', type: :model 
     versioned_otc = instance_v1.versioned_definition.option_type_config_for(:default)
     expect(versioned_otc).not_to be_nil
     expect(versioned_otc.fields).not_to include(new_field),
-      "Expected versioned option_type_config fields for a v1 instance NOT to include '#{new_field}', " \
-      "but got: #{versioned_otc.fields}"
+                                        "Expected versioned option_type_config fields for a v1 instance NOT to include '#{new_field}', " \
+                                        "but got: #{versioned_otc.fields}"
   end
 
   it 'returns only old fields from edit_form_field_list for instances created under a previous version' do
@@ -195,7 +205,7 @@ RSpec.describe 'Versioned field list for dynamic model instances', type: :model 
     # v2 instance should include the new field in edit_form_field_list
     v2_edit_fields = instance_v2.edit_form_field_list
     expect(v2_edit_fields.map(&:to_s)).to include(new_field),
-      "Expected v2 instance edit_form_field_list to include '#{new_field}', but got: #{v2_edit_fields}"
+                                          "Expected v2 instance edit_form_field_list to include '#{new_field}', but got: #{v2_edit_fields}"
 
     # Reload the v1 instance to clear memoization
     instance_v1 = DynamicModel::TestCreatedByRec.find(instance_v1.id)
@@ -204,8 +214,8 @@ RSpec.describe 'Versioned field list for dynamic model instances', type: :model 
     # v1 instance should NOT include the new field in edit_form_field_list
     v1_edit_fields_after = instance_v1.edit_form_field_list
     expect(v1_edit_fields_after.map(&:to_s)).not_to include(new_field),
-      "Expected v1 instance edit_form_field_list NOT to include '#{new_field}', " \
-      "but got: #{v1_edit_fields_after}"
+                                                    "Expected v1 instance edit_form_field_list NOT to include '#{new_field}', " \
+                                                    "but got: #{v1_edit_fields_after}"
   end
 
   it 'returns only old fields from TemplateOptionMapping.dynamic_model_mapping for versioned definitions' do
@@ -242,13 +252,13 @@ RSpec.describe 'Versioned field list for dynamic model instances', type: :model 
 
     # The item_list in the mapping should only include old fields, NOT the new field
     expect(mapping[:item_list]).not_to include(new_field),
-      "Expected TemplateOptionMapping item_list for versioned definition NOT to include '#{new_field}', " \
-      "but got: #{mapping[:item_list]}"
+                                       "Expected TemplateOptionMapping item_list for versioned definition NOT to include '#{new_field}', " \
+                                       "but got: #{mapping[:item_list]}"
 
     # Verify the current definition DOES include the new field
     current_otc = dmdef.option_type_config_for(:default)
     current_mapping = OptionConfigs::TemplateOptionMapping.dynamic_model_mapping(dmdef, current_otc, @user)
     expect(current_mapping[:item_list]).to include(new_field),
-      "Expected current TemplateOptionMapping item_list to include '#{new_field}'"
+                                           "Expected current TemplateOptionMapping item_list to include '#{new_field}'"
   end
 end

--- a/spec/requests/activity_log/embedded_versioned_template_config_spec.rb
+++ b/spec/requests/activity_log/embedded_versioned_template_config_spec.rb
@@ -1,0 +1,278 @@
+# frozen_string_literal: true
+
+# Request specs for issue #1238 — activity log embedded dynamic models fail to
+# render in show (read-only) mode when the embedded dynamic model uses
+# "definition versioning: version at record creation".
+#
+# User-facing symptom: after saving an activity log embedded form, the
+# read-only (show) form does not appear, and the browser console logs:
+#   fpa_state_item: could not find template_config dynamic_model__... v123
+# Editing the activity correctly shows the edit form, but on save/cancel the
+# read-only form is missing.
+#
+# Root cause exercised here: the activity log `template_config` endpoint builds
+# the Handlebars template-config <script> blocks for the embedded dynamic model
+# (see app/views/common_templates/_search_results_template.html.erb). For a
+# dynamic model, that partial aliases the per-version template object under the
+# model's alternative resource names (the plural `resource_name`, the pluralized
+# name, and the short name). It aliased only the BASE object, not the specific
+# `.v<def_version>` key. When the base object already exists from the initial
+# page load (the current version), an older version's template — loaded on demand
+# via this endpoint — was never linked onto the plural resource name. The browser
+# data item looks up `template_config.<resource_name>.v<version>`, finds nothing,
+# and logs `could not find template_config dynamic_model__... v123`, so the
+# read-only (show) form never renders. Unversioned models always use the current
+# version, which is already loaded, so they were unaffected.
+#
+# These tests assert that the activity log template_config response aliases the
+# embedded dynamic model's per-version template onto its plural resource name,
+# for both a versioned and an unversioned embedded dynamic model, including when
+# the embedded record was created under an older definition version.
+
+require 'rails_helper'
+require './db/table_generators/dynamic_models_table'
+
+RSpec.describe 'ActivityLog embedded dynamic model template_config', type: :request do
+  include MasterSupport
+  include ModelSupport
+  include ActivityLogSupport
+  include PlayerContactSupport
+  include DynamicModelSupport
+
+  AlNameEmbedTplCfg = 'Embed Template Config 1238'
+
+  before(:all) do
+    @prev_allow_dms = Settings::AllowDynamicMigrations
+    change_setting('AllowDynamicMigrations', true)
+    @prev_disable_vdef = Settings::DisableVDef
+    # Ensure definition versioning is active so the versioned dynamic model
+    # genuinely relies on the on-demand template_config endpoint.
+    change_setting('DisableVDef', false)
+  end
+
+  after(:all) do
+    change_setting('AllowDynamicMigrations', @prev_allow_dms)
+    change_setting('DisableVDef', @prev_disable_vdef)
+  end
+
+  before(:each) do
+    @admin = create_admin.first
+    @user = create_user.first
+    @master = create_master(@user)
+
+    @al_table = 'activity_log_player_contact_test_embeds'
+    @al_fk = "#{@al_table.singularize}_id"
+
+    setup_embed_target_models
+    setup_activity_log_with_embed
+
+    setup_access :player_contacts, user: @user
+    @player_contact = @master.player_contacts.create!(
+      current_user: @user, data: '(516)262-1291', rec_type: 'phone', rank: 10
+    )
+  end
+
+  # Build the two embed-target dynamic models, both with the FK column required
+  # for a direct embed:
+  #   - test_embed_versioned_recs    — uses definition-at-record-creation
+  #                                    versioning (default; no use_current_version)
+  #   - test_embed_unversioned_recs  — uses current version via
+  #                                    _configurations.use_current_version: true
+  def setup_embed_target_models
+    %w[test_embed_versioned_recs test_embed_unversioned_recs].each do |tn|
+      unless Admin::MigrationGenerator.table_exists? tn
+        TableGenerators.dynamic_models_table(tn, :create_do, 'test1', 'test2', @al_fk)
+      end
+    end
+
+    DynamicModel.active
+                .where(table_name: %w[test_embed_versioned_recs test_embed_unversioned_recs])
+                .each { |dm| dm.disable!(@admin) }
+
+    # Remove any stale Ruby implementation class constants from a previous test's run.
+    # With use_transactional_fixtures the DB rolls back between tests but in-memory Ruby
+    # constants persist. If the old class is still defined, prevent_regenerate_model will
+    # return it and skip regeneration for the new DM record, leaving the new DM's
+    # definition_id disconnected from the class (issue manifests as def_version = nil).
+    %w[test_embed_versioned_recs test_embed_unversioned_recs].each do |tn|
+      class_name = tn.singularize.ns_camelize
+      [DynamicModel, Object].each do |ns|
+        ns.send(:remove_const, class_name) if ns.const_defined?(class_name, false)
+      rescue NameError
+        nil
+      end
+    end
+
+    DynamicModel.create!(current_admin: @admin, name: 'test embed versioned recs',
+                         table_name: 'test_embed_versioned_recs',
+                         schema_name: 'dynamic_test', category: :test)
+                .update_tracker_events
+
+    unversioned_opts = <<~YAML
+      _configurations:
+        use_current_version: true
+
+      default:
+        label: Unversioned embed
+    YAML
+    DynamicModel.create!(current_admin: @admin, name: 'test embed unversioned recs',
+                         table_name: 'test_embed_unversioned_recs',
+                         schema_name: 'dynamic_test', category: :test,
+                         options: unversioned_opts)
+                .update_tracker_events
+
+    let_user_create :dynamic_model__test_embed_versioned_recs
+    let_user_create :dynamic_model__test_embed_unversioned_recs
+  end
+
+  # Configure ActivityLog::PlayerContactTestEmbed with two extra_log_types, each
+  # directly embedding one of the dynamic models above.
+  def setup_activity_log_with_embed
+    SetupHelper.setup_al_gen_tests AlNameEmbedTplCfg, 'test_embed', 'player_contact'
+
+    al = ActivityLog.active.where(name: AlNameEmbedTplCfg).first
+    raise "Activity Log #{AlNameEmbedTplCfg} not set up" if al.nil?
+
+    al.extra_log_types = <<~END_DEF
+      test_activity_versioned:
+        label: Versioned activity
+        fields:
+          - select_call_direction
+          - select_who
+        embed: dynamic_model__test_embed_versioned_recs
+
+      test_activity_unversioned:
+        label: Unversioned activity
+        fields:
+          - select_call_direction
+          - select_who
+        embed: dynamic_model__test_embed_unversioned_recs
+    END_DEF
+
+    al.current_admin = @admin
+    al.save!
+
+    @activity_log = al
+    @implementation_class = al.implementation_class
+
+    setup_access :activity_log__player_contact_test_embeds, user: @user
+    al.option_configs.each do |c|
+      setup_access c.resource_name, resource_type: :activity_log_type, user: @user
+    end
+  end
+
+  # Create an activity log record for the given extra_log_type and populate its
+  # directly embedded dynamic model with values, mirroring the user saving the
+  # embedded form.
+  def create_activity_with_embed(extra_log_type)
+    al = @player_contact.activity_log__player_contact_test_embeds.build(
+      select_call_direction: 'to player',
+      select_who: 'user',
+      extra_log_type:
+    )
+    al.master = @master
+    al.current_user = @user
+    al.save!
+
+    embed = al.create_embedded_item({ test1: 'embedded one', test2: 'embedded two' })
+    expect(embed).not_to be_nil
+    expect(embed.id).not_to be_nil
+
+    al.reload
+    al
+  end
+
+  def login_user(user = nil)
+    user ||= @user
+    sign_out :user
+    user.confirmed_at ||= Time.now
+    user.current_admin ||= @admin
+    user.save
+    get '/users/sign_in'
+    expect(response.status).to eq 200
+    sign_in user
+  end
+
+  def template_config_path(al)
+    "/masters/#{@master.id}/#{@implementation_class.definition.base_route_segments}/#{al.id}/template_config"
+  end
+
+  before(:each) do
+    login_user
+  end
+
+  # The plural resource_name is the key the browser data item uses to look up its
+  # template_config (e.g. `template_config.dynamic_model__test_embed_versioned_recs`).
+  # The per-version template MUST be aliased onto that name keyed by the record's
+  # def_version, otherwise show mode fails for that version (issue #1238).
+  def embedded_def_version(al)
+    al = @implementation_class.find(al.id)
+    al.current_user = @user
+    al.embedded_item&.def_version
+  end
+
+  describe 'versioned embedded dynamic model' do
+    it 'includes the embedded model template config in the template_config response' do
+      al = create_activity_with_embed('test_activity_versioned')
+
+      get template_config_path(al)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('template_config.dynamic_model__test_embed_versioned_recs')
+    end
+
+    context 'when the embedded record was created under an older definition version' do
+      it 'aliases the record\'s older version of the embedded template onto the plural resource name' do
+        al = create_activity_with_embed('test_activity_versioned')
+
+        # Create newer definition versions of the embedded dynamic model until the
+        # record above resolves to a concrete, older (non-current) definition
+        # version. This is the scenario that triggers issue #1238: the record's
+        # template must be fetched on demand for that older version. Dynamic
+        # migrations are disabled during each bump to avoid a table-comment
+        # migration competing for a lock with the just-created record; version
+        # history is recorded independently of migrations.
+        record_version = nil
+        5.times do
+          sleep 2
+          dm = DynamicModel.active.find_by(table_name: 'test_embed_versioned_recs')
+          change_setting('AllowDynamicMigrations', false)
+          dm.current_admin = @admin
+          dm.options = "default:\n  label: Versioned embed v#{SecureRandom.hex(2)}\n"
+          dm.save!
+          change_setting('AllowDynamicMigrations', true)
+          DynamicModel.define_models
+          Application.refresh_dynamic_defs
+
+          record_version = embedded_def_version(al)
+          break if record_version.present?
+        end
+
+        expect(record_version)
+          .to be_present, 'expected the embedded record to resolve to a concrete older definition version'
+
+        get template_config_path(al)
+        expect(response).to have_http_status(:ok)
+
+        # The per-version template for the record's older version must be aliased
+        # onto the plural resource_name the browser data item looks up. Without the
+        # fix only the base object is aliased, so this version key is missing and
+        # the show-mode form fails to render (issue #1238).
+        expect(response.body)
+          .to match(/template_config\.dynamic_model__test_embed_versioned_recs\.v#{record_version}\s*=/),
+              "expected plural resource alias for version v#{record_version} to be present"
+      end
+    end
+  end
+
+  describe 'unversioned embedded dynamic model' do
+    it 'includes the embedded model template config in the template_config response' do
+      al = create_activity_with_embed('test_activity_unversioned')
+
+      get template_config_path(al)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('template_config.dynamic_model__test_embed_unversioned_recs')
+    end
+  end
+end

--- a/spec/requests/dynamic_model/versioned_field_list_render_spec.rb
+++ b/spec/requests/dynamic_model/versioned_field_list_render_spec.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+# Render-layer regression guard for GitHub Issue #665:
+# "New fields appear in dynamic model instances that were created in a previous
+# definition version"
+#
+# PR #1031 added a model-layer guard (spec/models/dynamic/versioned_field_list_spec.rb)
+# but explicitly did NOT cover the rendering/template layer where the user-reported
+# symptom actually appears. This request spec closes that gap: it exercises the
+# per-record `template_config` endpoint (the path the browser uses to fetch the
+# Handlebars template-config for a record), and asserts that a record created under
+# an older definition version receives the OLD field list (`item_list`) — i.e. a
+# field added to the definition later does not leak into the older record's
+# rendered field set — while a record created under the current version does
+# include the new field.
+#
+# This is the render-layer counterpart to PR #1031's
+# `TemplateOptionMapping.dynamic_model_mapping[:item_list]` model-layer assertion,
+# and is the mechanism through which the issue #1238 fix (emitting per-version
+# template_config) keeps versioned records rendering correctly.
+#
+# Note: the emitted template_config also includes `field_types`, derived from all
+# physical table columns, so the new column name appears there for every version.
+# The assertions below therefore target the `item_list` value specifically, which
+# is what the browser uses to decide which fields to show.
+
+require 'rails_helper'
+require './db/table_generators/dynamic_models_table'
+
+RSpec.describe 'DynamicModel versioned field list rendering', type: :request do
+  include MasterSupport
+  include ModelSupport
+  include DynamicModelSupport
+
+  DmTableVersionedRender = 'test_created_by_recs'
+  DmNewFieldVersionedRender = 'text_array'
+  DmV1FieldsVersionedRender = 'test1 test2'
+  DmV2FieldsVersionedRender = 'test1 test2 text_array'
+
+  before(:all) do
+    @prev_allow_dms = Settings::AllowDynamicMigrations
+    change_setting('AllowDynamicMigrations', true)
+    # Definition-at-record-creation versioning must be active for an older record
+    # to resolve to its historical definition version. In the test environment
+    # DisableVDef already defaults to false, but set it explicitly so the
+    # versioned behavior is self-documenting and cannot be accidentally disabled.
+    @prev_disable_vdef = Settings::DisableVDef
+    change_setting('DisableVDef', false)
+  end
+
+  after(:all) do
+    change_setting('AllowDynamicMigrations', @prev_allow_dms)
+    change_setting('DisableVDef', @prev_disable_vdef)
+  end
+
+  before(:each) do
+    @admin = create_admin.first
+    @user = create_user.first
+    @master = create_master(@user)
+    @master.current_user = @user
+
+    @dm = setup_dynamic_model
+    setup_access :dynamic_model__test_created_by_recs, user: @user
+  end
+
+  # Create the dynamic model with an explicit, restricted v1 field_list
+  # ("test1 test2") on a table that physically also has the later-added
+  # "text_array" column. This mirrors PR #1031's setup and lets us add the new
+  # field to the definition (v2) without an ALTER TABLE.
+  def setup_dynamic_model
+    unless Admin::MigrationGenerator.table_exists?(DmTableVersionedRender)
+      TableGenerators.dynamic_models_table(DmTableVersionedRender, :create_do,
+                                           'test1', 'test2', 'created_by_user_id',
+                                           'use_def_version_time', 'text_array')
+    end
+
+    DynamicModel.active.where(table_name: DmTableVersionedRender).each { |dm| dm.disable!(@admin) }
+
+    dm = DynamicModel.create!(
+      current_admin: @admin,
+      name: 'test created by',
+      table_name: DmTableVersionedRender,
+      primary_key_name: :id,
+      foreign_key_name: :master_id,
+      field_list: DmV1FieldsVersionedRender,
+      category: :test
+    )
+    dm.update_tracker_events
+    dm.send :reset_all_versions
+    DynamicModel.define_models
+    DynamicModel.routes_reload
+    Application.refresh_dynamic_defs
+    dm
+  end
+
+  # Bump the dynamic model definition to v2, adding the new field. Migrations are
+  # disabled during the save because the column already exists; we only need a new
+  # version-history entry.
+  def bump_dynamic_model
+    sleep 2
+    change_setting('AllowDynamicMigrations', nil)
+    @dm.current_admin = @admin
+    @dm.update!(field_list: DmV2FieldsVersionedRender)
+    change_setting('AllowDynamicMigrations', true)
+    DynamicModel.define_models
+    DynamicModel.routes_reload
+    Application.refresh_dynamic_defs
+    @dm
+  end
+
+  def create_dm_record
+    @master.dynamic_model__test_created_by_recs.create!(current_user: @user, test1: 'a value')
+  end
+
+  def template_config_path(rec)
+    "/masters/#{@master.id}/#{rec.class.definition.base_route_segments}/#{rec.id}/template_config"
+  end
+
+  # Extract the emitted `item_list: '...'` value from the template_config response
+  # so assertions target the field list specifically (not field_types, which lists
+  # all physical columns).
+  def emitted_item_list(body)
+    body[/item_list:\s*'([^']*)'/, 1]
+  end
+
+  def login_user(user = nil)
+    user ||= @user
+    sign_out :user
+    user.confirmed_at ||= Time.now
+    user.current_admin ||= @admin
+    user.save
+    get '/users/sign_in'
+    expect(response.status).to eq 200
+    sign_in user
+  end
+
+  before(:each) do
+    login_user
+  end
+
+  describe 'per-record template_config field list' do
+    it 'serves the older version field list for a record created before a field was added' do
+      # Record created under v1 (fields: test1, test2)
+      v1_record = create_dm_record
+
+      # Add a new field to the definition (v2)
+      bump_dynamic_model
+
+      # Record created under v2 (fields: test1, test2, text_array)
+      v2_record = create_dm_record
+
+      # Confirm the records genuinely resolve to different definition versions
+      v1_record = DynamicModel::TestCreatedByRec.find(v1_record.id)
+      v1_record.current_user = @user
+      expect(v1_record.versioned_definition.field_list_array).not_to include(DmNewFieldVersionedRender)
+
+      # The v1 record's template_config must expose only the old fields
+      get template_config_path(v1_record)
+      expect(response).to have_http_status(:ok)
+      v1_item_list = emitted_item_list(response.body)
+      expect(v1_item_list).to be_present
+      expect(v1_item_list).to include('test1')
+      expect(v1_item_list).to include('test2')
+      expect(v1_item_list).not_to include(DmNewFieldVersionedRender),
+                                  "Expected v1 record item_list to exclude '#{DmNewFieldVersionedRender}', " \
+                                  "but got: #{v1_item_list}"
+
+      # The v2 record's template_config must include the new field
+      get template_config_path(v2_record)
+      expect(response).to have_http_status(:ok)
+      v2_item_list = emitted_item_list(response.body)
+      expect(v2_item_list).to include(DmNewFieldVersionedRender),
+                              "Expected v2 record item_list to include '#{DmNewFieldVersionedRender}', " \
+                              "but got: #{v2_item_list}"
+    end
+  end
+end

--- a/spec/requests/external_identifier/versioned_template_config_spec.rb
+++ b/spec/requests/external_identifier/versioned_template_config_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+# Request specs for issue #1238 — extending the definition-versioning fix to
+# external identifiers.
+#
+# Background: the master record search-results page emits, at page load, the
+# Handlebars template-config <script> blocks for every active definition (see
+# app/views/common_templates/_search_results_template.html.erb). For dynamic
+# models and activity logs the global page template iterates the definition's
+# version history (`all_versions`) so that records created under an older
+# definition version can still resolve their `.v<def_version>` template-config
+# key. The external identifier global template
+# (app/views/external_identifiers/_search_results_template.html.erb) previously
+# emitted only the current version, so an external identifier record created
+# before a definition version bump could not resolve its older version key and
+# its show-mode form would silently fail to render.
+#
+# These tests assert that the page template (pages#template) emits a per-version
+# template-config block for an external identifier's older definition version,
+# including the field labels captured at that version, in addition to the current
+# version. Without the fix only the current version's block is present.
+#
+# To exercise genuine field-label versioning (rather than only the id attribute,
+# whose display caption is also influenced by the definition `label`), the
+# external identifier is given an additional descriptive data field (`note`) via
+# `extra_fields`, and it is that field's label that is changed between versions.
+
+require 'rails_helper'
+require './db/table_generators/external_identifiers_table'
+
+RSpec.describe 'ExternalIdentifier versioned template config', type: :request do
+  include ModelSupport
+  include MasterSupport
+  include ExternalIdentifierSupport
+
+  EiNameVersionedTplCfg = 'test_show1238_eids'
+  EiAttrVersionedTplCfg = 'test_show1238_id'
+  EiExtraFieldVersionedTplCfg = 'note'
+
+  before(:all) do
+    @prev_allow_dms = Settings::AllowDynamicMigrations
+    # The underlying table (with its extra `note` column) is created directly
+    # below, so auto migrations are not needed and are kept off to avoid a
+    # table-comment migration competing for a lock during definition saves.
+    change_setting('AllowDynamicMigrations', false)
+    @prev_disable_vdef = Settings::DisableVDef
+    # Ensure definition versioning is active so older versions are genuinely
+    # distinct from the current version.
+    change_setting('DisableVDef', false)
+
+    create_external_identifier_table
+  end
+
+  after(:all) do
+    change_setting('AllowDynamicMigrations', @prev_allow_dms)
+    change_setting('DisableVDef', @prev_disable_vdef)
+  end
+
+  before(:each) do
+    @admin = create_admin.first
+    @user = create_user.first
+    @master = create_master(@user)
+
+    setup_external_identifier('EiFieldLabelV1')
+
+    setup_access EiNameVersionedTplCfg.to_sym, user: @user
+  end
+
+  # Create the external identifier table, with an additional `note` data column
+  # beyond the id attribute, so the definition can expose a genuine descriptive
+  # field whose label can be versioned.
+  def create_external_identifier_table
+    unless Admin::MigrationGenerator.table_exists?(EiNameVersionedTplCfg)
+      TableGenerators.external_identifiers_table(EiNameVersionedTplCfg, true, EiAttrVersionedTplCfg)
+    end
+
+    columns = Admin::MigrationGenerator.table_column_names(EiNameVersionedTplCfg)
+    return if columns.include?(EiExtraFieldVersionedTplCfg)
+
+    ActiveRecord::Base.connection.execute(
+      "ALTER TABLE #{EiNameVersionedTplCfg} ADD COLUMN #{EiExtraFieldVersionedTplCfg} character varying"
+    )
+  end
+
+  # Create (or re-enable) the external identifier definition exposing the `note`
+  # field, with a distinctive label for it so we can detect which definition
+  # version a given template-config block came from.
+  def setup_external_identifier(field_label)
+    ExternalIdentifier.active.where(name: EiNameVersionedTplCfg).each { |e| e.disable!(@admin) }
+
+    @external_identifier = ExternalIdentifier.create!(
+      name: EiNameVersionedTplCfg,
+      label: 'Show 1238 EID',
+      external_id_attribute: EiAttrVersionedTplCfg,
+      extra_fields: EiExtraFieldVersionedTplCfg,
+      min_id: 1,
+      max_id: 99_999_999,
+      disabled: false,
+      current_admin: @admin,
+      options: ei_options(field_label)
+    )
+
+    ExternalIdentifier.define_models
+    Application.refresh_dynamic_defs
+    @external_identifier
+  end
+
+  # Bump the external identifier definition to a new version, changing only the
+  # `note` field label, recording a new entry in the definition's version
+  # history. Version history is recorded independently of migrations.
+  def bump_external_identifier(field_label)
+    sleep 2
+    ei = ExternalIdentifier.active.find_by(name: EiNameVersionedTplCfg)
+    ei.current_admin = @admin
+    ei.options = ei_options(field_label)
+    ei.save!
+    ExternalIdentifier.define_models
+    Application.refresh_dynamic_defs
+    ei
+  end
+
+  def ei_options(field_label)
+    <<~OPTS
+      default:
+        labels:
+          #{EiExtraFieldVersionedTplCfg}: "#{field_label}"
+    OPTS
+  end
+
+  def login_user(user = nil)
+    user ||= @user
+    sign_out :user
+    user.confirmed_at ||= Time.now
+    user.current_admin ||= @admin
+    user.save
+    get '/users/sign_in'
+    expect(response.status).to eq 200
+    sign_in user
+  end
+
+  before(:each) do
+    login_user
+  end
+
+  describe 'older definition version field labels' do
+    it 'emits a per-version template-config block for an older definition version on the page template' do
+      bump_external_identifier('EiFieldLabelV2')
+
+      ei = ExternalIdentifier.active.find_by(name: EiNameVersionedTplCfg)
+      current_version = ei.all_versions.first&.def_version
+      older_version = ei.all_versions
+                        .map(&:def_version)
+                        .compact
+                        .uniq
+                        .reject { |v| v == current_version }
+                        .first
+
+      expect(older_version)
+        .to be_present, 'expected the external identifier to have an older definition version in its history'
+
+      name_with_option_type = "#{ei.item_type_name}_#{ei.default_options.name}".underscore
+
+      get template_page_path(1)
+
+      expect(response).to have_http_status(:ok)
+
+      # The fix: the older version's block must also be emitted, carrying the
+      # `note` field label captured at that version. Without the fix only the
+      # current version's block (and thus only the current label) is present.
+      expect(response.body)
+        .to include("fpa_state_config--#{name_with_option_type}--v#{older_version}")
+      # EiFieldLabelV2 is the current version's `note` label; EiFieldLabelV1
+      # belongs to the older version and is only present when the older version's
+      # block is emitted.
+      expect(response.body).to include('EiFieldLabelV1')
+      expect(response.body).to include('EiFieldLabelV2')
+    end
+  end
+end

--- a/spec/system/activity_log/embedded_versioned_show_mode_spec.rb
+++ b/spec/system/activity_log/embedded_versioned_show_mode_spec.rb
@@ -1,0 +1,643 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require './db/table_generators/dynamic_models_table'
+
+# System (acceptance) tests for issue #1238 — activity log embedded dynamic
+# models fail to render in show (read-only) mode after save when the embedded
+# dynamic model uses "definition versioning: version at record creation".
+#
+# Purpose / acceptance criteria (verbatim from the issue):
+#   "Acceptance tests must show that embedded dynamic models for versioned and
+#    unversioned work correctly and view in edit and show modes."
+#   "To avoid regressions, we must also test an activity log activity that has a
+#    `references` config with a single entry, so that the item appears embedded,
+#    even though it is referenced through model references."
+#
+# Strategy: AL records and their embedded / referenced DM records are created
+# programmatically (in the test thread, visible to the browser via Rails 7
+# transactional system tests). The browser then navigates to the master page
+# and we verify that the Handlebars client-side templates correctly render
+# the embedded DM in show (read-only) mode.  The KEY regression from issue
+# #1238 is that the plural resource-name alias in template_config was missing
+# the per-version key (e.g. `.v254`), so versioned-DM records at any version
+# other than the latest showed nothing.  After the fix the alias is set for
+# every version, so old records still render.
+#
+# Follows the pattern of spec/system/page_layout/initial_show_tab_spec.rb:
+# user + master created once in before(:all), login per example, page layout
+# created explicitly so the AL panel auto-expands via initial_show.
+describe 'Activity log embedded versioned dynamic model show mode (issue 1238)',
+         js: true, driver: $browser_driver do
+  include FeatureSupport
+  include MasterSupport
+  include ModelSupport
+  include PlayerContactSupport
+  include DynamicModelSupport
+
+  AlNameEmbedShow = 'Embed Show 1238'
+  AlProcessEmbedShow = 'embed_show'
+  AlFkEmbedShow = 'activity_log_player_contact_embed_show_id'
+
+  # Capybara wait (seconds) for asynchronously-rendered embedded show-mode
+  # content. After a definition version bump or a cache clear, the browser must
+  # fetch the per-version template_config and render the embedded DM show form
+  # client-side. Under combined-suite load this can take noticeably longer than
+  # the default Capybara wait, so use a generous timeout to avoid flakiness
+  # (the assertion still resolves as soon as the content becomes visible).
+  EmbeddedShowRenderWait = 60
+
+  def setup_embed_target_models
+    al_fk = AlFkEmbedShow
+    # Drop and recreate each table to ensure the FK column matches the current
+    # AL table name.  (If a previous test run used a different AL process name
+    # the table may have an incorrect FK column.)
+    %w[show1238_embed_versioned_recs show1238_embed_unversioned_recs].each do |tn|
+      TableGenerators.dynamic_models_table(tn, :drop_do)
+      TableGenerators.dynamic_models_table(tn, :create_do, 'test1', 'test2', al_fk)
+    end
+    TableGenerators.dynamic_models_table('show1238_ref_single_recs', :drop_do)
+    TableGenerators.dynamic_models_table('show1238_ref_single_recs', :create_do, 'test1', 'test2')
+
+    DynamicModel.active
+                .where(table_name: %w[show1238_embed_versioned_recs show1238_embed_unversioned_recs
+                                      show1238_ref_single_recs])
+                .each { |dm| dm.disable!(@admin) }
+
+    DynamicModel.create!(current_admin: @admin, name: 'show1238 embed versioned recs',
+                         table_name: 'show1238_embed_versioned_recs',
+                         schema_name: 'dynamic_test', category: :test,
+                         options: "default:\n  label: Embed1238V\n  labels:\n    test1: LabelField1V1234\n")
+                .update_tracker_events
+
+    DynamicModel.create!(current_admin: @admin, name: 'show1238 embed unversioned recs',
+                         table_name: 'show1238_embed_unversioned_recs',
+                         schema_name: 'dynamic_test', category: :test,
+                         options: "_configurations:\n  use_current_version: true\ndefault:\n  label: Embed1238U\n  labels:\n    test1: LabelField1U1234\n")
+                .update_tracker_events
+
+    DynamicModel.create!(current_admin: @admin, name: 'show1238 ref single recs',
+                         table_name: 'show1238_ref_single_recs',
+                         schema_name: 'dynamic_test', category: :test,
+                         options: "default:\n  label: Embed1238R\n")
+                .update_tracker_events
+  end
+
+  def setup_activity_log
+    SetupHelper.setup_al_gen_tests AlNameEmbedShow, AlProcessEmbedShow, 'player_contact'
+
+    al = ActivityLog.active.where(name: AlNameEmbedShow).first
+    raise "Activity Log #{AlNameEmbedShow} not set up" if al.nil?
+
+    al.extra_log_types = <<~END_DEF
+      versioned_activity:
+        label: Versioned activity
+        fields:
+          - select_call_direction
+          - select_who
+        embed: dynamic_model__show1238_embed_versioned_recs
+
+      unversioned_activity:
+        label: Unversioned activity
+        fields:
+          - select_call_direction
+          - select_who
+        embed: dynamic_model__show1238_embed_unversioned_recs
+
+      ref_single_activity:
+        label: Ref single activity
+        fields:
+          - select_call_direction
+          - select_who
+        references:
+          - dynamic_model__show1238_ref_single_recs:
+              label: Referenced single
+              from: this
+              add: one_to_this
+    END_DEF
+
+    al.current_admin = @admin
+    al.save!
+
+    @activity_log = al
+    @implementation_class = al.implementation_class
+  end
+
+  def setup_access_for_user
+    setup_access :player_contacts, user: @user
+    setup_access :player_infos, user: @user
+    setup_access :activity_log__player_contact_embed_shows, user: @user
+    @activity_log.option_configs.each do |c|
+      setup_access c.resource_name, resource_type: :activity_log_type, user: @user
+    end
+    %i[dynamic_model__show1238_embed_versioned_recs
+       dynamic_model__show1238_embed_unversioned_recs
+       dynamic_model__show1238_ref_single_recs].each do |rn|
+      setup_access rn, user: @user
+    end
+  end
+
+  before :all do
+    # AllowDynamicMigrations and TwoFactorAuthDisabledForUser are set globally
+    # by config.before(:all, type: :system) in rails_helper.rb.
+    @prev_disable_vdef = Settings::DisableVDef
+    change_setting('DisableVDef', false)
+
+    SetupHelper.feature_setup
+
+    @admin = create_admin.first
+    create_user(create_master: false)
+    @app_type = @user.app_type
+
+    setup_embed_target_models
+    setup_activity_log
+    setup_access_for_user
+
+    # Page layout: auto-expand our AL panel so each test sees it immediately
+    # after navigating to the master record (initial_show: true).
+    @al_page_layout = Admin::PageLayout.create!(
+      layout_name: 'master',
+      panel_name: 'show-embeds-1238',
+      panel_label: 'Show Embeds 1238',
+      panel_position: 99,
+      app_type: @app_type,
+      current_admin: @admin,
+      options: "contains:\n  resources:\n    " \
+               "- activity_log__player_contact_embed_shows\n" \
+               "view_options:\n  initial_show: true\n"
+    )
+
+    @master = Master.create!(current_user: @user)
+    @master.current_user = @user
+    @master.player_infos.create!(first_name: 'Embed1238', last_name: 'Test', source: 'nflpa')
+    @player_contact = @master.player_contacts.create!(
+      current_user: @user, data: '(516)262-1291', rec_type: 'phone', rank: 10
+    )
+
+    DynamicModel.define_models
+    ActivityLog.define_models
+    DynamicModel.routes_reload
+    Rails.application.routes_reloader.reload!
+  end
+
+  after :all do
+    change_setting('DisableVDef', @prev_disable_vdef)
+    if @al_page_layout
+      # History records reference the layout via FK — must be deleted first.
+      ActiveRecord::Base.connection.execute(
+        "DELETE FROM page_layout_history WHERE page_layout_id = #{@al_page_layout.id}"
+      )
+      @al_page_layout.destroy
+    end
+  end
+
+  before :each do
+    # Clear precompiled Handlebars templates so the page layout created in
+    # before(:all) is included in the compiled master template for each example.
+    # (Pattern from spec/system/page_layout/initial_show_tab_spec.rb)
+    Admin::AppConfiguration.clear_memo!
+    HandlebarsPrecompiler.cleanup_tmp_dir
+    HandlebarsPrecompiler.cleanup_public_dir
+    Rails.cache.delete('server_cache_version')
+    login
+    # Each example creates its own records before calling navigate_to_master,
+    # so that the browser sees fresh data when the page loads.
+  end
+
+  # ===================================================================
+  # Programmatic record-creation helpers
+  # (Records are created in the test thread; they are visible to the browser
+  #  via the shared database transaction in Rails 7 system tests.)
+  # ===================================================================
+
+  # Create an AL record for @player_contact / @master.
+  def create_al_record(extra_log_type:)
+    @implementation_class.create!(
+      extra_log_type: extra_log_type,
+      select_call_direction: 'to player',
+      select_who: 'user',
+      player_contact: @player_contact,
+      master: @master,
+      current_user: @user
+    )
+  end
+
+  # Create a brand-new master (with a player_info + player_contact) and an AL
+  # record of the given type on it.  Used by the cross-master switching test so
+  # that two DIFFERENT masters can hold embedded DMs at different definition
+  # versions.  Returns [master, al_record].
+  def create_master_with_al_record(extra_log_type:, phone:, first_name:)
+    master = Master.create!(current_user: @user)
+    master.current_user = @user
+    master.player_infos.create!(first_name: first_name, last_name: 'Test', source: 'nflpa')
+    player_contact = master.player_contacts.create!(
+      current_user: @user, data: phone, rec_type: 'phone', rank: 10
+    )
+    al = @implementation_class.create!(
+      extra_log_type: extra_log_type,
+      select_call_direction: 'to player',
+      select_who: 'user',
+      player_contact: player_contact,
+      master: master,
+      current_user: @user
+    )
+    [master, al]
+  end
+
+  # Return the active implementation class for the given DM table name.
+  def dm_class_for(table_name)
+    DynamicModel.active.find_by(table_name: table_name).implementation_class
+  end
+
+  # Populate test1 on the auto-created embedded DM record (linked via FK) so
+  # that a concrete field value is visible in the rendered page.  The embed:
+  # config renders DM fields inline (seamless mode) without a label heading,
+  # so we assert on field VALUES rather than the DM label.
+  def set_embedded_dm_field(table_name, al_record, value)
+    dm_class = dm_class_for(table_name)
+    dm_rec = dm_class.find_by(AlFkEmbedShow => al_record.id)
+    raise "No auto-created DM found for AL #{al_record.id} in #{table_name}" unless dm_rec
+
+    dm_rec.current_user = @user
+    dm_rec.test1 = value
+    dm_rec.save!
+  end
+
+  # ===================================================================
+  # NOTE: for embed: config, the system auto-creates an embedded DM record
+  # via the link_embedded_item after_create callback when an AL is saved.
+  # Do NOT create DM records separately — that would create duplicates.
+  # ===================================================================
+
+  # ===================================================================
+  # Browser navigation helpers
+  # ===================================================================
+
+  # Navigate to the master page and expand the AL panel tab.
+  def navigate_and_expand_al_panel
+    navigate_to_master(@master.id)
+    expand_master_record_tab('activity_log__player_contact_embed_shows')
+    # Explicitly wait for the master search-results templates to compile.
+    # finish_page_loading exits early when body.sessions is present, so we must
+    # wait here to ensure Handlebars has the template_config and labels state
+    # before any label-specific assertions run.
+    page.has_css?('body.status-compiled', wait: 60)
+  end
+
+  # Clear Handlebars caches and re-navigate (needed after definition bumps).
+  def clear_caches_and_navigate
+    Admin::AppConfiguration.clear_memo!
+    HandlebarsPrecompiler.cleanup_tmp_dir
+    HandlebarsPrecompiler.cleanup_public_dir
+    Rails.cache.delete('server_cache_version')
+    navigate_and_expand_al_panel
+  end
+
+  # Bump the definition version of the given DM table by saving new options with
+  # the supplied label.  Disables dynamic migrations during the save so that the
+  # table-comment migration doesn't race with the just-created record; version
+  # history is tracked independently of migrations.  After saving it reloads
+  # model definitions and restarts the server so the new version is live.
+  def bump_dm_version(table_name, new_label)
+    sleep 2 # ensure a distinct created_at timestamp for the new version
+    dm = DynamicModel.active.find_by(table_name: table_name)
+    change_setting('AllowDynamicMigrations', false)
+    dm.current_admin = @admin
+    dm.options = "default:\n  label: #{new_label}\n  labels:\n    test1: #{new_label} Field\n"
+    dm.save!
+    change_setting('AllowDynamicMigrations', true)
+    DynamicModel.define_models
+    Application.refresh_dynamic_defs
+    AppControl.restart_server
+  end
+
+  # Save a NEW version of the activity log definition, changing the display
+  # label of the `select_who` field on the `versioned_activity` extra log type.
+  #
+  # All three extra log types are re-declared verbatim so the unversioned and
+  # references activities used by other examples are unaffected (only the
+  # versioned_activity select_who label changes).  Saving creates a new AL
+  # definition version — ActivityLog includes Dynamic::VersionHandler — so AL
+  # records created afterwards resolve to this version via `versioned_definition`,
+  # while records created beforehand keep resolving to the previous version.
+  #
+  # The change is made inside the example, so (like bump_dm_version) it rolls
+  # back with the transactional system-test wrapper after the example finishes.
+  def bump_al_field_label(who_label)
+    sleep 2 # ensure a distinct created_at timestamp for the new AL version
+    change_setting('AllowDynamicMigrations', false)
+    @activity_log.extra_log_types = <<~END_DEF
+      versioned_activity:
+        label: Versioned activity
+        fields:
+          - select_call_direction
+          - select_who
+        labels:
+          select_who: #{who_label}
+        embed: dynamic_model__show1238_embed_versioned_recs
+
+      unversioned_activity:
+        label: Unversioned activity
+        fields:
+          - select_call_direction
+          - select_who
+        embed: dynamic_model__show1238_embed_unversioned_recs
+
+      ref_single_activity:
+        label: Ref single activity
+        fields:
+          - select_call_direction
+          - select_who
+        references:
+          - dynamic_model__show1238_ref_single_recs:
+              label: Referenced single
+              from: this
+              add: one_to_this
+    END_DEF
+    @activity_log.current_admin = @admin
+    @activity_log.save!
+    change_setting('AllowDynamicMigrations', true)
+    ActivityLog.define_models
+    Application.refresh_dynamic_defs
+    AppControl.restart_server
+  end
+
+  # ===================================================================
+  # Shared examples
+  # ===================================================================
+
+  # Verifies that multiple AL instances each automatically show their own
+  # embedded DM block in show (read-only) mode.  Creating the AL record is
+  # sufficient — the link_embedded_item after_create callback auto-creates
+  # one DM record per AL via the FK column.  The `embed:` config then renders
+  # that DM form inside the AL show block.
+  #
+  # `dm_table` is the DM table name (e.g. 'show1238_embed_versioned_recs').
+  # The embed: config renders DM fields in seamless mode (inline, no label
+  # heading), so we populate test1 on each auto-created DM and assert on
+  # the titleized field VALUE appearing in the page.  If the template_config
+  # alias is missing (the issue-1238 bug) the entire block is absent and the
+  # field values never appear.
+  # `dm_label` is the version-specific label for the test1 field (from the DM
+  # options `labels:` config).  Its presence proves the correct per-version
+  # template is being used to render the embedded DM block.
+  shared_examples 'an embedded activity viewable in show mode' do |extra_log_type, dm_table, dm_label|
+    it 'shows embedded DM blocks in read-only mode and exposes edit buttons for each AL instance' do
+      # Two AL instances of the same type — the system auto-creates one
+      # embedded DM per AL via the link_embedded_item after_create callback.
+      al1 = create_al_record(extra_log_type: extra_log_type)
+      set_embedded_dm_field(dm_table, al1, 'embed item alpha')
+      al2 = create_al_record(extra_log_type: extra_log_type)
+      set_embedded_dm_field(dm_table, al2, 'embed item beta')
+
+      navigate_and_expand_al_panel
+
+      # Version-specific field label confirms the correct per-version template
+      # is rendered.  (Before the fix the block was entirely absent for
+      # versioned DMs; neither the label nor the value would appear.)
+      expect(page).to have_text(dm_label, wait: EmbeddedShowRenderWait)
+      # Both field values must also appear — proves each AL instance's embedded
+      # DM block is rendered.
+      expect(page).to have_text('Embed Item Alpha')
+      expect(page).to have_text('Embed Item Beta')
+
+      # Each AL instance has its own edit button.
+      expect(page).to have_css('.edit-entity', minimum: 2, wait: 10)
+    end
+  end
+
+  # ===================================================================
+  # Versioned embedded dynamic model
+  # ===================================================================
+
+  describe 'versioned embedded dynamic model' do
+    include_examples 'an embedded activity viewable in show mode',
+                     :versioned_activity, 'show1238_embed_versioned_recs', 'LabelField1V1234'
+
+    # KEY regression test for issue #1238: after the DM definition version is
+    # bumped, a previously saved record is now on an OLDER version.  Without the
+    # fix in _search_results_template.html.erb the browser JS logs:
+    #   "could not find template_config dynamic_model__..._recs v<n>"
+    # and the show-mode form never renders.  With the fix the per-version alias
+    # is set on the plural resource-name key, so old records still display.
+    it 'still renders the older-version embedded item in show mode after a definition version bump' do
+      # Two AL instances at version N — auto-created embedded DMs via after_create.
+      # Populate test1 so we can assert on field values in the page.
+      al1 = create_al_record(extra_log_type: :versioned_activity)
+      set_embedded_dm_field('show1238_embed_versioned_recs', al1, 'pre bump alpha')
+      al2 = create_al_record(extra_log_type: :versioned_activity)
+      set_embedded_dm_field('show1238_embed_versioned_recs', al2, 'pre bump beta')
+
+      # First navigation: both AL instances show their embedded DM at version N.
+      navigate_and_expand_al_panel
+      # Version-specific field label confirms the initial version template is rendered.
+      expect(page).to have_text('LabelField1V1234', wait: 60)
+      expect(page).to have_text('Pre Bump Alpha')
+      expect(page).to have_css('.edit-entity', minimum: 2, wait: 10)
+
+      # Bump definition version (uses the bump_dm_version helper).
+      bump_dm_version('show1238_embed_versioned_recs', "Versioned v#{SecureRandom.hex(2)}")
+
+      # Re-navigate with fresh template_config (now at version N+1).
+      # With the fix the plural alias also carries the v<N> key, so both
+      # older-version AL instances must still render their embedded DM —
+      # confirmed by the original field label and values still appearing.
+      clear_caches_and_navigate
+      # Old version-specific label must still appear — proves the pre-bump template
+      # is still reachable via the plural alias after the version bump.
+      expect(page).to have_text('LabelField1V1234', wait: EmbeddedShowRenderWait)
+      expect(page).to have_text('Pre Bump Alpha')
+      expect(page).to have_text('Pre Bump Beta')
+      expect(page).to have_css('.edit-entity', minimum: 2, wait: 10)
+    end
+
+    # Strongest regression test for issue #1238: two AL records on the SAME
+    # master page, each with an embedded DM saved at a DIFFERENT definition
+    # version.  Both must render their embedded DM content.
+    #
+    # Without the fix only the current-version alias exists in template_config,
+    # so the older record's embed block is silently absent — its field values
+    # never appear.  With the fix both version keys exist on the plural alias,
+    # so both blocks render and both field values are visible.
+    it 'shows each embedded item with its own version-specific content when two versions coexist on the same page' do
+      # Step 1: Create AL record 1 at the current version.
+      # The link_embedded_item after_create callback auto-creates the embedded DM.
+      # Populate test1 with a unique value to assert rendering at this version.
+      al_v1 = create_al_record(extra_log_type: :versioned_activity)
+      set_embedded_dm_field('show1238_embed_versioned_recs', al_v1, 'version one data')
+
+      # Step 2: Bump the DM definition to a new version.
+      bump_dm_version('show1238_embed_versioned_recs', 'Embed1238-Two')
+
+      # Step 3: Create AL record 2 at the new version.
+      # Auto-created embedded DM now uses the new definition version.
+      al_v2 = create_al_record(extra_log_type: :versioned_activity)
+      set_embedded_dm_field('show1238_embed_versioned_recs', al_v2, 'version two data')
+
+      # Step 4: Navigate fresh so the browser loads template_config for both versions.
+      clear_caches_and_navigate
+
+      # Both embeds must appear with their own field labels and values visible.
+      # al_v1 resolves to version N   → label 'LabelField1V1234', value 'Version One Data'
+      #                                  (requires the plural-alias fix)
+      # al_v2 resolves to version N+1 → label 'Embed1238-Two Field', value 'Version Two Data'
+      expect(page).to have_text('LabelField1V1234', wait: EmbeddedShowRenderWait)
+      expect(page).to have_text('Version One Data')
+      expect(page).to have_text('Embed1238-Two Field')
+      expect(page).to have_text('Version Two Data')
+    end
+
+    # Cross-master switching regression for issue #1238 — the specific edge case
+    # around WHEN the per-version template_config aliases are created on demand.
+    #
+    # Scenario:
+    #   1. Master 1 holds an AL whose embedded DM was saved at version N (v1).
+    #   2. The DM definition is bumped to version N+1 (v2).
+    #   3. Master 2 holds an AL whose embedded DM was saved at the new version N+1.
+    #   4. A SINGLE search returns BOTH masters (nav_q_id=m1,m2).
+    #   5. Expand master 2 FIRST — this loads template_config for the CURRENT
+    #      version (v2) and builds the v(N+1) alias in the browser's JS state.
+    #   6. WITHOUT reloading or re-searching, expand master 1 — the OLDER
+    #      version (v1) alias must now be created/used on top of the existing
+    #      template_config state from master 2.
+    #
+    # This differs from the same-page coexistence test above: there both blocks
+    # are produced by one template_config fetch on one master.  Here the aliases
+    # are built incrementally across two separate master expansions in the same
+    # SPA session.  If the older-version alias is not created when the base
+    # template_config object already exists from the current version, master 1's
+    # embedded block is silently absent (the original issue-1238 symptom).
+    it 'renders each master\'s embedded item at its own version when switching ' \
+       'between masters in one session without reloading' do
+      # Master 1: AL + auto-embedded DM at the current version (v1).
+      al_m1 = create_al_record(extra_log_type: :versioned_activity)
+      set_embedded_dm_field('show1238_embed_versioned_recs', al_m1, 'master one data')
+
+      # Bump the DM definition to v2 (new version-specific field label).
+      bump_dm_version('show1238_embed_versioned_recs', 'Embed1238-CrossMaster')
+
+      # Master 2 (a different master record): AL + auto-embedded DM at v2.
+      master2, al_m2 = create_master_with_al_record(
+        extra_log_type: :versioned_activity, phone: '(516)262-9999', first_name: 'Embed1238b'
+      )
+      set_embedded_dm_field('show1238_embed_versioned_recs', al_m2, 'master two data')
+
+      # One search returns BOTH masters; expanding each is SPA navigation (no reload).
+      Admin::AppConfiguration.clear_memo!
+      HandlebarsPrecompiler.cleanup_tmp_dir
+      HandlebarsPrecompiler.cleanup_public_dir
+      Rails.cache.delete('server_cache_version')
+      visit "/masters/search?utf8=%E2%9C%93&nav_q_id=#{@master.id},#{master2.id}"
+      dismiss_modal
+      finish_page_loading
+      expect(page).to have_css('body.status-compiled', wait: 60)
+
+      # Step 1: Expand master 2 (CURRENT version) FIRST — builds the v2 alias.
+      expand_master_record(master_id: master2.id)
+      expect(page).to have_css("#master-#{master2.id}-main-container.in", wait: 10)
+      expand_master_record_tab('activity_log__player_contact_embed_shows', master_id: master2.id)
+      within("#master-#{master2.id}-main-container") do
+        expect(page).to have_text('Embed1238-CrossMaster Field', wait: EmbeddedShowRenderWait)
+        expect(page).to have_text('Master Two Data')
+      end
+
+      # Step 2: WITHOUT reloading, expand master 1 (OLDER version).  The v1 alias
+      # must be created/used correctly on top of master 2's existing
+      # template_config state — this is the issue-1238 cross-master edge case.
+      expand_master_record(master_id: @master.id)
+      expect(page).to have_css("#master-#{@master.id}-main-container.in", wait: 10)
+      expand_master_record_tab('activity_log__player_contact_embed_shows', master_id: @master.id)
+      within("#master-#{@master.id}-main-container") do
+        expect(page).to have_text('LabelField1V1234', wait: EmbeddedShowRenderWait)
+        expect(page).to have_text('Master One Data')
+      end
+    end
+  end
+
+  # ===================================================================
+  # Versioned activity log field labels (definition versioning of the AL itself)
+  # ===================================================================
+  #
+  # The #1238 embedded-DM fix patched the dynamic_models global page template to
+  # emit historical versions.  An activity log's OWN field labels resolve through
+  # a different, pre-existing path: the per-record `template_config` endpoint
+  # renders each record via `oi.versioned_definition` (ActivityLog includes
+  # Dynamic::VersionHandler).  This block verifies that path so that AL field
+  # label changes between definition versions render correctly in show mode —
+  # an older AL record keeps its original field label while a newer record shows
+  # the updated label, both visible together in one page load.
+  describe 'versioned activity log field labels' do
+    it 'shows each activity record\'s field label at its own definition version when versions coexist on the same page' do
+      # Version A: set the select_who field label, then create an AL record that
+      # is pinned to this version via versioned_definition.
+      bump_al_field_label('AlWhoLabelV1')
+      al_old = create_al_record(extra_log_type: :versioned_activity)
+      set_embedded_dm_field('show1238_embed_versioned_recs', al_old, 'al field old')
+
+      # Version B: change the select_who field label, then create a second AL
+      # record that resolves to this newer version.
+      bump_al_field_label('AlWhoLabelV2')
+      al_new = create_al_record(extra_log_type: :versioned_activity)
+      set_embedded_dm_field('show1238_embed_versioned_recs', al_new, 'al field new')
+
+      # Navigate fresh so the browser fetches per-record template_config for both
+      # AL records (each carrying its own vdef_version).
+      clear_caches_and_navigate
+
+      # Both version-specific field labels must appear together:
+      #   al_old → version A label 'AlWhoLabelV1'
+      #   al_new → version B label 'AlWhoLabelV2'
+      # If AL field-label versioning regressed (analogous to issue #1238) the
+      # older record would silently show the current-version label only.
+      expect(page).to have_text('AlWhoLabelV1', wait: 60)
+      expect(page).to have_text('AlWhoLabelV2')
+      expect(page).to have_css('.edit-entity', minimum: 2, wait: 10)
+    end
+  end
+
+  # ===================================================================
+  # Unversioned embedded dynamic model
+  # ===================================================================
+
+  describe 'unversioned embedded dynamic model' do
+    include_examples 'an embedded activity viewable in show mode',
+                     :unversioned_activity, 'show1238_embed_unversioned_recs', 'LabelField1U1234'
+  end
+
+  # ===================================================================
+  # Single-entry references: referenced item appears embedded in show view
+  # ===================================================================
+
+  describe 'single-entry references config' do
+    it 'shows the referenced DM item embedded in the activity show view for each AL instance' do
+      # Two AL instances each with a single referenced DM (mirrors "add: one_to_this").
+      # The references: config causes the linked DM to appear automatically embedded
+      # within each AL show block.
+      al1 = create_al_record(extra_log_type: :ref_single_activity)
+      ref_dm1 = dm_class_for('show1238_ref_single_recs').create!(
+        test1: 'ref item alpha',
+        test2: 'ref data alpha',
+        master: @master,
+        current_user: @user
+      )
+      ModelReference.create_with(al1, ref_dm1)
+
+      al2 = create_al_record(extra_log_type: :ref_single_activity)
+      ref_dm2 = dm_class_for('show1238_ref_single_recs').create!(
+        test1: 'ref item beta',
+        test2: 'ref data beta',
+        master: @master,
+        current_user: @user
+      )
+      ModelReference.create_with(al2, ref_dm2)
+
+      navigate_and_expand_al_panel
+
+      # Both referenced DM items must be visible — fields render as
+      # "field_name Titleized Value" pairs inline in the AL panel.
+      expect(page).to have_text('Ref Item Alpha', wait: EmbeddedShowRenderWait)
+      expect(page).to have_text('Ref Item Beta')
+      expect(page).to have_css('.edit-entity', minimum: 2, wait: 10)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #1238 — activity log embedded dynamic model items fail to render in read-only (show) mode when the embedded model uses definition versioning.

### Root Cause

Two related issues in the Handlebars template config generation:

1. **Alias loop missing version key** in `app/views/common_templates/_search_results_template.html.erb`: When aliasing an embedded dynamic model's template config onto the plural resource name, only the base object was aliased. The browser JS looks up `template_config.<resource_name>.v<def_version>` — the version-specific key was never copied onto the alias.

2. **Global template missing historical versions** in `app/views/dynamic_models/_search_results_template.html.erb`: The global template (loaded once at page load) only emitted JS config for the current (live) definition version. After a definition version bump, embedded DM records carry an older `def_version` key that was absent from the global template.

### Fix

- **`common_templates/_search_results_template.html.erb`**: The alias loop now also copies the `.v<def_version>` key onto each alternative resource name.
- **`dynamic_models/_search_results_template.html.erb`**: Now iterates `m.all_versions` to also emit lightweight JS config blocks for all historical definition versions (Handlebars HTML template re-rendering is skipped for historical versions via the existing `unless def_version` guard).

### Tests

- **Request spec** (`spec/requests/activity_log/embedded_versioned_template_config_spec.rb`): New spec asserting the `template_config` endpoint correctly aliases the per-version template onto the plural resource name, for both versioned and unversioned embedded dynamic models, including when the embedded record was created under an older definition version.
- **System spec** (`spec/system/activity_log/embedded_versioned_show_mode_spec.rb`): Browser-level acceptance tests covering:
  - Embedded DM items rendered in show mode without version bumps (versioned and unversioned)
  - Embedded DM items still rendered correctly after a definition version bump (pre-bump records use their historical version label)
  - Coexistence of AL records with embedded DMs at different definition versions on the same page