### PR TITLE
Fixed YAML corruption and config library cycle expansion in dynamic model options - fixes #676

### DIFF
--- a/app/models/dynamic_model.rb
+++ b/app/models/dynamic_model.rb
@@ -516,23 +516,31 @@ class DynamicModel < ActiveRecord::Base
   end
 
   #
-  # Add the hash to the start of the options text
-  # This really needs to be replaced with real configuration
-  # handling, but it works effectively when the configuration is new.
+  # Add the hash to the start of the options text, replacing any existing section
+  # with the same key. The existing section boundary is found by scanning lines
+  # forward from the key until the first line that starts with a non-whitespace
+  # character (the next top-level key, comment, or other column-0 content).
   def prepend_to_options(hash)
     hash.deep_stringify_keys!
     key = hash.keys.first
     new_options = String.yaml_dump(hash)
     self.options ||= ''
-    self.options = if self.options.index(/^#{key}:/)
-                     self.options = self.options.gsub(/^(#{key}:(.+?))(\n[^\s]|\z)/m) do
-                       "#{new_options}\n\n#{Regexp.last_match(3)}"
+    lines = options.lines
+    start_idx = lines.index { |l| l.match?(/\A#{Regexp.escape(key)}:/) }
+
+    self.options = if start_idx
+                     end_offset = lines[(start_idx + 1)..].find_index do |l|
+                       l.match?(/\A\S/)
                      end
+                     abs_end_idx = end_offset ? start_idx + 1 + end_offset : lines.length
+                     before = lines[0...start_idx].join
+                     after = lines[abs_end_idx..].join
+                     "#{before}#{new_options}\n\n#{after}"
                    else
-                     "#{new_options}\n\n#{self.options}"
+                     "#{new_options}\n\n#{options}"
                    end
 
-    self.options = self.options.gsub(/^---.*\n/, '')
+    self.options = options.gsub(/^---.*\n/, '')
   end
 
   #

--- a/app/models/option_configs/extra_options.rb
+++ b/app/models/option_configs/extra_options.rb
@@ -725,6 +725,15 @@ module OptionConfigs
       String.yaml_dump(hash_results)
     end
 
+    # Top-level configuration sections that describe the underlying database
+    # table (field comments, column types and the data dictionary) rather than
+    # the runtime option type configurations. They are consumed only by admin
+    # and migration flows and are deleted from the loaded config before any
+    # runtime use (see parse_config). If a previous corruption (issue #676)
+    # damaged one of these sections, the whole YAML document fails to parse even
+    # though the runtime configuration is intact.
+    DbDefinitionOnlySections = %w[_comments _db_columns _data_dictionary].freeze
+
     #
     # Parse the options text from the dynamic definition, producing an initial Hash
     # @param [ActiveRecord::Base] config_obj - dynamic definition record
@@ -738,7 +747,14 @@ module OptionConfigs
           loaded_config = YAML.safe_load(config_text, permitted_classes: [],
                                                       permitted_symbols: [],
                                                       aliases: true)
-        rescue Psych::SyntaxError, Psych::DisallowedClass, Psych::Exception => e
+        rescue Psych::Exception => e
+          # The DB-definition-only sections are not required for runtime usage.
+          # Strip them and retry so a corruption confined to (or removable with)
+          # those sections cannot break rendering for an otherwise-valid runtime
+          # configuration. Genuine runtime config errors still raise below.
+          recovered = recover_runtime_config(config_text, config_obj, e)
+          return recovered.deep_symbolize_keys! unless recovered.nil?
+
           linei = 0
           errtext = config_text.split("\n").map { |l| "#{linei += 1}: #{l}" }.join("\n")
           Rails.logger.warn e
@@ -747,7 +763,8 @@ module OptionConfigs
             $stderr.puts e
             $stderr.puts errtext
           end
-
+          Rails.logger.warn 'Failed configuration YAML at:'
+          Rails.logger.warn(ExceptionExtensions.short_string_backtrace(caller))
           bt = ["#{e.class.name} #{e}"] + [errtext]
           raise FphsOptionsParseError, "#{e.class.name} #{e} -- review failed configuration YAML", bt
         end
@@ -762,6 +779,56 @@ module OptionConfigs
       Rails.logger.error e.short_string_backtrace
       raise FphsException,
             "Error occurred in parse_options_text in #{config_obj}: #{e}"
+    end
+
+    #
+    # Attempt to recover a parseable runtime configuration from options text that
+    # failed to load, by removing the DB-definition-only sections
+    # (_comments, _db_columns, _data_dictionary). These describe the database
+    # table, not the runtime configuration, and are discarded before runtime use.
+    # @param [String] config_text - the full prepared options text that failed to parse
+    # @param [ActiveRecord::Base] config_obj - dynamic definition record (for logging)
+    # @param [Exception] original_error - the original parse failure (for logging)
+    # @return [Hash, nil] the recovered config hash, or nil if recovery was not possible
+    def self.recover_runtime_config(config_text, config_obj, original_error)
+      stripped = strip_db_definition_sections(config_text)
+      return nil if stripped == config_text
+
+      recovered = YAML.safe_load(stripped, permitted_classes: [], permitted_symbols: [], aliases: true)
+      return nil unless recovered.is_a?(Hash)
+
+      Rails.logger.warn(
+        "Recovered runtime configuration for #{config_obj} by ignoring corrupt DB-definition sections " \
+        "(#{original_error.class.name}: #{original_error.message}). The stored options need to be repaired."
+      )
+      recovered
+    rescue Psych::Exception
+      # The runtime configuration is genuinely broken (not just the DB-definition
+      # sections), so recovery is not possible. Let the caller raise the original error.
+      nil
+    end
+
+    #
+    # Remove the DB-definition-only top-level sections from options text using
+    # line-based scanning. A section starts at a line whose first character is one
+    # of the section keys followed by ':' (column 0) and continues until the next
+    # line that begins with a non-whitespace character (the next top-level key).
+    # Line scanning is used (rather than YAML parsing) precisely because the text
+    # may be malformed.
+    # @param [String] config_text
+    # @return [String] config_text with the DB-definition sections removed
+    def self.strip_db_definition_sections(config_text)
+      section_start = /\A(#{DbDefinitionOnlySections.join('|')}):/
+      skipping = false
+
+      config_text.lines.reject do |line|
+        if line.match?(section_start)
+          skipping = true
+        elsif skipping && line.match?(/\A\S/)
+          skipping = false
+        end
+        skipping
+      end.join
     end
 
     #
@@ -1108,19 +1175,40 @@ module OptionConfigs
 
       content_to_update = content_to_update.dup
       reg = LibraryMatchRegex
+      # Track libraries already sourced so a cyclic or self-referencing library
+      # (e.g. A -> B -> A, possible when resolving a historical library version
+      # with version_at) cannot be expanded repeatedly. Without this guard the
+      # while loop below grows the text without bound — exponentially when a
+      # cycle reintroduces more than one directive, since gsub! replaces every
+      # occurrence on each pass. See issue #676. This mirrors the cycle
+      # protection already present in requested_libraries.
+      seen = Set.new
       res = content_to_update.match reg
 
       while res
         category = res[1].strip
         name = res[2].strip
+        key = [category, name]
+
+        if seen.include?(key)
+          # Already sourced: neutralise the repeated reference rather than
+          # expanding it again. The replacement intentionally does not match
+          # LibraryMatchRegex, so the loop makes progress and terminates.
+          Rails.logger.warn "Skipped cyclic config library reference '#{category} #{name}' while including libraries"
+          content_to_update.gsub!(res[0], "# @library_cycle_skipped #{category} #{name}")
+          res = content_to_update.match reg
+          next
+        end
+        seen.add(key)
+
         lib = if version_at
                 Admin::ConfigLibrary.content_named_at(category, name, format: :yaml, at: version_at)
               else
                 Admin::ConfigLibrary.content_named(category, name, format: :yaml)
               end
         lib = (lib || '').dup
-        LibraryKeyRenamePatterns.each do |key|
-          lib.gsub!(/^#{key}:.*/, "#{key}__#{category}_#{name}:")
+        LibraryKeyRenamePatterns.each do |key_pattern|
+          lib.gsub!(/^#{key_pattern}:.*/, "#{key_pattern}__#{category}_#{name}:")
         end
         lib = "# @sourced_library_start #{category} #{name}\n#{lib}\n# @sourced_library_end #{category} #{name}\n"
         content_to_update.gsub!(res[0], lib)

--- a/spec/models/option_configs/dynamic_model_options_spec.rb
+++ b/spec/models/option_configs/dynamic_model_options_spec.rb
@@ -292,7 +292,6 @@ RSpec.describe 'Dynamic Model Options', type: :model do
         test1: A test comment
 
 
-
       default:
         label: Something
 
@@ -323,7 +322,6 @@ RSpec.describe 'Dynamic Model Options', type: :model do
         test1: A test comment
 
 
-
       default:
         label: Something
 
@@ -333,9 +331,8 @@ RSpec.describe 'Dynamic Model Options', type: :model do
   end
 
   # Test that prepend_to_options correctly handles _comments containing escaped single quotes.
-  # GitHub issue #1029: When a comment value contains a literal backslash-quote (e.g., Alzheimer\'s),
-  # YAML.dump produces text with \' which Ruby's gsub interprets as a postmatch backreference,
-  # corrupting the output.
+  # GitHub issue #1029: A comment value like Alzheimer\'s Disease must survive a replace cycle
+  # without corrupting the options text or losing other sections.
   it 'handles comments containing escaped quotes in prepend_to_options' do
     table_name = 'test_replace_opts'
     DynamicModel.active.where(table_name:).each { |dm| dm.disable!(@admin) }
@@ -422,8 +419,7 @@ RSpec.describe 'Dynamic Model Options', type: :model do
     expect { first_pass = YAML.safe_load(dm.options) }.not_to raise_error
 
     # Second prepend: simulate "Update Config from Table" re-generating _comments
-    # This is where the bug manifests — the already-corrupted options text
-    # gets further mangled on the second pass
+    # The section replacement must be idempotent across multiple passes
     hash2 = {
       _comments: {
         test1: comment_value
@@ -441,6 +437,205 @@ RSpec.describe 'Dynamic Model Options', type: :model do
 
     # The default section should still be intact
     expect(second_pass['default']['label']).to eq 'Test Label'
+  end
+
+  # Test that multiple prepend_to_options calls with a key that exists do not grow
+  # the options text, even when the options YAML fails to parse (e.g. due to
+  # unescaped single-quotes in a caption_before value as reported in issue #676).
+  it 'does not grow options text on repeated prepends when YAML is invalid' do
+    table_name = 'test_replace_opts'
+    DynamicModel.active.where(table_name:).each { |dm| dm.disable!(@admin) }
+
+    dm = DynamicModel.create! current_admin: @admin,
+                              name: 'test replace opts',
+                              table_name:,
+                              schema_name: 'ml_app',
+                              category: :test,
+                              options: nil
+
+    # Initial options contain a caption_before with unescaped single-quotes — valid
+    # YAML plain-scalar but adjacent to a key name that breaks parsing in context
+    dm.options = <<~END_OPT
+      _comments:
+        table: 'Dynamicmodel: Rc Femfl Cif Rc'
+        fields:
+          hear_about_wives_group: simple comment
+
+      _data_dictionary:
+        study: rcfemfl
+
+      default:
+        caption_before:
+          hear_about_wives_group: 'Which wives'/partners'/mothers' group? '
+
+    END_OPT
+
+    comments_hash = {
+      _comments: {
+        table: 'Dynamicmodel: Rc Femfl Cif Rc',
+        fields: {
+          hear_about_wives_group: "Which wives'/partners'/mothers' group?"
+        }
+      }
+    }
+
+    # Simulate multiple before_save / update_config_from_table cycles
+    length_after_first = nil
+    5.times do |i|
+      dm.prepend_to_options(comments_hash.deep_dup)
+      length_after_first ||= dm.options.length
+      expect(dm.options.scan(/^_comments:/).length).to eq(1),
+                                                       "Cycle #{i + 1}: _comments appeared more than once"
+      expect(dm.options.length).to eq(length_after_first),
+                                   "Cycle #{i + 1}: options text grew from #{length_after_first} to #{dm.options.length}"
+    end
+
+    # _data_dictionary must still be present as a top-level key
+    expect(dm.options).to match(/^_data_dictionary:/)
+    # default section must be intact
+    expect(dm.options).to match(/^default:/)
+  end
+
+  # Reproduces the exact symptom from issue #676: a caption containing single
+  # quotes (from a REDCap folded scalar) sitting in a _comments section directly
+  # followed by _data_dictionary must never merge into "...wivesdata_dictionary:".
+  # Repeated prepends must keep the options stable and parseable.
+  it 'keeps quoted captions adjacent to _data_dictionary intact across saves' do
+    table_name = 'test_replace_opts'
+    DynamicModel.active.where(table_name:).each { |dm| dm.disable!(@admin) }
+
+    dm = DynamicModel.create! current_admin: @admin,
+                              name: 'test replace opts',
+                              table_name:,
+                              schema_name: 'ml_app',
+                              category: :test,
+                              options: nil
+
+    dm.options = <<~END_OPT
+      _comments:
+        table: 'Dynamicmodel: Rc Femfl Cif Rc'
+        fields:
+          record_id: Study ID
+          hear_about_wives_group: old value
+
+      _data_dictionary:
+        study: rcfemfl
+
+      _db_columns:
+        record_id:
+          type: string
+
+    END_OPT
+
+    comments_hash = {
+      _comments: {
+        table: 'Dynamicmodel: Rc Femfl Cif Rc',
+        fields: {
+          record_id: 'Study ID',
+          hear_about_wives_group: "Which wives'/partners'/mothers' group?",
+          cis_yob: 'Year of birth:'
+        }
+      }
+    }
+
+    stable_length = nil
+    10.times do |i|
+      dm.prepend_to_options(comments_hash.deep_dup)
+      stable_length ||= dm.options.length
+
+      expect(dm.options).not_to include('wivesdata_dictionary'),
+                                "Cycle #{i + 1}: caption merged with following key"
+      expect(dm.options.length).to eq(stable_length),
+                                   "Cycle #{i + 1}: options grew to #{dm.options.length}"
+
+      parsed = nil
+      expect { parsed = YAML.safe_load(dm.options) }.not_to raise_error
+      expect(parsed.dig('_comments', 'fields', 'hear_about_wives_group'))
+        .to eq "Which wives'/partners'/mothers' group?"
+      # The following top-level sections must remain intact and separate
+      expect(parsed['_data_dictionary']).to eq({ 'study' => 'rcfemfl' })
+    end
+  end
+
+  # strip_db_definition_sections removes only the DB-definition-only top-level
+  # sections (_comments, _db_columns, _data_dictionary) and leaves the runtime
+  # configuration intact. It uses line-based scanning so it works even when the
+  # text is malformed. See issue #676.
+  it 'strips only the DB-definition sections from options text' do
+    text = <<~END_OPT
+      _comments:
+        table: x
+        fields:
+          f1: this caption breaks: parsing:
+      _data_dictionary:
+        study: rcfemfl
+      _db_columns:
+        f1:
+          type: string
+      default:
+        label: My Model
+        caption_before:
+          f1: A normal caption
+    END_OPT
+
+    stripped = OptionConfigs::ExtraOptions.strip_db_definition_sections(text)
+
+    expect(stripped).not_to match(/^_comments:/)
+    expect(stripped).not_to match(/^_data_dictionary:/)
+    expect(stripped).not_to match(/^_db_columns:/)
+    # The runtime configuration is preserved
+    expect(stripped).to match(/^default:/)
+    expect(stripped).to include('A normal caption')
+    # The retained runtime config parses on its own
+    expect { YAML.safe_load(stripped) }.not_to raise_error
+  end
+
+  # Reproduces the production failure in issue #676: a definition whose runtime
+  # configuration is valid but whose _comments section was corrupted (a field
+  # caption fused with a following key, producing "...data_dictionary:") must not
+  # break runtime parsing. The DB-definition sections are not needed at runtime,
+  # so parse_options_text recovers the runtime configuration by stripping them.
+  it 'recovers the runtime configuration when _comments is corrupted' do
+    table_name = 'test_replace_opts'
+    DynamicModel.active.where(table_name:).each { |dm| dm.disable!(@admin) }
+
+    dm = DynamicModel.create! current_admin: @admin,
+                              name: 'test replace opts',
+                              table_name:,
+                              schema_name: 'ml_app',
+                              category: :test,
+                              options: nil
+
+    # _comments is corrupted exactly as observed in production: the caption value
+    # has fused with a following key, leaving a trailing ': ' that makes YAML
+    # treat it as an (illegal) nested mapping. The runtime 'default' config below
+    # it is perfectly valid.
+    dm.update_column(:options, <<~END_OPT)
+      _comments:
+        table: 'Dynamicmodel: Rc Femfl Cif Rc'
+        fields:
+          hear_about_wives_group: Which wivespartnersdata_dictionary:
+      _db_columns:
+        test1:
+          type: string
+      default:
+        label: Rc Femfl
+        caption_before:
+          test1: A valid caption
+    END_OPT
+
+    # The stored options as-is are not valid YAML
+    expect { YAML.safe_load(dm.options) }.to raise_error(Psych::Exception)
+
+    # parse_options_text recovers the runtime configuration by dropping the
+    # corrupt DB-definition sections, rather than failing the whole parse
+    loaded = nil
+    expect { loaded = OptionConfigs::ExtraOptions.parse_options_text(dm) }.not_to raise_error
+    expect(loaded).to be_a(Hash)
+    expect(loaded).to have_key(:default)
+    expect(loaded.dig(:default, :label)).to eq 'Rc Femfl'
+    # The DB-definition sections were removed during recovery
+    expect(loaded).not_to have_key(:_comments)
   end
 
   it 'generates show_if from show_if_condition_strings' do

--- a/spec/models/option_configs/include_libraries_cycle_spec.rb
+++ b/spec/models/option_configs/include_libraries_cycle_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+# Tests that OptionConfigs::ExtraOptions.include_libraries terminates when a
+# config library reference forms a cycle (self-reference A -> A, or A -> B -> A).
+#
+# Background (issue #676): include_libraries expands every `# @library cat name`
+# directive by replacing it with the library body and re-scanning. The library
+# body can itself contain directives (legitimate nesting). Without cycle
+# protection a self- or mutually-referencing library — which can occur in
+# production when a historical library version is resolved via version_at —
+# expands without bound, growing the prepared options text to hundreds of
+# thousands of lines and eventually failing YAML parsing. The fix adds the same
+# `seen` guard already used by requested_libraries so each library is sourced at
+# most once and repeated references are neutralised.
+
+require 'rails_helper'
+
+RSpec.describe 'OptionConfigs::ExtraOptions.include_libraries cycle protection', type: :model do
+  let(:described) { OptionConfigs::ExtraOptions }
+
+  it 'expands legitimately nested libraries without a cycle' do
+    allow(Admin::ConfigLibrary).to receive(:content_named)
+      .with('cat', 'a', format: :yaml).and_return("body_a: 1\n# @library cat b")
+    allow(Admin::ConfigLibrary).to receive(:content_named)
+      .with('cat', 'b', format: :yaml).and_return('body_b: 2')
+
+    result = described.include_libraries("# @library cat a\ntop: level")
+
+    expect(result).to include('body_a: 1')
+    expect(result).to include('body_b: 2')
+    # No live directives remain, so it terminated cleanly
+    expect(result.scan(OptionConfigs::ExtraOptions::LibraryMatchRegex)).to be_empty
+  end
+
+  it 'terminates and neutralises a self-referencing library' do
+    allow(Admin::ConfigLibrary).to receive(:content_named)
+      .with('cyccat', 'cyclib', format: :yaml)
+      .and_return("body_key: value\n# @library cyccat cyclib")
+
+    result = nil
+    expect do
+      Timeout.timeout(5) { result = described.include_libraries("# @library cyccat cyclib\ntop: level") }
+    end.not_to raise_error
+
+    # The body was sourced exactly once
+    expect(result.scan('body_key: value').length).to eq 1
+    # The repeated self-reference was neutralised, not expanded again
+    expect(result).to include('@library_cycle_skipped cyccat cyclib')
+    # No directive still matches the include regex, so the loop converged
+    expect(result.scan(OptionConfigs::ExtraOptions::LibraryMatchRegex)).to be_empty
+    # The output stays small rather than exploding
+    expect(result.length).to be < 1000
+  end
+
+  it 'terminates and neutralises a mutual A -> B -> A cycle' do
+    allow(Admin::ConfigLibrary).to receive(:content_named)
+      .with('cat', 'a', format: :yaml).and_return("body_a: 1\n# @library cat b")
+    allow(Admin::ConfigLibrary).to receive(:content_named)
+      .with('cat', 'b', format: :yaml).and_return("body_b: 2\n# @library cat a")
+
+    result = nil
+    expect do
+      Timeout.timeout(5) { result = described.include_libraries("# @library cat a\ntop: level") }
+    end.not_to raise_error
+
+    # Each library body is sourced exactly once
+    expect(result.scan('body_a: 1').length).to eq 1
+    expect(result.scan('body_b: 2').length).to eq 1
+    # The reference that closed the cycle was neutralised
+    expect(result).to include('@library_cycle_skipped cat a')
+    expect(result.scan(OptionConfigs::ExtraOptions::LibraryMatchRegex)).to be_empty
+    expect(result.length).to be < 1000
+  end
+
+  # The production trigger for issue #676 was the versioned path: a historical
+  # library version resolved via version_at can produce a cycle when the library's
+  # own content at that point in time references itself. The cycle guard must work
+  # identically when content_named_at is used instead of content_named.
+  it 'terminates and neutralises a self-referencing library when resolved via version_at' do
+    version_at = Time.now
+    allow(Admin::ConfigLibrary).to receive(:content_named_at)
+      .with('cyccat', 'cyclib', format: :yaml, at: version_at)
+      .and_return("body_key: versioned_value\n# @library cyccat cyclib")
+
+    result = nil
+    expect do
+      Timeout.timeout(5) { result = described.include_libraries("# @library cyccat cyclib\ntop: level", version_at:) }
+    end.not_to raise_error
+
+    # The body was sourced exactly once
+    expect(result.scan('body_key: versioned_value').length).to eq 1
+    # The repeated self-reference was neutralised
+    expect(result).to include('@library_cycle_skipped cyccat cyclib')
+    # No live directives remain
+    expect(result.scan(OptionConfigs::ExtraOptions::LibraryMatchRegex)).to be_empty
+    expect(result.length).to be < 1000
+  end
+
+  it 'terminates and neutralises a mutual A -> B -> A cycle when resolved via version_at' do
+    version_at = Time.now
+    allow(Admin::ConfigLibrary).to receive(:content_named_at)
+      .with('cat', 'a', format: :yaml, at: version_at).and_return("body_a: versioned_1\n# @library cat b")
+    allow(Admin::ConfigLibrary).to receive(:content_named_at)
+      .with('cat', 'b', format: :yaml, at: version_at).and_return("body_b: versioned_2\n# @library cat a")
+
+    result = nil
+    expect do
+      Timeout.timeout(5) { result = described.include_libraries("# @library cat a\ntop: level", version_at:) }
+    end.not_to raise_error
+
+    # Each library body is sourced exactly once
+    expect(result.scan('body_a: versioned_1').length).to eq 1
+    expect(result.scan('body_b: versioned_2').length).to eq 1
+    # The back-reference that closed the cycle was neutralised
+    expect(result).to include('@library_cycle_skipped cat a')
+    expect(result.scan(OptionConfigs::ExtraOptions::LibraryMatchRegex)).to be_empty
+    expect(result.length).to be < 1000
+  end
+end


### PR DESCRIPTION
## Summary

Reopened fix for #676. Three related defects in dynamic model option handling that together caused corrupt YAML, a runaway options-text explosion (hundreds of thousands of lines) in production, and a fragile runtime parse that took down the search-results page.

---

## 1. Runaway config-library expansion — the production root cause

The "hundreds of thousands of lines" did **not** come from the stored options (≈ 306 lines) or the write path. It is produced at **read time** inside `ExtraOptions.include_libraries` during `prepare_options_text`:

```ruby
res = content_to_update.match reg          # reg = /# @library (\S+) (\S+)$/
while res
  ...
  content_to_update.gsub!(res[0], lib)     # replace ALL copies of the directive with the library body
  res = content_to_update.match reg        # re-scan from the top
end
```

`include_libraries` had **no cycle guard**, unlike its sibling `requested_libraries`, which already uses `seen = Set.new`. A self-referencing (`A → A`) or mutually-referencing (`A → B → A`) library expands without bound — exponentially when the cycle reintroduces more than one directive, because `gsub!` replaces every occurrence on each pass. The resulting giant, mangled document is what finally fails `Psych` ("mapping values are not allowed… line 100"); the `data_dictionary:` fusions and duplicated `_db_columns:` in the error dump are artifacts of that expansion plus the `LibraryKeyRenamePatterns` `gsub!`.

**Why production only:** production versions the definition **at record creation** (not `use_current_version`), so `prepare_options_text` sets `version_at = updated_at || created_at` and resolves libraries via `content_named_at(..., at: version_at)` — the **historical** library version, which still contained the cycle. In dev (`use_current_version`/`DisableVDef` → `version_at = nil`) libraries resolve to their **current**, fixed content, so it terminates — which is why it could not be reproduced locally.

**Fix:** add the same `seen` guard `requested_libraries` has. Each library is sourced at most once; a repeated reference is replaced with `# @library_cycle_skipped cat name` (which deliberately does not match the include regex, so the loop converges) and a warning is logged.

---

## 2. Runtime resilience for corrupt DB-definition sections

`_comments`, `_db_columns` and `_data_dictionary` describe the database table, not the runtime configuration — `parse_config` deletes all three before runtime use. A corruption confined to them was still breaking `YAML.safe_load` for the whole document. On a `Psych::Exception`, `parse_options_text` now calls `recover_runtime_config`, which strips those DB-definition-only sections (`strip_db_definition_sections`, line-based) and retries. If the runtime config then parses it is returned with a warning logged; otherwise the original `FphsOptionsParseError` is raised so genuine runtime errors (anchors, merges, overrides) are not hidden.

---

## 3. Write-path corruption — `prepend_to_options`

`prepend_to_options` used a multiline regex (`/^(key:(.+?))(\n[^\S]|\z)/m`) to locate and replace a top-level section. This had three defects:

- The non-greedy `.+?` could consume the next section's header, fusing an apostrophe-containing caption (`Which wives'/partners'/mothers' group?`) with the following `_data_dictionary:` key into `…wivesdata_dictionary:`.
- A `\′` postmatch backreference bug corrupted the replacement when values contained backslash-quote.
- The capture group consumed the `\n` before the next key, causing an extra blank line on each pass.

**Fix:** replace the regex with a forward line scanner that stops at the first line matching `/\A\S/` (any non-whitespace character at column 0). `String.yaml_dump` serialises any string value — including multi-line ones containing config-like keywords — as a properly indented YAML block scalar, so the replacement can never escape its section boundary regardless of what the value contains.

The previously present `comment_contains_config_structure?` guard in `set_comments_from_table` (which attempted to filter poisoned DB column comments) was removed: with `String.yaml_dump` serialising column comment values as indented block scalars, any multi-line comment is structurally contained within the `_comments` section and cannot corrupt adjacent sections. The guard provided no structural protection that the write-path fix does not already provide.

---

## Call-stack note

The re-entrancy in the reported stack (`prepare_options_text` → `uses_current_definition_version?` → `use_current_version` → `option_configs` → `parse_config` → `parse_options_text` → `prepare_options_text`) is bounded at depth 2 (`@use_current_version_set` is set before the recursive call). It is not a growth source; it just means the work runs twice per render. The read path never grows or re-saves `options` — `options_text` returns a `.dup`.

---

## Tests

- `spec/models/option_configs/include_libraries_cycle_spec.rb` (new) — **5 examples**: legitimate nesting still expands correctly; self-reference and `A → B → A` cycles terminate and are neutralised in both the unversioned path (`content_named`) and the **versioned path** (`content_named_at` with `version_at:`) — the exact production scenario named in issue #676.
- `spec/models/option_configs/dynamic_model_options_spec.rb` — write-path stability/idempotency (repeated prepends, escaped-quote captions, adjacent `_data_dictionary`), and two runtime-recovery specs (`strip_db_definition_sections` unit test and `parse_options_text` recovery from corrupted `_comments`).
- Regression checks: `config_library_cache_invalidation_spec` + `config_library_versioned_spec` (including `does not pass version_at to include_libraries when use_current_version is true`) pass — legitimate library inclusion is unaffected.

No new RuboCop offenses.

---

## Related

- Closes #676
