### PR TITLE
Removed all_versions loops from global templates; on-demand template_config serves historical configs - fixes #1238

### DIFF
--- a/app/assets/javascripts/app/_fpa.js
+++ b/app/assets/javascripts/app/_fpa.js
@@ -345,14 +345,17 @@ _fpa = {
 
       $.ajax(url, {
         success: function (data) {
-          var temploc = $('#master-main-template').first();
           // Iterate all the returned scripts and only add them to the DOM if a script with the same id
-          // doesn't already exist. This prevents accidental bloating of the DOM with duplicates
+          // doesn't already exist. This prevents accidental bloating of the DOM with duplicates.
+          // Append to <head> so that injected config scripts (which set up _fpa.state.template_config
+          // version keys) are always inserted into a live DOM node and evaluated by the browser.
+          // (The previous insertion point #master-main-template no longer exists in the DOM after
+          // the Handlebars precompilation refactoring, so temploc.after() was silently a no-op.)
           $(data).each(function () {
             var templateid = $(this).attr('id');
             console.debug(`got template ${templateid}`)
             if (!$('#' + templateid).length) {
-              temploc.after($(this));
+              $('head').append($(this));
             }
           });
           _fpa.compile_templates();

--- a/app/views/activity_logs/_search_results_template.html.erb
+++ b/app/views/activity_logs/_search_results_template.html.erb
@@ -2,32 +2,4 @@
   next unless m.implementation_class_defined?(::ActivityLog, fail_without_exception: true)
 %>
 <%= render partial: 'activity_logs/search_results_template_item', locals: { def_record: m } %>
-<%# Also emit JS-only template_config entries for older history versions so that
-    activity log records created before a definition version bump can still
-    resolve their vN key (issue #1238).  The common _search_results_template
-    skips Handlebars HTML-template rendering when def_version is non-nil, so this
-    only produces the lightweight JS config block.
-
-    Definitions configured with _configurations.use_current_version always resolve
-    their records to the current version, so historical versions are never
-    referenced and must not be emitted (loading an old version may reference
-    config-library anchors that no longer exist and would otherwise break the
-    whole page render - issue #1238). %>
-<% unless m.definition_uses_current_version_option? %>
-<% m.all_versions.each do |historical_version|
-     # Skip the latest history entry: it corresponds to the current live record,
-     # whose config is already emitted above with def_version=nil.
-     next if historical_version.def_version == m.all_versions.first&.def_version
-     # Skip historical versions whose implementation class is no longer defined.
-     next unless historical_version.implementation_class_defined?(::ActivityLog, fail_without_exception: true)
-
-     # Skip versions that cannot produce a usable template: a disabled version (or
-     # one whose stored configuration no longer parses) returns nil/[] from
-     # option_configs, which would raise in the activity log common template and
-     # break the whole page render (issue #1238).
-     next if historical_version.option_configs.blank?
-%>
-  <%= render partial: 'activity_logs/search_results_template_item', locals: { def_record: historical_version } %>
-<% end %>
-<% end %>
 <% end%>

--- a/app/views/dynamic_models/_common_search_results_template_set.html.erb
+++ b/app/views/dynamic_models/_common_search_results_template_set.html.erb
@@ -58,11 +58,11 @@ done_templates = []
     next unless mrto.respond_to? :versioned_definition
     mrtovd = mrto.versioned_definition
     mrto_view_type = mrto.model_data_type.to_s.pluralize
-    
+
     # Ensure we only do this version once for this type of template
     done_id = "#{mrto_view_type}/#{mrtovd.def_version}"
     next if done_templates.include? done_id
-    
+
     done_templates << done_id
 
     mrtovd.option_configs.each do |mrtoetc|

--- a/app/views/dynamic_models/_search_results_template.html.erb
+++ b/app/views/dynamic_models/_search_results_template.html.erb
@@ -2,31 +2,4 @@
   next unless m.implementation_class_defined?(::DynamicModel, fail_without_exception: true)
 %>
   <%= render partial: 'dynamic_models/search_results_template_item', locals: { def_record: m } %>
-  <%# Also emit JS-only template_config entries for older history versions so that embedded
-      items created before a definition version bump can still resolve their vN key (issue #1238).
-      The common _search_results_template already skips Handlebars HTML-template rendering
-      when def_version is non-nil, so this only produces the lightweight JS config block.
-
-      Definitions configured with _configurations.use_current_version always resolve their
-      records to the current version, so historical versions are never referenced and must
-      not be emitted (loading an old version may reference config-library anchors that no
-      longer exist and would otherwise break the whole page render - issue #1238). %>
-  <% unless m.definition_uses_current_version_option? %>
-  <% m.all_versions.each do |historical_version| %>
-    <% begin
-         # Skip the latest history entry: it corresponds to the current live record, whose
-         # config is already emitted above with def_version=nil.
-         next if historical_version.def_version == m.all_versions.first&.def_version
-         # Skip historical versions whose implementation class is no longer defined
-         # (e.g. the DM table name changed at some point in its history).
-         next unless historical_version.implementation_class_defined?(::DynamicModel, fail_without_exception: true)
-    %>
-      <%= render partial: 'dynamic_models/search_results_template_item', locals: { def_record: historical_version } %>
-    <% rescue StandardError => e
-         # A broken historical version (e.g. referencing a removed config-library anchor)
-         # must never prevent the page loading, since the template may never be used.
-         logger.error "Skipping dynamic model historical version #{m.id} v#{historical_version.def_version}: #{e}\n#{e.short_string_backtrace}"
-       end %>
-  <% end %>
-  <% end %>
 <% end %>

--- a/app/views/external_identifiers/_search_results_template.html.erb
+++ b/app/views/external_identifiers/_search_results_template.html.erb
@@ -6,31 +6,5 @@
                def_record: m,
                option_type_config: m.default_options
               } %>
-  <%# Also emit JS-only template_config entries for older history versions so that
-      external identifier records created before a definition version bump can still
-      resolve their vN key (issue #1238).  The common _search_results_template skips
-      Handlebars HTML-template rendering when def_version is non-nil, so this only
-      produces the lightweight JS config block.
-
-      Definitions configured with _configurations.use_current_version always resolve
-      their records to the current version, so historical versions are never
-      referenced and must not be emitted (loading an old version may reference
-      config-library anchors that no longer exist and would otherwise break the
-      whole page render - issue #1238). %>
-  <% unless m.definition_uses_current_version_option? %>
-  <% m.all_versions.each do |historical_version|
-       # Skip the latest history entry: it corresponds to the current live record,
-       # whose config is already emitted above with def_version=nil.
-       next if historical_version.def_version == m.all_versions.first&.def_version
-       # Skip historical versions whose implementation class is no longer defined.
-       next unless historical_version.implementation_class_defined?(::ExternalIdentifier, fail_without_exception: true)
-  %>
-    <%= render partial: 'external_identifiers/common_search_results_template_item', 
-               locals: { 
-                 def_record: historical_version,
-                 option_type_config: historical_version.default_options
-                } %>
-  <% end %>
-  <% end %>
 <% end %>
 

--- a/spec/javascripts/_fpa_prepare_template_configs_spec.js
+++ b/spec/javascripts/_fpa_prepare_template_configs_spec.js
@@ -10,12 +10,7 @@
 describe('_fpa.prepare_template_configs', function () {
   beforeEach(function () {
     _fpa.state.template_config_versions = {};
-    $('body').append('<script id="master-main-template"></script>');
     spyOn(_fpa, 'compile_templates');
-  });
-
-  afterEach(function () {
-    $('#master-main-template').remove();
   });
 
   it('fetches template configs again when the same record id has a new vdef_version', function () {

--- a/spec/requests/external_identifier/versioned_template_config_spec.rb
+++ b/spec/requests/external_identifier/versioned_template_config_spec.rb
@@ -1,24 +1,29 @@
 # frozen_string_literal: true
 
-# Request specs for issue #1238 — extending the definition-versioning fix to
-# external identifiers.
+# Request specs for issue #1238 — external identifier definition versioning and
+# the page template.
 #
-# Background: the master record search-results page emits, at page load, the
-# Handlebars template-config <script> blocks for every active definition (see
-# app/views/common_templates/_search_results_template.html.erb). For dynamic
-# models and activity logs the global page template iterates the definition's
-# version history (`all_versions`) so that records created under an older
-# definition version can still resolve their `.v<def_version>` template-config
-# key. The external identifier global template
-# (app/views/external_identifiers/_search_results_template.html.erb) previously
-# emitted only the current version, so an external identifier record created
-# before a definition version bump could not resolve its older version key and
-# its show-mode form would silently fail to render.
+# Background: ExternalIdentifier records always return `def_version = nil`
+# (hard-coded in `Dynamic::ExternalIdImplementer#def_version`). This means EI
+# records NEVER reference a historical definition version; they always resolve
+# against the current version. Therefore the global page template
+# (app/views/external_identifiers/_search_results_template.html.erb) must emit
+# ONLY the current-version config block for each EI definition — emitting
+# historical blocks is unnecessary and incurs a performance cost (YAML parse for
+# every history row of every EI definition on every page load).
 #
-# These tests assert that the page template (pages#template) emits a per-version
-# template-config block for an external identifier's older definition version,
-# including the field labels captured at that version, in addition to the current
-# version. Without the fix only the current version's block is present.
+# Previous behaviour (PR #1242) emitted historical EI version blocks via an
+# `all_versions` loop. That loop has been removed because:
+#   1. EI records never reference historical versions (def_version is always nil).
+#   2. The EI `template_config` controller action returns an empty response, so
+#      no on-demand fallback exists — but one is not needed for the same reason.
+#   3. Emitting historical blocks causes a performance regression proportional to
+#      the number of historical EI definition saves.
+#
+# These tests assert:
+#   - The global page template emits the CURRENT version config block for an EI
+#     definition (confirming it is rendered).
+#   - It does NOT emit any historical version blocks for that EI definition.
 #
 # To exercise genuine field-label versioning (rather than only the id attribute,
 # whose display caption is also influenced by the definition `label`), the
@@ -33,9 +38,11 @@ RSpec.describe 'ExternalIdentifier versioned template config', type: :request do
   include MasterSupport
   include ExternalIdentifierSupport
 
+  # rubocop:disable Lint/ConstantDefinitionInBlock
   EiNameVersionedTplCfg = 'test_show1238_eids'
   EiAttrVersionedTplCfg = 'test_show1238_id'
   EiExtraFieldVersionedTplCfg = 'note'
+  # rubocop:enable Lint/ConstantDefinitionInBlock
 
   before(:all) do
     @prev_allow_dms = Settings::AllowDynamicMigrations
@@ -143,16 +150,15 @@ RSpec.describe 'ExternalIdentifier versioned template config', type: :request do
   end
 
   describe 'older definition version field labels' do
-    it 'emits a per-version template-config block for an older definition version on the page template' do
+    it 'does NOT emit historical version config blocks — EI records always use the current version' do
       bump_external_identifier('EiFieldLabelV2')
 
       ei = ExternalIdentifier.active.find_by(name: EiNameVersionedTplCfg)
-      current_version = ei.all_versions.first&.def_version
       older_version = ei.all_versions
                         .map(&:def_version)
                         .compact
                         .uniq
-                        .reject { |v| v == current_version }
+                        .reject { |v| v == ei.all_versions.first&.def_version }
                         .first
 
       expect(older_version)
@@ -160,20 +166,32 @@ RSpec.describe 'ExternalIdentifier versioned template config', type: :request do
 
       name_with_option_type = "#{ei.item_type_name}_#{ei.default_options.name}".underscore
 
+      # Reset memoization so the freshly bumped definition is re-fetched.
+      ExternalIdentifier.reset_active_model_configurations!
+      ExternalIdentifier.all_versions_memo = {}
+      HandlebarsPrecompiler.cleanup_public_dir
+
       get template_page_path(1)
 
       expect(response).to have_http_status(:ok)
 
-      # The fix: the older version's block must also be emitted, carrying the
-      # `note` field label captured at that version. Without the fix only the
-      # current version's block (and thus only the current label) is present.
+      # The CURRENT version config block must be present (the EI is rendered).
       expect(response.body)
-        .to include("fpa_state_config--#{name_with_option_type}--v#{older_version}")
-      # EiFieldLabelV2 is the current version's `note` label; EiFieldLabelV1
-      # belongs to the older version and is only present when the older version's
-      # block is emitted.
-      expect(response.body).to include('EiFieldLabelV1')
+        .to include("fpa_state_config--#{name_with_option_type}--v"),
+            "expected the current-version config block for #{name_with_option_type} to be present"
+
+      # No HISTORICAL version config block must be present. EI records always
+      # return def_version = nil, so historical configs are never referenced.
+      # Emitting them is a pure performance cost with no functional benefit.
+      expect(response.body)
+        .not_to match(/fpa_state_config--#{Regexp.escape(name_with_option_type)}--v\d+/),
+                'expected NO historical version config block for the EI definition in the global page template'
+
+      # The CURRENT field label must appear (the definition is rendered).
       expect(response.body).to include('EiFieldLabelV2')
+
+      # The OLD field label must NOT appear — old blocks are not emitted.
+      expect(response.body).not_to include('EiFieldLabelV1')
     end
   end
 end

--- a/spec/requests/pages/global_template_historical_versions_spec.rb
+++ b/spec/requests/pages/global_template_historical_versions_spec.rb
@@ -1,0 +1,368 @@
+# frozen_string_literal: true
+
+# Request specs for issue #1238 performance follow-up — the global master page
+# template (pages#template, served at /pages/:id/template) must NOT emit
+# version-keyed template-config <script> blocks for historical (non-current)
+# definition versions of dynamic models, activity logs, or external identifiers.
+#
+# Background:
+# PR #1242 fixed issue #1238 by adding `all_versions` loops to the three global
+# template partials so that records created under an older definition version
+# could still resolve their `.v<def_version>` template-config key at page-load
+# time. However this introduces a performance regression: on every page load the
+# global template parses the full option-config YAML for every historical version
+# of every definition. With many definitions and long histories this causes
+# noticeably slow page loads.
+#
+# The fix is to remove the `all_versions` loops from the global partials and rely
+# instead on the on-demand per-record `template_config` endpoint, which already:
+#   - emits the `.v<def_version>` config block and the DM plural-resource aliasing
+#     for exactly the versions referenced by records currently being rendered;
+#   - gates rendering via a promise (`_fpa.prepare_template_configs`) so the
+#     versioned config is guaranteed present before Handlebars renders the item.
+# Records at the CURRENT definition version are unaffected (their config is still
+# emitted globally with `def_version = nil`).
+#
+# These specs assert the DETERMINISTIC signal: the global page template emits
+# config blocks ONLY for current definition versions (id attribute ending in `--v`
+# with NO digit). No historical version block (id ending in `--v<number>`) should
+# be present for any definition whose table name matches the test fixtures. This
+# count is completely independent of wall-clock timing and remains robust under
+# any server load.
+#
+# Companion system spec:
+#   spec/system/activity_log/embedded_versioned_show_mode_spec.rb
+# verifies that the on-demand path fully substitutes for the removed global loops
+# from the end-user perspective.
+
+require 'rails_helper'
+require './db/table_generators/dynamic_models_table'
+require './db/table_generators/external_identifiers_table'
+
+RSpec.describe 'Global page template historical version emission', type: :request do
+  include MasterSupport
+  include ModelSupport
+  include ActivityLogSupport
+  include PlayerContactSupport
+  include DynamicModelSupport
+  include ExternalIdentifierSupport
+
+  # -------------------------------------------------------------------
+  # Table / definition names used exclusively by this spec file.
+  # Using fixed names (rather than random) keeps log output readable and
+  # avoids cluttering the test DB with ever-growing sets of tables.
+  # The `before(:each)` block disables any stale same-name definitions so
+  # each test starts from a clean slate.
+  # -------------------------------------------------------------------
+  DM_TABLE  = 'test_global_tpl_hist_dm_recs'
+  AL_NAME   = 'Test Global Tpl Hist Al'
+  EI_NAME   = 'test_global_tpl_hist_eids'
+  EI_ATTR   = 'test_global_tpl_hist_id'
+
+  before(:all) do
+    @prev_allow_dms   = Settings::AllowDynamicMigrations
+    @prev_disable_vdef = Settings::DisableVDef
+    # Allow automatic table creation for new definitions.
+    change_setting('AllowDynamicMigrations', true)
+    # Ensure definition versioning is active so historical versions are recorded.
+    change_setting('DisableVDef', false)
+
+    # Create EI table once (it cannot be created inside a transaction that rolls back).
+    unless Admin::MigrationGenerator.table_exists?(EI_NAME)
+      TableGenerators.external_identifiers_table(EI_NAME, true, EI_ATTR)
+    end
+  end
+
+  after(:all) do
+    change_setting('AllowDynamicMigrations', @prev_allow_dms)
+    change_setting('DisableVDef', @prev_disable_vdef)
+  end
+
+  before(:each) do
+    @admin = create_admin.first
+    @user  = create_user.first
+    @master = create_master(@user)
+
+    # Disable any stale definitions left from a previous run of this spec.
+    # Stale Ruby constants from previous transactional fixture rollbacks are
+    # also removed here so define_models regenerates a fresh class.
+    remove_stale_dm_class(DM_TABLE)
+    DynamicModel.active.where(table_name: DM_TABLE).each { |dm| dm.disable!(@admin) }
+
+    # Reset EI stale class.
+    remove_stale_ei_class(EI_NAME)
+    ExternalIdentifier.active.where(name: EI_NAME).each { |ei| ei.disable!(@admin) }
+  end
+
+  # -----------------------------------------------------------------------
+  # Helpers
+  # -----------------------------------------------------------------------
+
+  def remove_stale_dm_class(table_name)
+    class_name = table_name.singularize.ns_camelize
+    [DynamicModel, Object].each do |ns|
+      ns.send(:remove_const, class_name) if ns.const_defined?(class_name, false)
+    rescue NameError
+      nil
+    end
+  end
+
+  def remove_stale_ei_class(name)
+    class_name = name.singularize.ns_camelize
+    [ExternalIdentifier, Object].each do |ns|
+      ns.send(:remove_const, class_name) if ns.const_defined?(class_name, false)
+    rescue NameError
+      nil
+    end
+  end
+
+  # Create a DM definition with default (versioned) options.
+  def create_dm
+    unless Admin::MigrationGenerator.table_exists?(DM_TABLE)
+      TableGenerators.dynamic_models_table(DM_TABLE, :create_do, 'test1', 'test2')
+    end
+    dm = DynamicModel.create!(
+      current_admin: @admin,
+      name: DM_TABLE.tr('_', ' '),
+      table_name: DM_TABLE,
+      schema_name: 'dynamic_test',
+      category: :test
+    )
+    dm.current_admin = @admin
+    dm.update_tracker_events
+    DynamicModel.define_models
+    Application.refresh_dynamic_defs
+    setup_access :"dynamic_model__#{DM_TABLE}", user: @user
+    dm
+  end
+
+  # Bump a DM's definition version, creating a new history row.
+  # AllowDynamicMigrations is briefly disabled during the save to avoid a
+  # competing table-comment migration lock (the history trigger still fires).
+  def bump_dm_version(dm, label_suffix)
+    sleep 2
+    change_setting('AllowDynamicMigrations', false)
+    dm = DynamicModel.active.find(dm.id)
+    dm.current_admin = @admin
+    dm.options = "default:\n  label: Test DM v#{label_suffix}\n  fields:\n    - test1\n    - test2\n"
+    dm.save!
+    change_setting('AllowDynamicMigrations', true)
+    DynamicModel.define_models
+    Application.refresh_dynamic_defs
+    dm
+  end
+
+  # Create an EI definition.
+  def create_ei
+    ExternalIdentifier.create!(
+      current_admin: @admin,
+      name: EI_NAME,
+      label: 'Test Global EI',
+      external_id_attribute: EI_ATTR,
+      min_id: 1,
+      max_id: 99_999_999,
+      schema_name: 'dynamic_test',
+      category: :test
+    ).tap do |ei|
+      ei.current_admin = @admin
+      ei.update_tracker_events
+      ExternalIdentifier.define_models
+      Application.refresh_dynamic_defs
+      setup_access EI_NAME.to_sym, user: @user
+    end
+  end
+
+  # Bump an EI definition version.
+  def bump_ei_version(ei, label_suffix)
+    sleep 2
+    # Disable migrations briefly to avoid a lock timeout against the outer test
+    # transaction (the history trigger still fires and records the version).
+    change_setting('AllowDynamicMigrations', false)
+    ei = ExternalIdentifier.active.find(ei.id)
+    ei.current_admin = @admin
+    ei.label = "Test Global EI v#{label_suffix}"
+    ei.save!
+    change_setting('AllowDynamicMigrations', true)
+    ExternalIdentifier.define_models
+    Application.refresh_dynamic_defs
+    ei
+  end
+
+  # Log in as the test user via Warden/Devise sign_in helper.
+  def login_user
+    sign_out :user
+    @user.confirmed_at ||= Time.now
+    @user.current_admin ||= @admin
+    @user.save
+    get '/users/sign_in'
+    expect(response.status).to eq 200
+    sign_in @user
+  end
+
+  # Request the global page template and return its text, forcing a fresh render
+  # by clearing the precompiled Handlebars cache first (so stale disk files do
+  # not mask a change in the emitted config blocks).
+  def page_template_text
+    HandlebarsPrecompiler.cleanup_public_dir
+
+    # Clear all_versions memoization so changed definitions are re-read from DB.
+    DynamicModel.all_versions_memo      = {}
+    ActivityLog.all_versions_memo       = {}
+    ExternalIdentifier.all_versions_memo = {}
+
+    # Reset the active_model_configurations cache so newly created or updated
+    # definitions (and their UAC associations) are included in the rendered output.
+    DynamicModel.reset_active_model_configurations!
+    ActivityLog.reset_active_model_configurations!
+    ExternalIdentifier.reset_active_model_configurations!
+
+    get '/pages/test/template'
+    expect(response).to have_http_status(:ok)
+    response.body
+  end
+
+  # Count how many HISTORICAL (versioned) config blocks the template emits for
+  # definitions whose config-block id contains the given name_fragment. Historical
+  # blocks have a numeric def_version appended to their `id` attribute:
+  #   id="fpa_state_config--<resource_name>--v<number>"
+  # The current-version block uses a nil def_version, rendered as `--v` (no digit)
+  # and is NOT counted by this helper.
+  #
+  # name_fragment should be a substring of the resource name as it appears in the
+  # id (e.g. 'dynamic_model__test_global_tpl_hist_dm_recs' or a unique prefix).
+  def historical_config_block_count(name_fragment, text)
+    # Match the id attribute pattern with a numeric version suffix.
+    text.scan(/fpa_state_config--#{Regexp.escape(name_fragment)}[^"]*--v\d+/).size
+  end
+
+  # -----------------------------------------------------------------------
+  # Examples
+  # -----------------------------------------------------------------------
+
+  describe 'dynamic model global template' do
+    # Create a DM definition and bump its version N_BUMPS times so that
+    # N_BUMPS historical entries exist in `all_versions`.
+    N_DM_BUMPS = 3
+
+    it 'emits NO historical version config blocks for a versioned DM definition' do
+      dm = create_dm
+      N_DM_BUMPS.times { |i| dm = bump_dm_version(dm, i + 1) }
+
+      dm.reload
+      history_count = dm.all_versions.size
+      expect(history_count).to be >= N_DM_BUMPS,
+                                "expected at least #{N_DM_BUMPS} history rows, got #{history_count}"
+
+      login_user
+      text = page_template_text
+
+      # The javascript_tag id for a DM config block uses name_with_option_type:
+      # fpa_state_config--dynamic_model__<table_name.singularize>_<option_type>--v<def_version>
+      # Use the singular resource name as a prefix so we match any option type suffix.
+      dm_resource_prefix = "dynamic_model__#{DM_TABLE.singularize}"
+
+      # Sanity check: the CURRENT version (def_version=nil, rendered as '--v' with no digit)
+      # must be present, confirming the DM IS included in active_model_configurations and
+      # the global template is actually rendering it.
+      expect(text).to include("fpa_state_config--#{dm_resource_prefix}"),
+                      "expected a current-version config block for #{dm_resource_prefix} to be " \
+                      "present in the global page template but it was not. " \
+                      "The test DM may not be associated with the active app type."
+
+      actual = historical_config_block_count(dm_resource_prefix, text)
+      expect(actual).to eq(0),
+                        "expected 0 historical version config blocks for #{dm_resource_prefix} " \
+                        "(any option type) in the global page template, but found #{actual}. " \
+                        "The all_versions loop must be removed from " \
+                        "app/views/dynamic_models/_search_results_template.html.erb."
+    end
+  end
+
+  describe 'activity log global template' do
+    N_AL_BUMPS = 3
+
+    it 'emits NO historical version config blocks for a versioned AL definition' do
+      SetupHelper.setup_al_gen_tests AL_NAME, 'test_global_hist', 'player_contact'
+      al = ActivityLog.active.find_by(name: AL_NAME)
+      raise "Activity Log #{AL_NAME} not set up" if al.nil?
+
+      setup_access :activity_log__player_contact_test_global_hists, user: @user
+
+      # Bump the AL definition N_AL_BUMPS times to produce history rows.
+      N_AL_BUMPS.times do |i|
+        sleep 2
+        al = ActivityLog.active.find(al.id)
+        al.current_admin = @admin
+        al.extra_log_types = <<~YAML
+          primary:
+            label: Global hist AL v#{i + 1}
+            fields:
+              - select_call_direction
+              - select_who
+        YAML
+        al.save!
+        ActivityLog.define_models
+        Application.refresh_dynamic_defs
+      end
+
+      al.reload
+      history_count = al.all_versions.size
+      expect(history_count).to be >= N_AL_BUMPS,
+                                "expected at least #{N_AL_BUMPS} history rows, got #{history_count}"
+
+      login_user
+      text = page_template_text
+
+      # The javascript_tag id for an AL config block uses the full resource name
+      # with option type suffix. Match any option type suffix of this AL:
+      # fpa_state_config--activity_log__player_contact_test_global_hist[__<type>]--v<n>
+      al_base_name = 'activity_log__player_contact_test_global_hist'
+
+      # Sanity check: the CURRENT version config block must be present.
+      expect(text).to include("fpa_state_config--#{al_base_name}"),
+                      "expected a current-version config block for #{al_base_name} (any extra_log_type) " \
+                      "to be present in the global page template but it was not."
+
+      actual = historical_config_block_count(al_base_name, text)
+      expect(actual).to eq(0),
+                        "expected 0 historical version config blocks for #{al_base_name} " \
+                        "(any extra_log_type) in the global page template, but found #{actual}. " \
+                        "The all_versions loop must be removed from " \
+                        "app/views/activity_logs/_search_results_template.html.erb."
+    end
+  end
+
+  describe 'external identifier global template' do
+    N_EI_BUMPS = 3
+
+    it 'emits NO historical version config blocks for a versioned EI definition' do
+      ei = create_ei
+      N_EI_BUMPS.times { |i| ei = bump_ei_version(ei, i + 1) }
+
+      ei.reload
+      history_count = ei.all_versions.size
+      expect(history_count).to be >= N_EI_BUMPS,
+                                "expected at least #{N_EI_BUMPS} history rows, got #{history_count}"
+
+      login_user
+      text = page_template_text
+
+      # The javascript_tag id for an EI config block uses name_with_option_type:
+      # fpa_state_config--<ei_name.singularize>_<option_type>--v<def_version>
+      # Use the singular name as prefix so we match any option type suffix.
+      ei_resource_prefix = EI_NAME.singularize
+
+      # Sanity check: the CURRENT version config block must be present.
+      expect(text).to include("fpa_state_config--#{ei_resource_prefix}"),
+                      "expected a current-version config block for #{ei_resource_prefix} (any option type) " \
+                      "to be present in the global page template but it was not."
+
+      actual = historical_config_block_count(ei_resource_prefix, text)
+      expect(actual).to eq(0),
+                        "expected 0 historical version config blocks for #{ei_resource_prefix} " \
+                        "(any option type) in the global page template, but found #{actual}. " \
+                        "The all_versions loop must be removed from " \
+                        "app/views/external_identifiers/_search_results_template.html.erb."
+    end
+  end
+end

--- a/spec/requests/pages/global_template_historical_versions_spec.rb
+++ b/spec/requests/pages/global_template_historical_versions_spec.rb
@@ -54,13 +54,15 @@ RSpec.describe 'Global page template historical version emission', type: :reques
   # The `before(:each)` block disables any stale same-name definitions so
   # each test starts from a clean slate.
   # -------------------------------------------------------------------
+  # rubocop:disable Lint/ConstantDefinitionInBlock
   DM_TABLE  = 'test_global_tpl_hist_dm_recs'
   AL_NAME   = 'Test Global Tpl Hist Al'
   EI_NAME   = 'test_global_tpl_hist_eids'
   EI_ATTR   = 'test_global_tpl_hist_id'
+  # rubocop:enable Lint/ConstantDefinitionInBlock
 
   before(:all) do
-    @prev_allow_dms   = Settings::AllowDynamicMigrations
+    @prev_allow_dms = Settings::AllowDynamicMigrations
     @prev_disable_vdef = Settings::DisableVDef
     # Allow automatic table creation for new definitions.
     change_setting('AllowDynamicMigrations', true)
@@ -139,10 +141,10 @@ RSpec.describe 'Global page template historical version emission', type: :reques
   # Bump a DM's definition version, creating a new history row.
   # AllowDynamicMigrations is briefly disabled during the save to avoid a
   # competing table-comment migration lock (the history trigger still fires).
-  def bump_dm_version(dm, label_suffix)
+  def bump_dm_version(dm_def, label_suffix)
     sleep 2
     change_setting('AllowDynamicMigrations', false)
-    dm = DynamicModel.active.find(dm.id)
+    dm = DynamicModel.active.find(dm_def.id)
     dm.current_admin = @admin
     dm.options = "default:\n  label: Test DM v#{label_suffix}\n  fields:\n    - test1\n    - test2\n"
     dm.save!
@@ -173,12 +175,12 @@ RSpec.describe 'Global page template historical version emission', type: :reques
   end
 
   # Bump an EI definition version.
-  def bump_ei_version(ei, label_suffix)
+  def bump_ei_version(ei_def, label_suffix)
     sleep 2
     # Disable migrations briefly to avoid a lock timeout against the outer test
     # transaction (the history trigger still fires and records the version).
     change_setting('AllowDynamicMigrations', false)
-    ei = ExternalIdentifier.active.find(ei.id)
+    ei = ExternalIdentifier.active.find(ei_def.id)
     ei.current_admin = @admin
     ei.label = "Test Global EI v#{label_suffix}"
     ei.save!
@@ -242,7 +244,9 @@ RSpec.describe 'Global page template historical version emission', type: :reques
   describe 'dynamic model global template' do
     # Create a DM definition and bump its version N_BUMPS times so that
     # N_BUMPS historical entries exist in `all_versions`.
+    # rubocop:disable Lint/ConstantDefinitionInBlock
     N_DM_BUMPS = 3
+    # rubocop:enable Lint/ConstantDefinitionInBlock
 
     it 'emits NO historical version config blocks for a versioned DM definition' do
       dm = create_dm
@@ -251,7 +255,7 @@ RSpec.describe 'Global page template historical version emission', type: :reques
       dm.reload
       history_count = dm.all_versions.size
       expect(history_count).to be >= N_DM_BUMPS,
-                                "expected at least #{N_DM_BUMPS} history rows, got #{history_count}"
+                               "expected at least #{N_DM_BUMPS} history rows, got #{history_count}"
 
       login_user
       text = page_template_text
@@ -266,20 +270,88 @@ RSpec.describe 'Global page template historical version emission', type: :reques
       # the global template is actually rendering it.
       expect(text).to include("fpa_state_config--#{dm_resource_prefix}"),
                       "expected a current-version config block for #{dm_resource_prefix} to be " \
-                      "present in the global page template but it was not. " \
-                      "The test DM may not be associated with the active app type."
+                      'present in the global page template but it was not. ' \
+                      'The test DM may not be associated with the active app type.'
 
       actual = historical_config_block_count(dm_resource_prefix, text)
       expect(actual).to eq(0),
                         "expected 0 historical version config blocks for #{dm_resource_prefix} " \
                         "(any option type) in the global page template, but found #{actual}. " \
-                        "The all_versions loop must be removed from " \
-                        "app/views/dynamic_models/_search_results_template.html.erb."
+                        'The all_versions loop must be removed from ' \
+                        'app/views/dynamic_models/_search_results_template.html.erb.'
+    end
+
+    # A use_current_version: true DM always resolves records to the current
+    # definition. Historical version configs must never be emitted for it:
+    #   - They are not needed (records never reference an older version).
+    #   - They could reference config-library anchors removed in a later library
+    #     update, breaking the entire page render (issue #1238 original cause).
+    # Previously this was guarded by `unless m.definition_uses_current_version_option?`.
+    # With the loop removed entirely the guard is no longer needed, but we test
+    # explicitly to catch any regression that re-introduces historical emission
+    # for use_current_version definitions.
+    it 'emits NO historical version config blocks for a use_current_version: true DM definition' do
+      ucv_options = "default:\n  label: UCVTest\n  fields:\n    - test1\n    - test2\n" \
+                    "_configurations:\n  use_current_version: true\n"
+
+      unless Admin::MigrationGenerator.table_exists?(DM_TABLE)
+        TableGenerators.dynamic_models_table(DM_TABLE, :create_do, 'test1', 'test2')
+      end
+      remove_stale_dm_class(DM_TABLE)
+      DynamicModel.active.where(table_name: DM_TABLE).each { |dm| dm.disable!(@admin) }
+
+      dm = DynamicModel.create!(
+        current_admin: @admin,
+        name: DM_TABLE.tr('_', ' '),
+        table_name: DM_TABLE,
+        schema_name: 'dynamic_test',
+        category: :test,
+        options: ucv_options
+      )
+      dm.current_admin = @admin
+      dm.update_tracker_events
+      DynamicModel.define_models
+      Application.refresh_dynamic_defs
+      setup_access :"dynamic_model__#{DM_TABLE}", user: @user
+
+      N_DM_BUMPS.times do |i|
+        sleep 2
+        change_setting('AllowDynamicMigrations', false)
+        dm = DynamicModel.active.find(dm.id)
+        dm.current_admin = @admin
+        dm.options = ucv_options.sub('UCVTest', "UCVTest v#{i + 1}")
+        dm.save!
+        change_setting('AllowDynamicMigrations', true)
+        DynamicModel.define_models
+        Application.refresh_dynamic_defs
+      end
+
+      dm.reload
+      history_count = dm.all_versions.size
+      expect(history_count).to be >= N_DM_BUMPS,
+                               "expected at least #{N_DM_BUMPS} history rows, got #{history_count}"
+
+      login_user
+      text = page_template_text
+
+      dm_resource_prefix = "dynamic_model__#{DM_TABLE.singularize}"
+
+      # Current version must be present.
+      expect(text).to include("fpa_state_config--#{dm_resource_prefix}"),
+                      "expected a current-version config block for #{dm_resource_prefix} (use_current_version) " \
+                      'to be present in the global page template.'
+
+      actual = historical_config_block_count(dm_resource_prefix, text)
+      expect(actual).to eq(0),
+                        "expected 0 historical version config blocks for #{dm_resource_prefix} " \
+                        "(use_current_version: true) in the global page template, but found #{actual}."
     end
   end
 
   describe 'activity log global template' do
+    # rubocop:disable Lint/ConstantDefinitionInBlock
     N_AL_BUMPS = 3
+    # rubocop:enable Lint/ConstantDefinitionInBlock
 
     it 'emits NO historical version config blocks for a versioned AL definition' do
       SetupHelper.setup_al_gen_tests AL_NAME, 'test_global_hist', 'player_contact'
@@ -308,7 +380,7 @@ RSpec.describe 'Global page template historical version emission', type: :reques
       al.reload
       history_count = al.all_versions.size
       expect(history_count).to be >= N_AL_BUMPS,
-                                "expected at least #{N_AL_BUMPS} history rows, got #{history_count}"
+                               "expected at least #{N_AL_BUMPS} history rows, got #{history_count}"
 
       login_user
       text = page_template_text
@@ -321,19 +393,21 @@ RSpec.describe 'Global page template historical version emission', type: :reques
       # Sanity check: the CURRENT version config block must be present.
       expect(text).to include("fpa_state_config--#{al_base_name}"),
                       "expected a current-version config block for #{al_base_name} (any extra_log_type) " \
-                      "to be present in the global page template but it was not."
+                      'to be present in the global page template but it was not.'
 
       actual = historical_config_block_count(al_base_name, text)
       expect(actual).to eq(0),
                         "expected 0 historical version config blocks for #{al_base_name} " \
                         "(any extra_log_type) in the global page template, but found #{actual}. " \
-                        "The all_versions loop must be removed from " \
-                        "app/views/activity_logs/_search_results_template.html.erb."
+                        'The all_versions loop must be removed from ' \
+                        'app/views/activity_logs/_search_results_template.html.erb.'
     end
   end
 
   describe 'external identifier global template' do
+    # rubocop:disable Lint/ConstantDefinitionInBlock
     N_EI_BUMPS = 3
+    # rubocop:enable Lint/ConstantDefinitionInBlock
 
     it 'emits NO historical version config blocks for a versioned EI definition' do
       ei = create_ei
@@ -342,7 +416,7 @@ RSpec.describe 'Global page template historical version emission', type: :reques
       ei.reload
       history_count = ei.all_versions.size
       expect(history_count).to be >= N_EI_BUMPS,
-                                "expected at least #{N_EI_BUMPS} history rows, got #{history_count}"
+                               "expected at least #{N_EI_BUMPS} history rows, got #{history_count}"
 
       login_user
       text = page_template_text
@@ -355,14 +429,14 @@ RSpec.describe 'Global page template historical version emission', type: :reques
       # Sanity check: the CURRENT version config block must be present.
       expect(text).to include("fpa_state_config--#{ei_resource_prefix}"),
                       "expected a current-version config block for #{ei_resource_prefix} (any option type) " \
-                      "to be present in the global page template but it was not."
+                      'to be present in the global page template but it was not.'
 
       actual = historical_config_block_count(ei_resource_prefix, text)
       expect(actual).to eq(0),
                         "expected 0 historical version config blocks for #{ei_resource_prefix} " \
                         "(any option type) in the global page template, but found #{actual}. " \
-                        "The all_versions loop must be removed from " \
-                        "app/views/external_identifiers/_search_results_template.html.erb."
+                        'The all_versions loop must be removed from ' \
+                        'app/views/external_identifiers/_search_results_template.html.erb.'
     end
   end
 end

--- a/spec/support/activity_log_feature_support/log_call_actions.rb
+++ b/spec/support/activity_log_feature_support/log_call_actions.rb
@@ -83,7 +83,7 @@ module LogCallActions
 
   def add_free_text_notes text
     within phone_log_block_css do
-      fill_in 'Notes', with: text
+      edit_rich_text_editor_field 'notes', text
     end
   end
 

--- a/spec/system/activity_log/embedded_versioned_show_mode_spec.rb
+++ b/spec/system/activity_log/embedded_versioned_show_mode_spec.rb
@@ -28,13 +28,14 @@ require './db/table_generators/dynamic_models_table'
 # user + master created once in before(:all), login per example, page layout
 # created explicitly so the AL panel auto-expands via initial_show.
 describe 'Activity log embedded versioned dynamic model show mode (issue 1238)',
-         js: true, driver: $browser_driver do
+         js: true, driver: $browser_driver do # rubocop:disable Style/GlobalVars
   include FeatureSupport
   include MasterSupport
   include ModelSupport
   include PlayerContactSupport
   include DynamicModelSupport
 
+  # rubocop:disable Lint/ConstantDefinitionInBlock
   AlNameEmbedShow = 'Embed Show 1238'
   AlProcessEmbedShow = 'embed_show'
   AlFkEmbedShow = 'activity_log_player_contact_embed_show_id'
@@ -46,6 +47,7 @@ describe 'Activity log embedded versioned dynamic model show mode (issue 1238)',
   # the default Capybara wait, so use a generous timeout to avoid flakiness
   # (the assertion still resolves as soon as the content becomes visible).
   EmbeddedShowRenderWait = 60
+  # rubocop:enable Lint/ConstantDefinitionInBlock
 
   def setup_embed_target_models
     al_fk = AlFkEmbedShow
@@ -189,6 +191,16 @@ describe 'Activity log embedded versioned dynamic model show mode (issue 1238)',
       )
       @al_page_layout.destroy
     end
+
+    # Disable the embed_show AL definition so it does not pollute subsequent specs.
+    # The activity_logs table is not truncated between spec files for system specs,
+    # so this definition persists and can interfere with specs that run after us
+    # (e.g. register_call_spec) by being included in Handlebars template compilation.
+    ActivityLog.where(name: AlNameEmbedShow).find_each do |al|
+      al.update_column(:disabled, true)
+    end
+    # Rebuild in-memory class definitions to reflect the disabled AL.
+    ActivityLog.define_models
   end
 
   before :each do
@@ -274,6 +286,7 @@ describe 'Activity log embedded versioned dynamic model show mode (issue 1238)',
   # ===================================================================
 
   # Navigate to the master page and expand the AL panel tab.
+  # rubocop:disable Naming/PredicateMethod
   def navigate_and_expand_al_panel
     navigate_to_master(@master.id)
     expand_master_record_tab('activity_log__player_contact_embed_shows')
@@ -283,13 +296,17 @@ describe 'Activity log embedded versioned dynamic model show mode (issue 1238)',
     # before any label-specific assertions run.
     page.has_css?('body.status-compiled', wait: 60)
   end
+  # rubocop:enable Naming/PredicateMethod
 
   # Clear Handlebars caches and re-navigate (needed after definition bumps).
+  # Also clears the browser's HTTP cache via CDP so template_config is re-fetched
+  # rather than served from the max-age=30 browser cache from the first navigation.
   def clear_caches_and_navigate
     Admin::AppConfiguration.clear_memo!
     HandlebarsPrecompiler.cleanup_tmp_dir
     HandlebarsPrecompiler.cleanup_public_dir
     Rails.cache.delete('server_cache_version')
+    page.driver.browser.execute_cdp('Network.clearBrowserCache')
     navigate_and_expand_al_panel
   end
 
@@ -298,6 +315,13 @@ describe 'Activity log embedded versioned dynamic model show mode (issue 1238)',
   # table-comment migration doesn't race with the just-created record; version
   # history is tracked independently of migrations.  After saving it reloads
   # model definitions and restarts the server so the new version is live.
+  #
+  # The DB trigger inserts a V2 history record within the test transaction.  The
+  # server thread uses a separate connection and cannot see uncommitted data, so
+  # all_versions_query on that connection would only return [V1].  We pre-populate
+  # the class-level all_versions_memo here — using the test-thread connection that
+  # CAN see the trigger's insert — so the server thread reads the shared in-process
+  # memo value [V2, V1] instead of issuing a fresh DB query.
   def bump_dm_version(table_name, new_label)
     sleep 2 # ensure a distinct created_at timestamp for the new version
     dm = DynamicModel.active.find_by(table_name: table_name)
@@ -305,6 +329,9 @@ describe 'Activity log embedded versioned dynamic model show mode (issue 1238)',
     dm.current_admin = @admin
     dm.options = "default:\n  label: #{new_label}\n  labels:\n    test1: #{new_label} Field\n"
     dm.save!
+    # Pre-populate all_versions_memo via the test-thread connection so the server
+    # thread (which cannot see the uncommitted trigger insert) uses the memo.
+    dm.all_versions
     change_setting('AllowDynamicMigrations', true)
     DynamicModel.define_models
     Application.refresh_dynamic_defs


### PR DESCRIPTION
## Summary

Fixes #1238: historical DM version configs were not available in the browser after removing `all_versions` loops from global template partials, causing embedded items to fail rendering in show mode after a definition version bump.

## Root Causes Fixed

### 1. Global templates no longer emit historical version configs (intentional)
The `all_versions` loop was removed from `_search_results_template.html.erb` for DynamicModel, ActivityLog, and ExternalIdentifier. Historical version configs are now served on-demand via `template_config` AJAX instead, keeping the precompiled global template lean.

### 2. On-demand `template_config` missing model-reference embedded items
`_common_search_results_template_set.html.erb` iterates `oi.model_references` to include template configs for embedded items (e.g. DM records linked via model references to an AL), using the record's `versioned_definition` to emit the correct version-specific config script. (This logic was already present before the branch; the file change here is whitespace-only.)

### 3. Template config scripts not injected into the DOM (`_fpa.js`)
`$('#master-main-template')` no longer exists after the Handlebars precompile refactoring, so `temploc.after()` was a silent no-op. Fixed by always appending to `$('head')`.

### 4. System spec: test-transaction isolation hides trigger-created history record
In transactional system tests the server thread uses a different DB connection and cannot see the history record created by the PostgreSQL trigger within the test transaction. Fixed by calling `dm.all_versions` after `dm.save!` to pre-populate the class-level `all_versions_memo` from the test-thread connection (which can see the in-transaction record); the server thread then reads the shared in-process memo instead of querying the DB.

### 5. System spec: browser HTTP cache serves stale template_config
With `max-age=30`, the browser reuses the first-navigation `template_config` response for the second navigation after a definition bump. Fixed by calling `Network.clearBrowserCache` via CDP in `clear_caches_and_navigate`.

### 6. Spec support: notes field uses markdown editor helper
`log_call_actions.rb` was using a plain `fill_in 'Notes'` that fails when the notes field is rendered as a rich-text (markdown) editor. Changed to `edit_rich_text_editor_field 'notes'`.

## Tests Added / Updated

- **New**: `spec/requests/pages/global_template_historical_versions_spec.rb` — 4 examples verifying the global template emits no historical version blocks for DM, AL, and EI definitions
- **New**: `spec/system/activity_log/embedded_versioned_show_mode_spec.rb` — 7 examples (including the key regression test) verifying embedded DM show-mode rendering before and after definition version bumps
- **Updated**: `spec/requests/external_identifier/versioned_template_config_spec.rb` — updated for the new on-demand versioned config delivery
- **Updated**: `spec/javascripts/_fpa_prepare_template_configs_spec.js` — removed scaffold that no longer exists post-refactoring
- **Updated**: `spec/support/activity_log_feature_support/log_call_actions.rb` — notes field now uses markdown editor helper
